### PR TITLE
fix(reddog): requeue incomplete signed worker queue stages

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_QUEUE_LOOP_INCOMPLETE_REQUEUE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added queue-chain completion telemetry to the signed worker serial-loop
+  runner. Non-terminal `next_action` values now emit
+  `queue_chain_requeue_required=true`; only `STOP_QUEUE_CHAIN_COMPLETE` is
+  terminal.
+- Updated OpenClaw signed-worker claiming so an accepted but incomplete
+  queue-loop stage is released back to AgentDB as `pending` instead of being
+  marked `completed`.
+- Extended the bounded signed-worker claim loop to count requeued claims,
+  preserve `requeued_task_ids`, and stop cleanly at the configured
+  `max_claims`.
+- Boundary remains explicit: no new worker authority, no shell execution, no
+  source-repo mutation, no Hermes dispatch, no HoloIndex re-index, no merge
+  authority, and no reward settlement are added.
+
 ## 2026-07-16: REDDOG_SIGNED_0102_BOUNDED_CODE_CHANGE_STAGE_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -40,6 +40,7 @@ READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT = "READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT"
 READONLY_AUDIT_OPENCLAW_CLAIM_IDLE = "READONLY_AUDIT_OPENCLAW_CLAIM_IDLE"
 READONLY_AUDIT_OPENCLAW_CLAIM_REJECT = "READONLY_AUDIT_OPENCLAW_CLAIM_REJECT"
 SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT = "SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT"
+SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED = "SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED"
 SIGNED_WORKER_OPENCLAW_CLAIM_IDLE = "SIGNED_WORKER_OPENCLAW_CLAIM_IDLE"
 SIGNED_WORKER_OPENCLAW_CLAIM_REJECT = "SIGNED_WORKER_OPENCLAW_CLAIM_REJECT"
 SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT = "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT"
@@ -369,6 +370,21 @@ def claim_reddog_signed_worker_dispatch_task_once(
             ),
         )
 
