### PR TITLE
feat(reddog): bind OpenClaw signed worker queue loop runner

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_OPENCLAW_QUEUE_LOOP_RUNTIME_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added an explicit runtime binding that builds the OpenClaw signed-worker
+  queue-loop runner from environment-provided outside-repo artifacts.
+- Wired `run_task.execute_task()` to use the bound runner when
+  `REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER=1`, preserving the default
+  fail-closed `RUNNER_MISSING` behavior when the binding is not requested.
+- Hardened the OpenClaw signed-worker claim seam so it only claims
+  `openclaw` / `candidate_queue_review` tasks; Hermes and 0102 signed-worker
+  tasks remain pending for future dedicated consumers instead of being failed
+  by the wrong runner.
+- Boundary remains non-mutating: no shell command, source repo mutation,
+  worktree creation, PR, Hermes dispatch, PatternMemory write, HoloIndex
+  re-index, or reward settlement is introduced by this slice.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -259,11 +259,23 @@ def _try_reddog_signed_worker_dispatch(
         return None
 
     try:
+        effective_runner = signed_worker_runner
+        if effective_runner is None:
+            binding_result = _build_signed_worker_queue_loop_runner(repo_root)
+            if binding_result is not None:
+                if getattr(binding_result, "accepted", False) is True:
+                    effective_runner = getattr(binding_result, "runner", None)
+                elif getattr(binding_result, "requested", False) is True:
+                    return {
+                        "ok": False,
+                        "detail": json.dumps(binding_result.to_dict(), default=str)[:1000],
+                        "executor": "reddog:signed_worker_dispatch",
+                    }
         execution = execute_reddog_signed_worker_dispatch_task(
             task_context=context,
             task_id=task_id,
             repo_root=repo_root,
-            runner=signed_worker_runner,
+            runner=effective_runner,
         )
         payload = execution.to_dict()
         return {
@@ -347,6 +359,23 @@ def _try_wre_dispatch(
         return {"ok": False, "detail": f"wre_error: {e}", "executor": "wre"}
 
     return None
+
+
+def _build_signed_worker_queue_loop_runner(repo_root: Path) -> Any | None:
+    """Build an explicitly enabled OpenClaw signed-worker queue-loop runner."""
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+            build_reddog_signed_worker_queue_loop_runner_from_env,
+        )
+    except ImportError as e:
+        logger.debug("[RUN_TASK] RedDog signed-worker queue-loop binding unavailable: %s", e)
+        return None
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo_root,
+        env=os.environ,
+    )
+    return binding
 
 
 def _try_self_audit_dispatch(repo_root: Path, context: dict) -> Dict[str, Any] | None:

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -265,6 +265,9 @@ def claim_reddog_signed_worker_dispatch_task_once(
         from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
             execute_reddog_signed_worker_dispatch_task,
         )
+        from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+            build_reddog_signed_worker_queue_loop_runner_from_env,
+        )
         from modules.infrastructure.database.src.agent_db import AgentDB
 
         factory = agent_db_factory or AgentDB
@@ -307,11 +310,31 @@ def claim_reddog_signed_worker_dispatch_task_once(
             rejection_reasons=(SignedWorkerOpenClawClaimReason.MALFORMED_CONTEXT,),
         )
 
+    effective_runner = signed_worker_runner
+    if effective_runner is None:
+        binding_result = build_reddog_signed_worker_queue_loop_runner_from_env(
+            repo_root=repo_root,
+            env=os.environ,
+        )
+        if binding_result.accepted:
+            effective_runner = binding_result.runner
+        elif binding_result.requested:
+            _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
+            return _signed_worker_claim_result(
+                accepted=False,
+                status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+                task_id=task_id,
+                rejection_reasons=(
+                    SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
+                    *binding_result.rejection_reasons,
+                ),
+            )
+
     run_result = execute_reddog_signed_worker_dispatch_task(
         task_context=context,
         task_id=task_id,
         repo_root=repo_root,
-        runner=signed_worker_runner,
+        runner=effective_runner,
     )
     if not run_result.accepted:
         _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
@@ -378,17 +401,37 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
     agent_id: str,
     source: str,
 ) -> Optional[Dict[str, Any]]:
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+        is_openclaw_candidate_signed_worker_context,
+    )
+
     with db.db.get_connection() as conn:
