### PR TITLE
feat(reddog): derive pattern memory admission request

### DIFF
--- a/main.py
+++ b/main.py
@@ -1611,6 +1611,9 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_EVIDENCE_COMMAND_RUNNER_MODE                  Optional `real` evidence command runner mode
         REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH                 Outside-repo draft PR publish request JSON
         REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING              Derive draft PR publish request from queue chain state
+        REDDOG_OUTCOME_RATCHET_REQUEST_BINDING               Derive outcome-ratchet request from queue chain state
+        REDDOG_HELD_OUT_GATE_REQUEST_BINDING                 Derive held-out gate request from queue chain state
+        REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING      Derive PatternMemory admission request from queue chain state
         REDDOG_WRE_QUEUE_ITEM_ID                             Optional exact queue item id
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
@@ -1725,6 +1728,18 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             evidence_command_runner_mode=os.getenv("REDDOG_EVIDENCE_COMMAND_RUNNER_MODE", "") or None,
             draft_pr_publish_request_binding_enabled=os.getenv(
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING", "0"
+            )
+            != "0",
+            outcome_ratchet_request_binding_enabled=os.getenv(
+                "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING", "0"
+            )
+            != "0",
+            held_out_gate_request_binding_enabled=os.getenv(
+                "REDDOG_HELD_OUT_GATE_REQUEST_BINDING", "0"
+            )
+            != "0",
+            pattern_memory_admission_request_binding_enabled=os.getenv(
+                "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING", "0"
             )
             != "0",
             draft_pr_runner=draft_pr_runner,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added an opt-in resident queue binding for PatternMemory admission requests:
+  `REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING=1`.
+- The binding derives the admission request from the accepted held-out
+  regression gate already recorded in the resident queue chain, removing the
+  final operator-edited JSON request from the requeued signed-worker path.
+- Existing explicit `REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH` remains
+  authoritative when provided; the derived request is used only when the
+  explicit request is absent.
+- Boundary remains explicit: no new worker authority, no shell execution, no
+  source-repo mutation, no Hermes dispatch, no HoloIndex re-index, no merge
+  authority, and no reward settlement are added.
+
 ## 2026-07-16: REDDOG_OPENCLAW_SIGNED_WORKER_REQUEUE_DRAIN_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -158,6 +158,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     draft_pr_publish_request_binding_enabled: bool = False,
     outcome_ratchet_request_binding_enabled: bool = False,
     held_out_gate_request_binding_enabled: bool = False,
+    pattern_memory_admission_request_binding_enabled: bool = False,
     draft_pr_runner: Any = None,
     outcome_ratchet_store: Any = None,
     explicit_pattern_memory_write_requested: bool = False,
@@ -353,6 +354,8 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         ratchet_request = _derive_outcome_ratchet_request_from_chain(chain_state)
     if held_out_gate_request_binding_enabled and held_out_gate_request is None:
         held_out_gate_request = _derive_held_out_gate_request_from_chain(chain_state)
+    if pattern_memory_admission_request_binding_enabled and admission_request is None:
+        admission_request = _derive_pattern_memory_admission_request_from_chain(chain_state)
 
     resolved_outcome_ratchet_store, ratchet_store_reasons = _build_outcome_ratchet_store(
         root,
@@ -823,6 +826,37 @@ def _derive_held_out_gate_request_from_chain(
             "candidate_head_sha": head_sha,
         },
         "holoindex_evidence": _derived_holoindex_evidence(stages),
+    }
+
+
+def _derive_pattern_memory_admission_request_from_chain(
+    chain_state: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    stages = _chain_stage_results(chain_state)
+    held_out_stage = _nested_mapping(stages, "held_out_regression_gate")
+    gate_result = _nested_mapping(held_out_stage, "gate_result")
+    gate_receipt = _nested_mapping(gate_result, "receipt")
+    if (
+        not gate_result
+        or not gate_receipt
+        or gate_result.get("accepted") is not True
+        or gate_receipt.get("pattern_memory_admission_allowed") is not True
+    ):
+        return None
+    work_order_id = str(gate_receipt.get("work_order_id") or "")
+    if not work_order_id:
+        return None
+    return {
+        "work_order_id": work_order_id,
+        "admission_metadata": {
+            "source": "resident_queue_derived_pattern_memory_admission",
+            "gate_id": str(gate_receipt.get("gate_id") or ""),
+            "ratchet_id": str(gate_receipt.get("ratchet_id") or ""),
+            "verifier_receipt_id": str(gate_receipt.get("verifier_receipt_id") or ""),
+            "held_out_suite_id": str(gate_receipt.get("held_out_suite_id") or ""),
+            "held_out_suite_digest": str(gate_receipt.get("held_out_suite_digest") or ""),
+            "candidate_head_sha": str(gate_receipt.get("candidate_head_sha") or ""),
+        },
     }
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -245,6 +245,10 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         ("draft_pr_publish_request_binding_enabled", "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING"),
         ("outcome_ratchet_request_binding_enabled", "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING"),
         ("held_out_gate_request_binding_enabled", "REDDOG_HELD_OUT_GATE_REQUEST_BINDING"),
+        (
+            "pattern_memory_admission_request_binding_enabled",
+            "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING",
+        ),
     ):
         if _stripped(env.get(env_name)) == "1":
             payload[key] = True

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3660,11 +3660,14 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH": str(tmp_path / "publish_request.json"),
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING": "1",
                 "REDDOG_OUTCOME_RATCHET_REQUEST_PATH": str(tmp_path / "ratchet_request.json"),
