### PR TITLE
feat(reddog): claim signed worker dispatch tasks

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_TASK_OPENCLAW_CLAIM_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added the exact signed worker-dispatch AgentDB task executor that validates
+  the published worker-dispatch context and calls only an explicitly injected
+  runner.
+- Wired `run_task.execute_task()` to route signed worker-dispatch tasks before
+  generic WRE fallback, so a missing runner fails closed instead of executing
+  as a generic skill.
+- Added an OpenClaw claim-once seam for signed worker-dispatch tasks that
+  atomically claims the AgentDB task, runs the exact executor, completes or
+  fails the task, and returns a bounded claim receipt.
+- Boundary remains non-mutating by default: no default worker runner, shell
+  command, source repo mutation, worktree operation, Hermes dispatch, PR,
+  PatternMemory write, HoloIndex re-index, or reward settlement is performed
+  by this slice.
+
 ## 2026-07-16: REDDOG_OPENCLAW_HERMES_0102_WORKER_DISPATCH_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -29,7 +29,12 @@ sys.path.insert(0, str(REPO_ROOT))
 logger = logging.getLogger(__name__)
 
 
-def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
+def execute_task(
+    task_id: str,
+    repo_root: Path | None = None,
+    *,
+    signed_worker_runner: Any | None = None,
+) -> Dict[str, Any]:
     """
     Execute a single autonomous task from AgentDB.
 
@@ -80,7 +85,20 @@ def execute_task(task_id: str, repo_root: Path | None = None) -> Dict[str, Any]:
         if readonly_result is not None:
             result = readonly_result
 
-    # Dispatch path 2: WRE skill execution.
+    # Dispatch path 2: exact RedDog signed worker-dispatch task execution.
+    if not result["ok"] and result["detail"] == "no_executor_matched":
+        signed_worker_result = _try_reddog_signed_worker_dispatch(
+            repo_root,
+            task_id,
+            context,
+            required_skills,
+            source,
+            signed_worker_runner,
+        )
+        if signed_worker_result is not None:
+            result = signed_worker_result
+
+    # Dispatch path 3: WRE skill execution.
     if required_skills:
         if not result["ok"] and result["detail"] == "no_executor_matched":
             wre_result = _try_wre_dispatch(repo_root, task_id, required_skills, context, description)
@@ -212,6 +230,54 @@ def _try_reddog_readonly_audit_report_persist(
             "accepted": False,
             "status": "READONLY_AUDIT_REPORT_PERSIST_REJECT",
             "rejection_reasons": ["report_store_error"],
+        }
+
+
+def _try_reddog_signed_worker_dispatch(
+    repo_root: Path,
+    task_id: str,
+    context: dict,
+    required_skills: list,
+    source: str,
+    signed_worker_runner: Any | None,
+) -> Dict[str, Any] | None:
+    """Execute exact RedDog signed worker-dispatch tasks before WRE fallback."""
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
+            SIGNED_WORKER_DISPATCH_TASK_SKILL,
+            SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            execute_reddog_signed_worker_dispatch_task,
+        )
+    except ImportError as e:
+        logger.debug("[RUN_TASK] RedDog signed-worker executor unavailable: %s", e)
+        return None
+
+    if SIGNED_WORKER_DISPATCH_TASK_SKILL not in required_skills:
+        return None
+    if source != SIGNED_WORKER_DISPATCH_TASK_SOURCE:
+        return None
+
+    try:
+        execution = execute_reddog_signed_worker_dispatch_task(
+            task_context=context,
+            task_id=task_id,
+            repo_root=repo_root,
+            runner=signed_worker_runner,
+        )
+        payload = execution.to_dict()
+        return {
+            "ok": bool(execution.accepted),
+            "detail": json.dumps(payload, default=str)[:1000],
+            "executor": "reddog:signed_worker_dispatch",
+            "structured_result": payload,
+        }
+    except Exception as e:
+        logger.warning("[RUN_TASK] RedDog signed-worker dispatch error: %s", e)
+        return {
+            "ok": False,
+            "detail": f"reddog_signed_worker_dispatch_error: {e}",
+            "executor": "reddog:signed_worker_dispatch",
         }
 
 

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -39,6 +39,9 @@ logger = logging.getLogger(__name__)
 READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT = "READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT"
 READONLY_AUDIT_OPENCLAW_CLAIM_IDLE = "READONLY_AUDIT_OPENCLAW_CLAIM_IDLE"
 READONLY_AUDIT_OPENCLAW_CLAIM_REJECT = "READONLY_AUDIT_OPENCLAW_CLAIM_REJECT"
+SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT = "SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT"
+SIGNED_WORKER_OPENCLAW_CLAIM_IDLE = "SIGNED_WORKER_OPENCLAW_CLAIM_IDLE"
+SIGNED_WORKER_OPENCLAW_CLAIM_REJECT = "SIGNED_WORKER_OPENCLAW_CLAIM_REJECT"
 
 
 class ReadOnlyAuditOpenClawClaimReason:
@@ -48,6 +51,14 @@ class ReadOnlyAuditOpenClawClaimReason:
     TASK_EXECUTION_REJECTED = "REJECT_REDDOG_READONLY_AUDIT_TASK_EXECUTION_REJECTED"
     REPORT_PERSIST_REJECTED = "REJECT_REDDOG_READONLY_AUDIT_REPORT_PERSIST_REJECTED"
     AGENTDB_FAILURE = "REJECT_REDDOG_READONLY_AUDIT_AGENTDB_FAILURE"
+
+
+class SignedWorkerOpenClawClaimReason:
+    NO_PENDING_TASK = "NO_PENDING_REDDOG_SIGNED_WORKER_TASK"
+    CLAIM_RACE_LOST = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_RACE_LOST"
+    MALFORMED_CONTEXT = "REJECT_REDDOG_SIGNED_WORKER_MALFORMED_CONTEXT"
+    TASK_EXECUTION_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_TASK_EXECUTION_REJECTED"
+    AGENTDB_FAILURE = "REJECT_REDDOG_SIGNED_WORKER_AGENTDB_FAILURE"
 
 
 @dataclass
@@ -232,7 +243,141 @@ def claim_reddog_readonly_audit_task_once(
     )
 
 
+def claim_reddog_signed_worker_dispatch_task_once(
+    *,
+    repo_root: Path,
+    agent_id: str = "openclaw_supervisor",
+    agent_db_factory: Optional[Callable[[], Any]] = None,
+    signed_worker_runner: Any | None = None,
+) -> Dict[str, Any]:
+    """Claim and execute one signed RedDog worker-dispatch AgentDB task.
+
+    This is the OpenClaw-owned consumer for tasks published by the signed
+    worker-dispatch runtime. The task is claimed atomically from AgentDB and
+    then validated by the signed-worker task executor. A real worker runner
+    must be injected; no default runner is created here.
+    """
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+            SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        )
+        from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
+            execute_reddog_signed_worker_dispatch_task,
+        )
+        from modules.infrastructure.database.src.agent_db import AgentDB
+
+        factory = agent_db_factory or AgentDB
+        db = factory()
+        task = _claim_pending_reddog_signed_worker_dispatch_task(
+            db=db,
+            agent_id=agent_id,
+            source=SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        )
+    except Exception as exc:
+        return _signed_worker_claim_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.AGENTDB_FAILURE,),
+            detail=str(exc)[:300],
+        )
+
+    if task is None:
+        return _signed_worker_claim_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_IDLE,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.NO_PENDING_TASK,),
+        )
+    if task.get("claim_race_lost"):
+        return _signed_worker_claim_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            task_id=str(task.get("task_id") or ""),
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.CLAIM_RACE_LOST,),
+        )
+
+    task_id = str(task.get("task_id") or "")
+    context = task.get("context")
+    if not isinstance(context, dict):
+        _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
+        return _signed_worker_claim_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            task_id=task_id,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.MALFORMED_CONTEXT,),
+        )
+
+    run_result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id=task_id,
+        repo_root=repo_root,
+        runner=signed_worker_runner,
+    )
+    if not run_result.accepted:
+        _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
+        return _signed_worker_claim_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            task_id=task_id,
+            worker_role=run_result.worker_role,
+            worker_runtime=run_result.worker_runtime,
+            capability=run_result.capability,
+            rejection_reasons=(
+                SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
+                *run_result.rejection_reasons,
+            ),
+        )
+
+    db.complete_autonomous_task(task_id)
+    return _signed_worker_claim_result(
+        accepted=True,
+        status=SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
+        task_id=task_id,
+        worker_role=run_result.worker_role,
+        worker_runtime=run_result.worker_runtime,
+        capability=run_result.capability,
+        receipt_id=run_result.receipt_id,
+    )
+
+
 def _claim_pending_reddog_readonly_audit_task(*, db: Any, agent_id: str, source: str) -> Optional[Dict[str, Any]]:
+    with db.db.get_connection() as conn:
+        row = conn.execute(
+            """
+            SELECT task_id, context FROM agents_autonomous_tasks
+            WHERE status = 'pending' AND discovered_by = ?
+            ORDER BY priority_score DESC, discovered_at ASC
+            LIMIT 1
+            """,
+            (source,),
+        ).fetchone()
+        if not row:
+            return None
+        task_id = row["task_id"] if hasattr(row, "keys") else row[0]
+        updated = conn.execute(
+            """
+            UPDATE agents_autonomous_tasks
+            SET assigned_to = ?, assigned_at = CURRENT_TIMESTAMP, status = 'assigned'
+            WHERE task_id = ? AND status = 'pending' AND discovered_by = ?
+            """,
+            (agent_id, task_id, source),
+        ).rowcount
+        if updated != 1:
+            return {"task_id": task_id, "claim_race_lost": True}
+        raw_context = row["context"] if hasattr(row, "keys") else row[1]
+    try:
+        context = json.loads(raw_context) if isinstance(raw_context, str) else raw_context
+    except Exception:
+        context = None
+    return {"task_id": task_id, "context": context}
+
+
+def _claim_pending_reddog_signed_worker_dispatch_task(
+    *,
+    db: Any,
+    agent_id: str,
+    source: str,
+) -> Optional[Dict[str, Any]]:
     with db.db.get_connection() as conn:
         row = conn.execute(
             """
