### PR TITLE
feat(reddog): add bounded OpenClaw signed worker claim loop

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_UNTIL_IDLE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a bounded OpenClaw signed-worker claim loop that reuses the existing
+  one-task `claim_reddog_signed_worker_dispatch_task_once` primitive until
+  AgentDB is idle or `max_claims` is reached.
+- Preserved the signed OpenClaw `candidate_queue_review` boundary; the loop
+  does not add Hermes/0102 dispatch, shell execution, repository mutation,
+  HoloIndex re-index, reward settlement, or merge authority.
+- Added focused AgentDB regressions for multi-task draining, max-claim
+  stopping, idle behavior, non-OpenClaw task isolation, failure stop, invalid
+  max-claim rejection, and the `OpenClawSupervisor` instance entrypoint.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_PATTERN_MEMORY_ADMISSION_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -42,6 +42,9 @@ READONLY_AUDIT_OPENCLAW_CLAIM_REJECT = "READONLY_AUDIT_OPENCLAW_CLAIM_REJECT"
 SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT = "SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT"
 SIGNED_WORKER_OPENCLAW_CLAIM_IDLE = "SIGNED_WORKER_OPENCLAW_CLAIM_IDLE"
 SIGNED_WORKER_OPENCLAW_CLAIM_REJECT = "SIGNED_WORKER_OPENCLAW_CLAIM_REJECT"
+SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT = "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT"
+SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE = "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE"
+SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT = "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT"
 
 
 class ReadOnlyAuditOpenClawClaimReason:
@@ -59,6 +62,8 @@ class SignedWorkerOpenClawClaimReason:
     MALFORMED_CONTEXT = "REJECT_REDDOG_SIGNED_WORKER_MALFORMED_CONTEXT"
     TASK_EXECUTION_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_TASK_EXECUTION_REJECTED"
     AGENTDB_FAILURE = "REJECT_REDDOG_SIGNED_WORKER_AGENTDB_FAILURE"
+    MAX_CLAIMS_INVALID = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_MAX_CLAIMS_INVALID"
+    CLAIM_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_CLAIM_REJECTED"
 
 
 @dataclass
@@ -363,6 +368,94 @@ def claim_reddog_signed_worker_dispatch_task_once(
     )
 
 