+                "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING": "1",
                 "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(tmp_path / "ratchet.jsonl"),
                 "REDDOG_HELD_OUT_GATE_REQUEST_PATH": str(tmp_path / "held_out_gate_request.json"),
+                "REDDOG_HELD_OUT_GATE_REQUEST_BINDING": "1",
                 "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH": str(
                     tmp_path / "pattern_memory_admission_request.json"
                 ),
+                "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING": "1",
                 "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(
                     tmp_path / "pattern_memory.db"
                 ),
@@ -3727,12 +3730,15 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["outcome_ratchet_store_path"] == str(
         tmp_path / "ratchet.jsonl"
     )
+    assert mocked.call_args.kwargs["outcome_ratchet_request_binding_enabled"] is True
     assert mocked.call_args.kwargs["held_out_gate_request_path"] == str(
         tmp_path / "held_out_gate_request.json"
     )
+    assert mocked.call_args.kwargs["held_out_gate_request_binding_enabled"] is True
     assert mocked.call_args.kwargs["admission_request_path"] == str(
         tmp_path / "pattern_memory_admission_request.json"
     )
+    assert mocked.call_args.kwargs["pattern_memory_admission_request_binding_enabled"] is True
     assert mocked.call_args.kwargs["pattern_memory_admission_sink"] is not None
     assert str(mocked.call_args.kwargs["pattern_memory_admission_sink"].db_path) == str(
         tmp_path / "pattern_memory.db"

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -1499,11 +1499,6 @@ def test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues(
         "publish_request.json",
         _draft_pr_publish_request(worktree),
     )
-    admission_request = _write_runtime_json(
-        tmp_path,
-        "pattern_memory_admission_request.json",
-        _pattern_memory_admission_request(),
-    )
     outcome_store = tmp_path / "runtime" / "outcomes" / "signed-worker-ratchet.jsonl"
     pattern_memory_db = tmp_path / "runtime" / "pattern_memory.db"
 
@@ -1525,7 +1520,7 @@ def test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues(
     monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_REQUEST_BINDING", "1")
     monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", str(outcome_store))
     monkeypatch.setenv("REDDOG_HELD_OUT_GATE_REQUEST_BINDING", "1")
-    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH", str(admission_request))
+    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING", "1")
     monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", str(pattern_memory_db))
     monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)


### PR DESCRIPTION
## Summary
- derive PatternMemory admission requests from an accepted held-out regression gate already recorded in the resident queue chain
- add `REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING=1` to the OpenClaw signed-worker queue-loop runtime binding and `main.py` resident preflight
- prove the full OpenClaw signed-worker requeue-drain E2E no longer needs `REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH`

## WSP_97 Truth Boundary
- OBSERVED: explicit `REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH` remains authoritative when provided.
- OBSERVED: derived admission is opt-in only and requires accepted held-out evidence with PatternMemory admission allowed.
- OBSERVED: no new worker authority, shell execution, source-repo mutation, Hermes dispatch, HoloIndex re-index, merge authority, or reward settlement is added.
- SPECIFIED_NOT_IMPLEMENTED: broader autonomous task selection beyond the already gated resident queue chain.

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -s` -> exit 0
- `python -m compileall main.py modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py`
- `git diff --check`