@@ -276,6 +421,18 @@ def _mark_reddog_readonly_audit_task_failed(db: Any, task_id: str) -> None:
         logger.debug("[SUPERVISOR] Failed to mark RedDog readonly audit task failed", exc_info=True)
 
 
+def _mark_reddog_signed_worker_dispatch_task_failed(db: Any, task_id: str) -> None:
+    if not task_id:
+        return
+    try:
+        db.db.execute_write(
+            "UPDATE agents_autonomous_tasks SET status = 'failed', completed_at = CURRENT_TIMESTAMP WHERE task_id = ?",
+            (task_id,),
+        )
+    except Exception:
+        logger.debug("[SUPERVISOR] Failed to mark RedDog signed-worker task failed", exc_info=True)
+
+
 def _readonly_assignment_id(context: Dict[str, Any]) -> str:
     assignment = context.get("assignment") if isinstance(context, dict) else {}
     return str(assignment.get("assignment_id") or "") if isinstance(assignment, dict) else ""
@@ -306,6 +463,40 @@ def _readonly_claim_result(
         "no_worktree_operation_performed": True,
         "no_pr_created": True,
         "no_live_foundup_enqueue_performed": True,
+    }
+
+
+def _signed_worker_claim_result(
+    *,
+    accepted: bool,
+    status: str,
+    task_id: str | None = None,
+    worker_role: str | None = None,
+    worker_runtime: str | None = None,
+    capability: str | None = None,
+    receipt_id: str | None = None,
+    rejection_reasons=(),
+    detail: str = "",
+) -> Dict[str, Any]:
+    return {
+        "accepted": accepted,
+        "status": status,
+        "task_id": task_id,
+        "worker_role": worker_role,
+        "worker_runtime": worker_runtime,
+        "capability": capability,
+        "receipt_id": receipt_id,
+        "rejection_reasons": tuple(dict.fromkeys(str(reason) for reason in rejection_reasons if str(reason))),
+        "detail": detail,
+        "no_shell_command_executed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_live_foundup_enqueue_performed": True,
+        "no_pattern_memory_write_performed": True,
+        "no_reward_settlement_performed": True,
     }
 
 
