### PR TITLE
feat(reddog): bind signed 0102 bounded code stage

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_0102_BOUNDED_CODE_CHANGE_STAGE_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a stage-scoped signed 0102 `bounded_code_change` binding to the
+  resident queue-loop runner. It may advance exactly one queue stage only when
+  the authoritative chain is already at `bounded_worker_pilot`.
+- Required explicit artifact generation for 0102 coding tasks:
+  `artifact_generation_request_path` plus `artifact_generator_mode=foundups_fusion`;
+  static `artifact_contents_path` is rejected for this capability.
+- Wired OpenClaw task discovery to claim 0102 bounded-code tasks only when
+  `OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED=1`, the queue-loop runner is
+  configured, and the chain plan is stage-ready. Early tasks remain pending
+  instead of being failed.
+- Boundary remains explicit: no broad 0102 worker launch, no shell execution,
+  no source-repo mutation, no Hermes dispatch, no PR publish/merge, no
+  HoloIndex re-index, no reward settlement, and no authority beyond the
+  existing bounded-worker-pilot stage is added.
+
 ## 2026-07-16: REDDOG_SIGNED_0102_READONLY_REVIEW_RUNTIME_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -32,7 +32,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Deque, Dict, List, Optional
+from typing import Any, Callable, Deque, Dict, List, Mapping, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -289,6 +289,8 @@ def claim_reddog_signed_worker_dispatch_task_once(
                 signed_worker_runner is not None
                 or _signed_0102_readonly_tasks_enabled_from_env()
             ),
+            include_0102_bounded_code=_signed_0102_bounded_code_tasks_enabled_from_env(),
+            env=os.environ,
         )
     except Exception as exc:
         return _signed_worker_claim_result(
@@ -505,8 +507,11 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
     agent_id: str,
     source: str,
     include_0102_readonly: bool = False,
+    include_0102_bounded_code: bool = False,
+    env: Mapping[str, str] | None = None,
 ) -> Optional[Dict[str, Any]]:
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+        is_0102_bounded_code_change_signed_worker_context,
         is_openclaw_candidate_signed_worker_context,
     )
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
@@ -534,8 +539,17 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
                 candidate_context = json.loads(raw_candidate) if isinstance(raw_candidate, str) else raw_candidate
             except Exception:
                 candidate_context = None
-            if is_openclaw_candidate_signed_worker_context(candidate_context) or (
-                include_0102_readonly and is_0102_readonly_signed_worker_context(candidate_context)
+            if (
+                is_openclaw_candidate_signed_worker_context(candidate_context)
+                or (
+                    include_0102_readonly
+                    and is_0102_readonly_signed_worker_context(candidate_context)
+                )
+                or (
+                    include_0102_bounded_code
+                    and is_0102_bounded_code_change_signed_worker_context(candidate_context)
+                    and _signed_0102_bounded_code_stage_ready_from_env(candidate_context, env or os.environ)
+                )
             ):
                 row = candidate
                 raw_context = raw_candidate
@@ -713,11 +727,76 @@ def _signed_0102_readonly_tasks_enabled_from_env() -> bool:
     return os.getenv("OPENCLAW_SIGNED_0102_READONLY_TASKS_ENABLED", "0") == "1"
 
 
+def _signed_0102_bounded_code_tasks_enabled_from_env() -> bool:
+    return os.getenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "0") == "1"
+
+
+def _signed_0102_bounded_code_stage_ready_from_env(
+    context: Mapping[str, Any] | None,
+    env: Mapping[str, str],
+) -> bool:
+    """Return True only when a coding task may safely drive the artifact stage."""
+
+    if not isinstance(context, Mapping):
+        return False
+    if str(env.get("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER") or "").strip() != "1":
+        return False
+    if str(env.get("REDDOG_ARTIFACT_GENERATOR_MODE") or "").strip() != "foundups_fusion":
+        return False
+    if not str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH") or "").strip():
+        return False
+    if str(env.get("REDDOG_ARTIFACT_CONTENTS_PATH") or "").strip():
+        return False
+    work_state_path = str(env.get("REDDOG_AUTHORITATIVE_WORK_STATE_PATH") or "").strip()
+    chain_results_path = str(env.get("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH") or "").strip()
+    if not work_state_path or not chain_results_path:
+        return False
+    queue_item_id = str(context.get("queue_item_id") or "").strip()
+    if not queue_item_id:
+        return False
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+            NEXT_QUEUE_BOUNDED_WORKER_PILOT_INVOKE,
+            RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
+            plan_reddog_resident_queue_orchestration,
+        )
+
+        work_state = _read_json_mapping(Path(work_state_path))
+        chain_state = _read_json_mapping(Path(chain_results_path))
+        plan = plan_reddog_resident_queue_orchestration(
+            work_state,
+            chain_results=_resident_queue_stage_results(chain_state),
+            requested_queue_item_id=queue_item_id,
+            now_iso=str(env.get("REDDOG_RESIDENT_QUEUE_NOW_ISO") or ""),
+        )
+    except Exception:
+        return False
+    return (
+        plan.accepted is True
+        and plan.status == RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY
+        and plan.current_stage == "bounded_worker_pilot"
+        and plan.next_action == NEXT_QUEUE_BOUNDED_WORKER_PILOT_INVOKE
+    )
+
+
+def _read_json_mapping(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _resident_queue_stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
+
+
 def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
     from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
         SIGNED_WORKER_DISPATCH_TASK_SOURCE,
     )
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
+        is_0102_bounded_code_change_signed_worker_context,
         is_openclaw_candidate_signed_worker_context,
     )
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
@@ -726,14 +805,21 @@ def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
     from modules.infrastructure.database.src.agent_db import AgentDB
 
     include_0102_readonly = _signed_0102_readonly_tasks_enabled_from_env()
