### PR TITLE
feat(ai-gateway): verify signed model production evidence

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -75,8 +75,9 @@ select candidates for benchmarking. Production mode requires measured champion
 evidence and fails closed for unbenchmarked candidates.
 
 Production model selection must pass `production_evidence` containing
-receipt-bound benchmark and promotion proof. Catalog fields alone do not satisfy
-production authority, even when `promotion_state == CHAMPION`.
+typed, rehydrated and signature-verified benchmark/promotion proof. Catalog
+fields and raw evidence mappings do not satisfy production authority, even when
+`promotion_state == CHAMPION`.
 
 Panel mode emits role assignments and a topology digest. The candidate panel may
 include roles such as principal, researcher, critic and implementer; the verifier
@@ -176,9 +177,35 @@ produce a minimal RedDog bridge payload via `to_reddog_bridge_payload()`.
 
 The verifier role remains outside candidate panels. Catalog-only champions,
 evaluation selections, stale topology, mismatched benchmark evidence, missing
-signed promotion receipts, and below-threshold evidence fail closed. This API
-does not call model providers, run benchmarks, mutate the extension, persist
-runtime defaults, or write PatternMemory.
+verified production evidence, missing signed promotion receipts, and
+below-threshold evidence fail closed. Panel runtime binding is intentionally
+deferred until panel topology evidence is signed and verified. This API does not
+call model providers, run benchmarks, mutate the extension, persist runtime
+defaults, or write PatternMemory.
+
+#### Signed Production Evidence
+
+```python
+rehydrate_model_benchmark_evidence_receipt(...)
+rehydrate_model_promotion_evidence_receipt(...)
+rehydrate_model_selection_receipt(...)
+rehydrate_model_runtime_binding_receipt(...)
+rehydrate_model_signed_evidence_receipt(...)
+build_verified_model_production_evidence(...) -> VerifiedModelProductionEvidence
+verify_model_signed_evidence_receipt(...) -> SignedEvidenceVerificationResult
+```
+
+Signed evidence binds signer role, public key fingerprint, key epoch, model
+subject, catalog snapshot, selection receipt, benchmark run, benchmark evidence,
+task set, held-out split, verifier digest, prompt/topology digest, promotion
+evidence, promotion policy, issued/expiry time and nonce.
+
+Accepted signer roles are `benchmark_verifier` and `promotion_authority`.
+Signatures are verified through the existing RedDog `SignatureVerifier`
+interface; this module never signs, never holds private keys and never imports a
+crypto signing library. Nonces are consumed only when admission explicitly
+requests it. Downstream selection and runtime checks validate immutable verified
+evidence and do not consume single-use nonces again.
 
 ## Configuration
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,49 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Model Intelligence Receipt Rehydration and Signed Evidence
+
+**Who:** 0102 Codex
+**Type:** Runtime Foundation Hardening
+**Slice:** MODEL_INTELLIGENCE_RECEIPT_REHYDRATION_AND_SIGNED_EVIDENCE_VERIFICATION_PHASE1
+
+**What:** Added the signed production-evidence admission gate for model
+intelligence and wired production model selection/runtime binding to it.
+
+**Why:** Production selection previously accepted raw `production_evidence`
+mappings and presence-checked receipt IDs. A forged mapping could produce a
+production `ModelSelectionReceipt` without authentic benchmark-verifier and
+promotion-authority signatures.
+
+**Files:**
+- `src/model_signed_evidence.py` - receipt rehydration, deterministic ID
+  recomputation, role-specific signed evidence verification, nonce admission
+  handling, and typed `VerifiedModelProductionEvidence`.
+- `src/model_intelligence_selection.py` - production selection now rejects raw
+  mappings and requires verified signed evidence.
+- `src/model_runtime_binding.py` - runtime bridge binding now requires verified
+  production evidence and keeps panel runtime binding deferred.
+- `tests/test_model_signed_evidence.py` and helper - rehydration, tamper,
+  signer-role, signature, nonce and panel-deferred tests.
+- Existing selection/outcome/runtime-binding tests - updated for the new truth
+  boundary.
+- `README.md` and `INTERFACE.md` - API and truth-boundary notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: benchmark/promotion/catalog/selection/runtime receipts can be
+  rehydrated and digest-checked.
+- IMPLEMENTED: single-model production evidence requires signed
+  `benchmark_verifier` and `promotion_authority` receipts.
+- IMPLEMENTED: production selection rejects raw evidence mappings.
+- IMPLEMENTED: runtime binding requires verified production evidence.
+- IMPLEMENTED: panel runtime binding remains fail-closed/deferred.
+- NOT IMPLEMENTED: private-key handling, signing, provider calls, benchmark
+  execution, panel topology promotion, extension runtime mutation, PatternMemory
+  writes, or HoloIndex re-indexing.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - RedDog Dynamic Runtime Model Binding
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -97,6 +97,22 @@ defaults. This layer still does not call providers, run benchmarks, mutate the
 extension, persist champion ledgers, write PatternMemory, or change
 `extension.js`.
 
+## Signed Production Evidence
+
+`src/model_signed_evidence.py` is the production evidence admission gate between
+benchmark/promotion receipts and model selection/runtime binding. It rehydrates
+serialized catalog, selection, benchmark, promotion and runtime binding receipts,
+recomputes deterministic IDs, and verifies role-specific signed evidence through
+the existing RedDog signature verifier interface.
+
+Production selection no longer accepts raw `production_evidence` mappings as
+authority. Those mappings remain useful as legacy scalar projections, but
+`selection.purpose == production` requires a typed
+`VerifiedModelProductionEvidence` object that passed signed-evidence
+verification. Runtime binding also requires that verified object before a bridge
+payload can be emitted. Single-model chains can pass; panel runtime binding is
+still deferred until topology-bound panel evidence is signed and verified.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py
@@ -148,15 +148,19 @@ def select_models_for_task(
     snapshot: ModelCatalogSnapshot,
     requirements: ModelTaskRequirements,
     *,
-    production_evidence: Mapping[str, Mapping[str, Any]] | None = None,
+    production_evidence: Any | None = None,
 ) -> ModelSelectionReceipt:
     """Select eligible model candidates from a catalog snapshot."""
 
     normalized_requirements = requirements.normalized()
+    production_evidence_map, production_evidence_error = _production_evidence_map(
+        production_evidence,
+        normalized_requirements,
+    )
     ranked: list[ModelCandidateRanking] = []
     rejection_counts: dict[str, int] = {}
     for card in snapshot.cards:
-        ok, reasons = _eligible(card, normalized_requirements, production_evidence or {})
+        ok, reasons = _eligible(card, normalized_requirements, production_evidence_map, production_evidence_error)
         if not ok:
             for reason in reasons:
                 rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
@@ -199,6 +203,7 @@ def _eligible(
     card: ModelCapabilityCard,
     requirements: ModelTaskRequirements,
     production_evidence: Mapping[str, Mapping[str, Any]],
+    production_evidence_error: str | None = None,
 ) -> tuple[bool, tuple[str, ...]]:
     reasons: list[str] = []
     provider = _clean_token(card.provider)
