### PR TITLE
feat(reddog): add signed worker queue loop runner

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a signed-worker runner adapter for the OpenClaw candidate task that
+  advances the existing resident queue serial-loop bootstrap for the bound
+  queue item.
+- Restricted this runner to `openclaw` / `candidate_queue_review` signed
+  worker intents; 0102 coding workers and other capabilities remain blocked
+  for later dedicated runners.
+- Bound runner success to bootstrap acceptance plus no source-repo mutation and
+  no shell command execution, so it can be safely consumed by the signed-worker
+  task executor.
+- Boundary remains explicit and non-mutating by this adapter: no default
+  bootstrap bypass, no task creation, no signing, no source repo mutation, no
+  shell command, no PR, no PatternMemory write, no HoloIndex re-index, and no
+  reward settlement is performed by this slice.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_TASK_OPENCLAW_CLAIM_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -1,0 +1,235 @@
+"""Signed worker runner for the resident RedDog queue serial loop.
+
+Slice: REDDOG_SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_PHASE1
+
+This adapter implements the runner protocol consumed by
+reddog_signed_worker_dispatch_task_executor. It accepts only the OpenClaw
+candidate signed-worker task and advances the already-built resident queue
+serial loop for the bound queue item through the existing bootstrap.
+
+The adapter creates no tasks, performs no signing, creates no worktree, runs no
+shell commands, publishes no PR, settles no rewards, writes no PatternMemory,
+and re-indexes no HoloIndex. Any queue-chain work must pass through the
+existing serial-loop bootstrap and its handler gates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+
+SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT = (
+    "SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT"
+)
+SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT = (
+    "SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT"
+)
+
+
+class SignedWorkerQueueSerialLoopRunnerReason:
+    CONFIG_MISSING = "REJECT_SIGNED_WORKER_QUEUE_SERIAL_LOOP_CONFIG_MISSING"
+    QUEUE_ITEM_MISSING = "REJECT_SIGNED_WORKER_QUEUE_ITEM_MISSING"
+    UNSUPPORTED_WORKER_RUNTIME = "REJECT_UNSUPPORTED_WORKER_RUNTIME"
+    UNSUPPORTED_CAPABILITY = "REJECT_UNSUPPORTED_CAPABILITY"
+    BOOTSTRAP_REJECTED = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_REJECTED"
+    BOOTSTRAP_UNSAFE = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_UNSAFE"
+    BOOTSTRAP_EXCEPTION = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_EXCEPTION"
+    BOOTSTRAP_KWARG_CONFLICT = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_KWARG_CONFLICT"
+
+
+BootstrapCallable = Callable[..., Any]
+_RESERVED_BOOTSTRAP_KWARGS = frozenset(
+    {
+        "repo_root",
+        "work_state_path",
+        "chain_results_path",
+        "authority_profile_path",
+        "requested_queue_item_id",
+        "now_iso",
+        "now_epoch",
+        "max_steps",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SignedWorkerQueueSerialLoopRunnerConfig:
+    """Configuration for invoking the resident queue serial-loop bootstrap."""
+
+    work_state_path: Path | str
+    chain_results_path: Path | str
+    authority_profile_path: Path | str
+    repo_root: Optional[Path | str] = None
+    now_iso: Optional[str] = None
+    now_epoch: Optional[int] = None
+    max_steps: int = 1
+    bootstrap_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+
+class RedDogSignedWorkerQueueSerialLoopRunner:
+    """OpenClaw candidate runner backed by the resident queue serial loop."""
+
+    def __init__(
+        self,
+        config: SignedWorkerQueueSerialLoopRunnerConfig,
+        *,
+        bootstrap: Optional[BootstrapCallable] = None,
+    ) -> None:
+        self.config = config
+        self._bootstrap = bootstrap
+
+    def run_signed_worker_dispatch_task(
+        self,
+        *,
+        task_id: str,
+        task_context: Mapping[str, Any],
+        worker_dispatch_intent: Mapping[str, Any],
+        signed_authority_receipt: Mapping[str, Any],
+        repo_root: Path,
+    ) -> Mapping[str, Any]:
+        """Run one claimed OpenClaw candidate task through the queue loop."""
+
+        context = _mapping(task_context)
+        intent = _mapping(worker_dispatch_intent)
+        _ = signed_authority_receipt
+        reasons: list[str] = []
+
+        if str(intent.get("worker_runtime") or context.get("worker_runtime") or "") != "openclaw":
+            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME)
+        if str(intent.get("capability") or context.get("capability") or "") != "candidate_queue_review":
+            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_CAPABILITY)
+
+        queue_item_id = str(context.get("queue_item_id") or "").strip()
+        if not queue_item_id:
+            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.QUEUE_ITEM_MISSING)
+        if not self.config.work_state_path or not self.config.chain_results_path or not self.config.authority_profile_path:
+            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CONFIG_MISSING)
+        if any(key in _RESERVED_BOOTSTRAP_KWARGS for key in self.config.bootstrap_kwargs):
+            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_KWARG_CONFLICT)
+        if reasons:
+            return _reject(task_id, reasons)
+
+        bootstrap = self._bootstrap or _load_bootstrap()
+        try:
+            result = bootstrap(
+                repo_root=Path(self.config.repo_root or repo_root),
+                work_state_path=self.config.work_state_path,
+                chain_results_path=self.config.chain_results_path,
+                authority_profile_path=self.config.authority_profile_path,
+                requested_queue_item_id=queue_item_id,
+                now_iso=self.config.now_iso,
+                now_epoch=self.config.now_epoch,
+                max_steps=self.config.max_steps,
+                **dict(self.config.bootstrap_kwargs),
+            )
+        except Exception:
+            return _reject(task_id, [SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_EXCEPTION])
+
+        payload = _mapping(result)
+        if hasattr(result, "to_dict"):
+            payload = _mapping(result.to_dict())
+        if payload.get("accepted") is not True:
+            return _reject(
+                task_id,
+                [
+                    SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_REJECTED,
+                    *_string_list(payload.get("rejection_reasons")),
+                ],
+                bootstrap_result=payload,
+            )
+        if (
+            payload.get("no_repo_mutation_performed") is not True
+            or payload.get("no_shell_command_executed") is not True
+        ):
+            return _reject(
+                task_id,
+                [SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE],
+                bootstrap_result=payload,
+            )
+
+        return {
+            "accepted": True,
+            "decision": SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT,
+            "receipt_id": _receipt_id(task_id, queue_item_id, payload),
+            "queue_item_id": queue_item_id,
+            "bootstrap_result": dict(payload),
+            "rejection_reasons": [],
+            "no_source_repo_mutation_performed": True,
+            "no_shell_command_executed": True,
+            "no_holoindex_reindex_performed": bool(payload.get("no_holoindex_reindex_performed", True)),
+            "no_pr_created": bool(payload.get("no_pr_created", True)),
+            "no_pattern_memory_write_performed": bool(payload.get("no_pattern_memory_write_performed", True)),
+            "no_reward_settlement_performed": bool(payload.get("no_reward_settlement_performed", True)),
+        }
+
+
+def _load_bootstrap() -> BootstrapCallable:
+    from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
+        run_reddog_main_resident_queue_serial_loop_bootstrap,
+    )
+
+    return run_reddog_main_resident_queue_serial_loop_bootstrap
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple)):
+        return [str(item) for item in value if str(item or "").strip()]
+    return []
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _receipt_id(task_id: str, queue_item_id: str, bootstrap_result: Mapping[str, Any]) -> str:
+    return "signed_worker_queue_loop_" + _digest(
+        {
+            "task_id": task_id,
+            "queue_item_id": queue_item_id,
+            "store_revision": bootstrap_result.get("store_revision"),
+            "next_action": bootstrap_result.get("next_action"),
+        }
+    ).removeprefix("sha256:")[:16]
+
+
+def _reject(
+    task_id: str,
+    reasons: list[str],
+    *,
+    bootstrap_result: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    return {
+        "accepted": False,
+        "decision": SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT,
+        "receipt_id": "",
+        "task_id": task_id,
+        "bootstrap_result": dict(bootstrap_result) if isinstance(bootstrap_result, Mapping) else None,
+        "rejection_reasons": list(dict.fromkeys(reason for reason in reasons if reason)),
+        "no_source_repo_mutation_performed": True,
+        "no_shell_command_executed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_pr_created": True,
+        "no_pattern_memory_write_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+__all__ = [
+    "RedDogSignedWorkerQueueSerialLoopRunner",
+    "SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT",
+    "SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT",
+    "SignedWorkerQueueSerialLoopRunnerConfig",
+    "SignedWorkerQueueSerialLoopRunnerReason",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -1,0 +1,355 @@
+"""Tests for REDDOG_SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+    SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    WORKER_DISPATCH_RUNTIME_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
+    SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT,
+    SignedWorkerDispatchTaskExecutorReason,
+    execute_reddog_signed_worker_dispatch_task,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
+    RedDogSignedWorkerQueueSerialLoopRunner,
+    SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT,
+    SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT,
+    SignedWorkerQueueSerialLoopRunnerConfig,
+    SignedWorkerQueueSerialLoopRunnerReason,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signed_worker_queue_serial_loop_runner.py"
+)
+
+
+class _FakeBootstrapResult:
+    def __init__(self, payload):
+        self._payload = dict(payload)
+
+    def to_dict(self):
+        return dict(self._payload)
+
+
+class _FakeBootstrap:
+    def __init__(self, payload=None, *, raises: bool = False):
+        self.payload = payload or _bootstrap_payload()
+        self.raises = raises
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        if self.raises:
+            raise RuntimeError("bootstrap_failed")
+        return _FakeBootstrapResult(self.payload)
+
+
+def _digest(value: object) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _allocation():
+    return {
+        "schema_version": "reddog_wsp15_allocation_receipt.v1",
+        "receipt_id": "sha256:wsp15-allocation",
+        "mps_total": 20,
+        "priority": "P0",
+        "reasoning_tier": "ULTRA",
+        "worker_plan": {
+            "schema_version": "reddog_wsp15_worker_plan.v1",
+            "fusion_required": True,
+            "reasoning_tier": "ULTRA",
+            "critic_count": 1,
+            "coding_worker_count": 1,
+            "independent_verifier_required": True,
+            "openclaw_candidate": True,
+            "hermes_execution_allowed": False,
+            "queue_mutation_allowed": False,
+            "mode_selection_source": "reddog_wsp15_allocation_receipt.v1",
+        },
+    }
+
+
+def _intent(allocation=None, **overrides):
+    allocation = allocation or _allocation()
+    payload = {
+        "intent_id": "worker_dispatch_intent_openclaw_candidate",
+        "role": "openclaw_candidate",
+        "worker_runtime": "openclaw",
+        "capability": "candidate_queue_review",
+        "work_order_id": "wo-1",
+        "foundup_id": "paccess_001",
+        "requested_operation": "create_foundup",
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": _digest(allocation),
+        "dry_run_only": True,
+        "no_worker_spawn_performed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _context(**intent_overrides):
+    allocation = _allocation()
+    intent = _intent(allocation, **intent_overrides)
+    receipt = {
+        "receipt_id": "signed_authority_worker_dispatch_abc",
+        "work_order_id": "wo-1",
+        "foundup_id": "paccess_001",
+        "requested_operation": "create_foundup",
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": _digest(allocation),
+        "dispatch_intent_count": 1,
+        "dispatch_intents": [intent],
+        "no_worker_spawn_performed": True,
+        "no_queue_mutation_performed": True,
+        "no_worktree_created": True,
+        "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+    }
+    return {
+        "source": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        "schema_version": WORKER_DISPATCH_RUNTIME_SCHEMA_VERSION,
+        "queue_item_id": "queue-1",
+        "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+        "worker_runtime": intent["worker_runtime"],
+        "worker_role": intent["role"],
+        "capability": intent["capability"],
+        "signed_authority_worker_dispatch_receipt": receipt,
+        "worker_dispatch_intent": intent,
+        "wsp15_allocation_receipt": allocation,
+        "execution_allowed_by_dispatch_runtime": False,
+        "requires_downstream_stages": ["work_order_invocation"],
+        "report_contract": {
+            "worker_process_started": False,
+            "repo_mutation_performed": False,
+            "hermes_execution_performed": False,
+            "requires_signed_authority": True,
+        },
+    }
+
+
+def _config(tmp_path: Path) -> SignedWorkerQueueSerialLoopRunnerConfig:
+    return SignedWorkerQueueSerialLoopRunnerConfig(
+        repo_root=tmp_path / "repo",
+        work_state_path=tmp_path / "work_state.json",
+        chain_results_path=tmp_path / "chain_results.json",
+        authority_profile_path=tmp_path / "authority_profile.json",
+        now_iso="2026-07-16T00:00:00+00:00",
+        now_epoch=1000,
+        max_steps=1,
+        bootstrap_kwargs={"work_order_materializer_mode": "authority_profile"},
+    )
+
+
+def _bootstrap_payload(**overrides):
+    payload = {
+        "accepted": True,
+        "status": "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED",
+        "queue_item_id": "queue-1",
+        "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+        "steps_run": 1,
+        "dispatched_stages": ("work_order_invocation",),
+        "next_action": "RUN_QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN",
+        "chain_results_path": "O:/runtime/chain_results.json",
+        "store_revision": "sha256:chain-revision",
+        "rejection_reasons": (),
+        "no_repo_mutation_performed": True,
+        "no_shell_command_executed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_pr_created": True,
+        "no_pattern_memory_write_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_queue_serial_loop_runner_accepts_openclaw_candidate(tmp_path: Path) -> None:
+    bootstrap = _FakeBootstrap()
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=bootstrap)
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is True
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert result["queue_item_id"] == "queue-1"
+    assert result["receipt_id"]
+    assert result["no_source_repo_mutation_performed"] is True
+    assert result["no_shell_command_executed"] is True
+    assert bootstrap.calls[0]["requested_queue_item_id"] == "queue-1"
+    assert bootstrap.calls[0]["max_steps"] == 1
+    assert bootstrap.calls[0]["work_order_materializer_mode"] == "authority_profile"
+
+
+def test_queue_serial_loop_runner_rejects_non_openclaw_worker(tmp_path: Path) -> None:
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=_FakeBootstrap())
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT
+    assert SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME in result["rejection_reasons"]
+    assert SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_CAPABILITY in result["rejection_reasons"]
+
+
+def test_queue_serial_loop_runner_rejects_bootstrap_kwarg_override(tmp_path: Path) -> None:
+    config = SignedWorkerQueueSerialLoopRunnerConfig(
+        repo_root=tmp_path / "repo",
+        work_state_path=tmp_path / "work_state.json",
+        chain_results_path=tmp_path / "chain_results.json",
+        authority_profile_path=tmp_path / "authority_profile.json",
+        bootstrap_kwargs={"requested_queue_item_id": "attacker-queue"},
+    )
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=_FakeBootstrap())
+    context = _context()
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_KWARG_CONFLICT in result["rejection_reasons"]
+
+
+def test_queue_serial_loop_runner_rejects_failed_or_unsafe_bootstrap(tmp_path: Path) -> None:
+    rejected_runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(
+            _bootstrap_payload(accepted=False, rejection_reasons=("missing_work_order",))
+        ),
+    )
+    unsafe_runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(_bootstrap_payload(no_shell_command_executed=False)),
+    )
+    context = _context()
+
+    rejected = rejected_runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+    unsafe = unsafe_runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert rejected["accepted"] is False
+    assert SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_REJECTED in rejected["rejection_reasons"]
+    assert "missing_work_order" in rejected["rejection_reasons"]
+    assert unsafe["accepted"] is False
+    assert SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE in unsafe["rejection_reasons"]
+
+
+def test_signed_worker_executor_accepts_queue_serial_loop_runner(tmp_path: Path) -> None:
+    context = _context()
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=_FakeBootstrap())
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-1",
+        repo_root=tmp_path / "repo",
+        runner=runner,
+    )
+
+    assert result.accepted is True
+    assert result.decision == SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT
+    assert result.runner_result is not None
+    assert result.runner_result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+
+
+def test_signed_worker_executor_rejects_unsupported_queue_runner_target(tmp_path: Path) -> None:
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=_FakeBootstrap())
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-1",
+        repo_root=tmp_path / "repo",
+        runner=runner,
+    )
+
+    assert result.accepted is False
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED in result.rejection_reasons
+    assert SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME in result.rejection_reasons
+
+
+def test_queue_serial_loop_runner_ast_has_no_shell_network_or_mutation_calls() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    forbidden_text = (
+        "subprocess",
+        "requests",
+        "socket",
+        "holo_index.py --index",
+        "create_autonomous_task",
+        "complete_autonomous_task",
+        "git push",
+        "gh pr",
+    )
+    for token in forbidden_text:
+        assert token not in source
+
+    imported = set()
+    calls = set()
+    attrs = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            imported.add((node.module or "").split(".")[0])
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                calls.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                attrs.add(func.attr)
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "eval" not in calls
+    assert "exec" not in calls
+    assert "system" not in attrs
+    assert "popen" not in attrs


### PR DESCRIPTION
## Summary
- add an OpenClaw-candidate signed-worker runner that invokes the resident queue serial-loop bootstrap for the bound queue item
- reject non-OpenClaw worker runtimes/capabilities so 0102 coding workers remain blocked for a dedicated runner
- prevent bootstrap kwargs from overriding queue item or required runtime bindings

## WSP_97 Truth Boundary
- OBSERVED: signed worker tasks can now use an explicit runner that advances the existing resident queue chain
- OBSERVED: runner success requires bootstrap acceptance plus no source-repo mutation and no shell command execution
- SPECIFIED_NOT_IMPLEMENTED: no default runner wiring in main/OpenClaw, no coding-worker runner, no Hermes dispatch expansion, no source mutation, no PR creation, no PatternMemory write, no HoloIndex re-index, no reward settlement

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -> 7 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py -q -> 65 passed
- combined RedDog resident queue/runtime batch -> 170 passed
- python -m compileall -q touched files -> pass
- git diff --check -> clean
- rg non-ASCII on new files -> no hits