+    include_0102_bounded_code = _signed_0102_bounded_code_tasks_enabled_from_env()
     db = AgentDB()
     for task in db.get_autonomous_tasks(status="pending", limit=limit):
         if str(task.get("discovered_by") or "") != SIGNED_WORKER_DISPATCH_TASK_SOURCE:
             continue
         context = task.get("context")
         normalized = context if isinstance(context, dict) else None
-        if is_openclaw_candidate_signed_worker_context(normalized) or (
-            include_0102_readonly and is_0102_readonly_signed_worker_context(normalized)
+        if (
+            is_openclaw_candidate_signed_worker_context(normalized)
+            or (include_0102_readonly and is_0102_readonly_signed_worker_context(normalized))
+            or (
+                include_0102_bounded_code
+                and is_0102_bounded_code_change_signed_worker_context(normalized)
+                and _signed_0102_bounded_code_stage_ready_from_env(normalized, os.environ)
+            )
         ):
             return True
     return False

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -34,6 +34,8 @@ SIGNED_WORKER_QUEUE_LOOP_BINDING_REJECT = "SIGNED_WORKER_QUEUE_LOOP_BINDING_REJE
 
 OPENCLAW_SIGNED_WORKER_RUNTIME = "openclaw"
 OPENCLAW_CANDIDATE_QUEUE_REVIEW_CAPABILITY = "candidate_queue_review"
+SIGNED_0102_WORKER_RUNTIME = "0102"
+SIGNED_0102_BOUNDED_CODE_CHANGE_CAPABILITY = "bounded_code_change"
 
 
 class SignedWorkerOpenClawQueueLoopBindingReason:
@@ -91,6 +93,19 @@ def is_openclaw_candidate_signed_worker_context(context: Mapping[str, Any] | Non
         str(context.get("source") or "") == SIGNED_WORKER_DISPATCH_TASK_SOURCE
         and str(context.get("worker_runtime") or "").strip().lower() == OPENCLAW_SIGNED_WORKER_RUNTIME
         and str(context.get("capability") or "").strip().lower() == OPENCLAW_CANDIDATE_QUEUE_REVIEW_CAPABILITY
+    )
+
+
+def is_0102_bounded_code_change_signed_worker_context(context: Mapping[str, Any] | None) -> bool:
+    """Return True only for signed 0102 coding tasks handled at the bounded stage."""
+
+    if not isinstance(context, Mapping):
+        return False
+    return (
+        str(context.get("source") or "") == SIGNED_WORKER_DISPATCH_TASK_SOURCE
+        and str(context.get("worker_runtime") or "").strip() == SIGNED_0102_WORKER_RUNTIME
+        and str(context.get("capability") or "").strip().lower()
+        == SIGNED_0102_BOUNDED_CODE_CHANGE_CAPABILITY
     )
 
 
@@ -296,11 +311,14 @@ def _stripped(value: Any) -> str:
 __all__ = [
     "OPENCLAW_CANDIDATE_QUEUE_REVIEW_CAPABILITY",
     "OPENCLAW_SIGNED_WORKER_RUNTIME",
+    "SIGNED_0102_BOUNDED_CODE_CHANGE_CAPABILITY",
+    "SIGNED_0102_WORKER_RUNTIME",
     "SIGNED_WORKER_QUEUE_LOOP_BINDING_NOT_REQUESTED",
     "SIGNED_WORKER_QUEUE_LOOP_BINDING_READY",
     "SIGNED_WORKER_QUEUE_LOOP_BINDING_REJECT",
     "SignedWorkerOpenClawQueueLoopBindingReason",
     "SignedWorkerOpenClawQueueLoopBindingResult",
     "build_reddog_signed_worker_queue_loop_runner_from_env",
+    "is_0102_bounded_code_change_signed_worker_context",
     "is_openclaw_candidate_signed_worker_context",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -35,6 +35,10 @@ class SignedWorkerQueueSerialLoopRunnerReason:
     QUEUE_ITEM_MISSING = "REJECT_SIGNED_WORKER_QUEUE_ITEM_MISSING"
     UNSUPPORTED_WORKER_RUNTIME = "REJECT_UNSUPPORTED_WORKER_RUNTIME"
     UNSUPPORTED_CAPABILITY = "REJECT_UNSUPPORTED_CAPABILITY"
+    CODE_STAGE_NOT_READY = "REJECT_0102_BOUNDED_CODE_STAGE_NOT_READY"
+    CODE_STAGE_MAX_STEPS_INVALID = "REJECT_0102_BOUNDED_CODE_MAX_STEPS_INVALID"
+    CODE_ARTIFACT_GENERATION_MISSING = "REJECT_0102_BOUNDED_CODE_ARTIFACT_GENERATION_MISSING"
+    CODE_STATIC_ARTIFACTS_FORBIDDEN = "REJECT_0102_BOUNDED_CODE_STATIC_ARTIFACTS_FORBIDDEN"
     BOOTSTRAP_REJECTED = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_REJECTED"
     BOOTSTRAP_UNSAFE = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_UNSAFE"
     BOOTSTRAP_EXCEPTION = "REJECT_RESIDENT_QUEUE_BOOTSTRAP_EXCEPTION"
@@ -54,6 +58,14 @@ _RESERVED_BOOTSTRAP_KWARGS = frozenset(
         "max_steps",
     }
 )
+
+_OPENCLAW_QUEUE_RUNTIME = "openclaw"
+_OPENCLAW_QUEUE_CAPABILITY = "candidate_queue_review"
+_SIGNED_0102_RUNTIME = "0102"
+_SIGNED_0102_BOUNDED_CODE_CAPABILITY = "bounded_code_change"
+_BOUNDED_WORKER_PILOT_STAGE = "bounded_worker_pilot"
+_BOUNDED_WORKER_PILOT_ACTION = "RUN_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE"
+_ARTIFACT_GENERATOR_MODE_FOUNDUPS_FUSION = "foundups_fusion"
 
 
 @dataclass(frozen=True)
@@ -98,10 +110,16 @@ class RedDogSignedWorkerQueueSerialLoopRunner:
         _ = signed_authority_receipt
         reasons: list[str] = []
 
-        if str(intent.get("worker_runtime") or context.get("worker_runtime") or "") != "openclaw":
-            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME)
-        if str(intent.get("capability") or context.get("capability") or "") != "candidate_queue_review":
-            reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_CAPABILITY)
+        worker_runtime = str(intent.get("worker_runtime") or context.get("worker_runtime") or "")
+        capability = str(intent.get("capability") or context.get("capability") or "")
+        target_kind = _target_kind(worker_runtime=worker_runtime, capability=capability)
+        if target_kind is None:
+            if worker_runtime not in {_OPENCLAW_QUEUE_RUNTIME, _SIGNED_0102_RUNTIME}:
+                reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME)
+            if capability not in {_OPENCLAW_QUEUE_CAPABILITY, _SIGNED_0102_BOUNDED_CODE_CAPABILITY}:
+                reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_CAPABILITY)
+            if not reasons:
+                reasons.append(SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_CAPABILITY)
 
         queue_item_id = str(context.get("queue_item_id") or "").strip()
         if not queue_item_id:
