### PR TITLE
feat(reddog): prove signed worker bounded artifact handoff

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_BOUNDED_ARTIFACT_E2E_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added an end-to-end regression proving an AgentDB signed OpenClaw
+  `candidate_queue_review` task can be claimed, routed through the real
+  environment-bound queue-loop runner, and advance an already authorized queue
+  item into bounded artifact materialization in an isolated worktree.
+- Refined the queue-loop runner safety check: isolated worktree creation and
+  bounded file materialization are allowed only after the upstream queue gates
+  accept; shell execution, OpenClaw enqueue, Hermes dispatch, HoloIndex
+  re-index, PR creation, PatternMemory writes, and reward settlement remain
+  fail-closed.
+- Boundary remains explicit: the proof performs no source checkout write, no
+  shell command, no live model call, no PR publication, no HoloIndex mutation,
+  no PatternMemory admission, and no reward settlement.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_OPENCLAW_QUEUE_LOOP_RUNTIME_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -141,10 +141,7 @@ class RedDogSignedWorkerQueueSerialLoopRunner:
                 ],
                 bootstrap_result=payload,
             )
-        if (
-            payload.get("no_repo_mutation_performed") is not True
-            or payload.get("no_shell_command_executed") is not True
-        ):
+        if _unsafe_bootstrap_effect_detected(payload):
             return _reject(
                 task_id,
                 [SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE],
@@ -202,6 +199,28 @@ def _receipt_id(task_id: str, queue_item_id: str, bootstrap_result: Mapping[str,
             "next_action": bootstrap_result.get("next_action"),
         }
     ).removeprefix("sha256:")[:16]
+
+
+def _unsafe_bootstrap_effect_detected(payload: Mapping[str, Any]) -> bool:
+    """Reject effects outside the signed queue-loop boundary.
+
+    The serial-loop bootstrap is allowed to create an isolated worktree and
+    materialize bounded artifacts there after the upstream valve and writer
+    gates accept. That makes ``no_repo_mutation_performed`` false by design.
+    The runner still fails closed for side effects that are not permitted in
+    this OpenClaw queue-review handoff.
+    """
+
+    guarded_true_flags = (
+        "no_shell_command_executed",
+        "no_openclaw_enqueue_performed",
+        "no_hermes_dispatch_performed",
+        "no_holoindex_reindex_performed",
+        "no_pr_created",
+        "no_pattern_memory_write_performed",
+        "no_reward_settlement_performed",
+    )
+    return any(payload.get(flag) is not True for flag in guarded_true_flags)
 
 
 def _reject(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -29,6 +29,28 @@ from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task
     SignedWorkerDispatchTaskExecutorReason,
     execute_reddog_signed_worker_dispatch_task,
 )
+from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_serial_loop_bootstrap import (
+    NOW as BOOTSTRAP_NOW,
+    PILOT_ARTIFACT,
+    PILOT_OPERATION,
+    REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+    _ed25519_signing_material,
+    _FakeWorkerDispatchTaskWriter,
+    _FakeWorktreeRunner,
+    _pilot_allowed_paths,
+    _pilot_path_overrides,
+    _pilot_payloads,
+    _pilot_worktree_path,
+    _principals,
+    _profile as _bootstrap_profile,
+    _repo,
+    _snapshot as _bootstrap_snapshot,
+    _snapshots,
+    _valve_environment,
+    _work_order,
+    _write_runtime_json,
+    run_reddog_main_resident_queue_serial_loop_bootstrap,
+)
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
 
@@ -355,6 +377,125 @@ def test_run_task_uses_env_bound_queue_loop_runner_when_enabled(
     assert result["structured_result"]["accepted"] is True
     assert runner.calls[0]["task_id"] == task_id
     assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_claim_env_bound_queue_loop_runner_materializes_bounded_artifact(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _bootstrap_profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {str(work_order["work_order_id"]): work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+
+    seed = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worktree_runner=worktree_runner,
+        now_iso=BOOTSTRAP_NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=9,
+    )
+    assert seed.accepted is True
+    assert seed.dispatched_stages[-1] == "worktree_create"
+    assert worktree.exists()
+    assert not (worktree / PILOT_ARTIFACT).exists()
+
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(profile))
+    monkeypatch.setenv("REDDOG_WORK_ORDERS_PATH", str(work_orders))
+    monkeypatch.setenv("REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH", str(generic_writer))
+    monkeypatch.setenv("REDDOG_GOVERNED_SHELL_DRYRUN_RESULT_PATH", str(governed_shell))
+    monkeypatch.setenv("REDDOG_ARTIFACT_CONTENTS_PATH", str(artifacts))
+    monkeypatch.setenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", str(holoindex))
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert result["worker_runtime"] == "openclaw"
+    assert result["capability"] == "candidate_queue_review"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["bounded_worker_pilot"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT"
+    assert stage["bounded_task_execution_performed"] is True
+    assert stage["bounded_file_edit_performed"] is True
+    assert stage["shell_command_executed"] is False
+    assert stage["openclaw_enqueue_performed"] is False
+    assert stage["hermes_dispatch_performed"] is False
+    assert stage["holoindex_reindex_performed"] is False
+    assert (worktree / PILOT_ARTIFACT).read_text(encoding="utf-8").startswith(
+        "# Resident Queue Pilot"
+    )
+    assert not (repo / PILOT_ARTIFACT).exists()
 
 
 def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -189,6 +189,8 @@ def _bootstrap_payload(**overrides):
         "rejection_reasons": (),
         "no_repo_mutation_performed": True,
         "no_shell_command_executed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
         "no_holoindex_reindex_performed": True,
         "no_pr_created": True,
         "no_pattern_memory_write_performed": True,
@@ -360,6 +362,36 @@ def test_queue_serial_loop_runner_rejects_failed_or_unsafe_bootstrap(tmp_path: P
     assert "missing_work_order" in rejected["rejection_reasons"]
     assert unsafe["accepted"] is False
     assert SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE in unsafe["rejection_reasons"]
+
+
+def test_queue_serial_loop_runner_allows_bounded_isolated_worktree_progress(
+    tmp_path: Path,
+) -> None:
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(
+            _bootstrap_payload(
+                no_repo_mutation_performed=False,
+                no_worktree_created=False,
+                no_bounded_task_execution_performed=False,
+                no_bounded_file_edit_performed=False,
+            )
+        ),
+    )
+    context = _context()
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is True
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert result["no_source_repo_mutation_performed"] is True
+    assert result["no_shell_command_executed"] is True
 
 
 def test_signed_worker_executor_accepts_queue_serial_loop_runner(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- prove the real env-bound OpenClaw signed-worker queue-loop runner can advance an already-authorized queue item into bounded artifact materialization
- allow isolated worktree/bounded artifact progress while preserving fail-closed checks for shell, OpenClaw enqueue, Hermes dispatch, HoloIndex re-index, PR, PatternMemory, and reward side effects
- add regression coverage for the runner safety boundary and AgentDB/OpenClaw claim handoff

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q
- python -m compileall -q modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
- git diff --check
- added-line ASCII scan

## Boundary
No source checkout write, shell command, live model call, PR publication, HoloIndex mutation, PatternMemory admission, or reward settlement is introduced by this PR.