### PR TITLE
feat(reddog): bind signed worker draft PR runner

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_VERIFIED_DRAFT_PR_RUNNER_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added draft-PR runner construction to the signed OpenClaw queue-loop
+  environment binding, matching the existing `main.py` resident-loop mode:
+  `REDDOG_DRAFT_PR_RUNNER_MODE=real` plus a positive timeout.
+- Preserved fail-closed behavior for unsupported draft-PR runner modes and
+  invalid timeouts; default behavior still provides no draft-PR runner.
+- Refined the queue-loop runner safety rule so PR creation is accepted only
+  when the dispatched stage is `verified_draft_pr_publish`; unexpected PR
+  creation remains unsafe.
+- Added an end-to-end regression proving an AgentDB signed OpenClaw task can
+  advance from an accepted slice-verifier result to verified draft-PR publish
+  through the environment-bound runner, using a monkeypatched runner so no
+  real GitHub call occurs in tests.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_SLICE_VERIFIER_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -43,6 +43,12 @@ class SignedWorkerOpenClawQueueLoopBindingReason:
     AUTHORITY_PROFILE_PATH_MISSING = "REJECT_SIGNED_WORKER_QUEUE_LOOP_AUTHORITY_PROFILE_PATH_MISSING"
     MAX_STEPS_INVALID = "REJECT_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS_INVALID"
     NOW_EPOCH_INVALID = "REJECT_SIGNED_WORKER_QUEUE_LOOP_NOW_EPOCH_INVALID"
+    DRAFT_PR_RUNNER_MODE_UNSUPPORTED = (
+        "REJECT_SIGNED_WORKER_QUEUE_LOOP_DRAFT_PR_RUNNER_MODE_UNSUPPORTED"
+    )
+    DRAFT_PR_RUNNER_TIMEOUT_INVALID = (
+        "REJECT_SIGNED_WORKER_QUEUE_LOOP_DRAFT_PR_RUNNER_TIMEOUT_INVALID"
+    )
 
 
 @dataclass(frozen=True)
@@ -131,6 +137,12 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
         now_epoch = None
         reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.NOW_EPOCH_INVALID)
 
+    draft_pr_runner, draft_pr_reasons = _build_draft_pr_runner(
+        repo_root=repo_root,
+        env=env,
+    )
+    reasons.extend(draft_pr_reasons)
+
     if reasons:
         return SignedWorkerOpenClawQueueLoopBindingResult(
             accepted=False,
@@ -145,6 +157,8 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
         )
 
     bootstrap_kwargs = _bootstrap_kwargs(env)
+    if draft_pr_runner is not None:
+        bootstrap_kwargs["draft_pr_runner"] = draft_pr_runner
     config = SignedWorkerQueueSerialLoopRunnerConfig(
         work_state_path=str(work_state_path),
         chain_results_path=str(chain_results_path),
@@ -194,7 +208,6 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         "worktree_runner_mode": "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE",
         "artifact_generator_mode": "REDDOG_ARTIFACT_GENERATOR_MODE",
         "evidence_command_runner_mode": "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE",
-        "draft_pr_runner_mode": "REDDOG_DRAFT_PR_RUNNER_MODE",
     }
     payload: dict[str, Any] = {}
     for key, env_name in pairs.items():
@@ -209,6 +222,36 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         if _stripped(env.get(env_name)) == "1":
             payload[key] = True
     return payload
+
+
+def _build_draft_pr_runner(
+    *,
+    repo_root: Path | str,
+    env: Mapping[str, str],
+) -> tuple[Any, tuple[str, ...]]:
+    mode = _stripped(env.get("REDDOG_DRAFT_PR_RUNNER_MODE")).lower()
+    if not mode:
+        return None, ()
+    if mode != "real":
+        return None, (
+            SignedWorkerOpenClawQueueLoopBindingReason.DRAFT_PR_RUNNER_MODE_UNSUPPORTED,
+        )
+    timeout_raw = _stripped(env.get("REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S"))
+    try:
+        timeout_s = int(timeout_raw) if timeout_raw else 120
+    except ValueError:
+        timeout_s = 0
+    if timeout_s <= 0:
+        return None, (
+            SignedWorkerOpenClawQueueLoopBindingReason.DRAFT_PR_RUNNER_TIMEOUT_INVALID,
+        )
+
+    from modules.foundups.agent.src.worktree_pr_runner import RealWorktreeRunner
+
+    return RealWorktreeRunner(
+        repo_root=Path(repo_root).resolve(),
+        timeout_s=timeout_s,
+    ), ()
 
 
 def _stripped(value: Any) -> str:

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -216,11 +216,15 @@ def _unsafe_bootstrap_effect_detected(payload: Mapping[str, Any]) -> bool:
         "no_openclaw_enqueue_performed",
         "no_hermes_dispatch_performed",
         "no_holoindex_reindex_performed",
