### PR TITLE
feat(reddog): bind signed worker pattern memory admission

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_PATTERN_MEMORY_ADMISSION_E2E_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added PatternMemory admission sink construction to the signed OpenClaw
+  queue-loop environment binding using the existing explicit outside-repo
+  `REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH` adapter.
+- Refined the signed queue-loop safety classifier so a PatternMemory write is
+  accepted only when the dispatched stage is `pattern_memory_admission`;
+  unexpected memory writes remain fail-closed.
+- Added an end-to-end regression proving an AgentDB signed OpenClaw task can
+  advance from an accepted held-out gate into PatternMemory admission and write
+  exactly one verified outcome record to an outside-repo SQLite database.
+- Boundary remains explicit: no shell execution, PR publish, ready-for-review,
+  merge, HoloIndex re-index, or reward settlement is performed by this slice.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_HELD_OUT_REGRESSION_GATE_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -49,6 +49,9 @@ class SignedWorkerOpenClawQueueLoopBindingReason:
     DRAFT_PR_RUNNER_TIMEOUT_INVALID = (
         "REJECT_SIGNED_WORKER_QUEUE_LOOP_DRAFT_PR_RUNNER_TIMEOUT_INVALID"
     )
+    PATTERN_MEMORY_ADMISSION_DB_PATH_INVALID = (
+        "REJECT_SIGNED_WORKER_QUEUE_LOOP_PATTERN_MEMORY_ADMISSION_DB_PATH_INVALID"
+    )
 
 
 @dataclass(frozen=True)
@@ -142,6 +145,11 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
         env=env,
     )
     reasons.extend(draft_pr_reasons)
+    pattern_memory_admission_sink, pattern_memory_reasons = _build_pattern_memory_admission_sink(
+        repo_root=repo_root,
+        env=env,
+    )
+    reasons.extend(pattern_memory_reasons)
 
     if reasons:
         return SignedWorkerOpenClawQueueLoopBindingResult(
@@ -159,6 +167,8 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
     bootstrap_kwargs = _bootstrap_kwargs(env)
     if draft_pr_runner is not None:
         bootstrap_kwargs["draft_pr_runner"] = draft_pr_runner
+    if pattern_memory_admission_sink is not None:
+        bootstrap_kwargs["pattern_memory_admission_sink"] = pattern_memory_admission_sink
     config = SignedWorkerQueueSerialLoopRunnerConfig(
         work_state_path=str(work_state_path),
         chain_results_path=str(chain_results_path),
@@ -252,6 +262,31 @@ def _build_draft_pr_runner(
         repo_root=Path(repo_root).resolve(),
         timeout_s=timeout_s,
     ), ()
+
+
+def _build_pattern_memory_admission_sink(
+    *,
+    repo_root: Path | str,
+    env: Mapping[str, str],
+) -> tuple[Any, tuple[str, ...]]:
+    db_path = _stripped(env.get("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH"))
+    if not db_path:
+        return None, ()
+
+    from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
+        PatternMemorySinkConfigurationError,
+        build_reddog_verified_pattern_memory_sink,
+    )
+
+    try:
+        return build_reddog_verified_pattern_memory_sink(
+            repo_root=repo_root,
+            db_path=db_path,
+        ), ()
+    except PatternMemorySinkConfigurationError:
+        return None, (
+            SignedWorkerOpenClawQueueLoopBindingReason.PATTERN_MEMORY_ADMISSION_DB_PATH_INVALID,
+        )
 
 
 def _stripped(value: Any) -> str:

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -216,15 +216,19 @@ def _unsafe_bootstrap_effect_detected(payload: Mapping[str, Any]) -> bool:
         "no_openclaw_enqueue_performed",
         "no_hermes_dispatch_performed",
         "no_holoindex_reindex_performed",
-        "no_pattern_memory_write_performed",
         "no_reward_settlement_performed",
     )
     if any(payload.get(flag) is not True for flag in guarded_true_flags):
         return True
-    if payload.get("no_pr_created") is True:
-        return False
     dispatched = set(_string_list(payload.get("dispatched_stages")))