@@ -234,12 +239,40 @@ def _eligible(
             reasons.append("production_verifier_threshold_missing")
         if card.promotion_state != PromotionState.CHAMPION:
             reasons.append("not_production_champion")
+        if production_evidence_error:
+            reasons.append(production_evidence_error)
         evidence = production_evidence.get(card.canonical_model_id)
         if not evidence:
             reasons.append("missing_production_evidence")
         else:
             reasons.extend(_production_evidence_rejections(card, requirements, evidence))
     return not reasons, tuple(sorted(set(reasons)))
+
+
+def _production_evidence_map(
+    production_evidence: Any | None,
+    requirements: ModelTaskRequirements,
+) -> tuple[Mapping[str, Mapping[str, Any]], str | None]:
+    if requirements.purpose != SelectionPurpose.PRODUCTION:
+        if production_evidence is None:
+            return {}, None
+        if isinstance(production_evidence, Mapping):
+            return production_evidence, None
+        if hasattr(production_evidence, "to_selection_mapping"):
+            return production_evidence.to_selection_mapping(), None
+        return {}, None
+    if production_evidence is None:
+        return {}, None
+    try:
+        from .model_signed_evidence import VerifiedModelProductionEvidence
+    except Exception:
+        VerifiedModelProductionEvidence = ()  # type: ignore[assignment]
+    if not isinstance(production_evidence, VerifiedModelProductionEvidence):
+        return {}, "production_evidence_not_authenticated"
+    mapping = production_evidence.to_selection_mapping()
+    if not isinstance(mapping, Mapping):
+        return {}, "production_evidence_not_authenticated"
+    return mapping, None
 
 
 def _rank_candidate(card: ModelCapabilityCard, requirements: ModelTaskRequirements) -> ModelCandidateRanking:

--- a/modules/ai_intelligence/ai_gateway/src/model_runtime_binding.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_runtime_binding.py
@@ -165,6 +165,7 @@ def bind_reddog_runtime_models(
     benchmark_evidence_receipts: Sequence[ModelBenchmarkEvidenceReceipt],
     promotion_evidence_receipts: Sequence[ModelPromotionEvidenceReceipt],
     policy: ModelRuntimeBindingPolicy,
+    verified_production_evidence: Any | None = None,
 ) -> RedDogModelRuntimeBindingReceipt:
     """Validate and bind a production model selection for RedDog runtime."""
 
@@ -177,6 +178,7 @@ def bind_reddog_runtime_models(
         benchmark_by_model=benchmark_by_model,
         promotion_by_model=promotion_by_model,
         policy=normalized_policy,
+        verified_production_evidence=verified_production_evidence,
     )
     role_bindings: tuple[RuntimeModelRoleBinding, ...] = ()
     principal_model: str | None = None
@@ -246,6 +248,7 @@ def _runtime_binding_rejections(
     benchmark_by_model: Mapping[str, ModelBenchmarkEvidenceReceipt],
     promotion_by_model: Mapping[str, ModelPromotionEvidenceReceipt],
     policy: ModelRuntimeBindingPolicy,
+    verified_production_evidence: Any | None,
 ) -> list[str]:
     reasons: list[str] = []
     selected_ids = tuple(selection_receipt.selected_model_ids)
@@ -256,6 +259,18 @@ def _runtime_binding_rejections(
         reasons.append("selection_not_selected")
     if selection_receipt.requirements.purpose != SelectionPurpose.PRODUCTION:
         reasons.append("selection_not_production")
+    if not getattr(verified_production_evidence, "signed_evidence_verified", False):
+        reasons.append("missing_verified_production_evidence")
+    verified_model_ids: set[str] = set()
+    verified_selection_ids: tuple[str, ...] = ()
+    if getattr(verified_production_evidence, "signed_evidence_verified", False):
+        try:
+            verified_model_ids = set(verified_production_evidence.model_ids())
+            verified_selection_ids = tuple(verified_production_evidence.selection_receipt_ids())
+        except Exception:
+            reasons.append("invalid_verified_production_evidence")
+        if verified_selection_ids and verified_selection_ids != (selection_receipt.receipt_id,):
+            reasons.append("signed_evidence_selection_receipt_mismatch")
     if selection_receipt.requirements.task_family != policy.task_family:
         reasons.append("task_family_mismatch")
     if not selected_ids:
@@ -265,6 +280,7 @@ def _runtime_binding_rejections(
     elif selection_receipt.requirements.min_verifier_pass_rate < policy.min_verifier_pass_rate:
         reasons.append("selection_threshold_below_runtime_policy")
     if selection_receipt.requirements.selection_mode == SelectionMode.PANEL:
+        reasons.append("panel_runtime_binding_deferred")
         if not selection_receipt.panel_topology_digest:
             reasons.append("missing_panel_topology_digest")
         if policy.required_panel_topology_digest and selection_receipt.panel_topology_digest != policy.required_panel_topology_digest:
@@ -276,6 +292,8 @@ def _runtime_binding_rejections(
     for model_id in selected_ids:
         if model_id not in catalog_ids:
             reasons.append("selected_model_not_in_catalog")
+        if verified_model_ids and model_id not in verified_model_ids:
+            reasons.append("selected_model_missing_signed_evidence")
         benchmark = benchmark_by_model.get(model_id)
         promotion = promotion_by_model.get(model_id)
         if benchmark is None:

--- a/modules/ai_intelligence/ai_gateway/src/model_signed_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_signed_evidence.py
@@ -1,0 +1,884 @@
+"""Signed production-evidence verification for model intelligence.
+
+This module is the admission gate between benchmark/promotion receipts and
+production model selection. It rehydrates receipt mappings, recomputes their
+deterministic IDs, verifies role-specific signatures using the existing RedDog
+signature backend contract, and returns a typed object that production
+selection/runtime binding may consume.
+
+It does not sign, generate keys, call models, run benchmarks, execute commands,
+write PatternMemory, re-index HoloIndex, or promote a model by itself.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    NonceStore,
+    SignatureVerifier,
+    canonical_signing_input,
+    constant_time_compare,
+)
+
+from .model_intelligence_catalog import (
+    Availability,
+    ModelCapabilityCard,
+    ModelCatalogRejectedRecord,
+    ModelCatalogSnapshot,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from .model_intelligence_outcomes import (
+    ModelBenchmarkEvidenceReceipt,
+    ModelOutcomeMetrics,
+    ModelPromotionEvidenceReceipt,
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+    production_evidence_for_selection,
+)
+from .model_intelligence_selection import (
+    ModelCandidateRanking,
+    ModelPanelRoleAssignment,
+    ModelSelectionReceipt,
+    ModelTaskRequirements,
+    SelectionDecision,
+    SelectionMode,
+    SelectionPurpose,
+)
+from .model_runtime_binding import (
+    ModelRuntimeBindingDecision,
+    ModelRuntimeBindingPolicy,
+    RedDogModelRuntimeBindingReceipt,
+    RuntimeModelRoleBinding,
+)
+
+
+SIGNED_EVIDENCE_SCHEMA_VERSION = "model_signed_evidence_receipt.v1"
+VERIFIED_PRODUCTION_EVIDENCE_SCHEMA_VERSION = "verified_model_production_evidence.v1"
+PREFIX_MODEL_SIGNED_EVIDENCE = "reddog-model-evidence.v1"
+
+
+class ModelEvidenceSignerRole(str, Enum):
+    """Signer roles accepted by the model-evidence admission gate."""
+
+    BENCHMARK_VERIFIER = "benchmark_verifier"
+    PROMOTION_AUTHORITY = "promotion_authority"
+
+
+class ModelEvidenceSubjectType(str, Enum):
+    """Current signed evidence subject types."""
+
+    MODEL = "model"
+    PANEL = "panel"
+
+
+@dataclass(frozen=True)
+class ModelSignedEvidenceReceipt:
+    """Role-specific signed evidence over model benchmark/promotion receipts."""
+
+    receipt_id: str
+    signer_role: ModelEvidenceSignerRole
+    signer_public_key: str
+    signer_key_fingerprint: str
+    key_epoch: str
+    subject_type: ModelEvidenceSubjectType
+    model_or_panel_subject: str
+    catalog_snapshot_id: str
+    selection_receipt_id: str
+    benchmark_run_receipt_id: str
+    benchmark_evidence_receipt_id: str
+    task_family: str
+    task_set_digest: str
+    held_out_split_digest: str
+    verifier_digest: str
+    prompt_topology_digest: str
+    promotion_evidence_receipt_id: str | None
+    promotion_policy_digest: str | None
+    issued_at: int
+    expires_at: int
+    nonce: str
+    signature: str
+    schema_version: str = SIGNED_EVIDENCE_SCHEMA_VERSION
+
+    def to_signed_record(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "signer_role": self.signer_role.value,
+            "signer_public_key": self.signer_public_key,
+            "signer_key_fingerprint": self.signer_key_fingerprint,
+            "key_epoch": self.key_epoch,
+            "subject_type": self.subject_type.value,
+            "model_or_panel_subject": self.model_or_panel_subject,
+            "catalog_snapshot_id": self.catalog_snapshot_id,
+            "selection_receipt_id": self.selection_receipt_id,
+            "benchmark_run_receipt_id": self.benchmark_run_receipt_id,
+            "benchmark_evidence_receipt_id": self.benchmark_evidence_receipt_id,
+            "task_family": self.task_family,
+            "task_set_digest": self.task_set_digest,
+            "held_out_split_digest": self.held_out_split_digest,
+            "verifier_digest": self.verifier_digest,
+            "prompt_topology_digest": self.prompt_topology_digest,
+            "promotion_evidence_receipt_id": self.promotion_evidence_receipt_id,
+            "promotion_policy_digest": self.promotion_policy_digest,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "nonce": self.nonce,
+            "signature": self.signature,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"receipt_id": self.receipt_id, **self.to_signed_record()}
+
+
+@dataclass(frozen=True)
+class VerifiedModelEvidenceEntry:
+    """Authenticated production evidence for one model subject."""
+
+    model_id: str
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt
+    promotion_receipt: ModelPromotionEvidenceReceipt
+    benchmark_signature_receipt: ModelSignedEvidenceReceipt
+    promotion_signature_receipt: ModelSignedEvidenceReceipt
+
+    def to_selection_mapping(self) -> dict[str, Any]:
+        mapping = production_evidence_for_selection(self.benchmark_receipt, self.promotion_receipt)[self.model_id]
+        mapping.update(
+            {
+                "benchmark_signed_evidence_receipt_id": self.benchmark_signature_receipt.receipt_id,
+                "promotion_signed_evidence_receipt_id": self.promotion_signature_receipt.receipt_id,
+            }
+        )
+        return mapping
+
+
+@dataclass(frozen=True)
+class VerifiedModelProductionEvidence:
+    """Typed evidence object accepted by production model selection."""
+
+    entries: tuple[VerifiedModelEvidenceEntry, ...]
+    schema_version: str = VERIFIED_PRODUCTION_EVIDENCE_SCHEMA_VERSION
+    signed_evidence_verified: bool = True
+
+    def to_selection_mapping(self) -> dict[str, dict[str, Any]]:
+        return {entry.model_id: entry.to_selection_mapping() for entry in self.entries}
+
+    def selection_receipt_ids(self) -> tuple[str, ...]:
+        ids: set[str] = set()
+        for entry in self.entries:
+            ids.add(entry.benchmark_signature_receipt.selection_receipt_id)
+            ids.add(entry.promotion_signature_receipt.selection_receipt_id)
+        return tuple(sorted(ids))
+
+    def model_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(entry.model_id for entry in self.entries))
+
+
+@dataclass(frozen=True)
+class SignedEvidenceVerificationResult:
+    """Verification result for one signed model-evidence receipt."""
+
+    accepted: bool
+    reason_codes: tuple[str, ...] = ()
+
+    def __bool__(self) -> bool:
+        return self.accepted
+
+
+@runtime_checkable
+class ModelEvidenceKeyResolver(Protocol):
+    """Trust anchor for role-specific public keys."""
+
+    def resolve(self, signer_role: str, signer_key_fingerprint: str, key_epoch: str) -> str | None: ...
+
+
+class StaticModelEvidenceKeyResolver:
+    """Deterministic test/runtime adapter for trusted public model-evidence keys."""
+
+    def __init__(self, trusted_public_keys: Mapping[tuple[str, str, str], str] | Mapping[str, str]):
+        self._trusted_public_keys = dict(trusted_public_keys)
+
+    def resolve(self, signer_role: str, signer_key_fingerprint: str, key_epoch: str) -> str | None:
+        exact = self._trusted_public_keys.get((signer_role, signer_key_fingerprint, key_epoch))
+        if exact:
+            return exact
+        return self._trusted_public_keys.get(signer_role)
+
+
+class InMemoryEvidenceNonceStore:
+    """Small test/store adapter with the same consume-once shape as RedDog nonce stores."""
+
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+
+    def consume(self, nonce: str) -> bool:
+        if not isinstance(nonce, str) or not nonce or nonce in self._seen:
+            return False
+        self._seen.add(nonce)
+        return True
+
+
+def build_model_signed_evidence_receipt(
+    *,
+    signer_role: ModelEvidenceSignerRole | str,
+    signer_public_key: str,
+    signer_key_fingerprint: str,
+    key_epoch: str,
+    subject_type: ModelEvidenceSubjectType | str,
+    model_or_panel_subject: str,
+    catalog_snapshot_id: str,
+    selection_receipt_id: str,
+    benchmark_run_receipt_id: str,
+    benchmark_evidence_receipt_id: str,
+    task_family: str,
+    task_set_digest: str,
+    held_out_split_digest: str,
+    verifier_digest: str,
+    prompt_topology_digest: str,
+    promotion_evidence_receipt_id: str | None = None,
+    promotion_policy_digest: str | None = None,
+    issued_at: int,
+    expires_at: int,
+    nonce: str,
+    signature: str,
+) -> ModelSignedEvidenceReceipt:
+    """Build a deterministic signed-evidence receipt from already-issued signature text."""
+
+    role = _coerce_role(signer_role)
+    subject_kind = _coerce_subject_type(subject_type)
+    body = {
+        "schema_version": SIGNED_EVIDENCE_SCHEMA_VERSION,
+        "signer_role": role.value,
+        "signer_public_key": _required("signer_public_key", signer_public_key),
+        "signer_key_fingerprint": _required("signer_key_fingerprint", signer_key_fingerprint),
+        "key_epoch": _required("key_epoch", key_epoch),
+        "subject_type": subject_kind.value,
+        "model_or_panel_subject": _required("model_or_panel_subject", model_or_panel_subject),
+        "catalog_snapshot_id": _required("catalog_snapshot_id", catalog_snapshot_id),
+        "selection_receipt_id": _required("selection_receipt_id", selection_receipt_id),
+        "benchmark_run_receipt_id": _required("benchmark_run_receipt_id", benchmark_run_receipt_id),
+        "benchmark_evidence_receipt_id": _required(
+            "benchmark_evidence_receipt_id",
+            benchmark_evidence_receipt_id,
+        ),
+        "task_family": _clean_token(_required("task_family", task_family)),
+        "task_set_digest": _required("task_set_digest", task_set_digest),
+        "held_out_split_digest": _required("held_out_split_digest", held_out_split_digest),
+        "verifier_digest": _required("verifier_digest", verifier_digest),
+        "prompt_topology_digest": _required("prompt_topology_digest", prompt_topology_digest),
+        "promotion_evidence_receipt_id": _optional(promotion_evidence_receipt_id),
+        "promotion_policy_digest": _optional(promotion_policy_digest),
+        "issued_at": _int_value(issued_at, "issued_at"),
+        "expires_at": _int_value(expires_at, "expires_at"),
+        "nonce": _required("nonce", nonce),
+        "signature": _required("signature", signature),
+    }
+    if body["expires_at"] <= body["issued_at"]:
+        raise ValueError("invalid_evidence_ttl")
+    return ModelSignedEvidenceReceipt(
+        receipt_id=_digest_prefixed("model_signed_evidence", body),
+        signer_role=role,
+        signer_public_key=body["signer_public_key"],
+        signer_key_fingerprint=body["signer_key_fingerprint"],
+        key_epoch=body["key_epoch"],
+        subject_type=subject_kind,
+        model_or_panel_subject=body["model_or_panel_subject"],
+        catalog_snapshot_id=body["catalog_snapshot_id"],
+        selection_receipt_id=body["selection_receipt_id"],
+        benchmark_run_receipt_id=body["benchmark_run_receipt_id"],
+        benchmark_evidence_receipt_id=body["benchmark_evidence_receipt_id"],
+        task_family=body["task_family"],
+        task_set_digest=body["task_set_digest"],
+        held_out_split_digest=body["held_out_split_digest"],
+        verifier_digest=body["verifier_digest"],
+        prompt_topology_digest=body["prompt_topology_digest"],
+        promotion_evidence_receipt_id=body["promotion_evidence_receipt_id"],
+        promotion_policy_digest=body["promotion_policy_digest"],
+        issued_at=body["issued_at"],
+        expires_at=body["expires_at"],
+        nonce=body["nonce"],
+        signature=body["signature"],
+    )
+
+
+def model_signed_evidence_signing_input(receipt_or_record: ModelSignedEvidenceReceipt | Mapping[str, Any]) -> str:
+    """Return the domain-separated canonical signing input for model evidence."""
+
+    record = receipt_or_record.to_signed_record() if isinstance(receipt_or_record, ModelSignedEvidenceReceipt) else dict(receipt_or_record)
+    return canonical_signing_input(record, PREFIX_MODEL_SIGNED_EVIDENCE)
+
+
+def rehydrate_model_catalog_snapshot(data: Mapping[str, Any]) -> ModelCatalogSnapshot:
+    """Rehydrate a catalog snapshot and recompute its snapshot ID."""
+
+    if data.get("schema_version") != "model_catalog_snapshot.v1":
+        raise ValueError("invalid_catalog_schema")
+    cards = tuple(_rehydrate_card(item) for item in _list_value(data.get("cards"), "cards"))
+    rejected = tuple(_rehydrate_rejected_record(item) for item in _list_value(data.get("rejected_records", []), "rejected_records"))
+    snapshot = build_model_catalog_snapshot(
+        cards,
+        source_receipts=tuple(str(value) for value in _list_value(data.get("source_receipts", []), "source_receipts")),
+        rejected_records=rejected,
+        generated_at=_required("generated_at", data.get("generated_at")),
+    )
+    if not constant_time_compare(snapshot.snapshot_id, _required("snapshot_id", data.get("snapshot_id"))):
+        raise ValueError("catalog_snapshot_id_mismatch")
+    return snapshot
+
+
+def rehydrate_model_benchmark_evidence_receipt(data: Mapping[str, Any]) -> ModelBenchmarkEvidenceReceipt:
+    """Rehydrate benchmark evidence and recompute its receipt ID."""
+
+    if data.get("schema_version") != "model_benchmark_evidence_receipt.v1":
+        raise ValueError("invalid_benchmark_schema")
+    metrics_data = _mapping_value(data.get("metrics"), "metrics")
+    receipt = build_model_benchmark_evidence_receipt(
+        model_id=_required("model_id", data.get("model_id")),
+        task_family=_required("task_family", data.get("task_family")),
+        task_set_digest=_required("task_set_digest", data.get("task_set_digest")),
+        held_out_split_digest=_required("held_out_split_digest", data.get("held_out_split_digest")),
+        prompt_topology_digest=_required("prompt_topology_digest", data.get("prompt_topology_digest")),
+        verifier_digest=_required("verifier_digest", data.get("verifier_digest")),
+        verifier_receipt_id=_required("verifier_receipt_id", data.get("verifier_receipt_id")),
+        sample_count=_int_value(data.get("sample_count"), "sample_count"),
+        accepted_count=_int_value(data.get("accepted_count"), "accepted_count"),
+        metrics=ModelOutcomeMetrics(
+            latency_ms=metrics_data.get("latency_ms"),
+            input_tokens=metrics_data.get("input_tokens"),
+            output_tokens=metrics_data.get("output_tokens"),
+            cost_estimate_usd=metrics_data.get("cost_estimate_usd"),
+        ),
+    )
+    if not constant_time_compare(receipt.receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("benchmark_receipt_id_mismatch")
+    if float(data.get("verifier_pass_rate")) != receipt.verifier_pass_rate:
+        raise ValueError("benchmark_pass_rate_mismatch")
+    return receipt
+
+
+def rehydrate_model_promotion_evidence_receipt(
+    data: Mapping[str, Any],
+    *,
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt,
+) -> ModelPromotionEvidenceReceipt:
+    """Rehydrate promotion evidence and recompute its receipt ID."""
+
+    if data.get("schema_version") != "model_promotion_evidence_receipt.v1":
+        raise ValueError("invalid_promotion_schema")
+    receipt = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark_receipt,
+        promotion_state=PromotionState(_required("promotion_state", data.get("promotion_state"))),
+        promotion_authority_receipt_id=_required(
+            "promotion_authority_receipt_id",
+            data.get("promotion_authority_receipt_id"),
+        ),
+        signed_promotion_receipt_id=_required("signed_promotion_receipt_id", data.get("signed_promotion_receipt_id")),
+        min_verifier_pass_rate=float(data.get("min_verifier_pass_rate")),
+    )
+    if not constant_time_compare(receipt.receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("promotion_receipt_id_mismatch")
+    return receipt
+
+
+def rehydrate_model_selection_receipt(data: Mapping[str, Any]) -> ModelSelectionReceipt:
+    """Rehydrate a selection receipt and verify its deterministic digest."""
+
+    if data.get("schema_version") != "model_selection_receipt.v1":
+        raise ValueError("invalid_selection_schema")
+    requirements = _rehydrate_requirements(_mapping_value(data.get("requirements"), "requirements"))
+    decision = SelectionDecision(_required("decision", data.get("decision")))
+    rankings = tuple(_rehydrate_ranking(item) for item in _list_value(data.get("rankings"), "rankings"))
+    assignments = tuple(_rehydrate_assignment(item) for item in _list_value(data.get("role_assignments", []), "role_assignments"))
+    receipt = ModelSelectionReceipt(
+        receipt_id=_required("receipt_id", data.get("receipt_id")),
+        catalog_snapshot_id=_required("catalog_snapshot_id", data.get("catalog_snapshot_id")),
+        requirements=requirements,
+        decision=decision,
+        selected_model_ids=tuple(str(value) for value in _list_value(data.get("selected_model_ids"), "selected_model_ids")),
+        rankings=rankings,
+        role_assignments=assignments,
+        panel_topology_digest=_optional(data.get("panel_topology_digest")),
+        rejection_reasons=tuple(str(value) for value in _list_value(data.get("rejection_reasons", []), "rejection_reasons")),
+    )
+    body = {
+        "schema_version": receipt.schema_version,
+        "catalog_snapshot_id": receipt.catalog_snapshot_id,
+        "requirements": _requirements_to_json(receipt.requirements),
+        "decision": receipt.decision.value,
+        "selected_model_ids": list(receipt.selected_model_ids),
+        "rankings": [asdict(item) for item in receipt.rankings],
+        "role_assignments": [asdict(item) for item in receipt.role_assignments],
+        "panel_topology_digest": receipt.panel_topology_digest,
+        "rejection_reasons": list(receipt.rejection_reasons),
+    }
+    if not constant_time_compare(_digest_prefixed("model_selection_receipt", body), receipt.receipt_id):
+        raise ValueError("selection_receipt_id_mismatch")
+    return receipt
+
+
+def rehydrate_model_runtime_binding_receipt(data: Mapping[str, Any]) -> RedDogModelRuntimeBindingReceipt:
+    """Rehydrate a runtime binding receipt and verify its deterministic digest."""
+
+    if data.get("schema_version") != "reddog_model_runtime_binding_receipt.v1":
+        raise ValueError("invalid_runtime_binding_schema")
+    policy = _rehydrate_runtime_policy(_mapping_value(data.get("policy"), "policy"))
+    receipt = RedDogModelRuntimeBindingReceipt(
+        receipt_id=_required("receipt_id", data.get("receipt_id")),
+        decision=ModelRuntimeBindingDecision(_required("decision", data.get("decision"))),
+        runtime_surface=_required("runtime_surface", data.get("runtime_surface")),
+        catalog_snapshot_id=_required("catalog_snapshot_id", data.get("catalog_snapshot_id")),
+        selection_receipt_id=_required("selection_receipt_id", data.get("selection_receipt_id")),
+        task_family=_required("task_family", data.get("task_family")),
+        principal_model=_optional(data.get("principal_model")),
+        panel_models=tuple(str(value) for value in _list_value(data.get("panel_models", []), "panel_models")),
+        role_bindings=tuple(_rehydrate_runtime_role(item) for item in _list_value(data.get("role_bindings", []), "role_bindings")),
+        benchmark_evidence_receipt_ids=tuple(str(value) for value in _list_value(data.get("benchmark_evidence_receipt_ids", []), "benchmark_evidence_receipt_ids")),
+        promotion_evidence_receipt_ids=tuple(str(value) for value in _list_value(data.get("promotion_evidence_receipt_ids", []), "promotion_evidence_receipt_ids")),
+        signed_promotion_receipt_ids=tuple(str(value) for value in _list_value(data.get("signed_promotion_receipt_ids", []), "signed_promotion_receipt_ids")),
+        policy=policy,
+        rejection_reasons=tuple(str(value) for value in _list_value(data.get("rejection_reasons", []), "rejection_reasons")),
+    )
+    body = {
+        "schema_version": receipt.schema_version,
+        "decision": receipt.decision.value,
+        "runtime_surface": receipt.runtime_surface,
+        "catalog_snapshot_id": receipt.catalog_snapshot_id,
+        "selection_receipt_id": receipt.selection_receipt_id,
+        "task_family": receipt.task_family,
+        "principal_model": receipt.principal_model,
+        "panel_models": list(receipt.panel_models),
+        "role_bindings": [binding.to_dict() for binding in receipt.role_bindings],
+        "benchmark_evidence_receipt_ids": list(receipt.benchmark_evidence_receipt_ids),
+        "promotion_evidence_receipt_ids": list(receipt.promotion_evidence_receipt_ids),
+        "signed_promotion_receipt_ids": list(receipt.signed_promotion_receipt_ids),
+        "policy": policy.to_dict(),
+        "rejection_reasons": list(receipt.rejection_reasons),
+    }
+    if not constant_time_compare(_digest_prefixed("reddog_model_runtime_binding", body), receipt.receipt_id):
+        raise ValueError("runtime_binding_receipt_id_mismatch")
+    return receipt
+
+
+def rehydrate_model_signed_evidence_receipt(data: Mapping[str, Any]) -> ModelSignedEvidenceReceipt:
+    """Rehydrate signed evidence and recompute its receipt ID."""
+
+    if data.get("schema_version") != SIGNED_EVIDENCE_SCHEMA_VERSION:
+        raise ValueError("invalid_signed_evidence_schema")
+    receipt = build_model_signed_evidence_receipt(
+        signer_role=_required("signer_role", data.get("signer_role")),
+        signer_public_key=_required("signer_public_key", data.get("signer_public_key")),
+        signer_key_fingerprint=_required("signer_key_fingerprint", data.get("signer_key_fingerprint")),
+        key_epoch=_required("key_epoch", data.get("key_epoch")),
+        subject_type=_required("subject_type", data.get("subject_type")),
+        model_or_panel_subject=_required("model_or_panel_subject", data.get("model_or_panel_subject")),
+        catalog_snapshot_id=_required("catalog_snapshot_id", data.get("catalog_snapshot_id")),
+        selection_receipt_id=_required("selection_receipt_id", data.get("selection_receipt_id")),
+        benchmark_run_receipt_id=_required("benchmark_run_receipt_id", data.get("benchmark_run_receipt_id")),
+        benchmark_evidence_receipt_id=_required(
+            "benchmark_evidence_receipt_id",
+            data.get("benchmark_evidence_receipt_id"),
+        ),
+        task_family=_required("task_family", data.get("task_family")),
+        task_set_digest=_required("task_set_digest", data.get("task_set_digest")),
+        held_out_split_digest=_required("held_out_split_digest", data.get("held_out_split_digest")),
+        verifier_digest=_required("verifier_digest", data.get("verifier_digest")),
+        prompt_topology_digest=_required("prompt_topology_digest", data.get("prompt_topology_digest")),
+        promotion_evidence_receipt_id=_optional(data.get("promotion_evidence_receipt_id")),
+        promotion_policy_digest=_optional(data.get("promotion_policy_digest")),
+        issued_at=_int_value(data.get("issued_at"), "issued_at"),
+        expires_at=_int_value(data.get("expires_at"), "expires_at"),
+        nonce=_required("nonce", data.get("nonce")),
+        signature=_required("signature", data.get("signature")),
+    )
+    if not constant_time_compare(receipt.receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("signed_evidence_receipt_id_mismatch")
+    return receipt
+
+
+def verify_model_signed_evidence_receipt(
+    receipt: ModelSignedEvidenceReceipt,
+    *,
+    expected_role: ModelEvidenceSignerRole | str,
+    key_resolver: ModelEvidenceKeyResolver,
+    signature_verifier: SignatureVerifier,
+    now: int,
+    nonce_store: NonceStore | None = None,
+    consume_nonce: bool = False,
+    revoked_key_epochs: Sequence[str] = (),
+    leeway_s: int = 60,
+) -> SignedEvidenceVerificationResult:
+    """Verify role, trust anchor, TTL, revocation, signature and optional nonce."""
+
+    reasons: list[str] = []
+    role = _coerce_role(expected_role)
+    if receipt.signer_role != role:
+        reasons.append("signer_role_mismatch")
+    if receipt.key_epoch in {str(value) for value in revoked_key_epochs}:
+        reasons.append("key_epoch_revoked")
+    trusted_key = None
+    try:
+        trusted_key = key_resolver.resolve(
+            receipt.signer_role.value,
+            receipt.signer_key_fingerprint,
+            receipt.key_epoch,
+        )
+    except Exception:
+        trusted_key = None
+    if not trusted_key or not constant_time_compare(str(trusted_key), receipt.signer_public_key):
+        reasons.append("signer_key_untrusted")
+    if now + leeway_s < receipt.issued_at:
+        reasons.append("issued_in_future")
+    if now > receipt.expires_at + leeway_s:
+        reasons.append("signed_evidence_expired")
+    try:
+        signature_ok = signature_verifier.verify(
+            receipt.signer_public_key,
+            model_signed_evidence_signing_input(receipt),
+            receipt.signature,
+        ) is True
+    except Exception:
+        signature_ok = False
+    if not signature_ok:
+        reasons.append("signature_invalid")
+    if reasons:
+        return SignedEvidenceVerificationResult(False, tuple(sorted(set(reasons))))
+    if consume_nonce:
+        if nonce_store is None:
+            return SignedEvidenceVerificationResult(False, ("nonce_store_missing",))
+        try:
+            if not nonce_store.consume(receipt.nonce):
+                return SignedEvidenceVerificationResult(False, ("nonce_replay",))
+        except Exception:
+            return SignedEvidenceVerificationResult(False, ("nonce_replay",))
+    return SignedEvidenceVerificationResult(True, ())
+
+
+def build_verified_model_production_evidence(
+    *,
+    catalog_snapshot_id: str,
+    selection_receipt_id: str,
+    benchmark_run_receipt_id: str,
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt | Mapping[str, Any],
+    promotion_receipt: ModelPromotionEvidenceReceipt | Mapping[str, Any],
+    benchmark_signature_receipt: ModelSignedEvidenceReceipt | Mapping[str, Any],
+    promotion_signature_receipt: ModelSignedEvidenceReceipt | Mapping[str, Any],
+    key_resolver: ModelEvidenceKeyResolver,
+    signature_verifier: SignatureVerifier,
+    now: int,
+    nonce_store: NonceStore | None = None,
+    consume_nonces: bool = False,
+    revoked_key_epochs: Sequence[str] = (),
+    leeway_s: int = 60,
+) -> VerifiedModelProductionEvidence:
+    """Verify one single-model production evidence chain and return typed evidence."""
+
+    benchmark = (
+        benchmark_receipt
+        if isinstance(benchmark_receipt, ModelBenchmarkEvidenceReceipt)
+        else rehydrate_model_benchmark_evidence_receipt(benchmark_receipt)
+    )
+    promotion = (
+        promotion_receipt
+        if isinstance(promotion_receipt, ModelPromotionEvidenceReceipt)
+        else rehydrate_model_promotion_evidence_receipt(promotion_receipt, benchmark_receipt=benchmark)
+    )
+    benchmark_sig = (
+        benchmark_signature_receipt
+        if isinstance(benchmark_signature_receipt, ModelSignedEvidenceReceipt)
+        else rehydrate_model_signed_evidence_receipt(benchmark_signature_receipt)
+    )
+    promotion_sig = (
+        promotion_signature_receipt
+        if isinstance(promotion_signature_receipt, ModelSignedEvidenceReceipt)
+        else rehydrate_model_signed_evidence_receipt(promotion_signature_receipt)
+    )
+    _assert_single_model_chain(
+        catalog_snapshot_id=catalog_snapshot_id,
+        selection_receipt_id=selection_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark=benchmark,
+        promotion=promotion,
+        benchmark_sig=benchmark_sig,
+        promotion_sig=promotion_sig,
+    )
+    benchmark_result = verify_model_signed_evidence_receipt(
+        benchmark_sig,
+        expected_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        key_resolver=key_resolver,
+        signature_verifier=signature_verifier,
+        now=now,
+        nonce_store=nonce_store,
+        consume_nonce=consume_nonces,
+        revoked_key_epochs=revoked_key_epochs,
+        leeway_s=leeway_s,
+    )
+    if not benchmark_result.accepted:
+        raise ValueError("benchmark_signed_evidence_rejected:" + ",".join(benchmark_result.reason_codes))
+    promotion_result = verify_model_signed_evidence_receipt(
+        promotion_sig,
+        expected_role=ModelEvidenceSignerRole.PROMOTION_AUTHORITY,
+        key_resolver=key_resolver,
+        signature_verifier=signature_verifier,
+        now=now,
+        nonce_store=nonce_store,
+        consume_nonce=consume_nonces,
+        revoked_key_epochs=revoked_key_epochs,
+        leeway_s=leeway_s,
+    )
+    if not promotion_result.accepted:
+        raise ValueError("promotion_signed_evidence_rejected:" + ",".join(promotion_result.reason_codes))
+    return VerifiedModelProductionEvidence(
+        entries=(
+            VerifiedModelEvidenceEntry(
+                model_id=benchmark.model_id,
+                benchmark_receipt=benchmark,
+                promotion_receipt=promotion,
+                benchmark_signature_receipt=benchmark_sig,
+                promotion_signature_receipt=promotion_sig,
+            ),
+        )
+    )
+
+
+def _assert_single_model_chain(
+    *,
+    catalog_snapshot_id: str,
+    selection_receipt_id: str,
+    benchmark_run_receipt_id: str,
+    benchmark: ModelBenchmarkEvidenceReceipt,
+    promotion: ModelPromotionEvidenceReceipt,
+    benchmark_sig: ModelSignedEvidenceReceipt,
+    promotion_sig: ModelSignedEvidenceReceipt,
+) -> None:
+    if benchmark.model_id != promotion.model_id:
+        raise ValueError("promotion_model_mismatch")
+    if benchmark.task_family != promotion.task_family:
+        raise ValueError("promotion_task_mismatch")
+    if promotion.benchmark_evidence_receipt_id != benchmark.receipt_id:
+        raise ValueError("promotion_benchmark_mismatch")
+    if benchmark_sig.subject_type != ModelEvidenceSubjectType.MODEL or promotion_sig.subject_type != ModelEvidenceSubjectType.MODEL:
+        raise ValueError("panel_signed_evidence_deferred")
+    for receipt in (benchmark_sig, promotion_sig):
+        if receipt.model_or_panel_subject != benchmark.model_id:
+            raise ValueError("signed_evidence_subject_mismatch")
+        if receipt.catalog_snapshot_id != catalog_snapshot_id:
+            raise ValueError("signed_evidence_catalog_mismatch")
+        if receipt.selection_receipt_id != selection_receipt_id:
+            raise ValueError("signed_evidence_selection_mismatch")
+        if receipt.benchmark_run_receipt_id != benchmark_run_receipt_id:
+            raise ValueError("signed_evidence_benchmark_run_mismatch")
+        if receipt.benchmark_evidence_receipt_id != benchmark.receipt_id:
+            raise ValueError("signed_evidence_benchmark_mismatch")
+        if receipt.task_family != benchmark.task_family:
+            raise ValueError("signed_evidence_task_mismatch")
+        if receipt.task_set_digest != benchmark.task_set_digest:
+            raise ValueError("signed_evidence_task_set_mismatch")
+        if receipt.held_out_split_digest != benchmark.held_out_split_digest:
+            raise ValueError("signed_evidence_held_out_mismatch")
+        if receipt.verifier_digest != benchmark.verifier_digest:
+            raise ValueError("signed_evidence_verifier_mismatch")
+        if receipt.prompt_topology_digest != benchmark.prompt_topology_digest:
+            raise ValueError("signed_evidence_topology_mismatch")
+    if promotion_sig.promotion_evidence_receipt_id != promotion.receipt_id:
+        raise ValueError("signed_evidence_promotion_mismatch")
+    if not promotion_sig.promotion_policy_digest:
+        raise ValueError("missing_promotion_policy_digest")
+
+
+def _rehydrate_card(data: Mapping[str, Any]) -> ModelCapabilityCard:
+    if data.get("schema_version") != "model_capability_card.v1":
+        raise ValueError("invalid_card_schema")
+    return ModelCapabilityCard(
+        provider=_required("provider", data.get("provider")),
+        model_id=_required("model_id", data.get("model_id")),
+        canonical_model_id=_required("canonical_model_id", data.get("canonical_model_id")),
+        source=_required("source", data.get("source")),
+        availability=Availability(_required("availability", data.get("availability"))),
+        freshness=_required("freshness", data.get("freshness")),
+        promotion_state=PromotionState(_required("promotion_state", data.get("promotion_state"))),
+        task_families=tuple(str(value) for value in _list_value(data.get("task_families", []), "task_families")),
+        context_window=data.get("context_window"),
+        input_cost_per_million=data.get("input_cost_per_million"),
+        output_cost_per_million=data.get("output_cost_per_million"),
+        supports_tools=bool(data.get("supports_tools")),
+        supports_structured_output=bool(data.get("supports_structured_output")),
+        supports_reasoning=bool(data.get("supports_reasoning")),
+        modalities=tuple(str(value) for value in _list_value(data.get("modalities", []), "modalities")),
+        supported_parameters=tuple(str(value) for value in _list_value(data.get("supported_parameters", []), "supported_parameters")),
+        privacy_policy=_required("privacy_policy", data.get("privacy_policy")),
+        verifier_pass_rate=data.get("verifier_pass_rate"),
+        benchmark_scores=_mapping_value(data.get("benchmark_scores", {}), "benchmark_scores"),
+    ).normalized()
+
+
+def _rehydrate_rejected_record(data: Mapping[str, Any]) -> ModelCatalogRejectedRecord:
+    return ModelCatalogRejectedRecord(
+        source=_required("source", data.get("source")),
+        reason=_required("reason", data.get("reason")),
+        record_digest=_required("record_digest", data.get("record_digest")),
+    )
+
+
+def _rehydrate_requirements(data: Mapping[str, Any]) -> ModelTaskRequirements:
+    return ModelTaskRequirements(
+        task_family=_required("task_family", data.get("task_family")),
+        selection_mode=SelectionMode(_required("selection_mode", data.get("selection_mode"))),
+        purpose=SelectionPurpose(_required("purpose", data.get("purpose"))),
+        required_modalities=tuple(str(value) for value in _list_value(data.get("required_modalities", []), "required_modalities")),
+        min_context_window=data.get("min_context_window"),
+        require_tools=bool(data.get("require_tools")),
+        require_structured_output=bool(data.get("require_structured_output")),
+        require_reasoning=bool(data.get("require_reasoning")),
+        max_input_cost_per_million=data.get("max_input_cost_per_million"),
+        max_output_cost_per_million=data.get("max_output_cost_per_million"),
+        allowed_providers=tuple(str(value) for value in _list_value(data.get("allowed_providers", []), "allowed_providers")),
+        denied_providers=tuple(str(value) for value in _list_value(data.get("denied_providers", []), "denied_providers")),
+        max_candidates=_int_value(data.get("max_candidates"), "max_candidates"),
+        min_verifier_pass_rate=data.get("min_verifier_pass_rate"),
+        panel_roles=tuple(str(value) for value in _list_value(data.get("panel_roles", []), "panel_roles")),
+        panel_topology_digest=_optional(data.get("panel_topology_digest")),
+    ).normalized()
+
+
+def _rehydrate_ranking(data: Mapping[str, Any]) -> ModelCandidateRanking:
+    return ModelCandidateRanking(
+        canonical_model_id=_required("canonical_model_id", data.get("canonical_model_id")),
+        provider=_required("provider", data.get("provider")),
+        score=float(data.get("score")),
+        reasons=tuple(str(value) for value in _list_value(data.get("reasons", []), "reasons")),
+    )
+
+
+def _rehydrate_assignment(data: Mapping[str, Any]) -> ModelPanelRoleAssignment:
+    return ModelPanelRoleAssignment(
+        role=_required("role", data.get("role")),
+        canonical_model_id=_required("canonical_model_id", data.get("canonical_model_id")),
+        provider=_required("provider", data.get("provider")),
+    )
+
+
+def _rehydrate_runtime_policy(data: Mapping[str, Any]) -> ModelRuntimeBindingPolicy:
+    return ModelRuntimeBindingPolicy(
+        task_family=_required("task_family", data.get("task_family")),
+        runtime_surface=_required("runtime_surface", data.get("runtime_surface")),
+        min_verifier_pass_rate=float(data.get("min_verifier_pass_rate")),
+        required_task_set_digest=_required("required_task_set_digest", data.get("required_task_set_digest")),
+        required_held_out_split_digest=_required(
+            "required_held_out_split_digest",
+            data.get("required_held_out_split_digest"),
+        ),
+        required_verifier_digest=_required("required_verifier_digest", data.get("required_verifier_digest")),
+        max_panel_models=_int_value(data.get("max_panel_models"), "max_panel_models"),
+        required_panel_topology_digest=_optional(data.get("required_panel_topology_digest")),
+        authority_receipt_id=_optional(data.get("authority_receipt_id")),
+    ).normalized()
+
+
+def _rehydrate_runtime_role(data: Mapping[str, Any]) -> RuntimeModelRoleBinding:
+    return RuntimeModelRoleBinding(
+        role=_required("role", data.get("role")),
+        model_id=_required("model_id", data.get("model_id")),
+        provider=_required("provider", data.get("provider")),
+    )
+
+
+def _requirements_to_json(requirements: ModelTaskRequirements) -> dict[str, Any]:
+    normalized = requirements.normalized()
+    return {
+        "task_family": normalized.task_family,
+        "selection_mode": normalized.selection_mode.value,
+        "purpose": normalized.purpose.value,
+        "required_modalities": list(normalized.required_modalities),
+        "min_context_window": normalized.min_context_window,
+        "require_tools": normalized.require_tools,
+        "require_structured_output": normalized.require_structured_output,
+        "require_reasoning": normalized.require_reasoning,
+        "max_input_cost_per_million": normalized.max_input_cost_per_million,
+        "max_output_cost_per_million": normalized.max_output_cost_per_million,
+        "allowed_providers": list(normalized.allowed_providers),
+        "denied_providers": list(normalized.denied_providers),
+        "max_candidates": normalized.max_candidates,
+        "min_verifier_pass_rate": normalized.min_verifier_pass_rate,
+        "panel_roles": list(normalized.panel_roles),
+        "panel_topology_digest": normalized.panel_topology_digest,
+    }
+
+
+def _coerce_role(value: ModelEvidenceSignerRole | str) -> ModelEvidenceSignerRole:
+    if isinstance(value, ModelEvidenceSignerRole):
+        return value
+    return ModelEvidenceSignerRole(str(value).strip())
+
+
+def _coerce_subject_type(value: ModelEvidenceSubjectType | str) -> ModelEvidenceSubjectType:
+    if isinstance(value, ModelEvidenceSubjectType):
+        return value
+    return ModelEvidenceSubjectType(str(value).strip())
+
+
+def _mapping_value(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _list_value(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _required(name: str, value: Any) -> str:
+    cleaned = str(value).strip() if value is not None else ""
+    if not cleaned:
+        raise ValueError(f"missing_{name}")
+    return cleaned
+
+
+def _optional(value: Any) -> str | None:
+    cleaned = str(value).strip() if value is not None else ""
+    return cleaned or None
+
+
+def _int_value(value: Any, name: str) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid_{name}") from exc
+
+
+def _clean_token(value: Any) -> str:
+    return str(value).strip().lower().replace(" ", "_")
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+__all__ = [
+    "InMemoryEvidenceNonceStore",
+    "ModelEvidenceKeyResolver",
+    "ModelEvidenceSignerRole",
+    "ModelEvidenceSubjectType",
+    "ModelSignedEvidenceReceipt",
+    "PREFIX_MODEL_SIGNED_EVIDENCE",
+    "SignedEvidenceVerificationResult",
+    "StaticModelEvidenceKeyResolver",
+    "VerifiedModelEvidenceEntry",
+    "VerifiedModelProductionEvidence",
+    "build_model_signed_evidence_receipt",
+    "build_verified_model_production_evidence",
+    "model_signed_evidence_signing_input",
+    "rehydrate_model_benchmark_evidence_receipt",
+    "rehydrate_model_catalog_snapshot",
+    "rehydrate_model_promotion_evidence_receipt",
+    "rehydrate_model_runtime_binding_receipt",
+    "rehydrate_model_selection_receipt",
+    "rehydrate_model_signed_evidence_receipt",
+    "verify_model_signed_evidence_receipt",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/model_signed_evidence_test_helpers.py
+++ b/modules/ai_intelligence/ai_gateway/tests/model_signed_evidence_test_helpers.py
@@ -1,0 +1,159 @@
+"""Test helpers for signed model evidence."""
+
+from __future__ import annotations
+
+import hashlib
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelBenchmarkEvidenceReceipt,
+    ModelPromotionEvidenceReceipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    InMemoryEvidenceNonceStore,
+    ModelEvidenceSignerRole,
+    ModelEvidenceSubjectType,
+    ModelSignedEvidenceReceipt,
+    StaticModelEvidenceKeyResolver,
+    VerifiedModelProductionEvidence,
+    build_model_signed_evidence_receipt,
+    build_verified_model_production_evidence,
+    model_signed_evidence_signing_input,
+)
+
+
+BENCHMARK_PUBLIC_KEY = "ed25519-pub-v1:benchmark"
+PROMOTION_PUBLIC_KEY = "ed25519-pub-v1:promotion"
+BENCHMARK_FINGERPRINT = "fingerprint:benchmark"
+PROMOTION_FINGERPRINT = "fingerprint:promotion"
+KEY_EPOCH = "epoch-1"
+NOW = 1_800_000_000
+
+
+class DeterministicSignatureVerifier:
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        return signature == deterministic_signature(public_key, signing_input)
+
+
+def deterministic_signature(public_key: str, signing_input: str) -> str:
+    digest = hashlib.sha256(f"{public_key}\0{signing_input}".encode("utf-8")).hexdigest()
+    return f"test-sig:{digest}"
+
+
+def make_signed_evidence_receipt(
+    *,
+    signer_role: ModelEvidenceSignerRole,
+    public_key: str,
+    fingerprint: str,
+    model_id: str,
+    catalog_snapshot_id: str,
+    selection_receipt_id: str,
+    benchmark_run_receipt_id: str,
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt,
+    promotion_receipt: ModelPromotionEvidenceReceipt | None = None,
+    promotion_policy_digest: str | None = None,
+    nonce: str,
+    subject_type: ModelEvidenceSubjectType = ModelEvidenceSubjectType.MODEL,
+    signature_override: str | None = None,
+) -> ModelSignedEvidenceReceipt:
+    placeholder = build_model_signed_evidence_receipt(
+        signer_role=signer_role,
+        signer_public_key=public_key,
+        signer_key_fingerprint=fingerprint,
+        key_epoch=KEY_EPOCH,
+        subject_type=subject_type,
+        model_or_panel_subject=model_id,
+        catalog_snapshot_id=catalog_snapshot_id,
+        selection_receipt_id=selection_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_evidence_receipt_id=benchmark_receipt.receipt_id,
+        task_family=benchmark_receipt.task_family,
+        task_set_digest=benchmark_receipt.task_set_digest,
+        held_out_split_digest=benchmark_receipt.held_out_split_digest,
+        verifier_digest=benchmark_receipt.verifier_digest,
+        prompt_topology_digest=benchmark_receipt.prompt_topology_digest,
+        promotion_evidence_receipt_id=promotion_receipt.receipt_id if promotion_receipt else None,
+        promotion_policy_digest=promotion_policy_digest,
+        issued_at=NOW - 10,
+        expires_at=NOW + 3600,
+        nonce=nonce,
+        signature="placeholder",
+    )
+    signature = signature_override or deterministic_signature(public_key, model_signed_evidence_signing_input(placeholder))
+    return build_model_signed_evidence_receipt(
+        signer_role=signer_role,
+        signer_public_key=public_key,
+        signer_key_fingerprint=fingerprint,
+        key_epoch=KEY_EPOCH,
+        subject_type=subject_type,
+        model_or_panel_subject=model_id,
+        catalog_snapshot_id=catalog_snapshot_id,
+        selection_receipt_id=selection_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_evidence_receipt_id=benchmark_receipt.receipt_id,
+        task_family=benchmark_receipt.task_family,
+        task_set_digest=benchmark_receipt.task_set_digest,
+        held_out_split_digest=benchmark_receipt.held_out_split_digest,
+        verifier_digest=benchmark_receipt.verifier_digest,
+        prompt_topology_digest=benchmark_receipt.prompt_topology_digest,
+        promotion_evidence_receipt_id=promotion_receipt.receipt_id if promotion_receipt else None,
+        promotion_policy_digest=promotion_policy_digest,
+        issued_at=NOW - 10,
+        expires_at=NOW + 3600,
+        nonce=nonce,
+        signature=signature,
+    )
+
+
+def make_verified_production_evidence(
+    benchmark: ModelBenchmarkEvidenceReceipt,
+    promotion: ModelPromotionEvidenceReceipt,
+    *,
+    catalog_snapshot_id: str,
+    selection_receipt_id: str = "model_selection_receipt:pending",
+    benchmark_run_receipt_id: str = "model_combination_benchmark_run:test",
+    promotion_policy_digest: str = "sha256:promotion-policy",
+    consume_nonces: bool = False,
+) -> VerifiedModelProductionEvidence:
+    benchmark_signature = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint=BENCHMARK_FINGERPRINT,
+        model_id=benchmark.model_id,
+        catalog_snapshot_id=catalog_snapshot_id,
+        selection_receipt_id=selection_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_receipt=benchmark,
+        nonce=f"nonce:benchmark:{benchmark.receipt_id}:{selection_receipt_id}",
+    )
+    promotion_signature = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.PROMOTION_AUTHORITY,
+        public_key=PROMOTION_PUBLIC_KEY,
+        fingerprint=PROMOTION_FINGERPRINT,
+        model_id=benchmark.model_id,
+        catalog_snapshot_id=catalog_snapshot_id,
+        selection_receipt_id=selection_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_receipt=benchmark,
+        promotion_receipt=promotion,
+        promotion_policy_digest=promotion_policy_digest,
+        nonce=f"nonce:promotion:{promotion.receipt_id}:{selection_receipt_id}",
+    )
+    return build_verified_model_production_evidence(
+        catalog_snapshot_id=catalog_snapshot_id,
+        selection_receipt_id=selection_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_receipt=benchmark,
+        promotion_receipt=promotion,
+        benchmark_signature_receipt=benchmark_signature,
+        promotion_signature_receipt=promotion_signature,
+        key_resolver=StaticModelEvidenceKeyResolver(
+            {
+                ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY,
+                ModelEvidenceSignerRole.PROMOTION_AUTHORITY.value: PROMOTION_PUBLIC_KEY,
+            }
+        ),
+        signature_verifier=DeterministicSignatureVerifier(),
+        now=NOW,
+        nonce_store=InMemoryEvidenceNonceStore(),
+        consume_nonces=consume_nonces,
+    )

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
@@ -26,6 +26,7 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import 
     SelectionPurpose,
     select_models_for_task,
 )
+from model_signed_evidence_test_helpers import make_verified_production_evidence
 
 
 def _selected_receipt():
@@ -133,7 +134,58 @@ def test_promotion_evidence_requires_signed_authority_and_threshold():
         raise AssertionError("expected missing signature rejection")
 
 
-def test_production_evidence_map_feeds_hardened_selection():
+def test_verified_production_evidence_feeds_hardened_selection():
+    benchmark = build_model_benchmark_evidence_receipt(
+        model_id="provider/model",
+        task_family="architecture",
+        task_set_digest="sha256:taskset",
+        held_out_split_digest="sha256:heldout",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="verifier:1",
+        sample_count=10,
+        accepted_count=9,
+    )
+    promotion = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signature:1",
+        min_verifier_pass_rate=0.9,
+    )
+    snapshot = build_model_catalog_snapshot(
+        (
+            ModelCapabilityCard(
+                provider="provider",
+                model_id="provider/model",
+                canonical_model_id="provider/model",
+                source="test",
+                promotion_state=PromotionState.CHAMPION,
+                task_families=("architecture",),
+            ).normalized(),
+        ),
+        generated_at="2026-07-16T00:00:00+00:00",
+    )
+
+    verified_evidence = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=snapshot.snapshot_id,
+    )
+    receipt = select_models_for_task(
+        snapshot,
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+            min_verifier_pass_rate=0.9,
+        ),
+        production_evidence=verified_evidence,
+    )
+
+    assert receipt.selected_model_ids == ("provider/model",)
+
+
+def test_legacy_production_evidence_map_is_rejected_by_selection():
     benchmark = build_model_benchmark_evidence_receipt(
         model_id="provider/model",
         task_family="architecture",
@@ -176,7 +228,8 @@ def test_production_evidence_map_feeds_hardened_selection():
         production_evidence=production_evidence_for_selection(benchmark, promotion),
     )
 
-    assert receipt.selected_model_ids == ("provider/model",)
+    assert receipt.selected_model_ids == ()
+    assert "production_evidence_not_authenticated:1" in receipt.rejection_reasons
 
 
 def test_outcome_receipt_accepts_only_verified_complete_results():

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py
@@ -24,6 +24,7 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
     build_model_promotion_evidence_receipt,
     production_evidence_for_selection,
 )
+from model_signed_evidence_test_helpers import make_verified_production_evidence
 
 
 def _snapshot(*cards: ModelCapabilityCard):
@@ -148,6 +149,7 @@ def test_production_requires_explicit_nonzero_verifier_threshold():
 
     assert receipt.decision == SelectionDecision.REJECTED
     assert "production_verifier_threshold_missing:1" in receipt.rejection_reasons
+    assert "production_evidence_not_authenticated:1" in receipt.rejection_reasons
 
 
 def test_production_selects_champion_only_with_benchmark_and_signed_promotion_receipts():
@@ -184,8 +186,55 @@ def test_production_selects_champion_only_with_benchmark_and_signed_promotion_re
         signed_promotion_receipt_id="signed_promotion:1",
         min_verifier_pass_rate=0.9,
     )
+    snapshot = _snapshot(candidate, champion)
+    verified_evidence = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=snapshot.snapshot_id,
+    )
     receipt = select_models_for_task(
-        _snapshot(candidate, champion),
+        snapshot,
+        ModelTaskRequirements(
+            task_family="architecture",
+            purpose=SelectionPurpose.PRODUCTION,
+            min_verifier_pass_rate=0.9,
+        ),
+        production_evidence=verified_evidence,
+    )
+
+    assert receipt.decision == SelectionDecision.SELECTED
+    assert receipt.selected_model_ids == ("provider/champion",)
+    assert all(item.canonical_model_id != "provider/candidate" for item in receipt.rankings)
+
+
+def test_raw_production_evidence_mapping_is_not_authority():
+    champion = _card(
+        "provider/champion",
+        promotion_state=PromotionState.CHAMPION,
+        verifier_pass_rate=0.99,
+        benchmark_scores={"architecture": 0.99},
+    )
+    benchmark = build_model_benchmark_evidence_receipt(
+        model_id="provider/champion",
+        task_family="architecture",
+        task_set_digest="sha256:task-set",
+        held_out_split_digest="sha256:held-out",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="verifier_receipt:1",
+        sample_count=50,
+        accepted_count=47,
+    )
+    promotion = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="promotion_authority:1",
+        signed_promotion_receipt_id="signed_promotion:1",
+        min_verifier_pass_rate=0.9,
+    )
+
+    receipt = select_models_for_task(
+        _snapshot(champion),
         ModelTaskRequirements(
             task_family="architecture",
             purpose=SelectionPurpose.PRODUCTION,
@@ -194,9 +243,8 @@ def test_production_selects_champion_only_with_benchmark_and_signed_promotion_re
         production_evidence=production_evidence_for_selection(benchmark, promotion),
     )
 
-    assert receipt.decision == SelectionDecision.SELECTED
-    assert receipt.selected_model_ids == ("provider/champion",)
-    assert all(item.canonical_model_id != "provider/candidate" for item in receipt.rankings)
+    assert receipt.decision == SelectionDecision.REJECTED
+    assert "production_evidence_not_authenticated:1" in receipt.rejection_reasons
 
 
 def test_requirements_filter_context_tools_structured_reasoning_and_cost():

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py
@@ -16,7 +16,6 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
     ModelPromotionEvidenceReceipt,
     build_model_benchmark_evidence_receipt,
     build_model_promotion_evidence_receipt,
-    production_evidence_for_selection,
 )
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
     ModelTaskRequirements,
@@ -30,6 +29,8 @@ from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import (
     ModelRuntimeBindingPolicy,
     bind_reddog_runtime_models,
 )
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import VerifiedModelProductionEvidence
+from model_signed_evidence_test_helpers import make_verified_production_evidence
 
 
 TASK = "architecture"
@@ -77,11 +78,36 @@ def _promotion(benchmark: ModelBenchmarkEvidenceReceipt) -> ModelPromotionEviden
     )
 
 
-def _evidence_map(*pairs: tuple[ModelBenchmarkEvidenceReceipt, ModelPromotionEvidenceReceipt]):
-    evidence: dict[str, dict] = {}
+def _verified_evidence(
+    *,
+    snapshot_id: str,
+    selection_receipt_id: str = "model_selection_receipt:pending",
+    pairs: tuple[tuple[ModelBenchmarkEvidenceReceipt, ModelPromotionEvidenceReceipt], ...],
+) -> VerifiedModelProductionEvidence:
+    entries = []
     for benchmark, promotion in pairs:
-        evidence.update(production_evidence_for_selection(benchmark, promotion))
-    return evidence
+        entries.extend(
+            make_verified_production_evidence(
+                benchmark,
+                promotion,
+                catalog_snapshot_id=snapshot_id,
+                selection_receipt_id=selection_receipt_id,
+            ).entries
+        )
+    return VerifiedModelProductionEvidence(entries=tuple(entries))
+
+
+def _production_selection(snapshot, requirements, *pairs):
+    provisional = _verified_evidence(snapshot_id=snapshot.snapshot_id, pairs=tuple(pairs))
+    first = select_models_for_task(snapshot, requirements, production_evidence=provisional)
+    verified = _verified_evidence(
+        snapshot_id=snapshot.snapshot_id,
+        selection_receipt_id=first.receipt_id,
+        pairs=tuple(pairs),
+    )
+    second = select_models_for_task(snapshot, requirements, production_evidence=verified)
+    assert second.receipt_id == first.receipt_id
+    return second, verified
 
 
 def _policy(**overrides) -> ModelRuntimeBindingPolicy:
@@ -104,14 +130,14 @@ def test_single_model_runtime_binding_requires_receipt_bound_evidence():
     snapshot = build_model_catalog_snapshot((card,), generated_at="2026-07-16T00:00:00+00:00")
     benchmark = _benchmark("provider/champion")
     promotion = _promotion(benchmark)
-    selection = select_models_for_task(
+    selection, verified_evidence = _production_selection(
         snapshot,
         ModelTaskRequirements(
             task_family=TASK,
             purpose=SelectionPurpose.PRODUCTION,
             min_verifier_pass_rate=0.9,
         ),
-        production_evidence=_evidence_map((benchmark, promotion)),
+        (benchmark, promotion),
     )
 
     receipt = bind_reddog_runtime_models(
@@ -120,6 +146,7 @@ def test_single_model_runtime_binding_requires_receipt_bound_evidence():
         benchmark_evidence_receipts=(benchmark,),
         promotion_evidence_receipts=(promotion,),
         policy=_policy(),
+        verified_production_evidence=verified_evidence,
     )
 
     assert selection.decision == SelectionDecision.SELECTED
@@ -192,14 +219,14 @@ def test_runtime_binding_rejects_mismatched_receipts_and_policy():
     snapshot = build_model_catalog_snapshot((card,), generated_at="2026-07-16T00:00:00+00:00")
     benchmark = _benchmark("provider/champion")
     promotion = _promotion(benchmark)
-    selection = select_models_for_task(
+    selection, verified_evidence = _production_selection(
         snapshot,
         ModelTaskRequirements(
             task_family=TASK,
             purpose=SelectionPurpose.PRODUCTION,
             min_verifier_pass_rate=0.9,
         ),
-        production_evidence=_evidence_map((benchmark, promotion)),
+        (benchmark, promotion),
     )
 
     receipt = bind_reddog_runtime_models(
@@ -208,6 +235,7 @@ def test_runtime_binding_rejects_mismatched_receipts_and_policy():
         benchmark_evidence_receipts=(benchmark,),
         promotion_evidence_receipts=(promotion,),
         policy=_policy(required_task_set_digest="sha256:other", required_verifier_digest="sha256:other"),
+        verified_production_evidence=verified_evidence,
     )
 
     assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
@@ -215,7 +243,7 @@ def test_runtime_binding_rejects_mismatched_receipts_and_policy():
     assert "verifier_digest_mismatch" in receipt.rejection_reasons
 
 
-def test_panel_runtime_binding_uses_role_topology_and_keeps_verifier_outside_panel():
+def test_panel_runtime_binding_remains_deferred_even_with_role_topology():
     cards = (
         _card("provider/principal", provider="a"),
         _card("provider/researcher", provider="b"),
@@ -224,7 +252,7 @@ def test_panel_runtime_binding_uses_role_topology_and_keeps_verifier_outside_pan
     snapshot = build_model_catalog_snapshot(cards, generated_at="2026-07-16T00:00:00+00:00")
     benchmarks = tuple(_benchmark(card.canonical_model_id, topology=TOPOLOGY) for card in cards)
     promotions = tuple(_promotion(benchmark) for benchmark in benchmarks)
-    selection = select_models_for_task(
+    selection, verified_evidence = _production_selection(
         snapshot,
         ModelTaskRequirements(
             task_family=TASK,
@@ -235,7 +263,7 @@ def test_panel_runtime_binding_uses_role_topology_and_keeps_verifier_outside_pan
             panel_roles=("principal", "researcher", "critic"),
             panel_topology_digest=TOPOLOGY,
         ),
-        production_evidence=_evidence_map(*zip(benchmarks, promotions)),
+        *zip(benchmarks, promotions),
     )
 
     receipt = bind_reddog_runtime_models(
@@ -244,17 +272,19 @@ def test_panel_runtime_binding_uses_role_topology_and_keeps_verifier_outside_pan
         benchmark_evidence_receipts=benchmarks,
         promotion_evidence_receipts=promotions,
         policy=_policy(required_panel_topology_digest=TOPOLOGY),
+        verified_production_evidence=verified_evidence,
     )
 
     assert selection.decision == SelectionDecision.SELECTED
-    assert receipt.decision == ModelRuntimeBindingDecision.BOUND
-    assert receipt.principal_model == "provider/principal"
-    assert receipt.panel_models == ("provider/researcher", "provider/critic")
-    assert [binding.role for binding in receipt.role_bindings] == ["principal", "researcher", "critic"]
-    assert "verifier" not in {binding.role for binding in receipt.role_bindings}
-    payload = receipt.to_reddog_bridge_payload()
-    assert payload["lead_model"] == "provider/principal"
-    assert payload["panel_models"] == ["provider/researcher", "provider/critic"]
+    assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
+    assert "panel_runtime_binding_deferred" in receipt.rejection_reasons
+    assert receipt.principal_model is None
+    try:
+        receipt.to_reddog_bridge_payload()
+    except ValueError as exc:
+        assert str(exc) == "runtime_binding_not_bound"
+    else:
+        raise AssertionError("deferred panel binding must not produce a bridge payload")
 
 
 def test_panel_runtime_binding_rejects_topology_mismatch():
@@ -262,7 +292,7 @@ def test_panel_runtime_binding_rejects_topology_mismatch():
     snapshot = build_model_catalog_snapshot(cards, generated_at="2026-07-16T00:00:00+00:00")
     benchmarks = tuple(_benchmark(card.canonical_model_id, topology=TOPOLOGY) for card in cards)
     promotions = tuple(_promotion(benchmark) for benchmark in benchmarks)
-    selection = select_models_for_task(
+    selection, verified_evidence = _production_selection(
         snapshot,
         ModelTaskRequirements(
             task_family=TASK,
@@ -273,7 +303,7 @@ def test_panel_runtime_binding_rejects_topology_mismatch():
             panel_roles=("principal", "researcher"),
             panel_topology_digest=TOPOLOGY,
         ),
-        production_evidence=_evidence_map(*zip(benchmarks, promotions)),
+        *zip(benchmarks, promotions),
     )
 
     receipt = bind_reddog_runtime_models(
@@ -282,6 +312,7 @@ def test_panel_runtime_binding_rejects_topology_mismatch():
         benchmark_evidence_receipts=benchmarks,
         promotion_evidence_receipts=promotions,
         policy=_policy(required_panel_topology_digest="sha256:wrong"),
+        verified_production_evidence=verified_evidence,
     )
 
     assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
@@ -293,14 +324,14 @@ def test_runtime_binding_rejects_duplicate_evidence_receipts():
     promotion = _promotion(benchmark)
     card = _card("provider/champion")
     snapshot = build_model_catalog_snapshot((card,), generated_at="2026-07-16T00:00:00+00:00")
-    selection = select_models_for_task(
+    selection, verified_evidence = _production_selection(
         snapshot,
         ModelTaskRequirements(
             task_family=TASK,
             purpose=SelectionPurpose.PRODUCTION,
             min_verifier_pass_rate=0.9,
         ),
-        production_evidence=_evidence_map((benchmark, promotion)),
+        (benchmark, promotion),
     )
 
     try:
@@ -310,6 +341,7 @@ def test_runtime_binding_rejects_duplicate_evidence_receipts():
             benchmark_evidence_receipts=(benchmark, benchmark),
             promotion_evidence_receipts=(promotion,),
             policy=_policy(),
+            verified_production_evidence=verified_evidence,
         )
     except ValueError as exc:
         assert str(exc) == "duplicate_benchmark_receipt_for_model"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_signed_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_signed_evidence.py
@@ -1,0 +1,276 @@
+"""Tests for signed model evidence rehydration and verification."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from model_signed_evidence_test_helpers import (
+    BENCHMARK_FINGERPRINT,
+    BENCHMARK_PUBLIC_KEY,
+    DeterministicSignatureVerifier,
+    NOW,
+    make_signed_evidence_receipt,
+    make_verified_production_evidence,
+)
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    InMemoryEvidenceNonceStore,
+    ModelEvidenceSignerRole,
+    ModelEvidenceSubjectType,
+    StaticModelEvidenceKeyResolver,
+    build_verified_model_production_evidence,
+    rehydrate_model_benchmark_evidence_receipt,
+    rehydrate_model_catalog_snapshot,
+    rehydrate_model_signed_evidence_receipt,
+    verify_model_signed_evidence_receipt,
+)
+
+
+TASK = "architecture"
+TASK_SET = "sha256:task-set"
+HELD_OUT = "sha256:held-out"
+TOPOLOGY = "sha256:topology"
+VERIFIER = "sha256:verifier"
+CATALOG = "model_catalog_snapshot:test"
+SELECTION = "model_selection_receipt:test"
+BENCHMARK_RUN = "model_combination_benchmark_run:test"
+PROMOTION_POLICY = "sha256:promotion-policy"
+
+
+def _benchmark(model_id: str = "provider/model"):
+    return build_model_benchmark_evidence_receipt(
+        model_id=model_id,
+        task_family=TASK,
+        task_set_digest=TASK_SET,
+        held_out_split_digest=HELD_OUT,
+        prompt_topology_digest=TOPOLOGY,
+        verifier_digest=VERIFIER,
+        verifier_receipt_id=f"verifier:{model_id}",
+        sample_count=20,
+        accepted_count=19,
+    )
+
+
+def _promotion(benchmark):
+    return build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id=f"promotion-authority:{benchmark.model_id}",
+        signed_promotion_receipt_id=f"signed-promotion:{benchmark.model_id}",
+        min_verifier_pass_rate=0.9,
+    )
+
+
+def test_rehydrates_benchmark_and_catalog_by_recomputing_digest():
+    benchmark = _benchmark()
+    assert rehydrate_model_benchmark_evidence_receipt(benchmark.to_dict()) == benchmark
+
+    tampered = benchmark.to_dict()
+    tampered["accepted_count"] = 18
+    try:
+        rehydrate_model_benchmark_evidence_receipt(tampered)
+    except ValueError as exc:
+        assert str(exc) in {"benchmark_receipt_id_mismatch", "benchmark_pass_rate_mismatch"}
+    else:
+        raise AssertionError("tampered benchmark receipt must fail")
+
+    snapshot = build_model_catalog_snapshot(
+        (
+            ModelCapabilityCard(
+                provider="provider",
+                model_id="provider/model",
+                canonical_model_id="provider/model",
+                source="test",
+                promotion_state=PromotionState.CHAMPION,
+                task_families=(TASK,),
+            ).normalized(),
+        ),
+        generated_at="2026-07-16T00:00:00+00:00",
+    )
+    assert rehydrate_model_catalog_snapshot(snapshot.to_dict()) == snapshot
+
+    snapshot_tampered = snapshot.to_dict()
+    snapshot_tampered["cards"][0]["canonical_model_id"] = "provider/other"
+    try:
+        rehydrate_model_catalog_snapshot(snapshot_tampered)
+    except ValueError as exc:
+        assert str(exc) == "catalog_snapshot_id_mismatch"
+    else:
+        raise AssertionError("tampered catalog snapshot must fail")
+
+
+def test_signed_evidence_verifies_role_key_ttl_and_signature():
+    benchmark = _benchmark()
+    signed = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint=BENCHMARK_FINGERPRINT,
+        model_id=benchmark.model_id,
+        catalog_snapshot_id=CATALOG,
+        selection_receipt_id=SELECTION,
+        benchmark_run_receipt_id=BENCHMARK_RUN,
+        benchmark_receipt=benchmark,
+        nonce="nonce:benchmark",
+    )
+    assert rehydrate_model_signed_evidence_receipt(signed.to_dict()) == signed
+    result = verify_model_signed_evidence_receipt(
+        signed,
+        expected_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        key_resolver=StaticModelEvidenceKeyResolver(
+            {ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY}
+        ),
+        signature_verifier=DeterministicSignatureVerifier(),
+        now=NOW,
+    )
+    assert result.accepted is True
+
+    wrong_role = verify_model_signed_evidence_receipt(
+        signed,
+        expected_role=ModelEvidenceSignerRole.PROMOTION_AUTHORITY,
+        key_resolver=StaticModelEvidenceKeyResolver(
+            {ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY}
+        ),
+        signature_verifier=DeterministicSignatureVerifier(),
+        now=NOW,
+    )
+    assert wrong_role.accepted is False
+    assert "signer_role_mismatch" in wrong_role.reason_codes
+
+    forged = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint=BENCHMARK_FINGERPRINT,
+        model_id=benchmark.model_id,
+        catalog_snapshot_id=CATALOG,
+        selection_receipt_id=SELECTION,
+        benchmark_run_receipt_id=BENCHMARK_RUN,
+        benchmark_receipt=benchmark,
+        nonce="nonce:forged",
+        signature_override="test-sig:forged",
+    )
+    bad_signature = verify_model_signed_evidence_receipt(
+        forged,
+        expected_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        key_resolver=StaticModelEvidenceKeyResolver(
+            {ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY}
+        ),
+        signature_verifier=DeterministicSignatureVerifier(),
+        now=NOW,
+    )
+    assert bad_signature.accepted is False
+    assert "signature_invalid" in bad_signature.reason_codes
+
+
+def test_nonce_consumed_only_when_admission_requests_it():
+    benchmark = _benchmark()
+    signed = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint=BENCHMARK_FINGERPRINT,
+        model_id=benchmark.model_id,
+        catalog_snapshot_id=CATALOG,
+        selection_receipt_id=SELECTION,
+        benchmark_run_receipt_id=BENCHMARK_RUN,
+        benchmark_receipt=benchmark,
+        nonce="nonce:single-use",
+    )
+    store = InMemoryEvidenceNonceStore()
+    kwargs = {
+        "expected_role": ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        "key_resolver": StaticModelEvidenceKeyResolver(
+            {ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY}
+        ),
+        "signature_verifier": DeterministicSignatureVerifier(),
+        "now": NOW,
+        "nonce_store": store,
+    }
+    assert verify_model_signed_evidence_receipt(signed, consume_nonce=False, **kwargs).accepted is True
+    assert verify_model_signed_evidence_receipt(signed, consume_nonce=True, **kwargs).accepted is True
+    replay = verify_model_signed_evidence_receipt(signed, consume_nonce=True, **kwargs)
+    assert replay.accepted is False
+    assert replay.reason_codes == ("nonce_replay",)
+
+
+def test_build_verified_production_evidence_rejects_panel_and_tampered_bindings():
+    benchmark = _benchmark()
+    promotion = _promotion(benchmark)
+    evidence = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=CATALOG,
+        selection_receipt_id=SELECTION,
+        benchmark_run_receipt_id=BENCHMARK_RUN,
+        promotion_policy_digest=PROMOTION_POLICY,
+    )
+    assert evidence.signed_evidence_verified is True
+    assert evidence.model_ids() == (benchmark.model_id,)
+
+    panel_signature = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint=BENCHMARK_FINGERPRINT,
+        model_id=benchmark.model_id,
+        catalog_snapshot_id=CATALOG,
+        selection_receipt_id=SELECTION,
+        benchmark_run_receipt_id=BENCHMARK_RUN,
+        benchmark_receipt=benchmark,
+        nonce="nonce:panel",
+        subject_type=ModelEvidenceSubjectType.PANEL,
+    )
+    try:
+        build_verified_model_production_evidence(
+            catalog_snapshot_id=CATALOG,
+            selection_receipt_id=SELECTION,
+            benchmark_run_receipt_id=BENCHMARK_RUN,
+            benchmark_receipt=benchmark,
+            promotion_receipt=promotion,
+            benchmark_signature_receipt=panel_signature,
+            promotion_signature_receipt=evidence.entries[0].promotion_signature_receipt,
+            key_resolver=StaticModelEvidenceKeyResolver(
+                {ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY}
+            ),
+            signature_verifier=DeterministicSignatureVerifier(),
+            now=NOW,
+        )
+    except ValueError as exc:
+        assert str(exc) == "panel_signed_evidence_deferred"
+    else:
+        raise AssertionError("panel signed evidence must remain deferred")
+
+
+def test_signed_evidence_module_has_no_network_command_signer_or_runtime_mutation_imports():
+    source = Path("modules/ai_intelligence/ai_gateway/src/model_signed_evidence.py").read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    banned_calls: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name) and node.func.value.id in {
+                "os",
+                "subprocess",
+                "requests",
+                "urllib",
+                "socket",
+            }:
+                banned_calls.append(f"{node.func.value.id}.{node.func.attr}")
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported
+    assert "socket" not in imported
+    assert "cryptography" not in imported
+    assert banned_calls == []


