### PR TITLE
test(reddog): prove signed worker outcome ratchet handoff

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_VERIFIED_OUTCOME_RATCHET_E2E_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added an end-to-end regression proving an AgentDB signed OpenClaw
+  `candidate_queue_review` task can be claimed, routed through the real
+  environment-bound queue-loop runner, and advance an accepted verified draft
+  PR publish result into the verified-outcome ratchet stage.
+- Verified the env-bound runner consumes an outside-repo ratchet request and
+  writes the outcome ratchet JSONL store only outside the source repository.
+- Boundary remains explicit: no shell execution, PR publish, ready-for-review,
+  merge, PatternMemory admission, HoloIndex re-index, or reward settlement is
+  performed by this slice.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_VERIFIED_DRAFT_PR_RUNNER_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -38,6 +38,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     _ed25519_signing_material,
     _FakeWorkerDispatchTaskWriter,
     _FakeWorktreeRunner,
+    _outcome_ratchet_request,
     _pilot_allowed_paths,
     _pilot_path_overrides,
     _pilot_payloads,
@@ -776,6 +777,155 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_draft_pr_pu
     assert stage["no_pattern_memory_write_performed"] is True
     assert stage["no_reward_settlement_performed"] is True
     assert stage["no_holoindex_reindex_performed"] is True
+
+
+def test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_outcome_ratchet(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _bootstrap_profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {str(work_order["work_order_id"]): work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+    draft_runner = _FakeEnvDraftPrRunner(repo_root=repo, timeout_s=88)
+
+    seed = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        generic_writer_dryrun_result_path=generic_writer,
+        governed_shell_dryrun_result_path=governed_shell,
+        artifact_contents_path=artifacts,
+        holoindex_evidence_path=holoindex,
+        verifier_request_path=verifier,
+        publish_request_path=publish_request,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worktree_runner=worktree_runner,
+        draft_pr_runner=draft_runner,
+        now_iso=BOOTSTRAP_NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=12,
+    )
+    assert seed.accepted is True
+    assert seed.dispatched_stages[-1] == "verified_draft_pr_publish"
+    seeded = json.loads(chain.read_text(encoding="utf-8"))
+    verifier_stage = seeded["stage_results"]["slice_verifier"]
+    publish_stage = seeded["stage_results"]["verified_draft_pr_publish"]
+    assert publish_stage["publish_result"]["decision"] == "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT"
+
+    ratchet_request = _write_runtime_json(
+        tmp_path,
+        "ratchet_request.json",
+        _outcome_ratchet_request(verifier_stage["verifier_result"]),
+    )
+    outcome_store = tmp_path / "runtime" / "outcomes" / "signed-worker-ratchet.jsonl"
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(profile))
+    monkeypatch.setenv("REDDOG_WORK_ORDERS_PATH", str(work_orders))
+    monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_REQUEST_PATH", str(ratchet_request))
+    monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", str(outcome_store))
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["verified_outcome_ratchet"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT"
+    assert stage["ratchet_result"]["decision"] == "OUTCOME_RATCHET_RECORDED"
+    assert stage["ratchet_result"]["receipt"]["pattern_memory_write_performed"] is False
+    assert stage["no_command_execution_performed"] is True
+    assert stage["no_pr_publish_performed"] is True
+    assert stage["no_ready_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+    assert "held_out_regression_gate" not in stored["stage_results"]
+
+    records = [
+        json.loads(line)
+        for line in outcome_store.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(records) == 1
+    assert records[0]["ratchet_receipt"]["work_order_id"] == work_order["work_order_id"]
+    assert records[0]["publish_result"]["decision"] == "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT"
+    assert not (repo / "runtime" / "outcomes" / "signed-worker-ratchet.jsonl").exists()
 
 
 def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary

Implements `REDDOG_SIGNED_WORKER_VERIFIED_OUTCOME_RATCHET_E2E_PHASE1`.

- Adds an AgentDB/OpenClaw signed-worker e2e regression proving the env-bound queue-loop runner can advance an already accepted `verified_draft_pr_publish` stage into `verified_outcome_ratchet`.
- Reuses the existing signed authority, WSP_15 allocation, queue item, verifier receipt, draft PR publish receipt, and outcome-ratchet request path.
- Verifies the ratchet JSONL store is written only outside the source repo.

## Boundaries

- Test-only runtime proof; no production behavior change.
- No shell execution, PR publish, ready-for-review, merge, PatternMemory admission, HoloIndex re-index, or reward settlement.
- No extension runtime changes.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py::test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_outcome_ratchet -q` -> 1 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 120 passed
- `python -m compileall -q modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py` -> pass
- `git diff --check` -> clean
- added-line ASCII scan -> clean
