### PR TITLE
feat(reddog): accept artifact request binding for signed code

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_BOUNDED_CODE_ARTIFACT_REQUEST_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Updated the signed 0102 bounded-code queue-loop runner so
+  `REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING=1` can satisfy the artifact
+  generation readiness gate when paired with the existing explicit
+  `foundups_fusion` artifact generator mode.
+- Preserved existing boundaries: static `REDDOG_ARTIFACT_CONTENTS_PATH` remains
+  forbidden for signed bounded-code workers, `max_steps` must remain 1, and the
+  queue stage must already be `bounded_worker_pilot`.
+- Kept the legacy explicit `REDDOG_ARTIFACT_GENERATION_REQUEST_PATH` flow
+  working; this slice only removes the need for hand-authored request JSON when
+  the resident queue can derive it from signed chain state.
+
 ## 2026-07-16: REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -297,8 +297,12 @@ def _bounded_code_stage_reasons(
     kwargs = dict(config.bootstrap_kwargs)
     if kwargs.get("artifact_contents_path"):
         reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CODE_STATIC_ARTIFACTS_FORBIDDEN)
+    artifact_request_available = bool(
+        kwargs.get("artifact_generation_request_path")
+        or kwargs.get("artifact_generation_request_binding_enabled")
+    )
     if (
-        not kwargs.get("artifact_generation_request_path")
+        not artifact_request_available
         or str(kwargs.get("artifact_generator_mode") or "") != _ARTIFACT_GENERATOR_MODE_FOUNDUPS_FUSION
     ):
         reasons.append(SignedWorkerQueueSerialLoopRunnerReason.CODE_ARTIFACT_GENERATION_MISSING)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -266,7 +266,12 @@ def _accepted_results_through(stage_key: str) -> dict[str, dict[str, object]]:
     return accepted
 
 
-def _write_queue_stage_files(tmp_path: Path, *, through_stage: str) -> SignedWorkerQueueSerialLoopRunnerConfig:
+def _write_queue_stage_files(
+    tmp_path: Path,
+    *,
+    through_stage: str,
+    artifact_request_binding: bool = False,
+) -> SignedWorkerQueueSerialLoopRunnerConfig:
     (tmp_path / "work_state.json").write_text(json.dumps(_snapshot(), sort_keys=True), encoding="utf-8")
     (tmp_path / "chain_results.json").write_text(
         json.dumps(
@@ -278,17 +283,21 @@ def _write_queue_stage_files(tmp_path: Path, *, through_stage: str) -> SignedWor
         ),
         encoding="utf-8",
     )
-    (tmp_path / "artifact_request.json").write_text(
-        json.dumps({"explicit_artifact_generation_requested": True}, sort_keys=True),
-        encoding="utf-8",
-    )
+    bootstrap_kwargs = {
+        "work_order_materializer_mode": "authority_profile",
+        "artifact_generator_mode": "foundups_fusion",
+    }
+    if artifact_request_binding:
+        bootstrap_kwargs["artifact_generation_request_binding_enabled"] = True
+    else:
+        (tmp_path / "artifact_request.json").write_text(
+            json.dumps({"explicit_artifact_generation_requested": True}, sort_keys=True),
+            encoding="utf-8",
+        )
+        bootstrap_kwargs["artifact_generation_request_path"] = str(tmp_path / "artifact_request.json")
     return _config(
         tmp_path,
-        bootstrap_kwargs={
-            "work_order_materializer_mode": "authority_profile",
-            "artifact_generation_request_path": str(tmp_path / "artifact_request.json"),
-            "artifact_generator_mode": "foundups_fusion",
-        },
+        bootstrap_kwargs=bootstrap_kwargs,
     )
 
 
@@ -546,6 +555,67 @@ def test_queue_serial_loop_runner_accepts_0102_bounded_code_only_at_artifact_sta
     assert bootstrap.calls[0]["requested_queue_item_id"] == "queue-1"
     assert bootstrap.calls[0]["max_steps"] == 1
     assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
+
+
+def test_queue_serial_loop_runner_accepts_0102_bounded_code_with_artifact_request_binding(
+    tmp_path: Path,
+) -> None:
+    config = _write_queue_stage_files(
+        tmp_path,
+        through_stage="worktree_create",
+        artifact_request_binding=True,
+    )
+    bootstrap = _FakeBootstrap(_bootstrap_payload(dispatched_stages=("bounded_worker_pilot",)))
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=bootstrap)
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-0102-code",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is True, result
+    assert bootstrap.calls[0]["artifact_generation_request_binding_enabled"] is True
+    assert "artifact_generation_request_path" not in bootstrap.calls[0]
+    assert not (tmp_path / "artifact_request.json").exists()
+
+
+def test_queue_serial_loop_runner_rejects_0102_bounded_code_without_generation_source(
+    tmp_path: Path,
+) -> None:
+    config = _write_queue_stage_files(tmp_path, through_stage="worktree_create")
+    config = SignedWorkerQueueSerialLoopRunnerConfig(
+        repo_root=config.repo_root,
+        work_state_path=config.work_state_path,
+        chain_results_path=config.chain_results_path,
+        authority_profile_path=config.authority_profile_path,
+        now_iso=config.now_iso,
+        now_epoch=config.now_epoch,
+        max_steps=1,
+        bootstrap_kwargs={
+            "work_order_materializer_mode": "authority_profile",
+            "artifact_generator_mode": "foundups_fusion",
+        },
+    )
+    runner = RedDogSignedWorkerQueueSerialLoopRunner(config, bootstrap=_FakeBootstrap())
+    context = _context(worker_runtime="0102", role="coding_worker_1", capability="bounded_code_change")
+
+    result = runner.run_signed_worker_dispatch_task(
+        task_id="task-0102-code",
+        task_context=context,
+        worker_dispatch_intent=context["worker_dispatch_intent"],
+        signed_authority_receipt=context["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path / "repo",
+    )
+
+    assert result["accepted"] is False
+    assert (
+        SignedWorkerQueueSerialLoopRunnerReason.CODE_ARTIFACT_GENERATION_MISSING
+        in result["rejection_reasons"]
+    )
 
 
 def test_queue_serial_loop_runner_rejects_0102_bounded_code_before_artifact_stage(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow signed 0102 bounded-code queue-loop runs to use REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING=1 instead of hand-authored artifact request JSON
- preserve foundups_fusion artifact generator mode as mandatory before bounded code can execute
- keep static artifact contents forbidden for signed bounded-code workers
- add tests for request-path compatibility, binding acceptance, and missing-generation-source rejection

## WSP_97 Truth Boundary
- OBSERVED: legacy REDDOG_ARTIFACT_GENERATION_REQUEST_PATH remains accepted
- OBSERVED: derived artifact request binding is accepted only when artifact_generator_mode is foundups_fusion
- OBSERVED: static artifact contents remain rejected for signed 0102 bounded-code worker dispatch
- OBSERVED: runner still requires max_steps=1 and current queue stage bounded_worker_pilot
- SPECIFIED_NOT_IMPLEMENTED: this slice does not invoke the model, create worktrees, execute shell commands, publish PRs, merge, write PatternMemory, settle rewards, or re-index HoloIndex

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -s
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q -s
- python -m compileall modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
- git diff --check