### PR TITLE
feat(reddog): bind signed 0102 read-only review tasks

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_0102_READONLY_REVIEW_RUNTIME_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a signed 0102 read-only review runner that adapts signed worker
+  dispatch intents for `architect_review`, `adversarial_review`, and
+  `diff_verification` into the existing model-backed read-only audit worker.
+- Bound review evidence to the signed WSP_15 allocation receipt's
+  `allowed_read_targets`; `bounded_code_change` remains explicitly unsupported
+  by this read-only runner.
+- Wired OpenClaw signed-worker claiming to include 0102 read-only review tasks
+  only when `OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED=1`.
+- Boundary remains explicit: no shell execution, source repository mutation,
+  worktree operation, Hermes dispatch, PR publish, PatternMemory write,
+  HoloIndex re-index, reward settlement, or coding-worker execution is added.
+
 ## 2026-07-16: REDDOG_OPENCLAW_SUPERVISOR_SIGNED_WORKER_LOOP_RUNTIME_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -273,6 +273,10 @@ def claim_reddog_signed_worker_dispatch_task_once(
         from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
             build_reddog_signed_worker_queue_loop_runner_from_env,
         )
+        from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
+            Signed0102ReadOnlyReviewRunner,
+            is_0102_readonly_signed_worker_context,
+        )
         from modules.infrastructure.database.src.agent_db import AgentDB
 
         factory = agent_db_factory or AgentDB
@@ -281,6 +285,10 @@ def claim_reddog_signed_worker_dispatch_task_once(
             db=db,
             agent_id=agent_id,
             source=SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            include_0102_readonly=(
+                signed_worker_runner is not None
+                or _signed_0102_readonly_tasks_enabled_from_env()
+            ),
         )
     except Exception as exc:
         return _signed_worker_claim_result(
@@ -317,23 +325,26 @@ def claim_reddog_signed_worker_dispatch_task_once(
 
     effective_runner = signed_worker_runner
     if effective_runner is None:
-        binding_result = build_reddog_signed_worker_queue_loop_runner_from_env(
-            repo_root=repo_root,
-            env=os.environ,
-        )
-        if binding_result.accepted:
-            effective_runner = binding_result.runner
-        elif binding_result.requested:
-            _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
-            return _signed_worker_claim_result(
-                accepted=False,
-                status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-                task_id=task_id,
-                rejection_reasons=(
-                    SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
-                    *binding_result.rejection_reasons,
-                ),
+        if is_0102_readonly_signed_worker_context(context) and _signed_0102_readonly_tasks_enabled_from_env():
+            effective_runner = Signed0102ReadOnlyReviewRunner()
+        else:
+            binding_result = build_reddog_signed_worker_queue_loop_runner_from_env(
+                repo_root=repo_root,
+                env=os.environ,
             )
+            if binding_result.accepted:
+                effective_runner = binding_result.runner
+            elif binding_result.requested:
+                _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
+                return _signed_worker_claim_result(
+                    accepted=False,
+                    status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+                    task_id=task_id,
+                    rejection_reasons=(
+                        SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
+                        *binding_result.rejection_reasons,
+                    ),
+                )
 
     run_result = execute_reddog_signed_worker_dispatch_task(
         task_context=context,
@@ -493,9 +504,13 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
     db: Any,
     agent_id: str,
     source: str,
+    include_0102_readonly: bool = False,
 ) -> Optional[Dict[str, Any]]:
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
         is_openclaw_candidate_signed_worker_context,
+    )
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
+        is_0102_readonly_signed_worker_context,
     )
 
     with db.db.get_connection() as conn:
@@ -519,7 +534,9 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
                 candidate_context = json.loads(raw_candidate) if isinstance(raw_candidate, str) else raw_candidate
             except Exception:
                 candidate_context = None
-            if is_openclaw_candidate_signed_worker_context(candidate_context):
+            if is_openclaw_candidate_signed_worker_context(candidate_context) or (
+                include_0102_readonly and is_0102_readonly_signed_worker_context(candidate_context)
+            ):
                 row = candidate
                 raw_context = raw_candidate
                 context = candidate_context
@@ -692,6 +709,10 @@ def _signed_worker_task_max_claims_from_env() -> tuple[int, str | None]:
     return value, None
 
 
+def _signed_0102_readonly_tasks_enabled_from_env() -> bool:
+    return os.getenv("OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED", "0") == "1"
+
+
 def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
     from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
         SIGNED_WORKER_DISPATCH_TASK_SOURCE,
@@ -699,14 +720,21 @@ def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
         is_openclaw_candidate_signed_worker_context,
     )
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
+        is_0102_readonly_signed_worker_context,
+    )
     from modules.infrastructure.database.src.agent_db import AgentDB
 
