### PR TITLE
feat(reddog): derive artifact generation request

### DIFF
--- a/main.py
+++ b/main.py
@@ -1603,6 +1603,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_GOVERNED_SHELL_DRYRUN_RESULT_PATH             Outside-repo governed shell dry-run JSON
         REDDOG_ARTIFACT_CONTENTS_PATH                        Outside-repo artifact contents JSON
         REDDOG_ARTIFACT_GENERATION_REQUEST_PATH              Outside-repo artifact generation request JSON
+        REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING           Derive artifact generation request from queue chain state
         REDDOG_ARTIFACT_GENERATOR_MODE                       Optional `foundups_fusion` generator mode
         REDDOG_HOLOINDEX_EVIDENCE_PATH                       Outside-repo HoloIndex evidence JSON
         REDDOG_SLICE_VERIFIER_REQUEST_PATH                   Outside-repo slice verifier request JSON
@@ -1702,6 +1703,10 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             or None,
             artifact_contents_path=os.getenv("REDDOG_ARTIFACT_CONTENTS_PATH", "") or None,
             artifact_generation_request_path=os.getenv("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH", "") or None,
+            artifact_generation_request_binding_enabled=os.getenv(
+                "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING", "0"
+            )
+            != "0",
             holoindex_evidence_path=os.getenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", "") or None,
             verifier_request_path=os.getenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", "") or None,
             evidence_producer_request_path=os.getenv("REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING=1` for resident queue
+  runs. When explicit artifact contents and explicit artifact-generation
+  request JSON are both absent, the bootstrap can derive a bounded artifact
+  generation request from the signed work order and verified queue chain state.
+- Wired the binding through both `main.py` resident preflight and the OpenClaw
+  signed-worker queue-loop runtime adapter.
+- Existing `REDDOG_ARTIFACT_CONTENTS_PATH` and
+  `REDDOG_ARTIFACT_GENERATION_REQUEST_PATH` remain authoritative when provided;
+  the derived request is opt-in and fail-closed.
+- Boundary remains explicit: the slice derives a request only. Model execution
+  still requires the existing explicit artifact generator configuration; no
+  shell execution, source-repo mutation, Hermes dispatch, HoloIndex re-index,
+  merge authority, or reward settlement is added.
+
 ## 2026-07-16: REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -130,6 +130,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
     governed_shell_dryrun_result_path: Path | str | None = None,
     artifact_contents_path: Path | str | None = None,
     artifact_generation_request_path: Path | str | None = None,
+    artifact_generation_request_binding_enabled: bool = False,
     holoindex_evidence_path: Path | str | None = None,
     verifier_request_path: Path | str | None = None,
     evidence_producer_request_path: Path | str | None = None,
@@ -350,6 +351,17 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         return _not_ready(admission_request_reasons, chain_results_path=None)
 
     chain_state = _read_existing_chain_state(chain_path)
+    if (
+        artifact_generation_request_binding_enabled
+        and artifact_contents is None
+        and artifact_generation_request is None
+    ):
+        artifact_generation_request = _derive_artifact_generation_request_from_chain(
+            chain_state=chain_state,
+            work_orders=work_orders,
+            repo_root=root,
+            holoindex_evidence=holoindex_evidence,
+        )
     if outcome_ratchet_request_binding_enabled and ratchet_request is None:
         ratchet_request = _derive_outcome_ratchet_request_from_chain(chain_state)
     if held_out_gate_request_binding_enabled and held_out_gate_request is None:
@@ -435,6 +447,7 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
         governed_shell_dryrun_result=governed_shell_dryrun_result,
         artifact_contents=artifact_contents,
         artifact_generation_request=artifact_generation_request,
+        artifact_generation_request_binding_enabled=artifact_generation_request_binding_enabled,
         artifact_generator=resolved_artifact_generator,
         holoindex_evidence=holoindex_evidence,
         verifier_request=verifier_request,
@@ -716,6 +729,86 @@ def _read_existing_chain_state(chain_path: Path | None) -> Mapping[str, Any]:
 def _chain_stage_results(chain_state: Mapping[str, Any]) -> Mapping[str, Any]:
     stages = chain_state.get("stage_results")
     return stages if isinstance(stages, Mapping) else {}
+
+
+def _derive_artifact_generation_request_from_chain(
+    *,
+    chain_state: Mapping[str, Any],
+    work_orders: Mapping[str, Mapping[str, Any]] | None,
+    repo_root: Path,
+    holoindex_evidence: Mapping[str, Any] | None,
+) -> Mapping[str, Any] | None:
+    if not work_orders:
+        return None
+    stages = _chain_stage_results(chain_state)
+    worktree_stage = _nested_mapping(stages, "worktree_create")
+    worktree_result = _nested_mapping(worktree_stage, "worktree_create_result")
+    work_order_id = str(worktree_result.get("work_order_id") or "")
+    worktree_path = str(worktree_result.get("worktree_path") or "")
+    if not work_order_id or not worktree_path:
+        return None
+    work_order = JsonResidentQueueWorkOrderResolver(work_orders).resolve(
+        work_order_id=work_order_id,
+        queue_item_id=None,
+        selected_slice=None,
+    )
+    plan = _nested_mapping(work_order, "bounded_worker_plan")
+    planned_artifacts = _string_list(plan.get("planned_artifacts"))
+    signed_receipt_chain = _nested_mapping(plan, "signed_receipt_chain")
+    authority_stage = _nested_mapping(stages, "authority_runtime")
+    authority_result = _nested_mapping(authority_stage, "authority_result")
+    work_authority = _nested_mapping(authority_result, "work_authority")
+    authority_receipt = _nested_mapping(authority_result, "receipt")
+    if (
+        not plan
+        or not planned_artifacts
+        or not signed_receipt_chain
+        or authority_result.get("accepted") is not True
+        or not work_authority
+    ):
+        return None
+    evidence = (
+        (holoindex_evidence if isinstance(holoindex_evidence, Mapping) else {})
+        or _nested_mapping(work_order, "holoindex_evidence")
+        or _derived_holoindex_evidence(stages)
+    )
+    task_summary = str(work_order.get("task_summary") or "")
+    if not task_summary:
+        return None
+    signed_authority = {
+        **dict(work_authority),
+        "accepted": True,
+        "signature_gate_digest": str(
+            authority_receipt.get("work_authority_digest")
+            or authority_receipt.get("receipt_id")
+            or ""
+        ),
+    }
+    return {
+        "explicit_artifact_generation_requested": True,
+        "work_order_id": work_order_id,
+        "slice_name": str(work_order.get("requested_operation") or plan.get("operation") or ""),
+        "task_summary": task_summary,
+        "planned_artifacts": planned_artifacts,
+        "evidence_context": json.dumps(
+            {
+                "task_summary": task_summary,
+                "holoindex_evidence": dict(evidence),
+                "holoindex_evidence_refs": _string_list(
+                    work_order.get("holoindex_evidence_refs")
+                ),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ),
+        "repo_root": str(repo_root),
+        "worktree_path": worktree_path,
+        "holoindex_evidence": dict(evidence),
+        "signed_authority": signed_authority,
+        "signed_receipt_chain": dict(signed_receipt_chain),
+        "timeout_seconds": 30,
+    }
 
 
 def _derive_outcome_ratchet_request_from_chain(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_bounded_worker_pilot_handler.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_bounded_worker_pilot_handler.py
@@ -17,6 +17,7 @@ re-index HoloIndex.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Protocol
@@ -81,6 +82,14 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return {}
 
 
+def _list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
 def _stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
     raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
     if not isinstance(raw, Mapping):
@@ -124,6 +133,7 @@ class ResidentQueueBoundedWorkerPilotStageHandler:
     operation_cwd: Optional[Path] = None
     holoindex_evidence: Optional[Mapping[str, Any]] = None
     artifact_generation_request: Mapping[str, Any] | None = None
+    artifact_generation_request_binding_enabled: bool = False
     artifact_generator: Any = None
 
     def __call__(self, request: ResidentQueueStageDispatchRequest) -> Mapping[str, Any]:
@@ -192,6 +202,13 @@ class ResidentQueueBoundedWorkerPilotStageHandler:
         artifact_generation_result: Mapping[str, Any] | None = None
         if not artifact_contents:
             generation_request = _mapping(self.artifact_generation_request)
+            if not generation_request and self.artifact_generation_request_binding_enabled:
+                generation_request = _derive_artifact_generation_request(
+                    work_order=work_order,
+                    stage_results=stage_results,
+                    repo_root=self.repo_root,
+                    holoindex_evidence=self.holoindex_evidence,
+                )
             if not generation_request:
                 return _reject(FAIL_ARTIFACT_CONTENTS_MISSING)
             if self.artifact_generator is None:
@@ -236,6 +253,7 @@ def build_reddog_resident_queue_bounded_worker_pilot_stage_handler(
     operation_cwd: Optional[Path] = None,
     holoindex_evidence: Optional[Mapping[str, Any]] = None,
     artifact_generation_request: Mapping[str, Any] | None = None,
+    artifact_generation_request_binding_enabled: bool = False,
     artifact_generator: Any = None,
 ) -> ResidentQueueBoundedWorkerPilotStageHandler:
     """Build the injected bounded-worker-pilot handler for the dispatcher."""
@@ -250,8 +268,75 @@ def build_reddog_resident_queue_bounded_worker_pilot_stage_handler(
         operation_cwd=operation_cwd,
         holoindex_evidence=holoindex_evidence,
         artifact_generation_request=artifact_generation_request,
+        artifact_generation_request_binding_enabled=artifact_generation_request_binding_enabled,
         artifact_generator=artifact_generator,
     )
+
+
+def _derive_artifact_generation_request(
+    *,
+    work_order: Mapping[str, Any],
+    stage_results: Mapping[str, Mapping[str, Any]],
+    repo_root: Path,
+    holoindex_evidence: Optional[Mapping[str, Any]],
+) -> Mapping[str, Any]:
+    plan = _mapping(work_order.get("bounded_worker_plan"))
+    worktree_stage = _mapping(stage_results.get(WORKTREE_CREATE_STAGE_KEY))
+    worktree_result = _mapping(worktree_stage.get("worktree_create_result"))
+    authority_stage = _mapping(stage_results.get("authority_runtime"))
+    authority_result = _mapping(authority_stage.get("authority_result"))
+    work_authority = _mapping(authority_result.get("work_authority"))
+    authority_receipt = _mapping(authority_result.get("receipt"))
+    signed_receipt_chain = _mapping(plan.get("signed_receipt_chain"))
+    planned_artifacts = _list(plan.get("planned_artifacts"))
+    task_summary = str(work_order.get("task_summary") or "")
+    if (
+        not plan
+        or not planned_artifacts
+        or not signed_receipt_chain
+        or authority_result.get("accepted") is not True
+        or not work_authority
+        or not task_summary
+        or not worktree_result.get("worktree_path")
+    ):
+        return {}
+    evidence = (
+        holoindex_evidence
+        if isinstance(holoindex_evidence, Mapping)
+        else _mapping(work_order.get("holoindex_evidence"))
+    )
+    signed_authority = {
+        **dict(work_authority),
+        "accepted": True,
+        "signature_gate_digest": str(
+            authority_receipt.get("work_authority_digest")
+            or authority_receipt.get("receipt_id")
+            or ""
+        ),
+    }
+    return {
+        "explicit_artifact_generation_requested": True,
+        "work_order_id": str(work_order.get("work_order_id") or ""),
+        "slice_name": str(work_order.get("requested_operation") or plan.get("operation") or ""),
+        "task_summary": task_summary,
+        "planned_artifacts": planned_artifacts,
+        "evidence_context": json.dumps(
+            {
+                "task_summary": task_summary,
+                "holoindex_evidence": dict(evidence),
+                "holoindex_evidence_refs": _list(work_order.get("holoindex_evidence_refs")),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ),
+        "repo_root": str(repo_root),
+        "worktree_path": str(worktree_result.get("worktree_path") or ""),
+        "holoindex_evidence": dict(evidence),
+        "signed_authority": signed_authority,
+        "signed_receipt_chain": dict(signed_receipt_chain),
+        "timeout_seconds": 30,
+    }
 
 
 __all__ = [

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
@@ -201,6 +201,7 @@ def build_reddog_resident_queue_stage_handler_registry(
     governed_shell_dryrun_result: Optional[Mapping[str, Any]] = None,
     artifact_contents: Optional[Mapping[str, Any]] = None,
     artifact_generation_request: Optional[Mapping[str, Any]] = None,
+    artifact_generation_request_binding_enabled: bool = False,
     artifact_generator: Any = None,
     operation_cwd: Optional[Path] = None,
     holoindex_evidence: Optional[Mapping[str, Any]] = None,
@@ -372,6 +373,7 @@ def build_reddog_resident_queue_stage_handler_registry(
             governed_shell_dryrun_result=governed_shell_dryrun_result,
             artifact_contents=artifact_contents,
             artifact_generation_request=artifact_generation_request,
+            artifact_generation_request_binding_enabled=artifact_generation_request_binding_enabled,
             artifact_generator=artifact_generator,
             pilot_dryrun_binding_enabled=pilot_dryrun_binding_enabled,
             repo_root=root,
@@ -386,6 +388,7 @@ def build_reddog_resident_queue_stage_handler_registry(
             operation_cwd=operation_cwd,
             holoindex_evidence=holoindex_evidence,
             artifact_generation_request=artifact_generation_request,
+            artifact_generation_request_binding_enabled=artifact_generation_request_binding_enabled,
             artifact_generator=artifact_generator,
         ),
     )
@@ -478,6 +481,7 @@ def _bounded_worker_pilot_missing(
     governed_shell_dryrun_result: Optional[Mapping[str, Any]],
     artifact_contents: Optional[Mapping[str, Any]],
     artifact_generation_request: Optional[Mapping[str, Any]],
+    artifact_generation_request_binding_enabled: bool,
     artifact_generator: Any,
     pilot_dryrun_binding_enabled: bool,
     repo_root: Optional[Path],
@@ -498,6 +502,8 @@ def _bounded_worker_pilot_missing(
     if artifact_contents:
         return tuple(reasons)
     if artifact_generation_request and artifact_generator is not None:
+        return tuple(reasons)
+    if artifact_generation_request_binding_enabled and artifact_generator is not None:
         return tuple(reasons)
     if not artifact_contents:
         reasons.append("missing_dependency:artifact_contents")

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -241,6 +241,10 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
             payload[key] = value
     for key, env_name in (
         ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
+        (
+            "artifact_generation_request_binding_enabled",
+            "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING",
+        ),
         ("slice_verifier_request_binding_enabled", "REDDOG_SLICE_VERIFIER_REQUEST_BINDING"),
         ("draft_pr_publish_request_binding_enabled", "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING"),
         ("outcome_ratchet_request_binding_enabled", "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING"),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -1998,7 +1998,10 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
     )
     snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
     principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
-    work_order = _work_order(**pilot_overrides)
+    work_order = _work_order(
+        **pilot_overrides,
+        bounded_worker_plan=_pilot_bounded_worker_plan(),
+    )
     work_orders = _write_runtime_json(
         tmp_path,
         "work_orders.json",
@@ -2022,11 +2025,6 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
         "governed_shell.json",
         pilot_payloads["governed_shell_dryrun_result"],
     )
-    artifact_request = _write_runtime_json(
-        tmp_path,
-        "artifact_generation_request.json",
-        _artifact_generation_request(worktree),
-    )
     holoindex = _write_runtime_json(
         tmp_path,
         "holoindex_evidence.json",
@@ -2042,7 +2040,7 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
         valve_environment_path=valve_env,
         generic_writer_dryrun_result_path=generic_writer,
         governed_shell_dryrun_result_path=governed_shell,
-        artifact_generation_request_path=artifact_request,
+        artifact_generation_request_binding_enabled=True,
         holoindex_evidence_path=holoindex,
         authority_state_path=authority_state,
         permission_snapshots_path=snapshots,
@@ -2059,9 +2057,12 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
         max_steps=10,
     )
 
-    assert result.accepted is True
+    assert result.accepted is True, result.rejection_reasons
     assert result.dispatched_stages[-1] == "bounded_worker_pilot"
     assert artifact_generator.calls
+    assert artifact_generator.calls[0]["binding"]["work_order_id"] == WORK_ORDER_ID
+    context = json.loads(str(artifact_generator.calls[0]["context"]))
+    assert context["holoindex_evidence"]["retrieval_quality"] == "HIGH"
     stored = json.loads(chain.read_text(encoding="utf-8"))
     stage = stored["stage_results"]["bounded_worker_pilot"]
     assert stage["decision"] == "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT"
@@ -3649,6 +3650,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_ARTIFACT_GENERATION_REQUEST_PATH": str(
                     tmp_path / "artifact_generation_request.json"
                 ),
+                "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "1",
                 "REDDOG_ARTIFACT_GENERATOR_MODE": "foundups_fusion",
                 "REDDOG_HOLOINDEX_EVIDENCE_PATH": str(tmp_path / "holoindex_evidence.json"),
                 "REDDOG_SLICE_VERIFIER_REQUEST_PATH": str(tmp_path / "verifier_request.json"),
@@ -3708,6 +3710,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["artifact_generation_request_path"] == str(
         tmp_path / "artifact_generation_request.json"
     )
+    assert mocked.call_args.kwargs["artifact_generation_request_binding_enabled"] is True
     assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
     assert mocked.call_args.kwargs["holoindex_evidence_path"] == str(
         tmp_path / "holoindex_evidence.json"

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py
@@ -193,6 +193,48 @@ def test_registry_registers_bounded_worker_pilot_from_artifact_generation_depend
     assert registry.no_default_runner_created is True
 
 
+def test_registry_registers_bounded_worker_pilot_from_artifact_generation_binding(
+    tmp_path: Path,
+) -> None:
+    dummy = Dummy()
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={"principal_id": "github:mjtrout"},
+        work_order_resolver=dummy,
+        repo_root=tmp_path,
+        generic_writer_dryrun_result={"accepted": True},
+        governed_shell_dryrun_result={"accepted": True},
+        artifact_generation_request_binding_enabled=True,
+        artifact_generator=dummy,
+        now_iso=NOW_ISO,
+    )
+
+    assert "bounded_worker_pilot" in registry.registered_stage_keys
+    assert "bounded_worker_pilot" not in registry.missing_stage_reasons
+    assert registry.no_default_runner_created is True
+
+
+def test_registry_artifact_generation_binding_still_requires_generator(tmp_path: Path) -> None:
+    dummy = Dummy()
+    registry = build_reddog_resident_queue_stage_handler_registry(
+        work_state_snapshot=_snapshot(),
+        chain_results_store=_store(),
+        authority_profile={"principal_id": "github:mjtrout"},
+        work_order_resolver=dummy,
+        repo_root=tmp_path,
+        generic_writer_dryrun_result={"accepted": True},
+        governed_shell_dryrun_result={"accepted": True},
+        artifact_generation_request_binding_enabled=True,
+        now_iso=NOW_ISO,
+    )
+
+    assert "bounded_worker_pilot" not in registry.registered_stage_keys
+    assert "missing_dependency:artifact_generator" in (
+        registry.missing_stage_reasons["bounded_worker_pilot"]
+    )
+
+
 def test_registry_registers_bounded_worker_pilot_from_pilot_dryrun_binding_dependencies(
     tmp_path: Path,
 ) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -435,6 +435,7 @@ def test_runtime_binding_builds_pattern_memory_admission_sink_from_outside_repo_
         "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
         "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
         "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "1",
         "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(tmp_path / "pattern_memory.db"),
     }
 
@@ -455,6 +456,7 @@ def test_runtime_binding_builds_pattern_memory_admission_sink_from_outside_repo_
     )
 
     assert result["accepted"] is True
+    assert bootstrap.calls[0]["artifact_generation_request_binding_enabled"] is True
     sink = bootstrap.calls[0]["pattern_memory_admission_sink"]
     assert sink.__class__.__name__ == "RedDogVerifiedPatternMemorySink"
     assert sink.db_path == (tmp_path / "pattern_memory.db").resolve()


### PR DESCRIPTION
## Summary
- add opt-in REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING for resident queue runs
- derive bounded artifact generation requests from signed work order and verified queue chain state when explicit artifact contents/request JSON are absent
- thread the flag through main.py resident preflight and the OpenClaw signed-worker queue-loop adapter
- keep explicit artifact contents/request authoritative and require an explicitly configured artifact generator before any model call

## WSP_97 Truth Boundary
- OBSERVED: request derivation requires bounded_worker_plan planned_artifacts, accepted authority runtime, signed receipt chain, worktree-create result, task summary, and HoloIndex evidence context
- OBSERVED: registry only marks bounded_worker_pilot ready through this binding when an artifact generator is injected
- OBSERVED: no shell execution, source-repo mutation, Hermes dispatch, HoloIndex re-index, merge authority, reward settlement, or default model runner is added
- SPECIFIED_NOT_IMPLEMENTED: autonomous coding model execution still requires the existing explicit artifact generator runtime mode and external OpenRouter configuration

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_bounded_artifact_generation_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_bounded_worker_pilot_handler.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_stage_handler_registry.py -q -s
- python -m compileall main.py modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_resident_queue_bounded_worker_pilot_handler.py modules/communication/moltbot_bridge/src/reddog_resident_queue_stage_handler_registry.py
- git diff --check