+    runner_result = (
+        run_result.runner_result if isinstance(run_result.runner_result, Mapping) else {}
+    )
+    if runner_result.get("queue_chain_requeue_required") is True:
+        _requeue_reddog_signed_worker_dispatch_task(db, task_id)
+        return _signed_worker_claim_result(
+            accepted=True,
+            status=SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
+            task_id=task_id,
+            worker_role=run_result.worker_role,
+            worker_runtime=run_result.worker_runtime,
+            capability=run_result.capability,
+            receipt_id=run_result.receipt_id,
+        )
+
     db.complete_autonomous_task(task_id)
     return _signed_worker_claim_result(
         accepted=True,
@@ -406,6 +422,7 @@ def claim_reddog_signed_worker_dispatch_tasks_until_idle(
 
     claim_results: list[Dict[str, Any]] = []
     completed_task_ids: list[str] = []
+    requeued_task_ids: list[str] = []
     failed_task_ids: list[str] = []
     idle = False
 
@@ -425,6 +442,14 @@ def claim_reddog_signed_worker_dispatch_tasks_until_idle(
                 completed_task_ids.append(task_id)
             continue
 
+        if (
+            claim.get("accepted") is True
+            and status == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
+        ):
+            if task_id:
+                requeued_task_ids.append(task_id)
+            continue
+
         if status == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE:
             idle = True
             break
@@ -441,20 +466,23 @@ def claim_reddog_signed_worker_dispatch_tasks_until_idle(
             max_claims=max_claims,
             claim_results=tuple(claim_results),
             completed_task_ids=tuple(completed_task_ids),
+            requeued_task_ids=tuple(requeued_task_ids),
             failed_task_ids=tuple(failed_task_ids),
             idle=idle,
         )
 
-    if completed_task_ids:
+    if completed_task_ids or requeued_task_ids:
         return _signed_worker_claim_loop_result(
             accepted=True,
             status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT,
             max_claims=max_claims,
             claim_results=tuple(claim_results),
             completed_task_ids=tuple(completed_task_ids),
+            requeued_task_ids=tuple(requeued_task_ids),
             failed_task_ids=tuple(failed_task_ids),
             idle=idle,
-            max_claims_reached=(not idle and len(completed_task_ids) >= max_claims),
+            max_claims_reached=not idle
+            and (len(completed_task_ids) + len(requeued_task_ids)) >= max_claims,
         )
 
     return _signed_worker_claim_loop_result(
@@ -464,6 +492,7 @@ def claim_reddog_signed_worker_dispatch_tasks_until_idle(
         max_claims=max_claims,
         claim_results=tuple(claim_results),
         completed_task_ids=tuple(completed_task_ids),
+        requeued_task_ids=tuple(requeued_task_ids),
         failed_task_ids=tuple(failed_task_ids),
         idle=True,
     )
@@ -600,6 +629,22 @@ def _mark_reddog_signed_worker_dispatch_task_failed(db: Any, task_id: str) -> No
         logger.debug("[SUPERVISOR] Failed to mark RedDog signed-worker task failed", exc_info=True)
 
 
+def _requeue_reddog_signed_worker_dispatch_task(db: Any, task_id: str) -> None:
+    if not task_id:
+        return
+    try:
+        db.db.execute_write(
+            """
+            UPDATE agents_autonomous_tasks
+            SET assigned_to = NULL, assigned_at = NULL, status = 'pending'
+            WHERE task_id = ?
+            """,
+            (task_id,),
+        )
+    except Exception:
+        logger.debug("[SUPERVISOR] Failed to requeue RedDog signed-worker task", exc_info=True)
+
+
 def _readonly_assignment_id(context: Dict[str, Any]) -> str:
     assignment = context.get("assignment") if isinstance(context, dict) else {}
     return str(assignment.get("assignment_id") or "") if isinstance(assignment, dict) else ""
@@ -674,6 +719,7 @@ def _signed_worker_claim_loop_result(
     max_claims: int,
     claim_results=(),
     completed_task_ids=(),
+    requeued_task_ids=(),
     failed_task_ids=(),
     rejection_reasons=(),
     idle: bool = False,
@@ -699,8 +745,10 @@ def _signed_worker_claim_loop_result(
         "accepted": accepted,
         "status": status,
         "max_claims": max_claims,
-        "claimed_count": len(tuple(completed_task_ids or ())),
+        "claimed_count": len(tuple(completed_task_ids or ()))
+        + len(tuple(requeued_task_ids or ())),
         "completed_task_ids": tuple(completed_task_ids or ()),
+        "requeued_task_ids": tuple(requeued_task_ids or ()),
         "failed_task_ids": tuple(failed_task_ids or ()),
         "idle": idle,
         "max_claims_reached": max_claims_reached,

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -66,6 +66,7 @@ _SIGNED_0102_BOUNDED_CODE_CAPABILITY = "bounded_code_change"
 _BOUNDED_WORKER_PILOT_STAGE = "bounded_worker_pilot"
 _BOUNDED_WORKER_PILOT_ACTION = "RUN_QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE"
 _ARTIFACT_GENERATOR_MODE_FOUNDUPS_FUSION = "foundups_fusion"
+_QUEUE_CHAIN_COMPLETE_ACTION = "STOP_QUEUE_CHAIN_COMPLETE"
 
 
 @dataclass(frozen=True)
@@ -167,6 +168,7 @@ class RedDogSignedWorkerQueueSerialLoopRunner:
                 [SignedWorkerQueueSerialLoopRunnerReason.BOOTSTRAP_UNSAFE],
                 bootstrap_result=payload,
             )
+        queue_chain_complete = str(payload.get("next_action") or "") == _QUEUE_CHAIN_COMPLETE_ACTION
 
         return {
             "accepted": True,
@@ -174,6 +176,8 @@ class RedDogSignedWorkerQueueSerialLoopRunner:
             "receipt_id": _receipt_id(task_id, queue_item_id, payload),
             "queue_item_id": queue_item_id,
             "bootstrap_result": dict(payload),
+            "queue_chain_complete": queue_chain_complete,
+            "queue_chain_requeue_required": not queue_chain_complete,
             "rejection_reasons": [],
             "no_source_repo_mutation_performed": True,
             "no_shell_command_executed": True,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -22,6 +22,7 @@ from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
     SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE,
     SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
     SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+    SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
     SignedWorkerOpenClawClaimReason,
     claim_reddog_signed_worker_dispatch_task_once,
     claim_reddog_signed_worker_dispatch_tasks_until_idle,
@@ -101,9 +102,16 @@ def isolated_agent_db(tmp_path, monkeypatch):
 
 
 class _FakeRunner:
-    def __init__(self, *, accepted: bool = True, unsafe: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        accepted: bool = True,
+        unsafe: bool = False,
+        requeue_required: bool = False,
+    ) -> None:
         self.accepted = accepted
         self.unsafe = unsafe
+        self.requeue_required = requeue_required
         self.calls = []
 
     def run_signed_worker_dispatch_task(
@@ -124,13 +132,17 @@ class _FakeRunner:
                 "repo_root": Path(repo_root),
             }
         )
-        return {
+        result = {
             "accepted": self.accepted,
             "receipt_id": "fake-signed-worker-runner-receipt",
             "rejection_reasons": [] if self.accepted else ["runner_declined"],
             "no_source_repo_mutation_performed": not self.unsafe,
             "no_shell_command_executed": not self.unsafe,
         }
+        if self.requeue_required:
+            result["queue_chain_complete"] = False
+            result["queue_chain_requeue_required"] = True
+        return result
 
 
 class _FakeQueryAdapter:
@@ -870,11 +882,11 @@ def test_openclaw_claim_env_bound_queue_loop_runner_materializes_bounded_artifac
     result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
-    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
     assert result["task_id"] == task_id
     assert result["worker_runtime"] == "openclaw"
     assert result["capability"] == "candidate_queue_review"
-    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
     stored = json.loads(chain.read_text(encoding="utf-8"))
     stage = stored["stage_results"]["bounded_worker_pilot"]
@@ -993,11 +1005,11 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_slice_verifier(
     result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
-    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
     assert result["task_id"] == task_id
     assert result["worker_runtime"] == "openclaw"
     assert result["capability"] == "candidate_queue_review"
-    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
     stored = json.loads(chain.read_text(encoding="utf-8"))
     stage = stored["stage_results"]["slice_verifier"]
@@ -1128,9 +1140,9 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_draft_pr_pu
     result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
-    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
     assert result["task_id"] == task_id
-    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
     assert len(_FakeEnvDraftPrRunner.instances) == 1
     draft_runner = _FakeEnvDraftPrRunner.instances[0]
     assert draft_runner.repo_root == repo.resolve()
@@ -1269,9 +1281,9 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_outcome_rat
     result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
-    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
     assert result["task_id"] == task_id
-    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
     stored = json.loads(chain.read_text(encoding="utf-8"))
     stage = stored["stage_results"]["verified_outcome_ratchet"]
@@ -1321,9 +1333,9 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_held_out_regression_
     result = claim_reddog_signed_worker_dispatch_task_once(repo_root=ctx["repo"])
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
-    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
     assert result["task_id"] == task_id
-    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
     stored = json.loads(Path(ctx["chain"]).read_text(encoding="utf-8"))
     stage = stored["stage_results"]["held_out_regression_gate"]
@@ -1408,6 +1420,26 @@ def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path
     assert result["worker_runtime"] == "openclaw"
     assert result["receipt_id"]
     assert db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+
+def test_openclaw_claim_requeues_incomplete_queue_chain_task(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task()
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(requeue_required=True),
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
+    assert result["task_id"] == task_id
+    assert result["worker_runtime"] == "openclaw"
+    assert result["receipt_id"]
+    stored = db.get_autonomous_task_by_id(task_id)
+    assert stored["status"] == "pending"
+    assert stored["assigned_to"] is None
+    assert stored["assigned_at"] is None
 
 
 def test_openclaw_claim_ignores_non_openclaw_signed_worker_task(tmp_path: Path) -> None:
@@ -1510,6 +1542,27 @@ def test_openclaw_claim_loop_respects_max_claims(tmp_path: Path) -> None:
     assert result["idle"] is False
     assert db.get_autonomous_task_by_id(task_id_1)["status"] == "completed"
     assert db.get_autonomous_task_by_id(task_id_2)["status"] == "pending"
+
+
+def test_openclaw_claim_loop_counts_requeued_claims(tmp_path: Path) -> None:
+    task_id = _publish_agentdb_task(intent_id="worker_dispatch_intent_openclaw_candidate_1")
+    db = AgentDB()
+
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(requeue_required=True),
+        max_claims=2,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT
+    assert result["claimed_count"] == 2
+    assert result["completed_task_ids"] == ()
+    assert result["requeued_task_ids"] == (task_id, task_id)
+    assert result["failed_task_ids"] == ()
+    assert result["idle"] is False
+    assert result["max_claims_reached"] is True
+    assert db.get_autonomous_task_by_id(task_id)["status"] == "pending"
 
 
 def test_openclaw_claim_loop_reports_idle_without_work(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -682,6 +682,8 @@ def test_queue_serial_loop_runner_allows_bounded_isolated_worktree_progress(
     assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
     assert result["no_source_repo_mutation_performed"] is True
     assert result["no_shell_command_executed"] is True
+    assert result["queue_chain_complete"] is False
+    assert result["queue_chain_requeue_required"] is True
 
 
 def test_queue_serial_loop_runner_allows_verified_draft_pr_publish_progress(
@@ -711,6 +713,8 @@ def test_queue_serial_loop_runner_allows_verified_draft_pr_publish_progress(
     assert result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
     assert result["no_pr_created"] is False
     assert result["no_shell_command_executed"] is True
+    assert result["queue_chain_complete"] is False
+    assert result["queue_chain_requeue_required"] is True
 
 
 def test_queue_serial_loop_runner_rejects_unexpected_pr_creation(tmp_path: Path) -> None:
@@ -765,6 +769,8 @@ def test_queue_serial_loop_runner_allows_pattern_memory_admission_progress(
     assert result["no_pattern_memory_write_performed"] is False
     assert result["no_reward_settlement_performed"] is True
     assert result["no_holoindex_reindex_performed"] is True
+    assert result["queue_chain_complete"] is True
+    assert result["queue_chain_requeue_required"] is False
 
 
 def test_queue_serial_loop_runner_rejects_unexpected_pattern_memory_write(
@@ -808,6 +814,7 @@ def test_signed_worker_executor_accepts_queue_serial_loop_runner(tmp_path: Path)
     assert result.decision == SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT
     assert result.runner_result is not None
     assert result.runner_result["decision"] == SIGNED_WORKER_QUEUE_SERIAL_LOOP_RUNNER_ACCEPT
+    assert result.runner_result["queue_chain_requeue_required"] is True
 
 
 def test_signed_worker_executor_rejects_unsupported_queue_runner_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Implements REDDOG_SIGNED_WORKER_QUEUE_LOOP_INCOMPLETE_REQUEUE_PHASE1.

- Adds queue-chain completion telemetry to the signed worker serial-loop runner.
- Requeues accepted but non-terminal resident queue stages instead of marking the AgentDB task completed.
- Extends the bounded OpenClaw claim loop to report requeued task IDs and count requeued claims toward max_claims.
- Preserves the terminal behavior: only STOP_QUEUE_CHAIN_COMPLETE completes the task.

## WSP_97 Truth Boundary

OBSERVED:
- Non-terminal queue stages now return SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED and leave the task pending/unassigned.
- Terminal pattern-memory admission still completes the AgentDB task.
- Loop claims include completed_task_ids and requeued_task_ids separately.

SPECIFIED_NOT_IMPLEMENTED / unchanged:
- No new worker authority.
- No shell execution.
- No source-repo mutation.
- No Hermes dispatch.
- No HoloIndex re-index.
- No merge authority or reward settlement.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q -s` -> 77 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_bounded_worker_pilot_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -s` -> exit 0
- `python -m compileall modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py` -> pass
- `git diff --check` -> clean