+    include_0102_readonly = _signed_0102_readonly_tasks_enabled_from_env()
     db = AgentDB()
     for task in db.get_autonomous_tasks(status="pending", limit=limit):
         if str(task.get("discovered_by") or "") != SIGNED_WORKER_DISPATCH_TASK_SOURCE:
             continue
         context = task.get("context")
-        if is_openclaw_candidate_signed_worker_context(context if isinstance(context, dict) else None):
+        normalized = context if isinstance(context, dict) else None
+        if is_openclaw_candidate_signed_worker_context(normalized) or (
+            include_0102_readonly and is_0102_readonly_signed_worker_context(normalized)
+        ):
             return True
     return False
 

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py
@@ -1,0 +1,297 @@
+"""Runtime binding for signed 0102 read-only review worker tasks.
+
+Slice: REDDOG_SIGNED_0102_READONLY_REVIEW_RUNTIME_BINDING_PHASE1
+
+This module adapts signed RedDog worker-dispatch tasks for 0102 review roles
+into the existing model-backed read-only audit worker. It accepts only review
+capabilities and derives evidence targets from the bound WSP_15 allocation
+receipt. It does not execute shell commands, mutate the repository, create
+worktrees, dispatch Hermes, publish PRs, write PatternMemory, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+    SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    MODEL_WORKER_MODE,
+    REPO_CODE_AUDIT_LANE,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
+    READONLY_AUDIT_TASK_SOURCE,
+    execute_reddog_readonly_audit_task,
+)
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    canonical_reddog_wsp15_allocation_digest,
+    validate_reddog_wsp15_allocation_receipt,
+)
+
+
+SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT = "SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT"
+SIGNED_0102_READONLY_REVIEW_BINDING_REJECT = "SIGNED_0102_READONLY_REVIEW_BINDING_REJECT"
+
+SIGNED_0102_WORKER_RUNTIME = "0102"
+SIGNED_0102_READONLY_CAPABILITIES = frozenset(
+    {
+        "architect_review",
+        "adversarial_review",
+        "diff_verification",
+    }
+)
+
+
+class Signed0102ReadOnlyReviewBindingReason:
+    UNSUPPORTED_CONTEXT = "REJECT_SIGNED_0102_READONLY_UNSUPPORTED_CONTEXT"
+    ALLOCATION_MISSING_OR_INVALID = "REJECT_SIGNED_0102_READONLY_ALLOCATION_INVALID"
+    TARGETS_MISSING = "REJECT_SIGNED_0102_READONLY_TARGETS_MISSING"
+    READONLY_WORKER_REJECTED = "REJECT_SIGNED_0102_READONLY_WORKER_REJECTED"
+
+
+@dataclass(frozen=True)
+class Signed0102ReadOnlyReviewRunner:
+    """Signed-worker runner that delegates to the read-only 0102 audit worker."""
+
+    model_runner: Any | None = None
+    holoindex_adapter: Any | None = None
+    codeindex_adapter: Any | None = None
+    external_research_retriever: Any | None = None
+    timeout_seconds: int = 60
+
+    def run_signed_worker_dispatch_task(
+        self,
+        *,
+        task_id: str,
+        task_context: Mapping[str, Any],
+        worker_dispatch_intent: Mapping[str, Any],
+        signed_authority_receipt: Mapping[str, Any],
+        repo_root: Path,
+    ) -> Mapping[str, Any]:
+        if not is_0102_readonly_signed_worker_context(task_context):
+            return _runner_reject(
+                task_id=task_id,
+                reasons=(Signed0102ReadOnlyReviewBindingReason.UNSUPPORTED_CONTEXT,),
+            )
+
+        allocation = _mapping(task_context.get("wsp15_allocation_receipt"))
+        validation = validate_reddog_wsp15_allocation_receipt(allocation)
+        if not validation.accepted:
+            return _runner_reject(
+                task_id=task_id,
+                reasons=(
+                    Signed0102ReadOnlyReviewBindingReason.ALLOCATION_MISSING_OR_INVALID,
+                    *validation.rejection_reasons,
+                ),
+            )
+
+        targets = _text_tuple(allocation.get("allowed_read_targets"))
+        if not targets:
+            return _runner_reject(
+                task_id=task_id,
+                reasons=(Signed0102ReadOnlyReviewBindingReason.TARGETS_MISSING,),
+            )
+
+        readonly_context = build_readonly_0102_context_from_signed_worker(
+            task_id=task_id,
+            task_context=task_context,
+            worker_dispatch_intent=worker_dispatch_intent,
+            signed_authority_receipt=signed_authority_receipt,
+            allocation=allocation,
+            targets=targets,
+        )
+        readonly_result = execute_reddog_readonly_audit_task(
+            task_context=readonly_context,
+            repo_root=repo_root,
+            task_id=task_id,
+            model_runner=self.model_runner,
+            holoindex_adapter=self.holoindex_adapter,
+            codeindex_adapter=self.codeindex_adapter,
+            external_research_retriever=self.external_research_retriever,
+            timeout_seconds=self.timeout_seconds,
+        )
+        payload = readonly_result.to_dict()
+        if not readonly_result.accepted:
+            return _runner_reject(
+                task_id=task_id,
+                reasons=(
+                    Signed0102ReadOnlyReviewBindingReason.READONLY_WORKER_REJECTED,
+                    *readonly_result.rejection_reasons,
+                ),
+                readonly_result=payload,
+            )
+
+        return {
+            "accepted": True,
+            "decision": SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT,
+            "receipt_id": _receipt_id(task_id, readonly_context, payload),
+            "worker_runtime": SIGNED_0102_WORKER_RUNTIME,
+            "capability": str(task_context.get("capability") or ""),
+            "readonly_context_digest": _digest(readonly_context),
+            "readonly_result": payload,
+            "rejection_reasons": [],
+            "no_source_repo_mutation_performed": True,
+            "no_shell_command_executed": True,
+            "no_holoindex_reindex_performed": True,
+            "no_hermes_dispatch_performed": True,
+            "no_worktree_operation_performed": True,
+            "no_pr_created": True,
+            "no_pattern_memory_write_performed": True,
+            "no_reward_settlement_performed": True,
+        }
+
+
+def is_0102_readonly_signed_worker_context(context: Mapping[str, Any] | None) -> bool:
+    """Return True only for signed 0102 review tasks that are read-only."""
+
+    if not isinstance(context, Mapping):
+        return False
+    return (
+        str(context.get("source") or "") == SIGNED_WORKER_DISPATCH_TASK_SOURCE
+        and str(context.get("worker_runtime") or "").strip().lower() == SIGNED_0102_WORKER_RUNTIME
+        and str(context.get("capability") or "").strip().lower() in SIGNED_0102_READONLY_CAPABILITIES
+    )
+
+
+def build_readonly_0102_context_from_signed_worker(
+    *,
+    task_id: str,
+    task_context: Mapping[str, Any],
+    worker_dispatch_intent: Mapping[str, Any],
+    signed_authority_receipt: Mapping[str, Any],
+    allocation: Mapping[str, Any],
+    targets: tuple[str, ...] | None = None,
+) -> Mapping[str, Any]:
+    """Build the read-only audit context consumed by the 0102 worker."""
+
+    targets = targets or _text_tuple(allocation.get("allowed_read_targets"))
+    allocation_digest = canonical_reddog_wsp15_allocation_digest(allocation)
+    work_order_id = str(signed_authority_receipt.get("work_order_id") or worker_dispatch_intent.get("work_order_id") or "")
+    foundup_id = str(signed_authority_receipt.get("foundup_id") or worker_dispatch_intent.get("foundup_id") or "")
+    principal_id = str(signed_authority_receipt.get("principal_id") or worker_dispatch_intent.get("principal_id") or "")
+    assignment = {
+        "assignment_id": "signed-0102-review-" + _digest(
+            {
+                "task_id": task_id,
+                "intent_id": worker_dispatch_intent.get("intent_id"),
+                "targets": targets,
+            }
+        ).removeprefix("sha256:")[:16],
+        "lane_id": REPO_CODE_AUDIT_LANE,
+        "snapshot_receipt_id": str(task_context.get("queue_item_id") or ""),
+        "allowed_read_targets": list(targets),
+        "foundup_id": foundup_id,
+        "principal_id": principal_id,
+        "work_order_id": work_order_id,
+        "queue_item_id": str(task_context.get("queue_item_id") or ""),
+        "selected_slice": str(task_context.get("selected_slice") or ""),
+        "signed_worker_task_id": str(task_id),
+        "signed_worker_role": str(task_context.get("worker_role") or ""),
+        "signed_worker_capability": str(task_context.get("capability") or ""),
+        "wsp15_allocation_receipt_id": str(allocation.get("receipt_id") or ""),
+        "wsp15_allocation_digest": allocation_digest,
+    }
+    return {
+        "source": READONLY_AUDIT_TASK_SOURCE,
+        "worker_mode": MODEL_WORKER_MODE,
+        "principal_id": principal_id,
+        "work_order_id": work_order_id,
+        "foundup_id": foundup_id,
+        "wsp15_allocation_receipt": dict(allocation),
+        "wsp15_allocation_receipt_id": str(allocation.get("receipt_id") or ""),
+        "wsp15_allocation_digest": allocation_digest,
+        "swarm_receipt": {
+            "swarm_id": "signed-worker-dispatch",
+            "signed_worker_task_id": str(task_id),
+            "source_dispatch_receipt_id": str(signed_authority_receipt.get("receipt_id") or ""),
+            "queue_item_id": str(task_context.get("queue_item_id") or ""),
+        },
+        "assignment": assignment,
+        "forbidden_actions": [
+            "repo_write",
+            "shell_execute",
+            "git_push",
+            "openclaw_enqueue",
+            "holoindex_reindex",
+            "hermes_dispatch",
+            "worktree_create",
+            "pr_publish",
+        ],
+        "signed_worker_binding": {
+            "source": str(task_context.get("source") or ""),
+            "worker_runtime": str(task_context.get("worker_runtime") or ""),
+            "worker_role": str(task_context.get("worker_role") or ""),
+            "capability": str(task_context.get("capability") or ""),
+            "intent_id": str(worker_dispatch_intent.get("intent_id") or ""),
+            "signed_authority_receipt_id": str(signed_authority_receipt.get("receipt_id") or ""),
+        },
+    }
+
+
+def _runner_reject(
+    *,
+    task_id: str,
+    reasons: tuple[str, ...],
+    readonly_result: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    return {
+        "accepted": False,
+        "decision": SIGNED_0102_READONLY_REVIEW_BINDING_REJECT,
+        "receipt_id": "",
+        "task_id": str(task_id),
+        "readonly_result": dict(readonly_result) if isinstance(readonly_result, Mapping) else None,
+        "rejection_reasons": list(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+        "no_source_repo_mutation_performed": True,
+        "no_shell_command_executed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_pattern_memory_write_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+
+
+def _text_tuple(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(dict.fromkeys(str(item).strip() for item in value if str(item).strip()))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        value = value.to_dict()
+    return value if isinstance(value, Mapping) else {}
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _receipt_id(task_id: str, readonly_context: Mapping[str, Any], readonly_result: Mapping[str, Any]) -> str:
+    return "signed_0102_readonly_review_" + _digest(
+        {
+            "task_id": task_id,
+            "readonly_context_digest": _digest(readonly_context),
+            "readonly_report_digest": _mapping(readonly_result.get("report")).get("report_digest"),
+        }
+    ).removeprefix("sha256:")[:16]
+
+
+__all__ = [
+    "SIGNED_0102_READONLY_CAPABILITIES",
+    "SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT",
+    "SIGNED_0102_READONLY_REVIEW_BINDING_REJECT",
+    "SIGNED_0102_WORKER_RUNTIME",
+    "Signed0102ReadOnlyReviewBindingReason",
+    "Signed0102ReadOnlyReviewRunner",
+    "build_readonly_0102_context_from_signed_worker",
+    "is_0102_readonly_signed_worker_context",
+]

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -172,6 +172,75 @@ def test_run_cycle_claims_signed_worker_tasks_when_enabled(tmp_path):
     assert any(event[0] == "supervisor_execute" for event in events)
 
 
+def test_run_cycle_claims_signed_0102_readonly_tasks_when_readonly_gate_enabled(tmp_path):
+    from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+        SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    )
+
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True, "recent_events": []}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 11,
+        "latest_sequence_id": 11,
+    }
+
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: None,
+        self_audit_factory=lambda repo_root: MagicMock(scan_once=MagicMock(return_value=0)),
+    )
+    supervisor._bootstrapped = True
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle = MagicMock(
+        return_value={
+            "accepted": True,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT",
+            "claimed_count": 1,
+            "completed_task_ids": ("task-0102",),
+            "failed_task_ids": (),
+            "rejection_reasons": (),
+        }
+    )
+    pending_task = {
+        "task_id": "task-0102",
+        "discovered_by": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        "context": {
+            "source": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            "worker_runtime": "0102",
+            "capability": "architect_review",
+        },
+    }
+
+    with patch.dict(
+        os.environ,
+        {
+            "OPENCLAW_SIGNED_WORKER_TASKS_ENABLED": "1",
+            "OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED": "1",
+            "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "1",
+        },
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = [pending_task]
+        result = supervisor.run_cycle()
+
+    assert result["plan"]["action"] == "claim_signed_worker_tasks_until_idle"
+    assert result["plan"]["max_claims"] == 1
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle.assert_called_once_with(
+        max_claims=1
+    )
+    assert result["verify"]["ok"] is True
+    assert result["verify"]["completed_task_ids"] == ("task-0102",)
+
+
 def test_run_cycle_signed_worker_loop_rejects_invalid_max_claims(tmp_path):
     broker = MagicMock()
     broker.get_runtime_status.side_effect = lambda dae_id: {

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -34,6 +34,17 @@ from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task
     SignedWorkerDispatchTaskExecutorReason,
     execute_reddog_signed_worker_dispatch_task,
 )
+from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
+    SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT,
+    Signed0102ReadOnlyReviewBindingReason,
+    Signed0102ReadOnlyReviewRunner,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    RepoAuditModelResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    allocate_reddog_wsp15_receipt,
+)
 from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_serial_loop_bootstrap import (
     NOW as BOOTSTRAP_NOW,
     PILOT_ARTIFACT,
@@ -122,6 +133,64 @@ class _FakeRunner:
         }
 
 
+class _FakeQueryAdapter:
+    def query(self, *, query: str, allowed_paths, limit: int):
+        path = allowed_paths[0] if allowed_paths else "docs/work_ledger.schema.json"
+        return {
+            "ok": True,
+            "source": "fake",
+            "query": query,
+            "freshness": "CURRENT",
+            "hits": [
+                {
+                    "path": path,
+                    "title": "fake hit",
+                    "score": 0.99,
+                    "digest": "sha256:index-hit",
+                }
+            ],
+            "error": "",
+            "freshness_generation_id": "generation-1",
+            "freshness_receipt_digest": "sha256:freshness",
+            "freshness_receipt_path": "O:/Foundups-Agent/.holoindex/freshness.json",
+            "repo_head_sha": "abc123",
+        }
+
+
+class _EchoEvidenceModelRunner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def run_repo_code_audit(self, *, prompt: str, context: str, binding, timeout_seconds: int):
+        self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
+        parsed = json.loads(context)
+        evidence_ref = parsed["untrusted_repository_evidence"][0]["evidence_ref"]
+        output = {
+            "summary": "Signed 0102 read-only review used supplied repository evidence.",
+            "evidence_refs": [evidence_ref],
+            "findings": [
+                {
+                    "finding_id": "signed-0102-readonly-review-1",
+                    "claim": "The signed 0102 review cited the bound repository evidence.",
+                    "wsp97_label": "OBSERVED",
+                    "recommended_action": "FIX",
+                    "wsp15_priority": "P1",
+                    "severity": "MAJOR",
+                    "evidence_refs": [evidence_ref],
+                    "next_slice_name": "REDDOG_NEXT_RUNTIME_SLICE_PHASE1",
+                }
+            ],
+        }
+        return RepoAuditModelResult(
+            ok=True,
+            status="MODEL_OK",
+            content=json.dumps(output, sort_keys=True),
+            model_receipt_id="model-receipt-1",
+            model_result_digest="sha256:model-result-1",
+            made_network_call=True,
+        )
+
+
 class _FakeEnvDraftPrRunner:
     instances: list["_FakeEnvDraftPrRunner"] = []
 
@@ -191,6 +260,14 @@ def _allocation(**overrides):
     }
     payload.update(overrides)
     return payload
+
+
+def _valid_readonly_allocation(*, targets=("docs/work_ledger.schema.json",)):
+    return allocate_reddog_wsp15_receipt(
+        requested_operation="signed_0102_readonly_review:redDog_runtime_security",
+        prompt_text="RedDog OpenClaw signed 0102 read-only review runtime security audit.",
+        allowed_read_targets=targets,
+    ).to_dict()
 
 
 def _intent(allocation=None, **overrides):
@@ -287,6 +364,27 @@ def _publish_agentdb_task(**intent_overrides) -> str:
     return result.receipt.task_ids[0]
 
 
+def _publish_agentdb_task_with_allocation(allocation, **intent_overrides) -> str:
+    intent = _intent(allocation, **intent_overrides)
+    result = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(allocation=allocation, intent=intent),
+        work_state_snapshot=_snapshot(allocation),
+        queue_item_id="queue-1",
+        writer=runtime.AgentDbSignedWorkerDispatchTaskWriter(),
+    )
+    assert result.accepted is True
+    assert result.receipt is not None
+    return result.receipt.task_ids[0]
+
+
+def _repo_with_readonly_target(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    target = root / "docs" / "work_ledger.schema.json"
+    target.parent.mkdir(parents=True)
+    target.write_text('{"schema": "work-ledger", "version": 1}\n', encoding="utf-8")
+    return root
+
+
 def test_signed_worker_executor_accepts_valid_task_with_injected_runner(tmp_path: Path) -> None:
     runner = _FakeRunner()
 
@@ -304,6 +402,82 @@ def test_signed_worker_executor_accepts_valid_task_with_injected_runner(tmp_path
     assert result.no_shell_command_executed is True
     assert result.no_source_repo_mutation_performed is True
     assert runner.calls[0]["worker_dispatch_intent"]["intent_id"] == "worker_dispatch_intent_openclaw_candidate"
+
+
+def test_signed_0102_readonly_runner_executes_architect_review_with_bound_targets(
+    tmp_path: Path,
+) -> None:
+    repo = _repo_with_readonly_target(tmp_path)
+    allocation = _valid_readonly_allocation()
+    intent = _intent(
+        allocation,
+        intent_id="worker_dispatch_intent_fusion_lead",
+        role="fusion_lead",
+        worker_runtime="0102",
+        capability="architect_review",
+    )
+    context = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(allocation=allocation, intent=intent),
+        work_state_snapshot=_snapshot(allocation),
+        queue_item_id="queue-1",
+        writer=_CollectingWriter(),
+    ).tasks[0].context
+    model_runner = _EchoEvidenceModelRunner()
+    runner = Signed0102ReadOnlyReviewRunner(
+        model_runner=model_runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-0102-1",
+        repo_root=repo,
+        runner=runner,
+    )
+
+    assert result.accepted is True
+    assert result.decision == SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT
+    assert result.worker_runtime == "0102"
+    assert result.capability == "architect_review"
+    assert result.runner_result["decision"] == SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT
+    readonly = result.runner_result["readonly_result"]
+    assert readonly["accepted"] is True
+    assert readonly["report"]["model_backed_0102_worker_performed"] is True
+    assert readonly["report"]["target_evidence"][0]["path"] == "docs/work_ledger.schema.json"
+    assert model_runner.calls[0]["binding"]["wsp15_allocation_receipt_id"] == allocation["receipt_id"]
+    assert result.no_source_repo_mutation_performed is True
+    assert result.no_shell_command_executed is True
+
+
+def test_signed_0102_readonly_runner_rejects_bounded_code_change(tmp_path: Path) -> None:
+    repo = _repo_with_readonly_target(tmp_path)
+    allocation = _valid_readonly_allocation()
+    intent = _intent(
+        allocation,
+        intent_id="worker_dispatch_intent_coding_worker_1",
+        role="coding_worker_1",
+        worker_runtime="0102",
+        capability="bounded_code_change",
+    )
+    context = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(allocation=allocation, intent=intent),
+        work_state_snapshot=_snapshot(allocation),
+        queue_item_id="queue-1",
+        writer=_CollectingWriter(),
+    ).tasks[0].context
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-0102-code",
+        repo_root=repo,
+        runner=Signed0102ReadOnlyReviewRunner(model_runner=_EchoEvidenceModelRunner()),
+    )
+
+    assert result.accepted is False
+    assert Signed0102ReadOnlyReviewBindingReason.UNSUPPORTED_CONTEXT in result.rejection_reasons
+    assert result.no_source_repo_mutation_performed is True
+    assert result.no_shell_command_executed is True
 
 
 def test_signed_worker_executor_rejects_without_runner(tmp_path: Path) -> None:
@@ -410,6 +584,79 @@ def test_run_task_uses_env_bound_queue_loop_runner_when_enabled(
     assert result["structured_result"]["accepted"] is True
     assert runner.calls[0]["task_id"] == task_id
     assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_claim_ignores_0102_readonly_task_until_env_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    allocation = _valid_readonly_allocation()
+    task_id = _publish_agentdb_task_with_allocation(
+        allocation,
+        intent_id="worker_dispatch_intent_fusion_lead",
+        role="fusion_lead",
+        worker_runtime="0102",
+        capability="architect_review",
+    )
+    monkeypatch.delenv("OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED", raising=False)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
+
+
+def test_openclaw_claim_executes_0102_readonly_task_when_env_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    allocation = _valid_readonly_allocation()
+    task_id = _publish_agentdb_task_with_allocation(
+        allocation,
+        intent_id="worker_dispatch_intent_fusion_lead",
+        role="fusion_lead",
+        worker_runtime="0102",
+        capability="architect_review",
+    )
+    runner = _FakeRunner()
+    monkeypatch.setenv("OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED", "1")
+    from modules.communication.moltbot_bridge.src import (
+        reddog_signed_worker_0102_readonly_review_binding as review_binding,
+    )
+
+    monkeypatch.setattr(review_binding, "Signed0102ReadOnlyReviewRunner", lambda: runner)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert result["worker_runtime"] == "0102"
+    assert result["capability"] == "architect_review"
+    assert runner.calls[0]["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_claim_does_not_claim_0102_bounded_code_change_even_when_readonly_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    allocation = _valid_readonly_allocation()
+    task_id = _publish_agentdb_task_with_allocation(
+        allocation,
+        intent_id="worker_dispatch_intent_coding_worker_1",
+        role="coding_worker_1",
+        worker_runtime="0102",
+        capability="bounded_code_change",
+    )
+    monkeypatch.setenv("OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED", "1")
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
 
 def test_openclaw_claim_env_bound_queue_loop_runner_materializes_bounded_artifact(


### PR DESCRIPTION
## Summary

Implements REDDOG_SIGNED_0102_READONLY_REVIEW_RUNTIME_BINDING_PHASE1.

- Adds a signed 0102 read-only review runner that adapts signed worker-dispatch intents for architect/adversarial/diff review into the existing model-backed read-only audit worker.
- Binds review evidence to the signed WSP_15 allocation receipt's allowed_read_targets.
- Wires OpenClaw signed-worker claiming to include 0102 read-only review tasks only behind OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED=1.
- Keeps bounded_code_change unsupported and unclaimed by this read-only runtime.

## Validation

- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q
- pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_serial_loop.py -q
- python -m compileall modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py
- git diff --check

## Boundary

No shell execution, source repository mutation, worktree operation, Hermes dispatch, PR publish, PatternMemory write, HoloIndex re-index, reward settlement, or coding-worker execution is added.

Worker-Lane: RedDog runtime
Slice: REDDOG_SIGNED_0102_READONLY_REVIEW_RUNTIME_BINDING_PHASE1