-        "no_pr_created",
         "no_pattern_memory_write_performed",
         "no_reward_settlement_performed",
     )
-    return any(payload.get(flag) is not True for flag in guarded_true_flags)
+    if any(payload.get(flag) is not True for flag in guarded_true_flags):
+        return True
+    if payload.get("no_pr_created") is True:
+        return False
+    dispatched = set(_string_list(payload.get("dispatched_stages")))
+    return "verified_draft_pr_publish" not in dispatched
 
 
 def _reject(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -34,6 +34,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     PILOT_ARTIFACT,
     PILOT_OPERATION,
     REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+    _draft_pr_publish_request,
     _ed25519_signing_material,
     _FakeWorkerDispatchTaskWriter,
     _FakeWorktreeRunner,
@@ -109,6 +110,24 @@ class _FakeRunner:
             "no_source_repo_mutation_performed": not self.unsafe,
             "no_shell_command_executed": not self.unsafe,
         }
+
+
+class _FakeEnvDraftPrRunner:
+    instances: list["_FakeEnvDraftPrRunner"] = []
+
+    def __init__(self, *, repo_root: Path, timeout_s: int) -> None:
+        self.repo_root = Path(repo_root)
+        self.timeout_s = timeout_s
+        self.calls: list[tuple[str, ...]] = []
+        self.__class__.instances.append(self)
+
+    def push_branch(self, *, worktree_path: Path, branch_name: str):
+        self.calls.append(("push_branch", str(worktree_path), branch_name))
+        return {"ok": True, "branch_name": branch_name}
+
+    def create_draft_pr(self, *, branch_name: str, base_branch: str, title: str, body: str):
+        self.calls.append(("create_draft_pr", branch_name, base_branch, title, body))
+        return "https://github.com/FOUNDUPS/Foundups-Agent/pull/4242"
 
 
 class _FakeBinding:
@@ -624,6 +643,139 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_slice_verifier(
     assert stage["no_holoindex_reindex_performed"] is True
     assert (worktree / PILOT_ARTIFACT).exists()
     assert not (repo / PILOT_ARTIFACT).exists()
+
+
+def test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_draft_pr_publish(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from modules.foundups.agent.src import worktree_pr_runner
+
+    _FakeEnvDraftPrRunner.instances.clear()
+    monkeypatch.setattr(worktree_pr_runner, "RealWorktreeRunner", _FakeEnvDraftPrRunner)
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _bootstrap_profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {str(work_order["work_order_id"]): work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+
+    seed = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worktree_runner=worktree_runner,
+        now_iso=BOOTSTRAP_NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=11,
+    )
+    assert seed.accepted is True
+    assert seed.dispatched_stages[-1] == "slice_verifier"
+
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(profile))
+    monkeypatch.setenv("REDDOG_WORK_ORDERS_PATH", str(work_orders))
+    monkeypatch.setenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", str(publish_request))
+    monkeypatch.setenv("REDDOG_DRAFT_PR_RUNNER_MODE", "real")
+    monkeypatch.setenv("REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S", "88")
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert len(_FakeEnvDraftPrRunner.instances) == 1
+    draft_runner = _FakeEnvDraftPrRunner.instances[0]
+    assert draft_runner.repo_root == repo.resolve()
+    assert draft_runner.timeout_s == 88
+    assert [call[0] for call in draft_runner.calls] == ["push_branch", "create_draft_pr"]
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["verified_draft_pr_publish"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT"
+    assert stage["publish_result"]["decision"] == "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT"
+    assert stage["no_ready_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_pattern_memory_write_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
 
 
 def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -71,6 +71,12 @@ class _FakeBootstrap:
         return _FakeBootstrapResult(self.payload)
 
 
+class _FakeDraftPrRunner:
+    def __init__(self, *, repo_root: Path, timeout_s: int) -> None:
+        self.repo_root = Path(repo_root)
+        self.timeout_s = timeout_s
+
+
 def _digest(value: object) -> str:
     raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
     return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
@@ -265,6 +271,67 @@ def test_runtime_binding_rejects_missing_required_paths(tmp_path: Path) -> None:
     assert SignedWorkerOpenClawQueueLoopBindingReason.AUTHORITY_PROFILE_PATH_MISSING in binding.rejection_reasons
 
 
+def test_runtime_binding_builds_draft_pr_runner_when_requested(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from modules.foundups.agent.src import worktree_pr_runner
+
+    monkeypatch.setattr(worktree_pr_runner, "RealWorktreeRunner", _FakeDraftPrRunner)
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        "REDDOG_DRAFT_PR_RUNNER_MODE": "real",
+        "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "88",
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    draft_runner = bootstrap.calls[0]["draft_pr_runner"]
+    assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
+    assert draft_runner.repo_root == tmp_path.resolve()
+    assert draft_runner.timeout_s == 88
+
+
+def test_runtime_binding_rejects_unsupported_draft_pr_runner_mode(tmp_path: Path) -> None:
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env={
+            "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+            "REDDOG_DRAFT_PR_RUNNER_MODE": "unsafe",
+        },
+        bootstrap=_FakeBootstrap(),
+    )
+
+    assert binding.accepted is False
+    assert binding.requested is True
+    assert (
+        SignedWorkerOpenClawQueueLoopBindingReason.DRAFT_PR_RUNNER_MODE_UNSUPPORTED
+        in binding.rejection_reasons
+    )
+
+
 def test_queue_serial_loop_runner_accepts_openclaw_candidate(tmp_path: Path) -> None:
     bootstrap = _FakeBootstrap()
     runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=bootstrap)
@@ -392,6 +459,59 @@ def test_queue_serial_loop_runner_allows_bounded_isolated_worktree_progress(
     assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
     assert result["no_source_repo_mutation_performed"] is True
     assert result["no_shell_command_executed"] is True
+
+
+def test_queue_serial_loop_runner_allows_verified_draft_pr_publish_progress(
+    tmp_path: Path,
+) -> None:
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(
+            _bootstrap_payload(
+                dispatched_stages=("verified_draft_pr_publish",),
+                no_pr_created=False,
+                next_action="RUN_QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE",
+            )
+        ),
+    )
+    context = _context()
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is True
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert result["no_pr_created"] is False
+    assert result["no_shell_command_executed"] is True
+
+
+def test_queue_serial_loop_runner_rejects_unexpected_pr_creation(tmp_path: Path) -> None:
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(
+            _bootstrap_payload(
+                dispatched_stages=("slice_verifier",),
+                no_pr_created=False,
+            )
+        ),
+    )
+    context = _context()
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE in result["rejection_reasons"]
 
 
 def test_signed_worker_executor_accepts_queue_serial_loop_runner(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary

Implements `REDDOG_SIGNED_WORKER_VERIFIED_DRAFT_PR_RUNNER_BINDING_PHASE1`.

- Adds env-bound construction of the draft PR runner for the signed OpenClaw queue-loop path.
- Keeps default behavior fail-closed: no runner unless `REDDOG_DRAFT_PR_RUNNER_MODE=real` is explicitly configured with a positive timeout.
- Rejects unsupported runner modes and invalid timeouts before runtime bootstrap.
- Allows the serial loop to treat `verified_draft_pr_publish` as an expected bounded effect while continuing to reject unexpected PR creation.
- Adds an AgentDB signed OpenClaw task regression proving an already accepted slice-verifier item can advance into `verified_draft_pr_publish` through the env-bound runner path with a monkeypatched PR runner.

## Boundaries

- No automatic merge or ready-for-review promotion.
- No PatternMemory, HoloIndex, reward, ready-for-review, or merge authority.
- No extension runtime changes.
- No real GitHub calls in tests; runner is injected/monkeypatched.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 30 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 119 passed
- `python -m compileall -q modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py` -> pass
- `git diff --check` -> clean
- added-line ASCII scan -> clean
