### PR TITLE
feat(reddog): promote architect fixes to signed WSP15 queue

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_ARCHITECT_FIX_TO_SIGNED_WSP15_WORK_ORDER_PROMOTION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added the backend RedDog architect `FIX` promotion bridge that turns one
+  accepted architect queue candidate into an authoritative work-state queue
+  item plus durable worker claim for the existing signed WSP_15 authority
+  chain.
+- Bound promotion to the architect determination receipt, WSP_15 allocation
+  digest, production model selection receipt, operational Memex supply
+  receipt, HoloIndex evidence mapping, and current freshness receipt before
+  any queue mutation is committed.
+- Preserved the authority boundary: no signing, worker spawn, OpenClaw enqueue,
+  Hermes dispatch, worktree creation, shell execution, source repo mutation,
+  PR creation, PatternMemory write, or HoloIndex re-index is performed by this
+  slice.
+
 ## 2026-07-16: REDDOG_OPERATIONAL_MEMEX_SNAPSHOT_SUPPLIER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -1,0 +1,630 @@
+"""Promote a backend architect FIX determination into the signed WSP15 queue.
+
+Slice: REDDOG_ARCHITECT_FIX_TO_SIGNED_WSP15_WORK_ORDER_PROMOTION_PHASE1
+
+This module is the runtime bridge between the backend architect determination
+receipt and the already-built resident queue signing chain. It atomically adds
+one durable worker claim and one WRE queue item to the authoritative work-state
+store, then returns the authority profile that the existing signer/materializer
+path consumes.
+
+It does not sign authority, spawn workers, create worktrees, run shell commands,
+enqueue OpenClaw, dispatch Hermes, create PRs, admit PatternMemory, settle
+rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    SelectionDecision,
+    SelectionPurpose,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    rehydrate_model_selection_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
+    AuthoritativeWorkStateStore,
+    WORK_STATE_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ACTION_FIX,
+    ARCHITECT_DETERMINATION_ACCEPT,
+    ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    canonical_reddog_wsp15_allocation_digest,
+    validate_reddog_wsp15_allocation_receipt,
+)
+
+
+ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT = "ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT"
+ARCHITECT_FIX_WSP15_PROMOTION_REJECT = "ARCHITECT_FIX_WSP15_PROMOTION_REJECT"
+ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION = (
+    "reddog_architect_fix_wsp15_work_order_promotion.v1"
+)
+
+
+class ArchitectFixPromotionReason:
+    WORK_STATE_SCHEMA = "REJECT_ARCHITECT_FIX_PROMOTION_WORK_STATE_SCHEMA"
+    WORK_STATE_FRESHNESS = "REJECT_ARCHITECT_FIX_PROMOTION_WORK_STATE_FRESHNESS"
+    DETERMINATION_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_DETERMINATION_MISSING"
+    DETERMINATION_NOT_ACCEPTED = "REJECT_ARCHITECT_FIX_PROMOTION_DETERMINATION_NOT_ACCEPTED"
+    DETERMINATION_NOT_FIX = "REJECT_ARCHITECT_FIX_PROMOTION_DETERMINATION_NOT_FIX"
+    QUEUE_CANDIDATE_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_QUEUE_CANDIDATE_MISSING"
+    QUEUE_CANDIDATE_MALFORMED = "REJECT_ARCHITECT_FIX_PROMOTION_QUEUE_CANDIDATE_MALFORMED"
+    WSP15_ALLOCATION_INVALID = "REJECT_ARCHITECT_FIX_PROMOTION_WSP15_ALLOCATION_INVALID"
+    WSP15_ALLOCATION_MISMATCH = "REJECT_ARCHITECT_FIX_PROMOTION_WSP15_ALLOCATION_MISMATCH"
+    MODEL_SELECTION_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_SELECTION_MISSING"
+    MODEL_SELECTION_INVALID = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_SELECTION_INVALID"
+    MODEL_SELECTION_NOT_PRODUCTION = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_SELECTION_NOT_PRODUCTION"
+    MEMEX_SUPPLY_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_MEMEX_SUPPLY_MISSING"
+    MEMEX_SUPPLY_INVALID = "REJECT_ARCHITECT_FIX_PROMOTION_MEMEX_SUPPLY_INVALID"
+    AUTHORITY_PROFILE_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_AUTHORITY_PROFILE_MISSING"
+    AUTHORITY_PROFILE_INCOMPLETE = "REJECT_ARCHITECT_FIX_PROMOTION_AUTHORITY_PROFILE_INCOMPLETE"
+    HOLOINDEX_EVIDENCE_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_HOLOINDEX_EVIDENCE_MISSING"
+    DUPLICATE_QUEUE_ITEM = "REJECT_ARCHITECT_FIX_PROMOTION_DUPLICATE_QUEUE_ITEM"
+    STORE_REJECTED = "REJECT_ARCHITECT_FIX_PROMOTION_STORE_REJECTED"
+
+
+_AUTHORITY_PROFILE_REQUIRED = (
+    "principal_id",
+    "principal_provider",
+    "principal_public_key",
+    "reddog_id",
+    "reddog_public_key",
+    "repo_full_name",
+    "foundup_id",
+    "allowed_paths",
+    "denied_paths",
+    "requested_operation",
+    "permission_snapshot_digest",
+    "identity_nonce",
+    "work_authority_nonce",
+    "issued_at",
+    "identity_expires_at",
+    "work_authority_expires_at",
+    "valve_state_required",
+    "key_epoch",
+    "required_tests",
+    "required_policy_gates",
+)
+
+
+@dataclass(frozen=True)
+class ArchitectFixPromotionReceipt:
+    schema_version: str
+    promotion_receipt_id: str
+    status: str
+    architect_determination_receipt_id: str
+    source_queue_candidate_id: str
+    queue_item_id: str
+    claim_id: str
+    selected_slice: str
+    worker_id: str
+    freshness_receipt_id: str
+    wsp15_allocation_receipt_id: str
+    wsp15_allocation_digest: str
+    model_catalog_snapshot_id: str
+    model_selection_receipt_id: str
+    model_selection_digest: str
+    memex_supply_receipt_id: str
+    memex_supply_digest: str
+    committed_revision: Optional[str]
+    no_signing_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    authoritative_work_state_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ArchitectFixPromotionResult:
+    accepted: bool
+    status: str
+    receipt: Optional[ArchitectFixPromotionReceipt]
+    rejection_reasons: tuple[str, ...]
+    authority_profile: Optional[Mapping[str, Any]] = None
+    work_state_snapshot: Optional[Mapping[str, Any]] = None
+    no_signing_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "receipt": self.receipt.to_dict() if self.receipt else None,
+            "rejection_reasons": list(self.rejection_reasons),
+            "authority_profile": dict(self.authority_profile or {}),
+            "work_state_snapshot": dict(self.work_state_snapshot or {}),
+            "no_signing_performed": self.no_signing_performed,
+            "no_worker_spawn_performed": self.no_worker_spawn_performed,
+            "no_worktree_created": self.no_worktree_created,
+            "no_shell_command_executed": self.no_shell_command_executed,
+            "no_openclaw_enqueue_performed": self.no_openclaw_enqueue_performed,
+            "no_hermes_dispatch_performed": self.no_hermes_dispatch_performed,
+            "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
+            "no_pr_created": self.no_pr_created,
+            "no_pattern_memory_write_performed": self.no_pattern_memory_write_performed,
+        }
+
+
+def promote_reddog_architect_fix_to_signed_wsp15_work_order(
+    *,
+    architect_determination: Mapping[str, Any],
+    work_state_store: AuthoritativeWorkStateStore,
+    authority_profile: Mapping[str, Any],
+    model_selection_receipt: Mapping[str, Any],
+    memex_supply_receipt: Mapping[str, Any],
+    worker_id: str,
+    now_iso: str,
+    claim_ttl_seconds: int = 3600,
+) -> ArchitectFixPromotionResult:
+    """Commit one architect FIX queue item and return its signer authority profile."""
+
+    current = work_state_store.load()
+    reasons: list[str] = []
+    if current.get("schema_version") != WORK_STATE_SCHEMA_VERSION:
+        reasons.append(ArchitectFixPromotionReason.WORK_STATE_SCHEMA)
+    freshness_id = _freshness_receipt_id(current)
+    if not freshness_id:
+        reasons.append(ArchitectFixPromotionReason.WORK_STATE_FRESHNESS)
+
+    determination = _determination_receipt(architect_determination)
+    candidate = _mapping(determination.get("queue_candidate"))
+    determination_id = str(determination.get("determination_receipt_id") or "")
+    if not determination:
+        reasons.append(ArchitectFixPromotionReason.DETERMINATION_MISSING)
+    elif determination.get("accepted") is not True or determination.get("status") != ARCHITECT_DETERMINATION_ACCEPT:
+        reasons.append(ArchitectFixPromotionReason.DETERMINATION_NOT_ACCEPTED)
+    elif str(determination.get("action") or "").upper() != ACTION_FIX:
+        reasons.append(ArchitectFixPromotionReason.DETERMINATION_NOT_FIX)
+    if not candidate:
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MISSING)
+
+    candidate_reasons = _validate_candidate(candidate, determination)
+    reasons.extend(candidate_reasons)
+    allocation = _mapping(candidate.get("wsp15_allocation_receipt"))
+    allocation_validation = validate_reddog_wsp15_allocation_receipt(allocation)
+    if not allocation_validation.accepted:
+        reasons.append(ArchitectFixPromotionReason.WSP15_ALLOCATION_INVALID)
+    elif (
+        str(determination.get("wsp15_allocation_receipt_id") or "") != str(allocation.get("receipt_id") or "")
+        or str(determination.get("wsp15_allocation_digest") or "")
+        != canonical_reddog_wsp15_allocation_digest(allocation)
+    ):
+        reasons.append(ArchitectFixPromotionReason.WSP15_ALLOCATION_MISMATCH)
+
+    selection_payload = _validate_model_selection(model_selection_receipt, reasons)
+    memex_payload = _validate_memex_supply(memex_supply_receipt, determination, reasons)
+    profile_reasons = _validate_authority_profile(authority_profile)
+    reasons.extend(profile_reasons)
+    holoindex_evidence = _mapping(authority_profile.get("holoindex_evidence"))
+    if not holoindex_evidence:
+        reasons.append(ArchitectFixPromotionReason.HOLOINDEX_EVIDENCE_MISSING)
+
+    selected_slice = str(determination.get("next_slice_name") or "")
+    if selected_slice and _duplicate_queue(current, selected_slice=selected_slice, determination_id=determination_id):
+        reasons.append(ArchitectFixPromotionReason.DUPLICATE_QUEUE_ITEM)
+
+    if reasons:
+        return _reject(reasons)
+
+    assert freshness_id
+    assert selection_payload
+    assert memex_payload
+    assert selected_slice
+    now = _parse_iso(now_iso)
+    expires_at = (now + timedelta(seconds=int(claim_ttl_seconds))).isoformat()
+    model_selection_digest = _digest(model_selection_receipt)
+    memex_supply_digest = _digest(memex_supply_receipt)
+    allocation_digest = canonical_reddog_wsp15_allocation_digest(allocation)
+
+    claim_seed = {
+        "selected_slice": selected_slice,
+        "determination_receipt_id": determination_id,
+        "model_selection_receipt_id": selection_payload["receipt_id"],
+        "memex_supply_receipt_id": memex_payload["receipt_id"],
+        "worker_id": worker_id,
+        "claimed_at": now_iso,
+        "freshness_receipt_id": freshness_id,
+    }
+    claim_id = _digest(claim_seed)
+    queue_seed = {
+        "slice_id": selected_slice,
+        "claim_id": claim_id,
+        "worker_id": worker_id,
+        "enqueued_at": now_iso,
+        "determination_receipt_id": determination_id,
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "model_selection_receipt_id": selection_payload["receipt_id"],
+        "memex_supply_receipt_id": memex_payload["receipt_id"],
+    }
+    queue_item_id = _digest(queue_seed)
+
+    claim = {
+        "claim_id": claim_id,
+        "slice_id": selected_slice,
+        "worker_id": worker_id,
+        "lane_id": "reddog_operational",
+        "claimed_at": now_iso,
+        "expires_at": expires_at,
+        "reconciliation_report_id": str(current.get("reconciliation_report_id") or determination_id),
+        "freshness_receipt_id": freshness_id,
+        "status": "ACTIVE",
+        "source_determination_receipt_id": determination_id,
+        "model_selection_receipt_id": selection_payload["receipt_id"],
+        "memex_supply_receipt_id": memex_payload["receipt_id"],
+    }
+    evidence_refs = tuple(
+        dict.fromkeys(
+            [
+                f"claim:{claim_id}",
+                f"freshness:{freshness_id}",
+                f"wsp15_allocation:{allocation['receipt_id']}",
+                f"architect_determination:{determination_id}",
+                f"model_selection:{selection_payload['receipt_id']}",
+                f"memex_supply:{memex_payload['receipt_id']}",
+                *[str(ref) for ref in candidate.get("evidence_refs") or ()],
+            ]
+        )
+    )
+    queue_item = {
+        "queue_item_id": queue_item_id,
+        "slice_id": selected_slice,
+        "claim_id": claim_id,
+        "worker_id": worker_id,
+        "status": "QUEUED",
+        "enqueued_at": now_iso,
+        "evidence_refs": list(evidence_refs),
+        "wsp15_allocation_receipt": dict(allocation),
+        "source_determination_receipt_id": determination_id,
+        "source_queue_candidate_id": str(candidate.get("queue_candidate_id") or ""),
+        "model_catalog_snapshot_id": selection_payload["catalog_snapshot_id"],
+        "model_selection_receipt_id": selection_payload["receipt_id"],
+        "model_selection_digest": model_selection_digest,
+        "memex_supply_receipt_id": memex_payload["receipt_id"],
+        "memex_supply_digest": memex_supply_digest,
+        "no_execution_performed": True,
+    }
+    sync_receipt = {
+        "sync_id": _digest({"queue_item_id": queue_item_id, "claim_id": claim_id}),
+        "status": "WRE_QUEUE_SYNCED",
+        "queue_item_ids": [queue_item_id],
+        "selected_slice": selected_slice,
+        "rejection_reasons": [],
+        "source": ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION,
+        "no_execution_performed": True,
+    }
+
+    promoted_profile = _promoted_authority_profile(
+        authority_profile=authority_profile,
+        determination=determination,
+        allocation=allocation,
+        model_selection=selection_payload,
+        model_selection_digest=model_selection_digest,
+        memex_supply=memex_payload,
+        memex_supply_digest=memex_supply_digest,
+        queue_item_id=queue_item_id,
+        claim_id=claim_id,
+        holoindex_evidence=holoindex_evidence,
+    )
+    updated = _append_queue_state(
+        current,
+        claim=claim,
+        queue_item=queue_item,
+        sync_receipt=sync_receipt,
+        promotion_record={
+            "schema_version": ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION,
+            "architect_determination_receipt_id": determination_id,
+            "queue_item_id": queue_item_id,
+            "claim_id": claim_id,
+            "model_selection_receipt_id": selection_payload["receipt_id"],
+            "memex_supply_receipt_id": memex_payload["receipt_id"],
+            "created_at": now_iso,
+        },
+    )
+
+    try:
+        committed_revision = work_state_store.commit(updated, expected_revision=current.get("revision"))
+    except Exception:
+        return _reject([ArchitectFixPromotionReason.STORE_REJECTED])
+    committed = work_state_store.load()
+
+    receipt_seed = {
+        "determination_receipt_id": determination_id,
+        "queue_item_id": queue_item_id,
+        "claim_id": claim_id,
+        "model_selection_receipt_id": selection_payload["receipt_id"],
+        "memex_supply_receipt_id": memex_payload["receipt_id"],
+        "committed_revision": committed_revision,
+    }
+    receipt = ArchitectFixPromotionReceipt(
+        schema_version=ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION,
+        promotion_receipt_id="architect_fix_promotion_" + _digest(receipt_seed).removeprefix("sha256:")[:16],
+        status=ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT,
+        architect_determination_receipt_id=determination_id,
+        source_queue_candidate_id=str(candidate.get("queue_candidate_id") or ""),
+        queue_item_id=queue_item_id,
+        claim_id=claim_id,
+        selected_slice=selected_slice,
+        worker_id=worker_id,
+        freshness_receipt_id=freshness_id,
+        wsp15_allocation_receipt_id=str(allocation["receipt_id"]),
+        wsp15_allocation_digest=allocation_digest,
+        model_catalog_snapshot_id=selection_payload["catalog_snapshot_id"],
+        model_selection_receipt_id=selection_payload["receipt_id"],
+        model_selection_digest=model_selection_digest,
+        memex_supply_receipt_id=memex_payload["receipt_id"],
+        memex_supply_digest=memex_supply_digest,
+        committed_revision=committed_revision,
+    )
+    return ArchitectFixPromotionResult(
+        accepted=True,
+        status=ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT,
+        receipt=receipt,
+        rejection_reasons=(),
+        authority_profile=promoted_profile,
+        work_state_snapshot=committed,
+    )
+
+
+def _reject(reasons: list[str]) -> ArchitectFixPromotionResult:
+    return ArchitectFixPromotionResult(
+        accepted=False,
+        status=ARCHITECT_FIX_WSP15_PROMOTION_REJECT,
+        receipt=None,
+        rejection_reasons=tuple(dict.fromkeys(reasons)),
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _parse_iso(value: str) -> datetime:
+    text = str(value or "").strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _determination_receipt(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    mapping = _mapping(value)
+    receipt = _mapping(mapping.get("receipt"))
+    return receipt if receipt else mapping
+
+
+def _freshness_receipt_id(snapshot: Mapping[str, Any]) -> str:
+    preferred = str(snapshot.get("refresh_receipt_id") or "")
+    receipts = snapshot.get("freshness_receipts")
+    if not isinstance(receipts, list):
+        return ""
+    for receipt in receipts:
+        if not isinstance(receipt, Mapping):
+            continue
+        receipt_id = str(receipt.get("receipt_id") or "")
+        if receipt_id and receipt.get("fresh") is True and (not preferred or receipt_id == preferred):
+            return receipt_id
+    return ""
+
+
+def _validate_candidate(candidate: Mapping[str, Any], determination: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if not candidate:
+        return reasons
+    if candidate.get("schema_version") != ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION:
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    if str(candidate.get("source_determination_receipt_id") or "") != str(
+        determination.get("determination_receipt_id") or ""
+    ):
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    if str(candidate.get("slice_id") or "") != str(determination.get("next_slice_name") or ""):
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    if str(candidate.get("status") or "").upper() != "CANDIDATE":
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    if candidate.get("no_execution_performed") is not True:
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    if not _mapping(candidate.get("wsp15_allocation_receipt")):
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    return reasons
+
+
+def _validate_model_selection(selection: Mapping[str, Any], reasons: list[str]) -> Mapping[str, Any]:
+    if not isinstance(selection, Mapping) or not selection:
+        reasons.append(ArchitectFixPromotionReason.MODEL_SELECTION_MISSING)
+        return {}
+    try:
+        receipt = rehydrate_model_selection_receipt(selection)
+    except Exception:
+        reasons.append(ArchitectFixPromotionReason.MODEL_SELECTION_INVALID)
+        return {}
+    if receipt.decision != SelectionDecision.SELECTED or not receipt.selected_model_ids:
+        reasons.append(ArchitectFixPromotionReason.MODEL_SELECTION_INVALID)
+    if receipt.requirements.purpose != SelectionPurpose.PRODUCTION:
+        reasons.append(ArchitectFixPromotionReason.MODEL_SELECTION_NOT_PRODUCTION)
+    return {
+        "receipt_id": receipt.receipt_id,
+        "catalog_snapshot_id": receipt.catalog_snapshot_id,
+        "selected_model_ids": tuple(receipt.selected_model_ids),
+        "task_family": receipt.requirements.task_family,
+        "panel_topology_digest": receipt.panel_topology_digest,
+    }
+
+
+def _validate_memex_supply(
+    memex_supply: Mapping[str, Any],
+    determination: Mapping[str, Any],
+    reasons: list[str],
+) -> Mapping[str, Any]:
+    if not isinstance(memex_supply, Mapping) or not memex_supply:
+        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_MISSING)
+        return {}
+    if memex_supply.get("schema_version") != "reddog_operational_memex_snapshot_supply_receipt.v1":
+        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
+    receipt_id = str(memex_supply.get("receipt_id") or "")
+    if not receipt_id.startswith("sha256:"):
+        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
+    snapshot_receipt_id = str(memex_supply.get("snapshot_receipt_id") or "")
+    if snapshot_receipt_id != str(determination.get("snapshot_receipt_id") or ""):
+        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
+    if memex_supply.get("no_holoindex_reindex_performed") is not True:
+        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
+    return {"receipt_id": receipt_id, "snapshot_receipt_id": snapshot_receipt_id}
+
+
+def _validate_authority_profile(profile: Mapping[str, Any]) -> list[str]:
+    if not isinstance(profile, Mapping) or not profile:
+        return [ArchitectFixPromotionReason.AUTHORITY_PROFILE_MISSING]
+    missing = [
+        field
+        for field in _AUTHORITY_PROFILE_REQUIRED
+        if field not in profile or profile.get(field) in (None, "", (), [], {})
+    ]
+    return [ArchitectFixPromotionReason.AUTHORITY_PROFILE_INCOMPLETE + ":" + field for field in missing]
+
+
+def _duplicate_queue(snapshot: Mapping[str, Any], *, selected_slice: str, determination_id: str) -> bool:
+    for item in snapshot.get("wre_queue_items") or ():
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("source_determination_receipt_id") or "") == determination_id:
+            return True
+        if str(item.get("slice_id") or "") == selected_slice and str(item.get("status") or "").upper() == "QUEUED":
+            return True
+    for claim in snapshot.get("worker_claims") or ():
+        if not isinstance(claim, Mapping):
+            continue
+        if str(claim.get("source_determination_receipt_id") or "") == determination_id:
+            return True
+        if str(claim.get("slice_id") or "") == selected_slice and str(claim.get("status") or "").upper() == "ACTIVE":
+            return True
+    return False
+
+
+def _promoted_authority_profile(
+    *,
+    authority_profile: Mapping[str, Any],
+    determination: Mapping[str, Any],
+    allocation: Mapping[str, Any],
+    model_selection: Mapping[str, Any],
+    model_selection_digest: str,
+    memex_supply: Mapping[str, Any],
+    memex_supply_digest: str,
+    queue_item_id: str,
+    claim_id: str,
+    holoindex_evidence: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    profile = dict(authority_profile)
+    determination_id = str(determination["determination_receipt_id"])
+    binding = {
+        "snapshot_receipt_id": str(determination.get("snapshot_receipt_id") or ""),
+        "context_view_id": str(determination.get("context_view_id") or ""),
+        "evidence_bundle_id": str(determination.get("evidence_bundle_id") or ""),
+        "determination_id": determination_id,
+        "readonly_audit_decision_id": determination_id,
+        "architect_determination_receipt_id": determination_id,
+        "queue_item_id": queue_item_id,
+        "claim_id": claim_id,
+        "wsp15_allocation_receipt": dict(allocation),
+        "model_catalog_snapshot_id": model_selection["catalog_snapshot_id"],
+        "model_selection_receipt_id": model_selection["receipt_id"],
+        "model_selection_digest": model_selection_digest,
+        "memex_supply_receipt_id": memex_supply["receipt_id"],
+        "memex_supply_digest": memex_supply_digest,
+        "holoindex_evidence": dict(holoindex_evidence),
+    }
+    profile.update(
+        {
+            "work_order_id": str(profile.get("work_order_id") or _work_order_id(queue_item_id)),
+            "task_summary": str(
+                profile.get("task_summary")
+                or f"RedDog architect FIX promotion for {determination.get('next_slice_name')}."
+            ),
+            "wsp15_allocation_receipt": dict(allocation),
+            "snapshot_receipt_id": binding["snapshot_receipt_id"],
+            "context_view_id": binding["context_view_id"],
+            "evidence_bundle_id": binding["evidence_bundle_id"],
+            "readonly_audit_decision_id": determination_id,
+            "determination_id": determination_id,
+            "model_catalog_snapshot_id": model_selection["catalog_snapshot_id"],
+            "model_selection_receipt_id": model_selection["receipt_id"],
+            "model_selection_digest": model_selection_digest,
+            "memex_supply_receipt_id": memex_supply["receipt_id"],
+            "memex_supply_digest": memex_supply_digest,
+            "operational_context_binding": binding,
+            "holoindex_evidence": dict(holoindex_evidence),
+        }
+    )
+    return profile
+
+
+def _work_order_id(queue_item_id: str) -> str:
+    return "wre-queue-" + hashlib.sha256(queue_item_id.encode("utf-8")).hexdigest()[:16]
+
+
+def _append_queue_state(
+    snapshot: Mapping[str, Any],
+    *,
+    claim: Mapping[str, Any],
+    queue_item: Mapping[str, Any],
+    sync_receipt: Mapping[str, Any],
+    promotion_record: Mapping[str, Any],
+) -> dict[str, Any]:
+    updated = json.loads(json.dumps(snapshot, sort_keys=True, default=str))
+    updated["worker_claims"] = [
+        dict(item) for item in updated.get("worker_claims", []) if isinstance(item, Mapping)
+    ] + [dict(claim)]
+    updated["wre_queue_items"] = [
+        dict(item) for item in updated.get("wre_queue_items", []) if isinstance(item, Mapping)
+    ] + [dict(queue_item)]
+    updated["queue_sync_receipts"] = [
+        dict(item) for item in updated.get("queue_sync_receipts", []) if isinstance(item, Mapping)
+    ] + [dict(sync_receipt)]
+    updated["architect_fix_promotions"] = [
+        dict(item) for item in updated.get("architect_fix_promotions", []) if isinstance(item, Mapping)
+    ] + [dict(promotion_record)]
+    updated["selected_slice"] = str(queue_item.get("slice_id") or updated.get("selected_slice") or "")
+    updated["no_execution_performed"] = True
+    updated["no_holoindex_mutation_performed"] = True
+    return updated
+
+
+__all__ = [
+    "ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT",
+    "ARCHITECT_FIX_WSP15_PROMOTION_REJECT",
+    "ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION",
+    "ArchitectFixPromotionReason",
+    "ArchitectFixPromotionReceipt",
+    "ArchitectFixPromotionResult",
+    "promote_reddog_architect_fix_to_signed_wsp15_work_order",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -1,0 +1,471 @@
+"""Tests for REDDOG_ARCHITECT_FIX_TO_SIGNED_WSP15_WORK_ORDER_PROMOTION_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    Availability,
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionMode,
+    SelectionPurpose,
+    select_models_for_task,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    ModelEvidenceSignerRole,
+    ModelEvidenceSubjectType,
+    VerifiedModelEvidenceEntry,
+    VerifiedModelProductionEvidence,
+    build_model_signed_evidence_receipt,
+)
+from modules.communication.moltbot_bridge.src import (
+    reddog_architect_fix_signed_wsp15_work_order_promotion as promotion,
+)
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
+    InMemoryAuthoritativeWorkStateStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ACTION_FIX,
+    ACTION_RESEARCH_MORE,
+    ARCHITECT_DETERMINATION_ACCEPT,
+    ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
+    WRE_QUEUE_CONSUMER_DRYRUN_READY,
+    plan_reddog_wre_queue_consumer_dry_run,
+)
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    allocate_reddog_wsp15_receipt,
+    canonical_reddog_wsp15_allocation_digest,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_architect_fix_signed_wsp15_work_order_promotion.py"
+)
+NOW = "2026-07-16T00:00:00+00:00"
+SNAPSHOT_ID = "sha256:snapshot-1"
+
+
+def _allocation() -> dict[str, Any]:
+    return allocate_reddog_wsp15_receipt(
+        requested_operation="architect_fix_promotion",
+        prompt_text="RedDog architect FIX promotion runtime authority",
+        changed_paths=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
+        allowed_read_targets=(
+            "modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",
+        ),
+    ).to_dict()
+
+
+def _work_state() -> dict[str, Any]:
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "revision": "sha256:work-state-rev-1",
+        "refresh_receipt_id": "sha256:fresh-1",
+        "reconciliation_report_id": "sha256:reconcile-1",
+        "freshness_receipts": [{"receipt_id": "sha256:fresh-1", "fresh": True}],
+        "worker_claims": [],
+        "wre_queue_items": [],
+        "queue_sync_receipts": [],
+    }
+
+
+def _determination(*, action: str = ACTION_FIX, allocation: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    allocation = allocation or _allocation()
+    determination_id = "sha256:architect-determination-1"
+    candidate = {
+        "schema_version": ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+        "queue_candidate_id": "sha256:queue-candidate-1",
+        "source_determination_receipt_id": determination_id,
+        "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+        "status": "CANDIDATE",
+        "evidence_refs": ["file:docs/audit.md:1"],
+        "wsp15_allocation_receipt": dict(allocation),
+        "no_queue_mutation_performed": True,
+        "no_execution_performed": True,
+        "no_worker_spawn_performed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+    return {
+        "schema_version": "reddog_architect_determination_receipt.v1",
+        "determination_receipt_id": determination_id,
+        "cycle_id": "sha256:cycle-1",
+        "accepted": True,
+        "status": ARCHITECT_DETERMINATION_ACCEPT,
+        "action": action,
+        "next_slice_name": candidate["slice_id"] if action == ACTION_FIX else None,
+        "summary": "Promote one verified FIX slice.",
+        "snapshot_receipt_id": SNAPSHOT_ID,
+        "snapshot_content_digest": "sha256:snapshot-content",
+        "context_view_id": "sha256:context-view",
+        "evidence_bundle_id": "sha256:evidence-bundle",
+        "report_bundle_id": "sha256:report-bundle",
+        "report_count": 5,
+        "audit_report_digests": ["sha256:report-1"],
+        "model_result_digest": "sha256:model-result",
+        "model_receipt_id": "model-receipt-1",
+        "fusion_quorum_passed": True,
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": canonical_reddog_wsp15_allocation_digest(allocation),
+        "queue_candidate": candidate if action == ACTION_FIX else None,
+        "decision_reasons": ["FIX is the next verified bridge."],
+        "rejection_reasons": [],
+    }
+
+
+def _authority_profile(**overrides: Any) -> dict[str, Any]:
+    profile = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "pub:principal",
+        "reddog_id": "reddog:architect",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/communication/moltbot_bridge/**"],
+        "denied_paths": ["modules/communication/moltbot_bridge/secrets/**"],
+        "requested_operation": "feature_slice",
+        "permission_snapshot_digest": "sha256:permission",
+        "identity_nonce": "identity-nonce-1",
+        "work_authority_nonce": "workauth-nonce-1",
+        "issued_at": 1000,
+        "identity_expires_at": 4600,
+        "work_authority_expires_at": 1300,
+        "valve_state_required": "VALVE_OPEN_WORKTREE_CREATE",
+        "key_epoch": "epoch-1",
+        "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+        "required_policy_gates": ["signed_work_order_authority", "execution_valve"],
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog architect FIX promotion",
+            "holoindex_status": "bundle_json_ok",
+            "index_gap_detected": False,
+            "retrieval_quality": "HIGH",
+            "applicable_wsps": ["WSP_15", "WSP_97"],
+            "evidence_refs": [
+                "modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py"
+            ],
+        },
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _memex_supply(**overrides: Any) -> dict[str, Any]:
+    payload = {
+        "schema_version": "reddog_operational_memex_snapshot_supply_receipt.v1",
+        "foundup_id": "paccess_001",
+        "principal_id": "github:mjtrout",
+        "snapshot_receipt_id": SNAPSHOT_ID,
+        "snapshot_content_digest": "sha256:snapshot-content",
+        "memex_view_id": "memex-view-1",
+        "holoindex_generation_id": "sha256:holo-generation",
+        "source_revision": "sha256:memex-source",
+        "policy_issued_at": NOW,
+        "policy_expires_at": "2026-07-16T01:00:00+00:00",
+        "assignment_id": "assignment-1",
+        "lane_id": "repo_code_audit",
+        "receipt_id": "sha256:memex-supply",
+        "no_memex_write_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _model_selection(*, purpose: SelectionPurpose = SelectionPurpose.PRODUCTION) -> dict[str, Any]:
+    model_id = "openai/gpt-5.6-code"
+    task_family = "reddog_architect_fix_promotion"
+    benchmark = build_model_benchmark_evidence_receipt(
+        model_id=model_id,
+        task_family=task_family,
+        task_set_digest="sha256:task-set",
+        held_out_split_digest="sha256:held-out",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="sha256:verifier-receipt",
+        sample_count=10,
+        accepted_count=10,
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=20),
+    )
+    promotion_receipt = build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="sha256:promotion-authority",
+        signed_promotion_receipt_id="signature:promotion",
+        min_verifier_pass_rate=0.8,
+    )
+    benchmark_sig = build_model_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        signer_public_key="pub:benchmark",
+        signer_key_fingerprint="fingerprint:benchmark",
+        key_epoch="epoch-1",
+        subject_type=ModelEvidenceSubjectType.MODEL,
+        model_or_panel_subject=model_id,
+        catalog_snapshot_id="model_catalog_snapshot:pending",
+        selection_receipt_id="model_selection_receipt:pending",
+        benchmark_run_receipt_id="model_combination_benchmark_run:1",
+        benchmark_evidence_receipt_id=benchmark.receipt_id,
+        task_family=task_family,
+        task_set_digest=benchmark.task_set_digest,
+        held_out_split_digest=benchmark.held_out_split_digest,
+        verifier_digest=benchmark.verifier_digest,
+        prompt_topology_digest=benchmark.prompt_topology_digest,
+        issued_at=1000,
+        expires_at=2000,
+        nonce="nonce:benchmark",
+        signature="signature:benchmark",
+    )
+    promotion_sig = build_model_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.PROMOTION_AUTHORITY,
+        signer_public_key="pub:promotion",
+        signer_key_fingerprint="fingerprint:promotion",
+        key_epoch="epoch-1",
+        subject_type=ModelEvidenceSubjectType.MODEL,
+        model_or_panel_subject=model_id,
+        catalog_snapshot_id="model_catalog_snapshot:pending",
+        selection_receipt_id="model_selection_receipt:pending",
+        benchmark_run_receipt_id="model_combination_benchmark_run:1",
+        benchmark_evidence_receipt_id=benchmark.receipt_id,
+        task_family=task_family,
+        task_set_digest=benchmark.task_set_digest,
+        held_out_split_digest=benchmark.held_out_split_digest,
+        verifier_digest=benchmark.verifier_digest,
+        prompt_topology_digest=benchmark.prompt_topology_digest,
+        promotion_evidence_receipt_id=promotion_receipt.receipt_id,
+        promotion_policy_digest="sha256:promotion-policy",
+        issued_at=1000,
+        expires_at=2000,
+        nonce="nonce:promotion",
+        signature="signature:promotion",
+    )
+    evidence = VerifiedModelProductionEvidence(
+        entries=(
+            VerifiedModelEvidenceEntry(
+                model_id=model_id,
+                benchmark_receipt=benchmark,
+                promotion_receipt=promotion_receipt,
+                benchmark_signature_receipt=benchmark_sig,
+                promotion_signature_receipt=promotion_sig,
+            ),
+        )
+    )
+    snapshot = build_model_catalog_snapshot(
+        (
+            ModelCapabilityCard(
+                provider="openai",
+                model_id=model_id,
+                canonical_model_id=model_id,
+                source="test",
+                availability=Availability.AVAILABLE,
+                promotion_state=PromotionState.CHAMPION,
+                task_families=(task_family,),
+                supports_structured_output=True,
+                supports_reasoning=True,
+                verifier_pass_rate=1.0,
+                benchmark_scores={task_family: 1.0},
+            ),
+        ),
+        generated_at=NOW,
+    )
+    receipt = select_models_for_task(
+        snapshot,
+        ModelTaskRequirements(
+            task_family=task_family,
+            purpose=purpose,
+            selection_mode=SelectionMode.SINGLE,
+            require_structured_output=True,
+            require_reasoning=True,
+            min_verifier_pass_rate=0.8,
+        ),
+        production_evidence=evidence if purpose == SelectionPurpose.PRODUCTION else None,
+    )
+    assert receipt.decision.value == "selected"
+    return json.loads(json.dumps(receipt.to_dict(), sort_keys=True))
+
+
+def _promote(**overrides: Any):
+    store = overrides.pop("store", InMemoryAuthoritativeWorkStateStore(_work_state()))
+    args = {
+        "architect_determination": _determination(),
+        "work_state_store": store,
+        "authority_profile": _authority_profile(),
+        "model_selection_receipt": _model_selection(),
+        "memex_supply_receipt": _memex_supply(),
+        "worker_id": "reddog-worker-1",
+        "now_iso": NOW,
+    }
+    args.update(overrides)
+    return promotion.promote_reddog_architect_fix_to_signed_wsp15_work_order(**args), store
+
+
+def test_promotes_fix_determination_to_queue_item_and_authority_profile() -> None:
+    result, store = _promote()
+
+    assert result.accepted is True
+    assert result.status == promotion.ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT
+    assert result.receipt is not None
+    assert result.receipt.model_selection_receipt_id.startswith("model_selection_receipt:")
+    assert result.receipt.memex_supply_receipt_id == "sha256:memex-supply"
+    assert result.authority_profile is not None
+    assert result.authority_profile["wsp15_allocation_receipt"]["receipt_id"] == _allocation()["receipt_id"]
+    assert result.authority_profile["operational_context_binding"]["model_selection_receipt_id"] == (
+        result.receipt.model_selection_receipt_id
+    )
+    assert result.authority_profile["operational_context_binding"]["memex_supply_receipt_id"] == (
+        result.receipt.memex_supply_receipt_id
+    )
+
+    snapshot = store.load()
+    assert len(snapshot["worker_claims"]) == 1
+    assert len(snapshot["wre_queue_items"]) == 1
+    queue_result = plan_reddog_wre_queue_consumer_dry_run(
+        snapshot,
+        now_iso="2026-07-16T00:10:00+00:00",
+    )
+    assert queue_result.accepted is True
+    assert queue_result.status == WRE_QUEUE_CONSUMER_DRYRUN_READY
+    assert queue_result.selected_slice == "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+
+
+def test_rejects_non_fix_determination_without_store_mutation() -> None:
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+    before = store.load()
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=_determination(action=ACTION_RESEARCH_MORE),
+    )
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.DETERMINATION_NOT_FIX in result.rejection_reasons
+    assert store.load() == before
+
+
+def test_rejects_missing_model_selection_before_store_mutation() -> None:
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(store=store, model_selection_receipt={})
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.MODEL_SELECTION_MISSING in result.rejection_reasons
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_evaluation_model_selection_for_signed_work_order_promotion() -> None:
+    result, _ = _promote(model_selection_receipt=_model_selection(purpose=SelectionPurpose.EVALUATION))
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.MODEL_SELECTION_NOT_PRODUCTION in result.rejection_reasons
+
+
+def test_rejects_missing_memex_supply_receipt() -> None:
+    result, _ = _promote(memex_supply_receipt={})
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.MEMEX_SUPPLY_MISSING in result.rejection_reasons
+
+
+def test_rejects_duplicate_active_queue_item_for_same_determination() -> None:
+    first, store = _promote()
+    assert first.accepted is True
+
+    second, _ = _promote(store=store)
+
+    assert second.accepted is False
+    assert promotion.ArchitectFixPromotionReason.DUPLICATE_QUEUE_ITEM in second.rejection_reasons
+    assert len(store.load()["wre_queue_items"]) == 1
+
+
+def test_rejects_conflicting_wsp15_allocation_before_store_mutation() -> None:
+    allocation = _allocation()
+    determination = _determination(allocation=allocation)
+    tampered = dict(determination)
+    tampered["wsp15_allocation_digest"] = "sha256:wrong"
+
+    result, store = _promote(architect_determination=tampered)
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.WSP15_ALLOCATION_MISMATCH in result.rejection_reasons
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_store_commit_failure_fails_closed() -> None:
+    store = InMemoryAuthoritativeWorkStateStore(_work_state(), fail_commit=True)
+
+    result, _ = _promote(store=store)
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.STORE_REJECTED in result.rejection_reasons
+
+
+def test_module_has_no_shell_execution_worker_spawn_or_network_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "gh",
+    }
+    banned_fragments = {
+        "openclaw_supervisor",
+        "hermes",
+        "worktree",
+        "draft_pr",
+        "pattern_memory",
+        "holo_indexer",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_import_roots
+                assert not any(fragment in alias.name for fragment in banned_fragments)
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            assert module.split(".")[0] not in banned_import_roots
+            assert not any(fragment in module for fragment in banned_fragments)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+
+def test_result_is_json_serializable() -> None:
+    result, _ = _promote()
+
+    json.dumps(result.to_dict(), sort_keys=True)
+    assert result.no_worker_spawn_performed is True
+    assert result.no_worktree_created is True
+    assert result.no_shell_command_executed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_hermes_dispatch_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert result.receipt is not None
+    assert result.receipt.no_repo_mutation_performed is True
+    assert result.receipt.authoritative_work_state_mutation_performed is True


### PR DESCRIPTION
## Summary
- Promote an accepted backend architect FIX determination into one authoritative work-state queue item and one durable worker claim.
- Bind the promotion to the architect determination, WSP_15 allocation, production model selection receipt, operational Memex supply receipt, freshness receipt, and HoloIndex evidence mapping.
- Preserve the runtime boundary: no signing, worker spawn, OpenClaw enqueue, Hermes dispatch, worktree creation, shell execution, source repo mutation, PR creation, PatternMemory write, or HoloIndex re-index.

## Verification
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_dryrun_handler.py modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py -q
- python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q
- python -m compileall modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
- git diff --cached --check