### PR TITLE
feat(reddog): add resident queue binding profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1590,6 +1590,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
 
     Env:
         REDDOG_RESIDENT_QUEUE_SERIAL_LOOP=0                  Enable loop (default OFF)
+        REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional `signed_0102_bounded_code`
         REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED=0         Block startup if not applied
         REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS=1        Bounded loop steps
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
@@ -1663,6 +1664,10 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
             run_reddog_main_resident_queue_serial_loop_bootstrap,
         )
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_binding_enabled,
+            resident_queue_materializer_mode,
+        )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
             build_reddog_verified_pattern_memory_sink,
         )
@@ -1691,7 +1696,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
             authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
             work_orders_path=os.getenv("REDDOG_WORK_ORDERS_PATH", "") or None,
-            work_order_materializer_mode=os.getenv("REDDOG_WORK_ORDER_MATERIALIZER_MODE", "") or None,
+            work_order_materializer_mode=resident_queue_materializer_mode(os.environ) or None,
             valve_environment_path=os.getenv("REDDOG_EXECUTION_VALVE_ENV_PATH", "") or None,
             generic_writer_dryrun_result_path=os.getenv(
                 "REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH", ""
@@ -1703,10 +1708,10 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             or None,
             artifact_contents_path=os.getenv("REDDOG_ARTIFACT_CONTENTS_PATH", "") or None,
             artifact_generation_request_path=os.getenv("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH", "") or None,
-            artifact_generation_request_binding_enabled=os.getenv(
-                "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING", "0"
-            )
-            != "0",
+            artifact_generation_request_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING",
+            ),
             holoindex_evidence_path=os.getenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", "") or None,
             verifier_request_path=os.getenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", "") or None,
             evidence_producer_request_path=os.getenv("REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH", "") or None,
@@ -1722,31 +1727,34 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             signer_socket_timeout_s=signer_socket_timeout_s,
             signer_socket_max_response_bytes=signer_socket_max_response_bytes,
             signature_verifier_backend=os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND", "") or None,
-            pilot_dryrun_binding_enabled=os.getenv("REDDOG_PILOT_DRYRUN_BINDING", "0") != "0",
+            pilot_dryrun_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_PILOT_DRYRUN_BINDING",
+            ),
             worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
             worktree_runner_timeout_s=worktree_runner_timeout_s,
             artifact_generator_mode=os.getenv("REDDOG_ARTIFACT_GENERATOR_MODE", "") or None,
-            slice_verifier_request_binding_enabled=os.getenv(
-                "REDDOG_SLICE_VERIFIER_REQUEST_BINDING", "0"
-            )
-            != "0",
+            slice_verifier_request_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_SLICE_VERIFIER_REQUEST_BINDING",
+            ),
             evidence_command_runner_mode=os.getenv("REDDOG_EVIDENCE_COMMAND_RUNNER_MODE", "") or None,