@@ -376,6 +567,21 @@ class OpenClawSupervisor:
             codeindex_adapter=codeindex_adapter,
             external_research_retriever=external_research_retriever,
             timeout_seconds=timeout_seconds,
+        )
+
+    def claim_reddog_signed_worker_dispatch_task_once(
+        self,
+        *,
+        agent_db_factory: Optional[Callable[[], Any]] = None,
+        signed_worker_runner: Any | None = None,
+    ) -> Dict[str, Any]:
+        """Claim one signed RedDog worker-dispatch task through OpenClaw."""
+
+        return claim_reddog_signed_worker_dispatch_task_once(
+            repo_root=self.repo_root,
+            agent_id="openclaw_supervisor",
+            agent_db_factory=agent_db_factory,
+            signed_worker_runner=signed_worker_runner,
         )
 
     def stop(self) -> None:

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py
@@ -1,0 +1,278 @@
+"""Execute one RedDog signed worker-dispatch AgentDB task.
+
+Slice: REDDOG_SIGNED_WORKER_TASK_OPENCLAW_CLAIM_RUNTIME_PHASE1
+
+This is the OpenClaw task-consumer seam for AgentDB tasks published by
+REDDOG_OPENCLAW_HERMES_0102_WORKER_DISPATCH_RUNTIME_PHASE1. It validates the
+signed worker-dispatch task context and then delegates to an explicitly
+injected worker runner. No default runner is created here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+    SIGNED_WORKER_DISPATCH_TASK_SKILL,
+    SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    WORKER_DISPATCH_RUNTIME_SCHEMA_VERSION,
+)
+
+
+SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT = "SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT"
+SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT = "SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT"
+
+
+class SignedWorkerDispatchTaskExecutorReason:
+    CONTEXT_MALFORMED = "REJECT_SIGNED_WORKER_CONTEXT_MALFORMED"
+    SOURCE_MISMATCH = "REJECT_SIGNED_WORKER_SOURCE_MISMATCH"
+    SCHEMA_MISMATCH = "REJECT_SIGNED_WORKER_SCHEMA_MISMATCH"
+    INTENT_MISSING = "REJECT_SIGNED_WORKER_INTENT_MISSING"
+    RECEIPT_MISSING = "REJECT_SIGNED_WORKER_RECEIPT_MISSING"
+    INTENT_NOT_IN_RECEIPT = "REJECT_SIGNED_WORKER_INTENT_NOT_IN_RECEIPT"
+    CONTEXT_INTENT_MISMATCH = "REJECT_SIGNED_WORKER_CONTEXT_INTENT_MISMATCH"
+    WSP15_MISMATCH = "REJECT_SIGNED_WORKER_WSP15_MISMATCH"
+    REPORT_CONTRACT_MISMATCH = "REJECT_SIGNED_WORKER_REPORT_CONTRACT_MISMATCH"
+    EXECUTION_FLAG_MISMATCH = "REJECT_SIGNED_WORKER_EXECUTION_FLAG_MISMATCH"
+    RUNNER_MISSING = "REJECT_SIGNED_WORKER_RUNNER_MISSING"
+    RUNNER_REJECTED = "REJECT_SIGNED_WORKER_RUNNER_REJECTED"
+    RUNNER_UNSAFE = "REJECT_SIGNED_WORKER_RUNNER_UNSAFE"
+
+
+class SignedWorkerDispatchTaskRunner(Protocol):
+    """Injected runner for an already-validated signed worker task."""
+
+    def run_signed_worker_dispatch_task(
+        self,
+        *,
+        task_id: str,
+        task_context: Mapping[str, Any],
+        worker_dispatch_intent: Mapping[str, Any],
+        signed_authority_receipt: Mapping[str, Any],
+        repo_root: Path,
+    ) -> Mapping[str, Any]: ...
+
+
+@dataclass(frozen=True)
+class SignedWorkerDispatchTaskExecutionResult:
+    accepted: bool
+    decision: str
+    task_id: str
+    executor: str
+    receipt_id: str
+    worker_role: str
+    worker_runtime: str
+    capability: str
+    runner_result: Optional[Mapping[str, Any]]
+    rejection_reasons: tuple[str, ...]
+    no_shell_command_executed: bool = True
+    no_source_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["runner_result"] = dict(self.runner_result) if isinstance(self.runner_result, Mapping) else None
+        payload["rejection_reasons"] = list(self.rejection_reasons)
+        return payload
+
+
+def execute_reddog_signed_worker_dispatch_task(
+    *,
+    task_context: Mapping[str, Any],
+    task_id: str,
+    repo_root: Path,
+    runner: Optional[SignedWorkerDispatchTaskRunner] = None,
+) -> SignedWorkerDispatchTaskExecutionResult:
+    """Validate and execute one signed worker-dispatch task via injected runner."""
+
+    context = _mapping(task_context)
+    reasons: list[str] = []
+    if not context:
+        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.CONTEXT_MALFORMED])
+    if context.get("source") != SIGNED_WORKER_DISPATCH_TASK_SOURCE:
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.SOURCE_MISMATCH)
+    if context.get("schema_version") != WORKER_DISPATCH_RUNTIME_SCHEMA_VERSION:
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.SCHEMA_MISMATCH)
+
+    intent = _mapping(context.get("worker_dispatch_intent"))
+    receipt = _mapping(context.get("signed_authority_worker_dispatch_receipt"))
+    allocation = _mapping(context.get("wsp15_allocation_receipt"))
+    if not intent:
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.INTENT_MISSING)
+    if not receipt:
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.RECEIPT_MISSING)
+    if intent and receipt and not _receipt_contains_intent(receipt, intent):
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.INTENT_NOT_IN_RECEIPT)
+
+    if intent:
+        for context_key, intent_key in (
+            ("worker_runtime", "worker_runtime"),
+            ("worker_role", "role"),
+            ("capability", "capability"),
+        ):
+            if str(context.get(context_key) or "") != str(intent.get(intent_key) or ""):
+                reasons.append(SignedWorkerDispatchTaskExecutorReason.CONTEXT_INTENT_MISMATCH)
+                break
+        if intent.get("dry_run_only") is not True:
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
+        if intent.get("no_worker_spawn_performed") is not True:
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
+        if intent.get("no_openclaw_enqueue_performed") is not True:
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
+        if intent.get("no_hermes_dispatch_performed") is not True:
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
+
+    if intent and allocation:
+        if str(intent.get("wsp15_allocation_receipt_id") or "") != str(allocation.get("receipt_id") or ""):
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
+        if str(intent.get("wsp15_allocation_digest") or "") != _digest(allocation):
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
+
+    if context.get("execution_allowed_by_dispatch_runtime") is not False:
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
+    contract = _mapping(context.get("report_contract"))
+    if (
+        contract.get("requires_signed_authority") is not True
+        or contract.get("worker_process_started") is not False
+        or contract.get("repo_mutation_performed") is not False
+        or contract.get("hermes_execution_performed") is not False
+    ):
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.REPORT_CONTRACT_MISMATCH)
+
+    if reasons:
+        return _reject(task_id, reasons, context=context)
+    if runner is None:
+        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.RUNNER_MISSING], context=context)
+
+    try:
+        runner_result = runner.run_signed_worker_dispatch_task(
+            task_id=task_id,
+            task_context=context,
+            worker_dispatch_intent=intent,
+            signed_authority_receipt=receipt,
+            repo_root=Path(repo_root),
+        )
+    except Exception:
+        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED], context=context)
+
+    runner_payload = _mapping(runner_result)
+    if runner_payload.get("accepted") is not True:
+        return _reject(
+            task_id,
+            [SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED, *_reasons(runner_payload)],
+            context=context,
+            runner_result=runner_payload,
+        )
+    if runner_payload.get("no_source_repo_mutation_performed") is not True:
+        return _reject(
+            task_id,
+            [SignedWorkerDispatchTaskExecutorReason.RUNNER_UNSAFE],
+            context=context,
+            runner_result=runner_payload,
+        )
+    if runner_payload.get("no_shell_command_executed") is not True:
+        return _reject(
+            task_id,
+            [SignedWorkerDispatchTaskExecutorReason.RUNNER_UNSAFE],
+            context=context,
+            runner_result=runner_payload,
+        )
+
+    return SignedWorkerDispatchTaskExecutionResult(
+        accepted=True,
+        decision=SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT,
+        task_id=str(task_id),
+        executor="reddog:signed_worker_dispatch",
+        receipt_id=_result_receipt_id(task_id, context, runner_payload),
+        worker_role=str(context.get("worker_role") or ""),
+        worker_runtime=str(context.get("worker_runtime") or ""),
+        capability=str(context.get("capability") or ""),
+        runner_result=dict(runner_payload),
+        rejection_reasons=(),
+    )
+
+
+def _reject(
+    task_id: str,
+    reasons: Sequence[str],
+    *,
+    context: Mapping[str, Any] | None = None,
+    runner_result: Mapping[str, Any] | None = None,
+) -> SignedWorkerDispatchTaskExecutionResult:
+    context = _mapping(context)
+    return SignedWorkerDispatchTaskExecutionResult(
+        accepted=False,
+        decision=SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT,
+        task_id=str(task_id),
+        executor="reddog:signed_worker_dispatch",
+        receipt_id="",
+        worker_role=str(context.get("worker_role") or ""),
+        worker_runtime=str(context.get("worker_runtime") or ""),
+        capability=str(context.get("capability") or ""),
+        runner_result=dict(runner_result) if isinstance(runner_result, Mapping) else None,
+        rejection_reasons=tuple(_dedupe(reasons)),
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        value = value.to_dict()
+    return value if isinstance(value, Mapping) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value or "").strip()))
+
+
+def _reasons(payload: Mapping[str, Any]) -> list[str]:
+    raw = payload.get("rejection_reasons")
+    if isinstance(raw, list):
+        return _dedupe([str(value) for value in raw])
+    if isinstance(raw, tuple):
+        return _dedupe([str(value) for value in raw])
+    return []
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _result_receipt_id(task_id: str, context: Mapping[str, Any], runner_result: Mapping[str, Any]) -> str:
+    return "signed_worker_task_execution_" + _digest(
+        {
+            "task_id": task_id,
+            "intent_id": _mapping(context.get("worker_dispatch_intent")).get("intent_id"),
+            "runner_receipt_id": runner_result.get("receipt_id"),
+        }
+    ).removeprefix("sha256:")[:16]
+
+
+def _receipt_contains_intent(receipt: Mapping[str, Any], intent: Mapping[str, Any]) -> bool:
+    intent_id = str(intent.get("intent_id") or "")
+    return intent_id in {
+        str(_mapping(value).get("intent_id") or "")
+        for value in _list(receipt.get("dispatch_intents"))
+    }
+
+
+__all__ = [
+    "SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT",
+    "SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT",
+    "SignedWorkerDispatchTaskExecutionResult",
+    "SignedWorkerDispatchTaskExecutorReason",
+    "SignedWorkerDispatchTaskRunner",
+    "execute_reddog_signed_worker_dispatch_task",
+    "SIGNED_WORKER_DISPATCH_TASK_SKILL",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -1,0 +1,398 @@
+"""Tests for REDDOG_SIGNED_WORKER_TASK_OPENCLAW_CLAIM_RUNTIME_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.scripts.run_task import execute_task
+from modules.communication.moltbot_bridge.src import (
+    reddog_openclaw_hermes_0102_worker_dispatch_runtime as runtime,
+)
+from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
+    OpenClawSupervisor,
+    SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
+    SIGNED_WORKER_OPENCLAW_CLAIM_IDLE,
+    SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+    SignedWorkerOpenClawClaimReason,
+    claim_reddog_signed_worker_dispatch_task_once,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_authority_worker_dispatch_dryrun import (
+    SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
+    SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT,
+    SignedWorkerDispatchTaskExecutorReason,
+    execute_reddog_signed_worker_dispatch_task,
+)
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+EXECUTOR_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signed_worker_dispatch_task_executor.py"
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_agent_db(tmp_path, monkeypatch):
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "foundups.db"))
+    DatabaseManager.reset_for_tests()
+    yield
+    DatabaseManager.reset_for_tests()
+
+
+class _FakeRunner:
+    def __init__(self, *, accepted: bool = True, unsafe: bool = False) -> None:
+        self.accepted = accepted
+        self.unsafe = unsafe
+        self.calls = []
+
+    def run_signed_worker_dispatch_task(
+        self,
+        *,
+        task_id,
+        task_context,
+        worker_dispatch_intent,
+        signed_authority_receipt,
+        repo_root,
+    ):
+        self.calls.append(
+            {
+                "task_id": task_id,
+                "task_context": dict(task_context),
+                "worker_dispatch_intent": dict(worker_dispatch_intent),
+                "signed_authority_receipt": dict(signed_authority_receipt),
+                "repo_root": Path(repo_root),
+            }
+        )
+        return {
+            "accepted": self.accepted,
+            "receipt_id": "fake-signed-worker-runner-receipt",
+            "rejection_reasons": [] if self.accepted else ["runner_declined"],
+            "no_source_repo_mutation_performed": not self.unsafe,
+            "no_shell_command_executed": not self.unsafe,
+        }
+
+
+class _CollectingWriter:
+    def enqueue_signed_worker_dispatch_tasks(self, tasks, receipt):
+        return {
+            "ok": True,
+            "created_task_ids": [task.task_id for task in tasks],
+        }
+
+
+def _digest(value: object) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _allocation(**overrides):
+    payload = {
+        "schema_version": "reddog_wsp15_allocation_receipt.v1",
+        "receipt_id": "sha256:wsp15-allocation",
+        "mps_total": 20,
+        "priority": "P0",
+        "reasoning_tier": "ULTRA",
+        "worker_plan": {
+            "schema_version": "reddog_wsp15_worker_plan.v1",
+            "fusion_required": True,
+            "reasoning_tier": "ULTRA",
+            "critic_count": 1,
+            "coding_worker_count": 1,
+            "independent_verifier_required": True,
+            "openclaw_candidate": True,
+            "hermes_execution_allowed": False,
+            "queue_mutation_allowed": False,
+            "mode_selection_source": "reddog_wsp15_allocation_receipt.v1",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _intent(allocation=None, **overrides):
+    allocation = allocation or _allocation()
+    payload = {
+        "intent_id": "worker_dispatch_intent_openclaw_candidate",
+        "role": "openclaw_candidate",
+        "worker_runtime": "openclaw",
+        "capability": "candidate_queue_review",
+        "work_order_id": "wo-1",
+        "foundup_id": "paccess_001",
+        "requested_operation": "create_foundup",
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": _digest(allocation),
+        "dry_run_only": True,
+        "no_worker_spawn_performed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _dryrun_result(allocation=None, intent=None):
+    allocation = allocation or _allocation()
+    intent = intent or _intent(allocation)
+    receipt = {
+        "receipt_id": "signed_authority_worker_dispatch_abc",
+        "work_order_id": "wo-1",
+        "foundup_id": "paccess_001",
+        "requested_operation": "create_foundup",
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": _digest(allocation),
+        "wsp15_priority": allocation["priority"],
+        "wsp15_mps_total": allocation["mps_total"],
+        "wsp15_reasoning_tier": allocation["reasoning_tier"],
+        "dispatch_intent_count": 1,
+        "dispatch_intents": [intent],
+        "no_worker_spawn_performed": True,
+        "no_queue_mutation_performed": True,
+        "no_worktree_created": True,
+        "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+    }
+    return {
+        "accepted": True,
+        "decision": SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT,
+        "rejection_reasons": [],
+        "receipt": receipt,
+    }
+
+
+def _snapshot(allocation=None):
+    allocation = allocation or _allocation()
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+                "status": "QUEUED",
+                "wsp15_allocation_receipt": allocation,
+            }
+        ],
+    }
+
+
+def _task_context():
+    result = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(),
+        work_state_snapshot=_snapshot(),
+        queue_item_id="queue-1",
+        writer=_CollectingWriter(),
+    )
+    assert result.accepted is True
+    task = result.tasks[0]
+    return dict(task.context)
+
+
+def _publish_agentdb_task() -> str:
+    result = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(),
+        work_state_snapshot=_snapshot(),
+        queue_item_id="queue-1",
+        writer=runtime.AgentDbSignedWorkerDispatchTaskWriter(),
+    )
+    assert result.accepted is True
+    assert result.receipt is not None
+    return result.receipt.task_ids[0]
+
+
+def test_signed_worker_executor_accepts_valid_task_with_injected_runner(tmp_path: Path) -> None:
+    runner = _FakeRunner()
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=_task_context(),
+        task_id="task-1",
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert result.accepted is True
+    assert result.decision == SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT
+    assert result.worker_runtime == "openclaw"
+    assert result.capability == "candidate_queue_review"
+    assert result.no_shell_command_executed is True
+    assert result.no_source_repo_mutation_performed is True
+    assert runner.calls[0]["worker_dispatch_intent"]["intent_id"] == "worker_dispatch_intent_openclaw_candidate"
+
+
+def test_signed_worker_executor_rejects_without_runner(tmp_path: Path) -> None:
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=_task_context(),
+        task_id="task-1",
+        repo_root=tmp_path,
+        runner=None,
+    )
+
+    assert result.accepted is False
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_MISSING in result.rejection_reasons
+
+
+def test_signed_worker_executor_rejects_tampered_receipt_and_wsp15(tmp_path: Path) -> None:
+    context = _task_context()
+    context["signed_authority_worker_dispatch_receipt"] = dict(
+        context["signed_authority_worker_dispatch_receipt"]
+    )
+    context["signed_authority_worker_dispatch_receipt"]["dispatch_intents"] = []
+    context["worker_dispatch_intent"] = dict(context["worker_dispatch_intent"])
+    context["worker_dispatch_intent"]["wsp15_allocation_digest"] = "sha256:tampered"
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-1",
+        repo_root=tmp_path,
+        runner=_FakeRunner(),
+    )
+
+    assert result.accepted is False
+    assert SignedWorkerDispatchTaskExecutorReason.INTENT_NOT_IN_RECEIPT in result.rejection_reasons
+    assert SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH in result.rejection_reasons
+
+
+def test_signed_worker_executor_rejects_unsafe_runner(tmp_path: Path) -> None:
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=_task_context(),
+        task_id="task-1",
+        repo_root=tmp_path,
+        runner=_FakeRunner(unsafe=True),
+    )
+
+    assert result.accepted is False
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_UNSAFE in result.rejection_reasons
+
+
+def test_run_task_routes_signed_worker_before_wre_fallback(tmp_path: Path, monkeypatch) -> None:
+    task_id = _publish_agentdb_task()
+    db = AgentDB()
+    assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+
+    result = execute_task(task_id, repo_root=tmp_path, signed_worker_runner=_FakeRunner())
+
+    assert result["ok"] is True
+    assert result["executor"] == "reddog:signed_worker_dispatch"
+    assert result["structured_result"]["accepted"] is True
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_run_task_rejects_signed_worker_without_runner_instead_of_wre_fallback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task()
+    db = AgentDB()
+    assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+
+    result = execute_task(task_id, repo_root=tmp_path)
+
+    assert result["ok"] is False
+    assert result["executor"] == "reddog:signed_worker_dispatch"
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_MISSING in result["detail"]
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "failed"
+
+
+def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task()
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert result["worker_runtime"] == "openclaw"
+    assert result["receipt_id"]
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_supervisor_instance_claims_signed_worker_task(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task()
+    supervisor = OpenClawSupervisor(repo_root=tmp_path)
+
+    result = supervisor.claim_reddog_signed_worker_dispatch_task_once(
+        signed_worker_runner=_FakeRunner(),
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_claim_rejects_without_runner_and_idle_when_empty(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task()
+    db = AgentDB()
+
+    rejected = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+    idle = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+    )
+
+    assert rejected["accepted"] is False
+    assert rejected["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REJECT
+    assert SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED in rejected["rejection_reasons"]
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_MISSING in rejected["rejection_reasons"]
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "failed"
+    assert idle["accepted"] is False
+    assert idle["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+
+
+def test_signed_worker_executor_ast_has_no_shell_network_or_runtime_mutation() -> None:
+    source = EXECUTOR_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_text = (
+        "subprocess",
+        "requests",
+        "socket",
+        "holo_index.py --index",
+        "create_autonomous_task",
+        "complete_autonomous_task",
+        "git push",
+        "gh pr",
+    )
+    for token in forbidden_text:
+        assert token not in source
+
+    imported = set()
+    calls = set()
+    attrs = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                calls.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                attrs.add(func.attr)
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "eval" not in calls
+    assert "exec" not in calls
+    assert "system" not in attrs
+    assert "popen" not in attrs


### PR DESCRIPTION
## Summary
- add exact RedDog signed worker-dispatch task executor for AgentDB tasks published by the worker-dispatch runtime
- route signed worker-dispatch tasks through run_task before generic WRE fallback
- add OpenClaw claim-once seam that claims, validates, completes/fails, and returns a bounded claim receipt

## WSP_97 Truth Boundary
- OBSERVED: signed worker-dispatch tasks now have an exact OpenClaw/run_task consumer path
- OBSERVED: missing runner fails closed instead of falling through to generic WRE
- OBSERVED: injected runner must attest no shell command and no source repo mutation
- SPECIFIED_NOT_IMPLEMENTED: no default Hermes/0102 coding runner, no source mutation, no PR publishing, no HoloIndex re-index, no PatternMemory promotion, no reward settlement

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q -> 10 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py -q -> 26 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_work_order_invocation_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_executor_plan_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_execution_valve_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worktree_create_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_bounded_worker_pilot_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_outcome_ratchet_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_pattern_memory_admission_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_held_out_regression_gate_handler.py -q -> 113 passed
- python -m compileall -q touched files -> pass
- git diff --check -> clean
- rg non-ASCII on new files -> no hits
- broad moltbot_bridge pytest --maxfail=1 -> 582 passed, then known unrelated test_e2e_foundup_job_seam manifest fixture failure