### PR TITLE
feat(openclaw): accept artifact binding for bounded code claims

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_OPENCLAW_BOUNDED_CODE_ARTIFACT_BINDING_STAGE_READY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Updated OpenClaw signed 0102 bounded-code stage readiness so
+  `REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING=1` can satisfy the artifact
+  request-source check without hand-authored request JSON.
+- Preserved fail-closed behavior: `foundups_fusion` artifact generator mode is
+  still required, static artifact contents still block 0102 bounded-code
+  claims, and the resident queue must already be at `bounded_worker_pilot`.
+- Added claim-path tests proving binding-based claim acceptance and rejection
+  when neither explicit request JSON nor derived request binding is present.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_BOUNDED_CODE_ARTIFACT_REQUEST_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -791,7 +791,11 @@ def _signed_0102_bounded_code_stage_ready_from_env(
         return False
     if str(env.get("REDDOG_ARTIFACT_GENERATOR_MODE") or "").strip() != "foundups_fusion":
         return False
-    if not str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH") or "").strip():
+    artifact_request_ready = bool(
+        str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH") or "").strip()
+        or str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING") or "").strip() == "1"
+    )
+    if not artifact_request_ready:
         return False
     if str(env.get("REDDOG_ARTIFACT_CONTENTS_PATH") or "").strip():
         return False

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -711,17 +711,44 @@ def test_openclaw_claim_0102_bounded_code_waits_for_bounded_stage(
         "chain_results.json",
         _queue_chain_results_through("execution_valve"),
     )
-    artifact_request = _write_runtime_json(
+    monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING", "1")
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATOR_MODE", "foundups_fusion")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
+
+
+def test_openclaw_claim_0102_bounded_code_requires_artifact_request_source(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task_with_allocation(
+        _allocation(),
+        intent_id="worker_dispatch_intent_coding_worker_1",
+        role="coding_worker_1",
+        worker_runtime="0102",
+        capability="bounded_code_change",
+    )
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    chain = _write_runtime_json(
         tmp_path,
-        "artifact_generation_request.json",
-        {"explicit_artifact_generation_requested": True},
+        "chain_results.json",
+        _queue_chain_results_through("worktree_create"),
     )
     monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
     monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
     monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
-    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH", str(artifact_request))
     monkeypatch.setenv("REDDOG_ARTIFACT_GENERATOR_MODE", "foundups_fusion")
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
 
@@ -749,18 +776,13 @@ def test_openclaw_claim_executes_0102_bounded_code_when_bounded_stage_ready(
         "chain_results.json",
         _queue_chain_results_through("worktree_create"),
     )
-    artifact_request = _write_runtime_json(
-        tmp_path,
-        "artifact_generation_request.json",
-        {"explicit_artifact_generation_requested": True},
-    )
     runner = _FakeRunner()
     monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
     monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
     monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
-    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH", str(artifact_request))
+    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING", "1")
     monkeypatch.setenv("REDDOG_ARTIFACT_GENERATOR_MODE", "foundups_fusion")
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
     from modules.communication.moltbot_bridge.src import (
@@ -781,6 +803,7 @@ def test_openclaw_claim_executes_0102_bounded_code_when_bounded_stage_ready(
     assert result["worker_runtime"] == "0102"
     assert result["capability"] == "bounded_code_change"
     assert runner.calls[0]["task_id"] == task_id
+    assert not (tmp_path / "artifact_generation_request.json").exists()
     assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
 
 


### PR DESCRIPTION
## Summary
- update OpenClaw signed 0102 bounded-code stage readiness to accept REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING=1 as the request source
- preserve foundups_fusion artifact generator mode, no static artifact contents, and bounded_worker_pilot stage readiness as hard gates
- update bounded-code claim tests to use derived artifact request binding without creating request JSON
- add a fail-closed test when neither request path nor binding is present

## WSP_97 Truth Boundary
- OBSERVED: request binding is accepted only as an alternative request source; it does not bypass model mode or queue-stage checks
- OBSERVED: REDDOG_ARTIFACT_CONTENTS_PATH still blocks signed 0102 bounded-code claims
- OBSERVED: missing request path and missing binding leaves the task pending/idling, not claimed
- SPECIFIED_NOT_IMPLEMENTED: this slice does not invoke models, create worktrees, execute shell, publish PRs, merge, write PatternMemory, settle rewards, or re-index HoloIndex

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py::test_openclaw_claim_0102_bounded_code_waits_for_bounded_stage modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py::test_openclaw_claim_0102_bounded_code_requires_artifact_request_source modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py::test_openclaw_claim_executes_0102_bounded_code_when_bounded_stage_ready -q -s
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -s
- python -m compileall modules/communication/moltbot_bridge/src/openclaw_supervisor.py
- git diff --check