-    return "verified_draft_pr_publish" not in dispatched
+    if (
+        payload.get("no_pattern_memory_write_performed") is not True
+        and "pattern_memory_admission" not in dispatched
+    ):
+        return True
+    if payload.get("no_pr_created") is not True and "verified_draft_pr_publish" not in dispatched:
+        return True
+    return False
 
 
 def _reject(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -40,6 +41,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     _FakeWorktreeRunner,
     _held_out_gate_request,
     _outcome_ratchet_request,
+    _pattern_memory_admission_request,
     _pilot_allowed_paths,
     _pilot_path_overrides,
     _pilot_payloads,
@@ -50,6 +52,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     _slice_verifier_request,
     _snapshot as _bootstrap_snapshot,
     _snapshots,
+    _run_bootstrap_to_held_out_regression_gate,
     _run_bootstrap_to_verified_outcome_ratchet,
     _valve_environment,
     _work_order,
@@ -974,6 +977,56 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_held_out_regression_
     assert stage["no_reward_settlement_performed"] is True
     assert stage["no_holoindex_reindex_performed"] is True
     assert "pattern_memory_admission" not in stored["stage_results"]
+
+
+def test_openclaw_claim_env_bound_queue_loop_runner_reaches_pattern_memory_admission(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    ctx = _run_bootstrap_to_held_out_regression_gate(tmp_path)
+    admission_request = _write_runtime_json(
+        tmp_path,
+        "pattern_memory_admission_request.json",
+        _pattern_memory_admission_request(),
+    )
+    pattern_memory_db = tmp_path / "runtime" / "pattern_memory.db"
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(ctx["state"]))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(ctx["chain"]))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(ctx["profile"]))
+    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH", str(admission_request))
+    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", str(pattern_memory_db))
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=ctx["repo"])
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+    stored = json.loads(Path(ctx["chain"]).read_text(encoding="utf-8"))
+    stage = stored["stage_results"]["pattern_memory_admission"]
+    assert stage["decision"] == "QUEUE_AUTHORIZED_PATTERN_MEMORY_ADMISSION_INVOKE_ACCEPT"
+    assert stage["pattern_memory_write_performed"] is True
+    assert stage["receipt"]["pattern_memory_record_id"].startswith("reddog_verified_outcome_")
+    assert stage["no_command_execution_performed"] is True
+    assert stage["no_pr_publish_performed"] is True
+    assert stage["no_merge_performed"] is True
+    assert stage["no_reward_settlement_performed"] is True
+    assert stage["no_holoindex_reindex_performed"] is True
+
+    with sqlite3.connect(pattern_memory_db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM skill_outcomes").fetchone()[0]
+        execution_id = conn.execute(
+            "SELECT execution_id FROM skill_outcomes LIMIT 1"
+        ).fetchone()[0]
+    assert count == 1
+    assert execution_id == stage["receipt"]["pattern_memory_record_id"]
+    assert not (ctx["repo"] / "runtime" / "pattern_memory.db").exists()
 
 
 def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -332,6 +332,67 @@ def test_runtime_binding_rejects_unsupported_draft_pr_runner_mode(tmp_path: Path
     )
 
 
+def test_runtime_binding_builds_pattern_memory_admission_sink_from_outside_repo_db(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(tmp_path / "pattern_memory.db"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=repo,
+    )
+
+    assert result["accepted"] is True
+    sink = bootstrap.calls[0]["pattern_memory_admission_sink"]
+    assert sink.__class__.__name__ == "RedDogVerifiedPatternMemorySink"
+    assert sink.db_path == (tmp_path / "pattern_memory.db").resolve()
+
+
+def test_runtime_binding_rejects_pattern_memory_admission_db_inside_repo(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo,
+        env={
+            "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+            "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(repo / "pattern_memory.db"),
+        },
+        bootstrap=_FakeBootstrap(),
+    )
+
+    assert binding.accepted is False
+    assert binding.requested is True
+    assert (
+        SignedWorkerOpenClawQueueLoopBindingReason.PATTERN_MEMORY_ADMISSION_DB_PATH_INVALID
+        in binding.rejection_reasons
+    )
+
+
 def test_queue_serial_loop_runner_accepts_openclaw_candidate(tmp_path: Path) -> None:
     bootstrap = _FakeBootstrap()
     runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=bootstrap)
@@ -497,6 +558,62 @@ def test_queue_serial_loop_runner_rejects_unexpected_pr_creation(tmp_path: Path)
             _bootstrap_payload(
                 dispatched_stages=("slice_verifier",),
                 no_pr_created=False,
+            )
+        ),
+    )
+    context = _context()
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE in result["rejection_reasons"]
+
+
+def test_queue_serial_loop_runner_allows_pattern_memory_admission_progress(
+    tmp_path: Path,
+) -> None:
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(
+            _bootstrap_payload(
+                dispatched_stages=("pattern_memory_admission",),
+                no_pattern_memory_write_performed=False,
+                next_action="STOP_QUEUE_CHAIN_COMPLETE",
+            )
+        ),
+    )
+    context = _context()
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is True
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert result["no_pattern_memory_write_performed"] is False
+    assert result["no_reward_settlement_performed"] is True
+    assert result["no_holoindex_reindex_performed"] is True
+
+
+def test_queue_serial_loop_runner_rejects_unexpected_pattern_memory_write(
+    tmp_path: Path,
+) -> None:
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(
+        _config(tmp_path),
+        bootstrap=_FakeBootstrap(
+            _bootstrap_payload(
+                dispatched_stages=("held_out_regression_gate",),
+                no_pattern_memory_write_performed=False,
             )
         ),
     )


### PR DESCRIPTION
﻿## Summary

Implements `REDDOG_SIGNED_WORKER_PATTERN_MEMORY_ADMISSION_E2E_PHASE1`.

- Adds env-bound construction of the existing explicit outside-repo `RedDogVerifiedPatternMemorySink` for signed OpenClaw queue-loop execution.
- Refines signed queue-loop safety so PatternMemory writes are accepted only when the dispatched stage is `pattern_memory_admission`; unexpected memory writes remain unsafe.
- Adds an AgentDB/OpenClaw signed-worker e2e regression proving the env-bound queue-loop runner can advance an accepted held-out gate into PatternMemory admission and persist exactly one verified outcome record to an outside-repo SQLite database.

## Boundaries

- PatternMemory write is allowed only for the final `pattern_memory_admission` stage.
- No shell execution, PR publish, ready-for-review, merge, HoloIndex re-index, or reward settlement.
- No extension runtime changes.

## Validation

- focused PatternMemory binding/e2e tests -> 5 passed
- resident queue/OpenClaw regression set -> 126 passed
- `python -m compileall -q modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py` -> pass
- `git diff --check` -> clean
- added-line ASCII scan -> clean
