### PR TITLE
feat(reddog): run signed worker claim loop from OpenClaw supervisor

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_OPENCLAW_SUPERVISOR_SIGNED_WORKER_LOOP_RUNTIME_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Wired the bounded signed-worker claim loop into `OpenClawSupervisor` as an
+  explicit opt-in resident action gated by `OPENCLAW_SIGNED_WORKER_TASKS_ENABLED=1`.
+- Added bounded claim limit parsing via `OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS`
+  and fail-closed triage for invalid limits before any AgentDB claim.
+- Added run-cycle regressions proving signed OpenClaw candidate tasks are
+  selected before generic autonomous tasks when enabled, and that invalid
+  loop configuration escalates without invoking the claim loop.
+- Boundary remains explicit: no default enablement, no Hermes/0102 dispatch,
+  no shell execution, no repository mutation, no HoloIndex re-index, no reward
+  settlement, and no merge authority is added.
+
 ## 2026-07-16: REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_UNTIL_IDLE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -681,6 +681,36 @@ def _signed_worker_claim_loop_result(
     }
 
 
+def _signed_worker_task_max_claims_from_env() -> tuple[int, str | None]:
+    raw = os.getenv("OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS", "1").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0, SignedWorkerOpenClawClaimReason.MAX_CLAIMS_INVALID
+    if value < 1:
+        return value, SignedWorkerOpenClawClaimReason.MAX_CLAIMS_INVALID
+    return value, None
+
+
+def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
+    from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+        SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    )
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+        is_openclaw_candidate_signed_worker_context,
+    )
+    from modules.infrastructure.database.src.agent_db import AgentDB
+
+    db = AgentDB()
+    for task in db.get_autonomous_tasks(status="pending", limit=limit):
+        if str(task.get("discovered_by") or "") != SIGNED_WORKER_DISPATCH_TASK_SOURCE:
+            continue
+        context = task.get("context")
+        if is_openclaw_candidate_signed_worker_context(context if isinstance(context, dict) else None):
+            return True
+    return False
+
+
 class OpenClawSupervisor:
     """
     Canonical 0102 supervisor for the resident OpenClaw runtime.
@@ -1169,6 +1199,22 @@ class OpenClawSupervisor:
                 "restart_budget": observation.get("restart_budget", {}),
             }
 
+        signed_worker_tasks_enabled = os.getenv("OPENCLAW_SIGNED_WORKER_TASKS_ENABLED", "0") == "1"
+        if signed_worker_tasks_enabled:
+            max_claims, max_claims_error = _signed_worker_task_max_claims_from_env()
+            if max_claims_error:
+                return {"kind": "escalate", "reason": max_claims_error}
+            try:
+                if _has_pending_reddog_signed_worker_dispatch_task():
+                    return {
+                        "kind": "action",
+                        "reason": "signed_worker_task_pending",
+                        "action": "claim_signed_worker_tasks_until_idle",
+                        "max_claims": max_claims,
+                    }
+            except Exception as exc:
+                logger.warning("Failed to check signed worker tasks: %s", exc)
+
         # Check AgentDB for pending autonomous tasks
         # CIRCUIT BREAKER: Only auto-execute if explicitly enabled by 012
         # Set OPENCLAW_AUTO_TASKS_ENABLED=1 after menu choice to activate
@@ -1338,6 +1384,9 @@ class OpenClawSupervisor:
         if triage["action"] == "execute_maintenance_task":
             plan["maintenance_selection"] = triage.get("maintenance_selection", {})
 
+        if triage["action"] == "claim_signed_worker_tasks_until_idle":
+            plan["max_claims"] = triage.get("max_claims", 1)
+
         # WSP 77: AI Overseer fast classification (Gemma 50-100ms)
         if self._ai_overseer is not None:
             try:
@@ -1389,6 +1438,50 @@ class OpenClawSupervisor:
                         _re_fail("openclaw_supervisor", "supervisor_execute", _rt_start,
                                  result.get("error", "unknown")[:200],
                                  details={"action": "start_openclaw"})
+                except Exception:
+                    pass
+            return result
+
+        elif plan["action"] == "claim_signed_worker_tasks_until_idle":
+            max_claims = plan.get("max_claims", 1)
+            result = self.claim_reddog_signed_worker_dispatch_tasks_until_idle(
+                max_claims=max_claims if isinstance(max_claims, int) else 1,
+            )
+            result = {
+                "ok": bool(result.get("accepted")),
+                "status": result.get("status", "unknown"),
+                "claimed_count": result.get("claimed_count", 0),
+                "completed_task_ids": result.get("completed_task_ids", ()),
+                "failed_task_ids": result.get("failed_task_ids", ()),
+                "rejection_reasons": result.get("rejection_reasons", ()),
+                "claim_loop": result,
+            }
+            self._action_reporter(
+                "supervisor_execute",
+                result.get("status", "unknown"),
+                {"plan": plan, "result": result},
+            )
+            if _rt_start is not None:
+                try:
+                    if result.get("ok"):
+                        _re_ok(
+                            "openclaw_supervisor",
+                            "supervisor_execute",
+                            _rt_start,
+                            details={
+                                "action": "claim_signed_worker_tasks_until_idle",
+                                "claimed_count": result.get("claimed_count", 0),
+                            },
+                        )
+                    else:
+                        _re_fail(
+                            "openclaw_supervisor",
+                            "supervisor_execute",
+                            _rt_start,
+                            ",".join(str(reason) for reason in result.get("rejection_reasons", ()))[:200]
+                            or str(result.get("status") or "unknown")[:200],
+                            details={"action": "claim_signed_worker_tasks_until_idle"},
+                        )
                 except Exception:
                     pass
             return result
@@ -1548,6 +1641,19 @@ class OpenClawSupervisor:
         broker = self._get_broker()
         if broker is None:
             return {"ok": False, "error": "broker_unavailable"}
+
+        if plan["action"] == "claim_signed_worker_tasks_until_idle":
+            ok = bool(action_result.get("ok"))
+            reasons = tuple(action_result.get("rejection_reasons") or ())
+            return {
+                "ok": ok,
+                "status": action_result,
+                "claimed_count": action_result.get("claimed_count", 0),
+                "completed_task_ids": action_result.get("completed_task_ids", ()),
+                "failed_task_ids": action_result.get("failed_task_ids", ()),
+                "error": "" if ok else ",".join(str(reason) for reason in reasons),
+                "fidelity": 0.85,
+            }
 
         if plan["action"] == "execute_autonomous_task":
             task = plan.get("task", {})

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -99,6 +99,121 @@ def test_run_cycle_idles_when_resident_runtime_is_healthy(tmp_path):
     assert any(action == "supervisor_cycle" for action, _, _ in events)
 
 
+def test_run_cycle_claims_signed_worker_tasks_when_enabled(tmp_path):
+    from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+        SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    )
+
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True, "recent_events": []}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 10,
+        "latest_sequence_id": 10,
+    }
+
+    events = []
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: events.append((action, result, details)),
+        self_audit_factory=lambda repo_root: MagicMock(scan_once=MagicMock(return_value=0)),
+    )
+    supervisor._bootstrapped = True
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle = MagicMock(
+        return_value={
+            "accepted": True,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT",
+            "claimed_count": 2,
+            "completed_task_ids": ("task-1", "task-2"),
+            "failed_task_ids": (),
+            "rejection_reasons": (),
+        }
+    )
+    pending_task = {
+        "task_id": "signed-task-1",
+        "discovered_by": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        "context": {
+            "source": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            "worker_runtime": "openclaw",
+            "capability": "candidate_queue_review",
+        },
+    }
+
+    with patch.dict(
+        os.environ,
+        {
+            "OPENCLAW_SIGNED_WORKER_TASKS_ENABLED": "1",
+            "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "2",
+            "OPENCLAW_AUTO_TASKS_ENABLED": "1",
+        },
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = [pending_task]
+        result = supervisor.run_cycle()
+
+    assert result["plan"]["action"] == "claim_signed_worker_tasks_until_idle"
+    assert result["plan"]["max_claims"] == 2
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle.assert_called_once_with(
+        max_claims=2
+    )
+    assert result["action_result"]["ok"] is True
+    assert result["action_result"]["claimed_count"] == 2
+    assert result["verify"]["ok"] is True
+    assert result["verify"]["completed_task_ids"] == ("task-1", "task-2")
+    assert any(event[0] == "supervisor_execute" for event in events)
+
+
+def test_run_cycle_signed_worker_loop_rejects_invalid_max_claims(tmp_path):
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True, "recent_events": []}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 11,
+        "latest_sequence_id": 11,
+    }
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: None,
+        self_audit_factory=lambda repo_root: MagicMock(scan_once=MagicMock(return_value=0)),
+    )
+    supervisor._bootstrapped = True
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle = MagicMock()
+
+    with patch.dict(
+        os.environ,
+        {
+            "OPENCLAW_SIGNED_WORKER_TASKS_ENABLED": "1",
+            "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "0",
+        },
+    ):
+        result = supervisor.run_cycle()
+
+    assert result["triage"]["kind"] == "escalate"
+    assert result["triage"]["reason"] == "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_MAX_CLAIMS_INVALID"
+    assert result["verify"]["ok"] is False
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle.assert_not_called()
+
+
 def test_run_cycle_escalates_when_restart_budget_is_exhausted(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENCLAW_SUPERVISOR_MAX_RESTARTS", "2")
     monkeypatch.setenv("OPENCLAW_SUPERVISOR_RESTART_WINDOW_SEC", "600")


### PR DESCRIPTION
## Summary

- Wire the bounded signed-worker claim loop into `OpenClawSupervisor` as an explicit opt-in resident action.
- Add `OPENCLAW_SIGNED_WORKER_TASKS_ENABLED=1` and bounded `OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS` handling.
- Select signed OpenClaw `candidate_queue_review` work before generic autonomous tasks only when enabled and only when AgentDB has a matching pending task.
- Add run-cycle tests for signed-worker loop execution and invalid max-claim fail-closed behavior.

## WSP_97 Truth Boundary

OBSERVED:
- The action calls the existing bounded `claim_reddog_signed_worker_dispatch_tasks_until_idle()` primitive.
- Default behavior is unchanged; the feature is disabled unless `OPENCLAW_SIGNED_WORKER_TASKS_ENABLED=1`.
- Invalid claim limits escalate before any task claim.
- Pending-task detection is query-only and filters to signed OpenClaw `candidate_queue_review` context.

NOT IMPLEMENTED:
- No Hermes/0102 worker runtime is enabled.
- No new shell execution, repo mutation, HoloIndex re-index, reward settlement, merge, or authority broadening.
- No `main.py` menu/default behavior change.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 20 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 44 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py -q` -> 59 passed
- `python -m compileall -q modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py`
- `git diff --check` -> clean, with CRLF normalization warnings only

Note: one all-in-one local pytest invocation hit a pytest capture teardown artifact after the supervisor suite; the same suites pass when split deterministically as above.