### PR TITLE
feat(reddog): wire OpenClaw signed-worker claim preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -1792,6 +1792,74 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
     return True
 
 
+def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> bool:
+    """
+    Optionally let OpenClaw claim signed RedDog worker-dispatch AgentDB tasks.
+
+    Env:
+        REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP=0           Enable loop (default OFF)
+        REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED=0  Block startup on reject
+        OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS=1             Bounded claims
+
+    This preflight does not create tasks, sign authority, create worktrees,
+    execute shell commands, publish PRs, dispatch Hermes, write PatternMemory,
+    settle rewards, or re-index HoloIndex. It only invokes the existing
+    OpenClaw signed-worker claim loop, whose per-task gates decide what can run.
+    """
+
+    if os.getenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP", "0") == "0":
+        logger.info("[REDDOG-OPENCLAW-CLAIM-LOOP] Startup claim loop disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED", "0") != "0"
+    max_claims_raw = os.getenv("OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS", "1").strip()
+    try:
+        max_claims = int(max_claims_raw)
+    except ValueError:
+        max_claims = 0
+    if max_claims < 1:
+        print("[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=FAIL error=invalid_max_claims")
+        return not enforced
+
+    try:
+        from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
+            claim_reddog_signed_worker_dispatch_tasks_until_idle,
+        )
+
+        result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+            repo_root=repo_root,
+            max_claims=max_claims,
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-OPENCLAW-CLAIM-LOOP] Startup claim loop failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    accepted = bool(result.get("accepted"))
+    status = str(result.get("status") or "(unknown)")
+    claimed_count = int(result.get("claimed_count") or 0)
+    completed = ",".join(str(item) for item in result.get("completed_task_ids", ()) or ()) or "(none)"
+    requeued = ",".join(str(item) for item in result.get("requeued_task_ids", ()) or ()) or "(none)"
+    failed = ",".join(str(item) for item in result.get("failed_task_ids", ()) or ()) or "(none)"
+    reasons = ",".join(str(reason) for reason in result.get("rejection_reasons", ()) or ()) or "(none)"
+    status_label = "PASS" if accepted else "WARN"
+    print(
+        f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight={status_label} status={status} "
+        f"claimed_count={claimed_count} max_claims={max_claims} "
+        f"completed={completed} requeued={requeued} failed={failed} reasons={reasons}"
+    )
+    if accepted:
+        return True
+
+    if enforced:
+        print("[REDDOG-OPENCLAW-CLAIM-LOOP] Startup blocked by REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED=1")
+        return False
+    return True
+
+
 def bootstrap_runtime_dae_launches() -> None:
     """Register broker-managed DAE entrypoints for an already running system."""
     daemon = get_central_daemon()
@@ -1979,6 +2047,8 @@ def main():
     if not run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root):
         return
     if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
+        return
+    if not run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MAIN_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added an opt-in `main.py` preflight,
+  `REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP=1`, that lets OpenClaw claim
+  signed RedDog worker-dispatch AgentDB tasks through the existing bounded
+  claim loop.
+- Preserved authority boundaries: the preflight creates no tasks, signs no
+  authority, enables no model/shell/worktree/PR modes, dispatches no Hermes,
+  writes no PatternMemory, settles no rewards, and never re-indexes HoloIndex.
+- Added focused tests for default-off behavior, bounded `max_claims`, enforced
+  reject blocking, invalid-claim rejection, and non-enforced exception handling.
+
 ## 2026-07-16: REDDOG_RESIDENT_QUEUE_BINDING_PROFILE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -1,0 +1,108 @@
+"""Tests for REDDOG_MAIN_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CLAIM_LOOP = (
+    "modules.communication.moltbot_bridge.src.openclaw_supervisor."
+    "claim_reddog_signed_worker_dispatch_tasks_until_idle"
+)
+
+
+def test_main_openclaw_signed_worker_claim_loop_disabled_by_default() -> None:
+    import main
+
+    with patch(CLAIM_LOOP, side_effect=AssertionError("claim loop must not run")):
+        with patch.dict("os.environ", {}, clear=True):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is True
+
+
+def test_main_openclaw_signed_worker_claim_loop_passes_when_idle(capsys) -> None:
+    import main
+
+    with patch(
+        CLAIM_LOOP,
+        return_value={
+            "accepted": True,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE",
+            "claimed_count": 0,
+            "completed_task_ids": (),
+            "requeued_task_ids": (),
+            "failed_task_ids": (),
+            "rejection_reasons": ("NO_PENDING_TASK",),
+        },
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP": "1",
+                "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "3",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["repo_root"] == REPO_ROOT
+    assert mocked.call_args.kwargs["max_claims"] == 3
+    captured = capsys.readouterr().out
+    assert "[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=PASS" in captured
+    assert "claimed_count=0" in captured
+    assert "max_claims=3" in captured
+
+
+def test_main_openclaw_signed_worker_claim_loop_blocks_when_enforced() -> None:
+    import main
+
+    with patch(
+        CLAIM_LOOP,
+        return_value={
+            "accepted": False,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT",
+            "claimed_count": 0,
+            "completed_task_ids": (),
+            "requeued_task_ids": (),
+            "failed_task_ids": ("task-1",),
+            "rejection_reasons": ("CLAIM_REJECTED",),
+        },
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP": "1",
+                "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is False
+
+
+def test_main_openclaw_signed_worker_claim_loop_rejects_invalid_max_claims_when_enforced() -> None:
+    import main
+
+    with patch(CLAIM_LOOP, side_effect=AssertionError("claim loop must not run")):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP": "1",
+                "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED": "1",
+                "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is False
+
+
+def test_main_openclaw_signed_worker_claim_loop_exception_is_nonblocking_by_default() -> None:
+    import main
+
+    with patch(CLAIM_LOOP, side_effect=RuntimeError("agentdb unavailable")):
+        with patch.dict(
+            "os.environ",
+            {"REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP": "1"},
+            clear=True,
+        ):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is True


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- Adds default-off `REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP=1` main startup preflight.
- The preflight invokes the existing `claim_reddog_signed_worker_dispatch_tasks_until_idle(...)` seam only.
- It passes bounded `OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS` and honors enforced/non-enforced startup behavior.
- It creates no tasks, signs no authority, enables no model/shell/worktree/PR modes, dispatches no Hermes, writes no PatternMemory, settles no rewards, and does not re-index HoloIndex.

SPECIFIED_NOT_IMPLEMENTED:
- No new worker capability.
- No automatic enabling of `REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER`, artifact generation, evidence command runner, real worktree runner, draft PR runner, or PatternMemory sink.
- No merge authority or reward settlement.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 5 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 36 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 50 passed
- `pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 21 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py`
- `git diff --check`

## WSP_15 Placement

This is the next operational step after queue-binding profile: RedDog can now opt into an OpenClaw-owned signed-worker claim loop from `main.py`, without user copy/paste or a new inline executor shortcut.