@@ -110,6 +128,8 @@ class RedDogSignedWorkerQueueSerialLoopRunner:
             reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CONFIG_MISSING)
         if any(key in _RESERVED_BOOTSTRAP_KWARGS for key in self.config.bootstrap_kwargs):
             reasons.append(SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_KWARG_CONFLICT)
+        if target_kind == "0102_bounded_code_change":
+            reasons.extend(_bounded_code_stage_reasons(self.config, queue_item_id=queue_item_id))
         if reasons:
             return _reject(task_id, reasons)
 
@@ -251,6 +271,83 @@ def _reject(
         "no_pattern_memory_write_performed": True,
         "no_reward_settlement_performed": True,
     }
+
+
+def _target_kind(*, worker_runtime: str, capability: str) -> str | None:
+    if worker_runtime == _OPENCLAW_QUEUE_RUNTIME and capability == _OPENCLAW_QUEUE_CAPABILITY:
+        return "openclaw_candidate_queue_review"
+    if worker_runtime == _SIGNED_0102_RUNTIME and capability == _SIGNED_0102_BOUNDED_CODE_CAPABILITY:
+        return "0102_bounded_code_change"
+    return None
+
+
+def _bounded_code_stage_reasons(
+    config: SignedWorkerQueueSerialLoopRunnerConfig,
+    *,
+    queue_item_id: str,
+) -> list[str]:
+    reasons: list[str] = []
+    if config.max_steps != 1:
+        reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CODE_STAGE_MAX_STEPS_INVALID)
+
+    kwargs = dict(config.bootstrap_kwargs)
+    if kwargs.get("artifact_contents_path"):
+        reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CODE_STATIC_ARTIFACTS_FORBIDDEN)
+    if (
+        not kwargs.get("artifact_generation_request_path")
+        or str(kwargs.get("artifact_generator_mode") or "") != _ARTIFACT_GENERATOR_MODE_FOUNDUPS_FUSION
+    ):
+        reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CODE_ARTIFACT_GENERATION_MISSING)
+
+    plan = _read_current_plan(config, queue_item_id=queue_item_id)
+    if (
+        not plan
+        or plan.get("accepted") is not True
+        or plan.get("current_stage") != _BOUNDED_WORKER_PILOT_STAGE
+        or plan.get("next_action") != _BOUNDED_WORKER_PILOT_ACTION
+    ):
+        reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CODE_STAGE_NOT_READY)
+    return reasons
+
+
+def _read_current_plan(
+    config: SignedWorkerQueueSerialLoopRunnerConfig,
+    *,
+    queue_item_id: str,
+) -> Mapping[str, Any]:
+    try:
+        work_state = _read_json_mapping(Path(config.work_state_path))
+        chain = _read_json_mapping(Path(config.chain_results_path))
+    except Exception:
+        return {}
+    if not work_state:
+        return {}
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
+            plan_reddog_resident_queue_orchestration,
+        )
+
+        plan = plan_reddog_resident_queue_orchestration(
+            work_state,
+            chain_results=_stage_results(chain),
+            requested_queue_item_id=queue_item_id,
+            now_iso=config.now_iso,
+        )
+    except Exception:
+        return {}
+    return plan.to_dict()
+
+
+def _read_json_mapping(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
+    raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
+    if not isinstance(raw, Mapping):
+        return {}
+    return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
 
 
 __all__ = [

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -377,6 +377,29 @@ def _publish_agentdb_task_with_allocation(allocation, **intent_overrides) -> str
     return result.receipt.task_ids[0]
 
 
+def _queue_chain_results_through(stage_key: str) -> dict[str, object]:
+    values = {
+        "authority_request": {"status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"},
+        "authority_runtime": {"decision": "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"},
+        "authority_verification": {"decision": "QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT"},
+        "worker_dispatch_dryrun": {"decision": "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT"},
+        "worker_dispatch_runtime": {"decision": "SIGNED_AUTHORITY_WORKER_DISPATCH_RUNTIME_ACCEPT"},
+        "work_order_invocation": {"decision": "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"},
+        "executor_plan": {"decision": "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"},
+        "execution_valve": {"decision": "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"},
+        "worktree_create": {"decision": "QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT"},
+    }
+    accepted = {}
+    for key, value in values.items():
+        accepted[key] = value
+        if key == stage_key:
+            break
+    return {
+        "schema_version": "reddog_resident_queue_chain_results.v1",
+        "stage_results": accepted,
+    }
+
+
 def _repo_with_readonly_target(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
     target = root / "docs" / "work_ledger.schema.json"
@@ -657,6 +680,96 @@ def test_openclaw_claim_does_not_claim_0102_bounded_code_change_even_when_readon
     assert result["accepted"] is False
     assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
     assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
+
+
+def test_openclaw_claim_0102_bounded_code_waits_for_bounded_stage(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task_with_allocation(
+        _allocation(),
+        intent_id="worker_dispatch_intent_coding_worker_1",
+        role="coding_worker_1",
+        worker_runtime="0102",
+        capability="bounded_code_change",
+    )
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    chain = _write_runtime_json(
+        tmp_path,
+        "chain_results.json",
+        _queue_chain_results_through("execution_valve"),
+    )
+    artifact_request = _write_runtime_json(
+        tmp_path,
+        "artifact_generation_request.json",
+        {"explicit_artifact_generation_requested": True},
+    )
+    monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH", str(artifact_request))
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATOR_MODE", "foundups_fusion")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
+
+
+def test_openclaw_claim_executes_0102_bounded_code_when_bounded_stage_ready(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task_with_allocation(
+        _allocation(),
+        intent_id="worker_dispatch_intent_coding_worker_1",
+        role="coding_worker_1",
+        worker_runtime="0102",
+        capability="bounded_code_change",
+    )
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    chain = _write_runtime_json(
+        tmp_path,
+        "chain_results.json",
+        _queue_chain_results_through("worktree_create"),
+    )
+    artifact_request = _write_runtime_json(
+        tmp_path,
+        "artifact_generation_request.json",
+        {"explicit_artifact_generation_requested": True},
+    )
+    runner = _FakeRunner()
+    monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH", str(artifact_request))
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATOR_MODE", "foundups_fusion")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+    from modules.communication.moltbot_bridge.src import (
+        reddog_signed_worker_openclaw_queue_loop_runtime_binding as binding_module,
+    )
+
+    monkeypatch.setattr(
+        binding_module,
+        "build_reddog_signed_worker_queue_loop_runner_from_env",
+        lambda *, repo_root, env: _FakeBinding(runner),
+    )
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert result["worker_runtime"] == "0102"
+    assert result["capability"] == "bounded_code_change"
+    assert runner.calls[0]["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
 
 
 def test_openclaw_claim_env_bound_queue_loop_runner_materializes_bounded_artifact(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -20,6 +20,7 @@ from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queu
     SIGNED_WORKER_QUEUE_LOOP_BINDING_READY,
     SignedWorkerOpenClawQueueLoopBindingReason,
     build_reddog_signed_worker_queue_loop_runner_from_env,
+    is_0102_bounded_code_change_signed_worker_context,
     is_openclaw_candidate_signed_worker_context,
 )
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
@@ -168,7 +169,12 @@ def _context(**intent_overrides):
     }
 
 
-def _config(tmp_path: Path) -> SignedWorkerQueueSerialLoopRunnerConfig:
+def _config(
+    tmp_path: Path,
+    *,
+    bootstrap_kwargs=None,
+    max_steps: int = 1,
+) -> SignedWorkerQueueSerialLoopRunnerConfig:
     return SignedWorkerQueueSerialLoopRunnerConfig(
         repo_root=tmp_path / "repo",
         work_state_path=tmp_path / "work_state.json",
@@ -176,8 +182,8 @@ def _config(tmp_path: Path) -> SignedWorkerQueueSerialLoopRunnerConfig:
         authority_profile_path=tmp_path / "authority_profile.json",
         now_iso="2026-07-16T00:00:00+00:00",
         now_epoch=1000,
-        max_steps=1,
-        bootstrap_kwargs={"work_order_materializer_mode": "authority_profile"},
+        max_steps=max_steps,
+        bootstrap_kwargs=bootstrap_kwargs or {"work_order_materializer_mode": "authority_profile"},
     )
 
 
@@ -206,8 +212,94 @@ def _bootstrap_payload(**overrides):
     return payload
 
 
+def _snapshot() -> dict[str, object]:
+    allocation = _allocation()
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": "2026-07-16T01:00:00+00:00",
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": [
+                    "claim:claim-1",
+                    "freshness:fresh-1",
+                    f"wsp15_allocation:{allocation['receipt_id']}",
+                ],
+                "wsp15_allocation_receipt": allocation,
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _accepted_results_through(stage_key: str) -> dict[str, dict[str, object]]:
+    values = {
+        "authority_request": {"status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"},
+        "authority_runtime": {"decision": "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"},
+        "authority_verification": {"decision": "QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT"},
+        "worker_dispatch_dryrun": {"decision": "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT"},
+        "worker_dispatch_runtime": {"decision": "SIGNED_AUTHORITY_WORKER_DISPATCH_RUNTIME_ACCEPT"},
+        "work_order_invocation": {"decision": "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"},
+        "executor_plan": {"decision": "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"},
+        "execution_valve": {"decision": "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"},
+        "worktree_create": {"decision": "QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT"},
+    }
+    accepted: dict[str, dict[str, object]] = {}
+    for key, value in values.items():
+        accepted[key] = value
+        if key == stage_key:
+            break
+    return accepted
+
+
+def _write_queue_stage_files(tmp_path: Path, *, through_stage: str) -> SignedWorkerQueueSerialLoopRunnerConfig:
+    (tmp_path / "work_state.json").write_text(json.dumps(_snapshot(), sort_keys=True), encoding="utf-8")
+    (tmp_path / "chain_results.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "reddog_resident_queue_chain_results.v1",
+                "stage_results": _accepted_results_through(through_stage),
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "artifact_request.json").write_text(
+        json.dumps({"explicit_artifact_generation_requested": True}, sort_keys=True),
+        encoding="utf-8",
+    )
+    return _config(
+        tmp_path,
+        bootstrap_kwargs={
+            "work_order_materializer_mode": "authority_profile",
+            "artifact_generation_request_path": str(tmp_path / "artifact_request.json"),
+            "artifact_generator_mode": "foundups_fusion",
+        },
+    )
+
+
 def test_openclaw_candidate_context_filter_accepts_only_target_capability() -> None:
     assert is_openclaw_candidate_signed_worker_context(_context()) is True
+    assert (
+        is_0102_bounded_code_change_signed_worker_context(
+            _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+        )
+        is True
+    )
     assert (
         is_openclaw_candidate_signed_worker_context(
             _context(worker_runtime="hermes", capability="candidate_queue_review")
@@ -416,8 +508,8 @@ def test_queue_serial_loop_runner_accepts_openclaw_candidate(tmp_path: Path) -> 
     assert bootstrap.calls[0]["work_order_materializer_mode"] == "authority_profile"
 
 
-def test_queue_serial_loop_runner_rejects_non_openclaw_worker(tmp_path: Path) -> None:
-    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+def test_queue_serial_loop_runner_rejects_unsupported_worker(tmp_path: Path) -> None:
+    context = _context(worker_runtime="hermes", role="coding_worker_1", capability="bounded_code_change")
     runner = RedDogSignedWorkerQueueSerialLoopRunner(_config(tmp_path), bootstrap=_FakeBootstrap())
 
     result = runner.run_signed_worker_dispatch_task(
@@ -431,7 +523,77 @@ def test_queue_serial_loop_runner_rejects_non_openclaw_worker(tmp_path: Path) ->
     assert result["accepted"] is False
     assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_REJECT
     assert SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME in result["rejection_reasons"]
-    assert SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_CAPABILITY in result["rejection_reasons"]
+
+
+def test_queue_serial_loop_runner_accepts_0102_bounded_code_only_at_artifact_stage(tmp_path: Path) -> None:
+    config = _write_queue_stage_files(tmp_path, through_stage="worktree_create")
+    bootstrap = _FakeBootstrap(_bootstrap_payload(dispatched_stages=("bounded_worker_pilot",)))
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=bootstrap)
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-0102-code",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is True, result
+    assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert bootstrap.calls[0]["requested_queue_item_id"] == "queue-1"
+    assert bootstrap.calls[0]["max_steps"] == 1
+    assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
+
+
+def test_queue_serial_loop_runner_rejects_0102_bounded_code_before_artifact_stage(tmp_path: Path) -> None:
+    config = _write_queue_stage_files(tmp_path, through_stage="execution_valve")
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=_FakeBootstrap())
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-0102-code",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert SignedWorkerQueueSerialLoopRunnerReason.CODE_STAGE_NOT_READY in result["rejection_reasons"]
+
+
+def test_queue_serial_loop_runner_rejects_0102_bounded_code_static_artifacts(tmp_path: Path) -> None:
+    config = _write_queue_stage_files(tmp_path, through_stage="worktree_create")
+    config = SignedWorkerQueueSerialLoopRunnerConfig(
+        repo_root=config.repo_root,
+        work_state_path=config.work_state_path,
+        chain_results_path=config.chain_results_path,
+        authority_profile_path=config.authority_profile_path,
+        now_iso=config.now_iso,
+        now_epoch=config.now_epoch,
+        max_steps=1,
+        bootstrap_kwargs={
+            **dict(config.bootstrap_kwargs),
+            "artifact_contents_path": str(tmp_path / "artifact_contents.json"),
+        },
+    )
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=_FakeBootstrap())
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-0102-code",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert (
+        SignedWorkerQueueSerialLoopRunnerReason.CODE_STATIC_ARTIFACTS_FORBIDDEN
+        in result["rejection_reasons"]
+    )
 
 
 def test_queue_serial_loop_runner_rejects_bootstrap_kwarg_override(tmp_path: Path) -> None:
@@ -661,7 +823,7 @@ def test_signed_worker_executor_rejects_unsupported_queue_runner_target(tmp_path
 
     assert result.accepted is False
     assert SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED in result.rejection_reasons
-    assert SignedWorkerQueueSerialLoopRunnerReason.UNSUPPORTED_WORKER_RUNTIME in result.rejection_reasons
+    assert SignedWorkerQueueSerialLoopRunnerReason.CODE_STAGE_NOT_READY in result.rejection_reasons
 
 
 def test_queue_serial_loop_runner_ast_has_no_shell_network_or_mutation_calls() -> None:


### PR DESCRIPTION
## Summary
- stage-scope signed `0102/bounded_code_change` worker tasks to the resident `bounded_worker_pilot` stage
- require explicit Fusion artifact generation for 0102 coding tasks and reject static artifact JSON for that capability
- gate OpenClaw claim discovery behind `OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED=1` plus queue-loop/artifact readiness so early coding tasks remain pending

## WSP_97 Evidence
- OBSERVED: signed dispatch already emits `0102/bounded_code_change` intents, but OpenClaw previously ignored them.
- OBSERVED: the bounded-worker-pilot stage already contains the governed artifact-generation and materialization guards.
- IMPLEMENTED: 0102 coding tasks may now drive exactly one stage only when the chain plan is already at `bounded_worker_pilot` and `artifact_generator_mode=foundups_fusion` is configured.
- NOT IMPLEMENTED: no broad 0102 worker process, shell execution, source-root mutation, Hermes dispatch, HoloIndex re-index, PR ready/merge, or reward settlement authority.

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_bounded_worker_pilot_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -s`
- `python -m compileall modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py`
- `git diff --check`