-            draft_pr_publish_request_binding_enabled=os.getenv(
-                "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING", "0"
-            )
-            != "0",
-            outcome_ratchet_request_binding_enabled=os.getenv(
-                "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING", "0"
-            )
-            != "0",
-            held_out_gate_request_binding_enabled=os.getenv(
-                "REDDOG_HELD_OUT_GATE_REQUEST_BINDING", "0"
-            )
-            != "0",
-            pattern_memory_admission_request_binding_enabled=os.getenv(
-                "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING", "0"
-            )
-            != "0",
+            draft_pr_publish_request_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING",
+            ),
+            outcome_ratchet_request_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING",
+            ),
+            held_out_gate_request_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_HELD_OUT_GATE_REQUEST_BINDING",
+            ),
+            pattern_memory_admission_request_binding_enabled=resident_queue_binding_enabled(
+                os.environ,
+                "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING",
+            ),
             draft_pr_runner=draft_pr_runner,
             pattern_memory_admission_sink=pattern_memory_admission_sink,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_QUEUE_BINDING_PROFILE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code`
+  as a safe resident-queue profile for derivation/request bindings.
+- The profile defaults only resident queue derivation flags plus
+  `REDDOG_WORK_ORDER_MATERIALIZER_MODE=authority_profile`; explicit env values
+  still win, including explicit `0` disables for individual bindings.
+- Boundary remains unchanged: the profile does not enable artifact generator
+  mode, evidence command runner mode, real worktree runner, draft PR runner,
+  PatternMemory sink, shell execution, model calls, HoloIndex re-index, merge
+  authority, or reward settlement.
+
 ## 2026-07-16: REDDOG_OPENCLAW_BOUNDED_CODE_ARTIFACT_BINDING_STAGE_READY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -785,6 +785,10 @@ def _signed_0102_bounded_code_stage_ready_from_env(
 ) -> bool:
     """Return True only when a coding task may safely drive the artifact stage."""
 
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+        resident_queue_binding_enabled,
+    )
+
     if not isinstance(context, Mapping):
         return False
     if str(env.get("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER") or "").strip() != "1":
@@ -793,7 +797,7 @@ def _signed_0102_bounded_code_stage_ready_from_env(
         return False
     artifact_request_ready = bool(
         str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH") or "").strip()
-        or str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING") or "").strip() == "1"
+        or resident_queue_binding_enabled(env, "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING")
     )
     if not artifact_request_ready:
         return False

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -1,0 +1,72 @@
+"""Resident RedDog queue binding profile helpers.
+
+Slice: REDDOG_RESIDENT_QUEUE_BINDING_PROFILE_PHASE1
+
+The profile defaults only derivation/request-binding controls. It does not
+enable model execution, shell execution, worktree runners, draft PR publishing,
+PatternMemory writes, reward settlement, or HoloIndex re-indexing.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+
+ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE = "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"
+PROFILE_SIGNED_0102_BOUNDED_CODE = "signed_0102_bounded_code"
+
+PROFILE_BINDING_FLAGS = frozenset(
+    {
+        "REDDOG_PILOT_DRYRUN_BINDING",
+        "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING",
+        "REDDOG_SLICE_VERIFIER_REQUEST_BINDING",
+        "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING",
+        "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING",
+        "REDDOG_HELD_OUT_GATE_REQUEST_BINDING",
+        "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING",
+    }
+)
+
+
+def resident_queue_binding_profile(env: Mapping[str, str]) -> str:
+    """Return the normalized resident queue binding profile."""
+
+    value = str(env.get(ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE) or "").strip().lower()
+    return value if value == PROFILE_SIGNED_0102_BOUNDED_CODE else ""
+
+
+def resident_queue_binding_enabled(env: Mapping[str, str], env_name: str) -> bool:
+    """Return whether a derivation binding flag is enabled.
+
+    Explicit environment values win. The profile only enables the known binding
+    flags and only when the flag is absent.
+    """
+
+    raw = str(env.get(env_name) or "").strip()
+    if raw:
+        return raw == "1"
+    return (
+        env_name in PROFILE_BINDING_FLAGS
+        and resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE
+    )
+
+
+def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
+    """Return explicit/default work-order materializer mode for the profile."""
+
+    raw = str(env.get("REDDOG_WORK_ORDER_MATERIALIZER_MODE") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE:
+        return "authority_profile"
+    return ""
+
+
+__all__ = [
+    "ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE",
+    "PROFILE_BINDING_FLAGS",
+    "PROFILE_SIGNED_0102_BOUNDED_CODE",
+    "resident_queue_binding_enabled",
+    "resident_queue_binding_profile",
+    "resident_queue_materializer_mode",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -22,6 +22,10 @@ from typing import Any, Callable, Mapping, Optional
 from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
     SIGNED_WORKER_DISPATCH_TASK_SOURCE,
 )
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+    resident_queue_binding_enabled,
+    resident_queue_materializer_mode,
+)
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
     RedDogSignedWorkerQueueSerialLoopRunner,
     SignedWorkerQueueSerialLoopRunnerConfig,
@@ -209,9 +213,9 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
 
 
 def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
+    materializer_mode = resident_queue_materializer_mode(env)
     pairs = {
         "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
-        "work_order_materializer_mode": "REDDOG_WORK_ORDER_MATERIALIZER_MODE",
         "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
         "generic_writer_dryrun_result_path": "REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH",
         "governed_shell_dryrun_result_path": "REDDOG_GOVERNED_SHELL_DRYRUN_RESULT_PATH",
@@ -235,6 +239,8 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         "evidence_command_runner_mode": "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE",
     }
     payload: dict[str, Any] = {}
+    if materializer_mode:
+        payload["work_order_materializer_mode"] = materializer_mode
     for key, env_name in pairs.items():
         value = _stripped(env.get(env_name))
         if value:
@@ -254,7 +260,7 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
             "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING",
         ),
     ):
-        if _stripped(env.get(env_name)) == "1":
+        if resident_queue_binding_enabled(env, env_name):
             payload[key] = True
     return payload
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3636,6 +3636,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
             "os.environ",
             {
                 "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
                 "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS": "1",
                 "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
                 "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
@@ -3643,33 +3644,26 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_WORK_ORDERS_PATH": str(tmp_path / "work_orders.json"),
                 "REDDOG_WORK_ORDER_MATERIALIZER_MODE": "",
                 "REDDOG_EXECUTION_VALVE_ENV_PATH": str(tmp_path / "valve_env.json"),
-                "REDDOG_PILOT_DRYRUN_BINDING": "1",
                 "REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH": str(tmp_path / "generic_writer.json"),
                 "REDDOG_GOVERNED_SHELL_DRYRUN_RESULT_PATH": str(tmp_path / "governed_shell.json"),
                 "REDDOG_ARTIFACT_CONTENTS_PATH": str(tmp_path / "artifact_contents.json"),
                 "REDDOG_ARTIFACT_GENERATION_REQUEST_PATH": str(
                     tmp_path / "artifact_generation_request.json"
                 ),
-                "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "1",
                 "REDDOG_ARTIFACT_GENERATOR_MODE": "foundups_fusion",
                 "REDDOG_HOLOINDEX_EVIDENCE_PATH": str(tmp_path / "holoindex_evidence.json"),
                 "REDDOG_SLICE_VERIFIER_REQUEST_PATH": str(tmp_path / "verifier_request.json"),
                 "REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH": str(
                     tmp_path / "evidence_producer_request.json"
                 ),
-                "REDDOG_SLICE_VERIFIER_REQUEST_BINDING": "1",
                 "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE": "real",
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH": str(tmp_path / "publish_request.json"),
-                "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING": "1",
                 "REDDOG_OUTCOME_RATCHET_REQUEST_PATH": str(tmp_path / "ratchet_request.json"),
-                "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING": "1",
                 "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(tmp_path / "ratchet.jsonl"),
                 "REDDOG_HELD_OUT_GATE_REQUEST_PATH": str(tmp_path / "held_out_gate_request.json"),
-                "REDDOG_HELD_OUT_GATE_REQUEST_BINDING": "1",
                 "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH": str(
                     tmp_path / "pattern_memory_admission_request.json"
                 ),
-                "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING": "1",
                 "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(
                     tmp_path / "pattern_memory.db"
                 ),
@@ -3695,7 +3689,7 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["chain_results_path"] == str(tmp_path / "chain.json")
     assert mocked.call_args.kwargs["authority_profile_path"] == str(tmp_path / "profile.json")
     assert mocked.call_args.kwargs["work_orders_path"] == str(tmp_path / "work_orders.json")
-    assert mocked.call_args.kwargs["work_order_materializer_mode"] is None
+    assert mocked.call_args.kwargs["work_order_materializer_mode"] == "authority_profile"
     assert mocked.call_args.kwargs["valve_environment_path"] == str(tmp_path / "valve_env.json")
     assert mocked.call_args.kwargs["pilot_dryrun_binding_enabled"] is True
     assert mocked.call_args.kwargs["generic_writer_dryrun_result_path"] == str(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -779,10 +779,10 @@ def test_openclaw_claim_executes_0102_bounded_code_when_bounded_stage_ready(
     runner = _FakeRunner()
     monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
     monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", "signed_0102_bounded_code")
     monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
-    monkeypatch.setenv("REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING", "1")
     monkeypatch.setenv("REDDOG_ARTIFACT_GENERATOR_MODE", "foundups_fusion")
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
     from modules.communication.moltbot_bridge.src import (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -471,6 +471,80 @@ def test_runtime_binding_builds_pattern_memory_admission_sink_from_outside_repo_
     assert sink.db_path == (tmp_path / "pattern_memory.db").resolve()
 
 
+def test_runtime_binding_profile_defaults_derivation_flags(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=repo,
+    )
+
+    assert result["accepted"] is True
+    call = bootstrap.calls[0]
+    assert call["work_order_materializer_mode"] == "authority_profile"
+    assert call["pilot_dryrun_binding_enabled"] is True
+    assert call["artifact_generation_request_binding_enabled"] is True
+    assert call["slice_verifier_request_binding_enabled"] is True
+    assert call["draft_pr_publish_request_binding_enabled"] is True
+    assert call["outcome_ratchet_request_binding_enabled"] is True
+    assert call["held_out_gate_request_binding_enabled"] is True
+    assert call["pattern_memory_admission_request_binding_enabled"] is True
+    assert "artifact_generator_mode" not in call
+    assert "draft_pr_runner" not in call
+
+
+def test_runtime_binding_profile_respects_explicit_binding_disable(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+        "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "0",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=repo,
+    )
+
+    assert result["accepted"] is True
+    assert "artifact_generation_request_binding_enabled" not in bootstrap.calls[0]
+
+
 def test_runtime_binding_rejects_pattern_memory_admission_db_inside_repo(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code
- default only resident queue derivation/request binding flags and authority_profile materializer through that profile
- wire profile defaults through main.py preflight, signed-worker queue-loop runtime binding, and OpenClaw bounded-code stage readiness
- keep explicit env values authoritative, including explicit 0 disables

## WSP_97 Truth Boundary
- OBSERVED: profile enables derivation flags only; it does not enable artifact generator mode, evidence command runner mode, real worktree runner, draft PR runner, PatternMemory sink, shell execution, model calls, HoloIndex re-index, merge authority, or reward settlement
- OBSERVED: OpenClaw bounded-code claim still requires foundups_fusion mode, no static artifact contents, and bounded_worker_pilot stage readiness
- OBSERVED: explicit environment values override profile defaults
- SPECIFIED_NOT_IMPLEMENTED: this profile does not by itself make RedDog perform live coding, model generation, verification commands, PR publishing, or recursive execution

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py::test_runtime_binding_profile_defaults_derivation_flags modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py::test_runtime_binding_profile_respects_explicit_binding_disable modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py::test_openclaw_claim_executes_0102_bounded_code_when_bounded_stage_ready modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_main_serial_loop_preflight_passes_when_bootstrap_applies -q -s
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q -s
- python -m compileall main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py
- git diff --check