+def claim_reddog_signed_worker_dispatch_tasks_until_idle(
+    *,
+    repo_root: Path,
+    agent_id: str = "openclaw_supervisor",
+    agent_db_factory: Optional[Callable[[], Any]] = None,
+    signed_worker_runner: Any | None = None,
+    max_claims: int = 1,
+) -> Dict[str, Any]:
+    """Claim signed RedDog worker-dispatch tasks until idle or max_claims.
+
+    This bounded resident-loop wrapper widens no authority: each task is still
+    claimed by the existing OpenClaw one-shot primitive and validated by the
+    signed-worker task executor.
+    """
+
+    if not isinstance(max_claims, int) or isinstance(max_claims, bool) or max_claims < 1:
+        return _signed_worker_claim_loop_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.MAX_CLAIMS_INVALID,),
+            max_claims=max_claims,
+        )
+
+    claim_results: list[Dict[str, Any]] = []
+    completed_task_ids: list[str] = []
+    failed_task_ids: list[str] = []
+    idle = False
+
+    for _ in range(max_claims):
+        claim = claim_reddog_signed_worker_dispatch_task_once(
+            repo_root=repo_root,
+            agent_id=agent_id,
+            agent_db_factory=agent_db_factory,
+            signed_worker_runner=signed_worker_runner,
+        )
+        claim_results.append(claim)
+
+        task_id = str(claim.get("task_id") or "")
+        status = str(claim.get("status") or "")
+        if claim.get("accepted") is True and status == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT:
+            if task_id:
+                completed_task_ids.append(task_id)
+            continue
+
+        if status == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE:
+            idle = True
+            break
+
+        if task_id:
+            failed_task_ids.append(task_id)
+        return _signed_worker_claim_loop_result(
+            accepted=False,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
+            rejection_reasons=(
+                SignedWorkerOpenClawClaimReason.CLAIM_REJECTED,
+                *tuple(claim.get("rejection_reasons") or ()),
+            ),
+            max_claims=max_claims,
+            claim_results=tuple(claim_results),
+            completed_task_ids=tuple(completed_task_ids),
+            failed_task_ids=tuple(failed_task_ids),
+            idle=idle,
+        )
+
+    if completed_task_ids:
+        return _signed_worker_claim_loop_result(
+            accepted=True,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT,
+            max_claims=max_claims,
+            claim_results=tuple(claim_results),
+            completed_task_ids=tuple(completed_task_ids),
+            failed_task_ids=tuple(failed_task_ids),
+            idle=idle,
+            max_claims_reached=(not idle and len(completed_task_ids) >= max_claims),
+        )
+
+    return _signed_worker_claim_loop_result(
+        accepted=True,
+        status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE,
+        rejection_reasons=(SignedWorkerOpenClawClaimReason.NO_PENDING_TASK,),
+        max_claims=max_claims,
+        claim_results=tuple(claim_results),
+        completed_task_ids=tuple(completed_task_ids),
+        failed_task_ids=tuple(failed_task_ids),
+        idle=True,
+    )
+
+
 def _claim_pending_reddog_readonly_audit_task(*, db: Any, agent_id: str, source: str) -> Optional[Dict[str, Any]]:
     with db.db.get_connection() as conn:
         row = conn.execute(
@@ -543,6 +636,51 @@ def _signed_worker_claim_result(
     }
 
 
+def _signed_worker_claim_loop_result(
+    *,
+    accepted: bool,
+    status: str,
+    max_claims: int,
+    claim_results=(),
+    completed_task_ids=(),
+    failed_task_ids=(),
+    rejection_reasons=(),
+    idle: bool = False,
+    max_claims_reached: bool = False,
+) -> Dict[str, Any]:
+    results = tuple(claim_results or ())
+    no_fields = (
+        "no_shell_command_executed",
+        "no_repo_mutation_performed",
+        "no_holoindex_reindex_performed",
+        "no_hermes_dispatch_performed",
+        "no_worktree_operation_performed",
+        "no_pr_created",
+        "no_live_foundup_enqueue_performed",
+        "no_pattern_memory_write_performed",
+        "no_reward_settlement_performed",
+    )
+    aggregate_no = {
+        key: all(bool(result.get(key, True)) for result in results)
+        for key in no_fields
+    }
+    return {
+        "accepted": accepted,
+        "status": status,
+        "max_claims": max_claims,
+        "claimed_count": len(tuple(completed_task_ids or ())),
+        "completed_task_ids": tuple(completed_task_ids or ()),
+        "failed_task_ids": tuple(failed_task_ids or ()),
+        "idle": idle,
+        "max_claims_reached": max_claims_reached,
+        "claim_results": results,
+        "rejection_reasons": tuple(
+            dict.fromkeys(str(reason) for reason in rejection_reasons if str(reason))
+        ),
+        **aggregate_no,
+    }
+
+
 class OpenClawSupervisor:
     """
     Canonical 0102 supervisor for the resident OpenClaw runtime.
@@ -625,6 +763,23 @@ class OpenClawSupervisor:
             agent_id="openclaw_supervisor",
             agent_db_factory=agent_db_factory,
             signed_worker_runner=signed_worker_runner,
+        )
+
+    def claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        self,
+        *,
+        agent_db_factory: Optional[Callable[[], Any]] = None,
+        signed_worker_runner: Any | None = None,
+        max_claims: int = 1,
+    ) -> Dict[str, Any]:
+        """Claim signed RedDog worker-dispatch tasks until idle/max."""
+
+        return claim_reddog_signed_worker_dispatch_tasks_until_idle(
+            repo_root=self.repo_root,
+            agent_id="openclaw_supervisor",
+            agent_db_factory=agent_db_factory,
+            signed_worker_runner=signed_worker_runner,
+            max_claims=max_claims,
         )
 
     def stop(self) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -18,9 +18,13 @@ from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
     OpenClawSupervisor,
     SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
     SIGNED_WORKER_OPENCLAW_CLAIM_IDLE,
+    SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT,
+    SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE,
+    SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
     SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
     SignedWorkerOpenClawClaimReason,
     claim_reddog_signed_worker_dispatch_task_once,
+    claim_reddog_signed_worker_dispatch_tasks_until_idle,
 )
 from modules.communication.moltbot_bridge.src.reddog_signed_authority_worker_dispatch_dryrun import (
     SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT,
@@ -1097,6 +1101,141 @@ def test_openclaw_claim_rejects_without_runner_and_idle_when_empty(tmp_path: Pat
     assert db.get_autonomous_task_by_id(task_id)["status"] == "failed"
     assert idle["accepted"] is False
     assert idle["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+
+
+def test_openclaw_claim_loop_claims_until_idle(tmp_path: Path) -> None:
+    task_id_1 = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_1")
+    task_id_2 = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_2")
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+        max_claims=5,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT
+    assert result["claimed_count"] == 2
+    assert set(result["completed_task_ids"]) == {task_id_1, task_id_2}
+    assert result["failed_task_ids"] == ()
+    assert result["idle"] is True
+    assert result["max_claims_reached"] is False
+    assert len(result["claim_results"]) == 3
+    assert result["claim_results"][-1]["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert db.get_autonomous_task_by_id(task_id_1)["status"] == "completed"
+    assert db.get_autonomous_task_by_id(task_id_2)["status"] == "completed"
+    assert result["no_shell_command_executed"] is True
+    assert result["no_repo_mutation_performed"] is True
+    assert result["no_holoindex_reindex_performed"] is True
+    assert result["no_hermes_dispatch_performed"] is True
+
+
+def test_openclaw_claim_loop_respects_max_claims(tmp_path: Path) -> None:
+    task_id_1 = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_1")
+    task_id_2 = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_2")
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+        max_claims=1,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT
+    assert result["claimed_count"] == 1
+    assert result["completed_task_ids"] == (task_id_1,)
+    assert result["max_claims_reached"] is True
+    assert result["idle"] is False
+    assert db.get_autonomous_task_by_id(task_id_1)["status"] == "completed"
+    assert db.get_autonomous_task_by_id(task_id_2)["status"] == "pending"
+
+
+def test_openclaw_claim_loop_reports_idle_without_work(tmp_path: Path) -> None:
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+        max_claims=3,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE
+    assert result["claimed_count"] == 0
+    assert result["idle"] is True
+    assert SignedWorkerOpenClawClaimReason.NO_PENDING_TASK in result["rejection_reasons"]
+
+
+def test_openclaw_claim_loop_ignores_non_openclaw_tasks(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task(
+        intent_id="worker_dispatch_intent_hermes_candidate",
+        role="hermes_candidate",
+        worker_runtime="hermes",
+        capability="bounded_code_change",
+    )
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+        max_claims=3,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE
+    assert result["claimed_count"] == 0
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "pending"
+
+
+def test_openclaw_claim_loop_stops_after_first_rejected_claim(tmp_path: Path) -> None:
+    task_id_1 = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_1")
+    task_id_2 = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_2")
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(accepted=False),
+        max_claims=5,
+    )
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT
+    assert result["claimed_count"] == 0
+    assert len(result["failed_task_ids"]) == 1
+    assert SignedWorkerOpenClawClaimReason.CLAIM_REJECTED in result["rejection_reasons"]
+    statuses = {
+        task_id_1: db.get_autonomous_task_by_id(task_id_1)["status"],
+        task_id_2: db.get_autonomous_task_by_id(task_id_2)["status"],
+    }
+    assert sorted(statuses.values()) == ["failed", "pending"]
+
+
+def test_openclaw_claim_loop_rejects_invalid_max_claims(tmp_path: Path) -> None:
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(),
+        max_claims=0,
+    )
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT
+    assert SignedWorkerOpenClawClaimReason.MAX_CLAIMS_INVALID in result["rejection_reasons"]
+
+
+def test_openclaw_supervisor_instance_claims_signed_worker_tasks_until_idle(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_1")
+    supervisor = OpenClawSupervisor(repo_root=tmp_path)
+
+    result = supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        signed_worker_runner=_FakeRunner(),
+        max_claims=2,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT
+    assert result["completed_task_ids"] == (task_id,)
+    assert result["idle"] is True
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
 
 
 def test_signed_worker_executor_ast_has_no_shell_network_or_runtime_mutation() -> None:


### PR DESCRIPTION
## Summary

- Add `claim_reddog_signed_worker_dispatch_tasks_until_idle()` as a bounded OpenClaw loop over the existing signed-worker one-shot claim primitive.
- Add an `OpenClawSupervisor` instance entrypoint for resident runtime callers.
- Add AgentDB regressions for multi-task draining, max-claim stopping, idle behavior, non-OpenClaw task isolation, rejection stop, invalid max-claim rejection, and supervisor instance use.

## WSP_97 Truth Boundary

OBSERVED:
- Reuses `claim_reddog_signed_worker_dispatch_task_once`; every task still passes through the existing signed-worker executor.
- Scope remains OpenClaw `candidate_queue_review`; Hermes/0102 worker dispatch is not enabled by this slice.
- Loop is bounded by `max_claims`; there is no infinite resident loop.
- Failure on any claimed task stops the loop and reports the rejected claim.

NOT IMPLEMENTED:
- No Hermes/0102 coding-worker dispatch.
- No shell execution, repository mutation, HoloIndex re-index, reward settlement, merge, or new live authority.
- No `main.py` resident loop wiring change.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 25 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 103 passed
- `python -m compileall -q modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py`
- `git diff --check` -> clean, with existing CRLF normalization warnings only