### PR DESCRIPTION
## Summary
- add `model_signed_evidence.py` for receipt rehydration, deterministic ID recomputation, and role-specific signed evidence verification
- make production model selection reject raw `production_evidence` mappings unless they are typed `VerifiedModelProductionEvidence`
- make RedDog runtime model binding require verified production evidence and keep panel runtime binding fail-closed/deferred
- update AI gateway docs and tests for the new production truth boundary

## WSP_97 Truth Boundary
- IMPLEMENTED: benchmark/promotion/catalog/selection/runtime receipts can be rehydrated and digest-checked
- IMPLEMENTED: single-model production evidence requires signed `benchmark_verifier` and `promotion_authority` receipts
- IMPLEMENTED: production selection rejects raw evidence mappings
- IMPLEMENTED: runtime binding requires verified production evidence
- IMPLEMENTED: panel runtime binding remains fail-closed/deferred
- NOT IMPLEMENTED: signing/private-key handling, provider calls, benchmark execution, panel topology promotion, extension runtime mutation, PatternMemory writes, or HoloIndex re-indexing

## Validation
- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 65 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_work_order_signature_verifier.py modules/communication/moltbot_bridge/tests/test_reddog_ed25519_signature_verifier_backend.py modules/communication/moltbot_bridge/tests/test_reddog_signed_receipt_chain.py -q` -> 54 passed
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_signed_evidence.py modules/ai_intelligence/ai_gateway/src/model_intelligence_selection.py modules/ai_intelligence/ai_gateway/src/model_runtime_binding.py modules/ai_intelligence/ai_gateway/tests/test_model_signed_evidence.py modules/ai_intelligence/ai_gateway/tests/model_signed_evidence_test_helpers.py`
- `git diff --check` -> clean (autocrlf warnings only)
- added/new non-ASCII scan -> 0

## HoloIndex
- `python holo_index.py --bundle-json --search "model signed evidence production evidence verifier promotion authority"` did not surface the new module.
- INDEX_GAP: `HOLOINDEX_MODEL_INTELLIGENCE_SIGNED_EVIDENCE_DISCOVERABILITY_PHASE1`.
- No runtime re-index performed; this remains a governed WRE/CI index maintenance action.