-        row = conn.execute(
+        rows = conn.execute(
             """
             SELECT task_id, context FROM agents_autonomous_tasks
             WHERE status = 'pending' AND discovered_by = ?
             ORDER BY priority_score DESC, discovered_at ASC
-            LIMIT 1
+            LIMIT 50
             """,
             (source,),
-        ).fetchone()
-        if not row:
+        ).fetchall()
+        if not rows:
+            return None
+        row = None
+        context: Any = None
+        raw_context: Any = None
+        for candidate in rows:
+            raw_candidate = candidate["context"] if hasattr(candidate, "keys") else candidate[1]
+            try:
+                candidate_context = json.loads(raw_candidate) if isinstance(raw_candidate, str) else raw_candidate
+            except Exception:
+                candidate_context = None
+            if is_openclaw_candidate_signed_worker_context(candidate_context):
+                row = candidate
+                raw_context = raw_candidate
+                context = candidate_context
+                break
+        if row is None:
             return None
         task_id = row["task_id"] if hasattr(row, "keys") else row[0]
         updated = conn.execute(
@@ -401,11 +444,11 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
         ).rowcount
         if updated != 1:
             return {"task_id": task_id, "claim_race_lost": True}
-        raw_context = row["context"] if hasattr(row, "keys") else row[1]
-    try:
-        context = json.loads(raw_context) if isinstance(raw_context, str) else raw_context
-    except Exception:
-        context = None
+    if context is None:
+        try:
+            context = json.loads(raw_context) if isinstance(raw_context, str) else raw_context
+        except Exception:
+            context = None
     return {"task_id": task_id, "context": context}
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -1,0 +1,228 @@
+"""Runtime binding for OpenClaw signed-worker queue-loop execution.
+
+Slice: REDDOG_SIGNED_WORKER_OPENCLAW_QUEUE_LOOP_RUNTIME_BINDING_PHASE1
+
+This module builds the narrow OpenClaw queue-loop runner used by signed
+worker-dispatch tasks. It is disabled unless explicitly requested through
+environment/configuration, accepts only the OpenClaw candidate queue-review
+capability, and delegates all queue advancement to the existing bounded
+resident queue serial-loop bootstrap.
+
+It does not execute shell commands, mutate repository files, create worktrees,
+publish PRs, dispatch Hermes, settle rewards, write PatternMemory, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+    SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
+    RedDogSignedWorkerQueueSerialLoopRunner,
+    SignedWorkerQueueSerialLoopRunnerConfig,
+)
+
+
+SIGNED_WORKER_QUEUE_LOOP_BINDING_READY = "SIGNED_WORKER_QUEUE_LOOP_BINDING_READY"
+SIGNED_WORKER_QUEUE_LOOP_BINDING_NOT_REQUESTED = "SIGNED_WORKER_QUEUE_LOOP_BINDING_NOT_REQUESTED"
+SIGNED_WORKER_QUEUE_LOOP_BINDING_REJECT = "SIGNED_WORKER_QUEUE_LOOP_BINDING_REJECT"
+
+OPENCLAW_SIGNED_WORKER_RUNTIME = "openclaw"
+OPENCLAW_CANDIDATE_QUEUE_REVIEW_CAPABILITY = "candidate_queue_review"
+
+
+class SignedWorkerOpenClawQueueLoopBindingReason:
+    NOT_REQUESTED = "SIGNED_WORKER_QUEUE_LOOP_BINDING_NOT_REQUESTED"
+    WORK_STATE_PATH_MISSING = "REJECT_SIGNED_WORKER_QUEUE_LOOP_WORK_STATE_PATH_MISSING"
+    CHAIN_RESULTS_PATH_MISSING = "REJECT_SIGNED_WORKER_QUEUE_LOOP_CHAIN_RESULTS_PATH_MISSING"
+    AUTHORITY_PROFILE_PATH_MISSING = "REJECT_SIGNED_WORKER_QUEUE_LOOP_AUTHORITY_PROFILE_PATH_MISSING"
+    MAX_STEPS_INVALID = "REJECT_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS_INVALID"
+    NOW_EPOCH_INVALID = "REJECT_SIGNED_WORKER_QUEUE_LOOP_NOW_EPOCH_INVALID"
+
+
+@dataclass(frozen=True)
+class SignedWorkerOpenClawQueueLoopBindingResult:
+    """Result from constructing the OpenClaw signed-worker runner."""
+
+    accepted: bool
+    status: str
+    requested: bool
+    runner: Optional[RedDogSignedWorkerQueueSerialLoopRunner]
+    rejection_reasons: tuple[str, ...]
+    work_state_path: Optional[str] = None
+    chain_results_path: Optional[str] = None
+    authority_profile_path: Optional[str] = None
+    max_steps: Optional[int] = None
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["runner"] = None if self.runner is None else self.runner.__class__.__name__
+        return payload
+
+
+def is_openclaw_candidate_signed_worker_context(context: Mapping[str, Any] | None) -> bool:
+    """Return True only for the signed worker task OpenClaw is allowed to claim."""
+
+    if not isinstance(context, Mapping):
+        return False
+    return (
+        str(context.get("source") or "") == SIGNED_WORKER_DISPATCH_TASK_SOURCE
+        and str(context.get("worker_runtime") or "").strip().lower() == OPENCLAW_SIGNED_WORKER_RUNTIME
+        and str(context.get("capability") or "").strip().lower() == OPENCLAW_CANDIDATE_QUEUE_REVIEW_CAPABILITY
+    )
+
+
+def build_reddog_signed_worker_queue_loop_runner_from_env(
+    *,
+    repo_root: Path | str,
+    env: Mapping[str, str],
+    bootstrap: Optional[Callable[..., Any]] = None,
+) -> SignedWorkerOpenClawQueueLoopBindingResult:
+    """Build the OpenClaw queue-loop runner from explicit runtime config."""
+
+    requested = str(env.get("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "0")).strip() == "1"
+    if not requested:
+        return SignedWorkerOpenClawQueueLoopBindingResult(
+            accepted=False,
+            status=SIGNED_WORKER_QUEUE_LOOP_BINDING_NOT_REQUESTED,
+            requested=False,
+            runner=None,
+            rejection_reasons=(SignedWorkerOpenClawQueueLoopBindingReason.NOT_REQUESTED,),
+        )
+
+    work_state_path = _stripped(env.get("REDDOG_AUTHORITATIVE_WORK_STATE_PATH"))
+    chain_results_path = _stripped(env.get("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH"))
+    authority_profile_path = _stripped(env.get("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH"))
+    reasons: list[str] = []
+    if not work_state_path:
+        reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.WORK_STATE_PATH_MISSING)
+    if not chain_results_path:
+        reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.CHAIN_RESULTS_PATH_MISSING)
+    if not authority_profile_path:
+        reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.AUTHORITY_PROFILE_PATH_MISSING)
+
+    max_steps_raw = _stripped(env.get("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS")) or _stripped(
+        env.get("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS")
+    )
+    try:
+        max_steps = int(max_steps_raw) if max_steps_raw else 1
+    except ValueError:
+        max_steps = 0
+    if max_steps < 1:
+        reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.MAX_STEPS_INVALID)
+
+    now_epoch_raw = _stripped(env.get("REDDOG_RESIDENT_QUEUE_NOW_EPOCH"))
+    try:
+        now_epoch = int(now_epoch_raw) if now_epoch_raw else None
+    except ValueError:
+        now_epoch = None
+        reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.NOW_EPOCH_INVALID)
+
+    if reasons:
+        return SignedWorkerOpenClawQueueLoopBindingResult(
+            accepted=False,
+            status=SIGNED_WORKER_QUEUE_LOOP_BINDING_REJECT,
+            requested=True,
+            runner=None,
+            rejection_reasons=tuple(dict.fromkeys(reasons)),
+            work_state_path=work_state_path,
+            chain_results_path=chain_results_path,
+            authority_profile_path=authority_profile_path,
+            max_steps=max_steps,
+        )
+
+    bootstrap_kwargs = _bootstrap_kwargs(env)
+    config = SignedWorkerQueueSerialLoopRunnerConfig(
+        work_state_path=str(work_state_path),
+        chain_results_path=str(chain_results_path),
+        authority_profile_path=str(authority_profile_path),
+        repo_root=Path(repo_root).resolve(),
+        now_iso=_stripped(env.get("REDDOG_RESIDENT_QUEUE_NOW_ISO")) or None,
+        now_epoch=now_epoch,
+        max_steps=max_steps,
+        bootstrap_kwargs=bootstrap_kwargs,
+    )
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=bootstrap)
+    return SignedWorkerOpenClawQueueLoopBindingResult(
+        accepted=True,
+        status=SIGNED_WORKER_QUEUE_LOOP_BINDING_READY,
+        requested=True,
+        runner=runner,
+        rejection_reasons=(),
+        work_state_path=work_state_path,
+        chain_results_path=chain_results_path,
+        authority_profile_path=authority_profile_path,
+        max_steps=max_steps,
+    )
+
+
+def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
+    pairs = {
+        "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
+        "work_order_materializer_mode": "REDDOG_WORK_ORDER_MATERIALIZER_MODE",
+        "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
+        "generic_writer_dryrun_result_path": "REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH",
+        "governed_shell_dryrun_result_path": "REDDOG_GOVERNED_SHELL_DRYRUN_RESULT_PATH",
+        "artifact_contents_path": "REDDOG_ARTIFACT_CONTENTS_PATH",
+        "artifact_generation_request_path": "REDDOG_ARTIFACT_GENERATION_REQUEST_PATH",
+        "holoindex_evidence_path": "REDDOG_HOLOINDEX_EVIDENCE_PATH",
+        "verifier_request_path": "REDDOG_SLICE_VERIFIER_REQUEST_PATH",
+        "evidence_producer_request_path": "REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH",
+        "publish_request_path": "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH",
+        "ratchet_request_path": "REDDOG_OUTCOME_RATCHET_REQUEST_PATH",
+        "outcome_ratchet_store_path": "REDDOG_OUTCOME_RATCHET_STORE_PATH",
+        "held_out_gate_request_path": "REDDOG_HELD_OUT_GATE_REQUEST_PATH",
+        "admission_request_path": "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH",
+        "authority_state_path": "REDDOG_AUTHORITY_RUNTIME_STATE_PATH",
+        "permission_snapshots_path": "REDDOG_PERMISSION_SNAPSHOTS_PATH",
+        "principal_authority_records_path": "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH",
+        "signer_socket_path": "REDDOG_SIGNER_SOCKET_PATH",
+        "signature_verifier_backend": "REDDOG_SIGNATURE_VERIFIER_BACKEND",
+        "worktree_runner_mode": "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE",
+        "artifact_generator_mode": "REDDOG_ARTIFACT_GENERATOR_MODE",
+        "evidence_command_runner_mode": "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE",
+        "draft_pr_runner_mode": "REDDOG_DRAFT_PR_RUNNER_MODE",
+    }
+    payload: dict[str, Any] = {}
+    for key, env_name in pairs.items():
+        value = _stripped(env.get(env_name))
+        if value:
+            payload[key] = value
+    for key, env_name in (
+        ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
+        ("slice_verifier_request_binding_enabled", "REDDOG_SLICE_VERIFIER_REQUEST_BINDING"),
+        ("draft_pr_publish_request_binding_enabled", "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING"),
+    ):
+        if _stripped(env.get(env_name)) == "1":
+            payload[key] = True
+    return payload
+
+
+def _stripped(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "OPENCLAW_CANDIDATE_QUEUE_REVIEW_CAPABILITY",
+    "OPENCLAW_SIGNED_WORKER_RUNTIME",
+    "SIGNED_WORKER_QUEUE_LOOP_BINDING_NOT_REQUESTED",
+    "SIGNED_WORKER_QUEUE_LOOP_BINDING_READY",
+    "SIGNED_WORKER_QUEUE_LOOP_BINDING_REJECT",
+    "SignedWorkerOpenClawQueueLoopBindingReason",
+    "SignedWorkerOpenClawQueueLoopBindingResult",
+    "build_reddog_signed_worker_queue_loop_runner_from_env",
+    "is_openclaw_candidate_signed_worker_context",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -85,6 +85,22 @@ class _FakeRunner:
         }
 
 
+class _FakeBinding:
+    def __init__(self, runner) -> None:
+        self.accepted = True
+        self.requested = True
+        self.runner = runner
+        self.rejection_reasons = ()
+
+    def to_dict(self):
+        return {
+            "accepted": self.accepted,
+            "requested": self.requested,
+            "runner": "FakeRunner",
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
 class _CollectingWriter:
     def enqueue_signed_worker_dispatch_tasks(self, tasks, receipt):
         return {
@@ -202,10 +218,12 @@ def _task_context():
     return dict(task.context)
 
 
-def _publish_agentdb_task() -> str:
+def _publish_agentdb_task(**intent_overrides) -> str:
+    allocation = _allocation()
+    intent = _intent(allocation, **intent_overrides)
     result = runtime.publish_reddog_signed_worker_dispatch_runtime(
-        worker_dispatch_dryrun_result=_dryrun_result(),
-        work_state_snapshot=_snapshot(),
+        worker_dispatch_dryrun_result=_dryrun_result(allocation=allocation, intent=intent),
+        work_state_snapshot=_snapshot(allocation),
         queue_item_id="queue-1",
         writer=runtime.AgentDbSignedWorkerDispatchTaskWriter(),
     )
@@ -309,6 +327,36 @@ def test_run_task_rejects_signed_worker_without_runner_instead_of_wre_fallback(
     assert db.get_autonomous_task_by_id(task_id)["status"] == "failed"
 
 
+def test_run_task_uses_env_bound_queue_loop_runner_when_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task()
+    db = AgentDB()
+    assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+
+    from modules.communication.moltbot_bridge.src import (
+        reddog_signed_worker_openclaw_queue_loop_runtime_binding as binding_module,
+    )
+
+    runner = _FakeRunner()
+    monkeypatch.setattr(
+        binding_module,
+        "build_reddog_signed_worker_queue_loop_runner_from_env",
+        lambda *, repo_root, env: _FakeBinding(runner),
+    )
+
+    result = execute_task(task_id, repo_root=tmp_path)
+
+    assert result["ok"] is True
+    assert result["executor"] == "reddog:signed_worker_dispatch"
+    assert result["structured_result"]["accepted"] is True
+    assert runner.calls[0]["task_id"] == task_id
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
 def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:
     task_id = _publish_agentdb_task()
     db = AgentDB()
@@ -324,6 +372,26 @@ def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path
     assert result["worker_runtime"] == "openclaw"
     assert result["receipt_id"]
     assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_claim_ignores_non_openclaw_signed_worker_task(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task(
+        intent_id="worker_dispatch_intent_hermes_candidate",
+        role="hermes_candidate",
+        worker_runtime="hermes",
+        capability="bounded_code_change",
+    )
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+    )
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert SignedWorkerOpenClawClaimReason.NO_PENDING_TASK in result["rejection_reasons"]
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "pending"
 
 
 def test_openclaw_supervisor_instance_claims_signed_worker_task(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -16,6 +16,12 @@ from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task
     SignedWorkerDispatchTaskExecutorReason,
     execute_reddog_signed_worker_dispatch_task,
 )
+from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+    SIGNED_WORKER_QUEUE_LOOP_BINDING_READY,
+    SignedWorkerOpenClawQueueLoopBindingReason,
+    build_reddog_signed_worker_queue_loop_runner_from_env,
+    is_openclaw_candidate_signed_worker_context,
+)
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
     RedDogSignedWorkerQueueSerialLoopRunner,
     SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT,
@@ -33,6 +39,14 @@ MODULE_PATH = (
     / "moltbot_bridge"
     / "src"
     / "reddog_signed_worker_queue_serial_loop_runner.py"
+)
+BINDING_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signed_worker_openclaw_queue_loop_runtime_binding.py"
 )
 
 
@@ -184,6 +198,71 @@ def _bootstrap_payload(**overrides):
     return payload
 
 
+def test_openclaw_candidate_context_filter_accepts_only_target_capability() -> None:
+    assert is_openclaw_candidate_signed_worker_context(_context()) is True
+    assert (
+        is_openclaw_candidate_signed_worker_context(
+            _context(worker_runtime="hermes", capability="candidate_queue_review")
+        )
+        is False
+    )
+    assert (
+        is_openclaw_candidate_signed_worker_context(
+            _context(worker_runtime="openclaw", capability="coding_worker")
+        )
+        is False
+    )
+
+
+def test_runtime_binding_builds_runner_from_explicit_env(tmp_path: Path) -> None:
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        "REDDOG_WORK_ORDER_MATERIALIZER_MODE": "authority_profile",
+        "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS": "1",
+        "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.status == SIGNED_WORKER_QUEUE_LOOP_BINDING_READY
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert bootstrap.calls[0]["requested_queue_item_id"] == "queue-1"
+    assert bootstrap.calls[0]["work_order_materializer_mode"] == "authority_profile"
+
+
+def test_runtime_binding_rejects_missing_required_paths(tmp_path: Path) -> None:
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env={"REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1"},
+        bootstrap=_FakeBootstrap(),
+    )
+
+    assert binding.accepted is False
+    assert binding.requested is True
+    assert SignedWorkerOpenClawQueueLoopBindingReason.WORK_STATE_PATH_MISSING in binding.rejection_reasons
+    assert SignedWorkerOpenClawQueueLoopBindingReason.CHAIN_RESULTS_PATH_MISSING in binding.rejection_reasons
+    assert SignedWorkerOpenClawQueueLoopBindingReason.AUTHORITY_PROFILE_PATH_MISSING in binding.rejection_reasons
+
+
 def test_queue_serial_loop_runner_accepts_openclaw_candidate(tmp_path: Path) -> None:
     bootstrap = _FakeBootstrap()
     runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=bootstrap)
@@ -317,39 +396,40 @@ def test_signed_worker_executor_rejects_unsupported_queue_runner_target(tmp_path
 
 
 def test_queue_serial_loop_runner_ast_has_no_shell_network_or_mutation_calls() -> None:
-    source = MODULE_PATH.read_text(encoding="utf-8")
-    tree = ast.parse(source)
     forbidden_text = (
         "subprocess",
         "requests",
-        "socket",
         "holo_index.py --index",
         "create_autonomous_task",
         "complete_autonomous_task",
         "git push",
         "gh pr",
     )
-    for token in forbidden_text:
-        assert token not in source
+    for path in (MODULE_PATH, BINDING_PATH):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for token in forbidden_text:
+            assert token not in source
 
-    imported = set()
-    calls = set()
-    attrs = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imported.update(alias.name.split(".")[0] for alias in node.names)
-        elif isinstance(node, ast.ImportFrom):
-            imported.add((node.module or "").split(".")[0])
-        elif isinstance(node, ast.Call):
-            func = node.func
-            if isinstance(func, ast.Name):
-                calls.add(func.id)
-            elif isinstance(func, ast.Attribute):
-                attrs.add(func.attr)
+        imported = set()
+        calls = set()
+        attrs = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.add((node.module or "").split(".")[0])
+            elif isinstance(node, ast.Call):
+                func = node.func
+                if isinstance(func, ast.Name):
+                    calls.add(func.id)
+                elif isinstance(func, ast.Attribute):
+                    attrs.add(func.attr)
 
-    assert "subprocess" not in imported
-    assert "requests" not in imported
-    assert "eval" not in calls
-    assert "exec" not in calls
-    assert "system" not in attrs
-    assert "popen" not in attrs
+        assert "subprocess" not in imported
+        assert "requests" not in imported
+        assert "socket" not in imported
+        assert "eval" not in calls
+        assert "exec" not in calls
+        assert "system" not in attrs
+        assert "popen" not in attrs


### PR DESCRIPTION
## Summary
- add explicit env/config binding for the OpenClaw signed-worker queue-loop runner
- route exact RedDog signed-worker tasks through the bound runner when enabled
- prevent OpenClaw from claiming non-openclaw signed-worker tasks so Hermes/0102 tasks remain pending for future consumers

## WSP_97 Truth Boundary
- OBSERVED: default signed-worker behavior remains fail-closed when no runner is injected or configured
- OBSERVED: runtime binding is explicit via REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER=1 and outside-repo artifact paths
- OBSERVED: OpenClaw claim surface is restricted to worker_runtime=openclaw and capability=candidate_queue_review
- SPECIFIED_NOT_IMPLEMENTED: Hermes/0102 coding-worker runners, shell execution, source mutation, PR publishing, reward settlement, HoloIndex re-index

## Tests
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q
- python -m compileall -q touched files
- git diff --check
