### PR TITLE
feat(reddog): default safe OpenClaw claim loop profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1798,6 +1798,7 @@ def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> b
 
     Env:
         REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP=0           Enable loop (default OFF)
+        REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional `signed_0102_bounded_code`
         REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED=0  Block startup on reject
         OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS=1             Bounded claims
 
@@ -1807,7 +1808,14 @@ def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> b
     OpenClaw signed-worker claim loop, whose per-task gates decide what can run.
     """
 
-    if os.getenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP", "0") == "0":
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+        resident_queue_runtime_flag_enabled,
+    )
+
+    if not resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP",
+    ):
         logger.info("[REDDOG-OPENCLAW-CLAIM-LOOP] Startup claim loop disabled")
         return True
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,17 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_PROFILE_OPENCLAW_CLAIM_LOOP_DEFAULTS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Extended `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code`
+  to default only the safe control-plane flags for the OpenClaw signed-worker
+  claim loop and signed-worker queue-loop runner.
+- Explicit env values still win, including explicit `0` disables.
+- Boundary remains unchanged: the profile still does not enable model
+  execution, shell execution, worktree runners, draft PR publishing,
+  PatternMemory writes, HoloIndex re-index, merge authority, or rewards.
+
 ## 2026-07-16: REDDOG_MAIN_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -27,6 +27,13 @@ PROFILE_BINDING_FLAGS = frozenset(
     }
 )
 
+PROFILE_RUNTIME_FLAGS = frozenset(
+    {
+        "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP",
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER",
+    }
+)
+
 
 def resident_queue_binding_profile(env: Mapping[str, str]) -> str:
     """Return the normalized resident queue binding profile."""
@@ -51,6 +58,24 @@ def resident_queue_binding_enabled(env: Mapping[str, str], env_name: str) -> boo
     )
 
 
+def resident_queue_runtime_flag_enabled(env: Mapping[str, str], env_name: str) -> bool:
+    """Return whether a safe resident runtime control-plane flag is enabled.
+
+    Explicit environment values win. The profile only enables known
+    control-plane flags that start existing gated loops; it never enables
+    model, shell, worktree, draft-PR, PatternMemory, HoloIndex, merge, or
+    reward-settlement effect modes.
+    """
+
+    raw = str(env.get(env_name) or "").strip()
+    if raw:
+        return raw == "1"
+    return (
+        env_name in PROFILE_RUNTIME_FLAGS
+        and resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE
+    )
+
+
 def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
     """Return explicit/default work-order materializer mode for the profile."""
 
@@ -65,8 +90,10 @@ def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
 __all__ = [
     "ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE",
     "PROFILE_BINDING_FLAGS",
+    "PROFILE_RUNTIME_FLAGS",
     "PROFILE_SIGNED_0102_BOUNDED_CODE",
     "resident_queue_binding_enabled",
     "resident_queue_binding_profile",
     "resident_queue_materializer_mode",
+    "resident_queue_runtime_flag_enabled",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -25,6 +25,7 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
     resident_queue_binding_enabled,
     resident_queue_materializer_mode,
+    resident_queue_runtime_flag_enabled,
 )
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
     RedDogSignedWorkerQueueSerialLoopRunner,
@@ -121,7 +122,10 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
 ) -> SignedWorkerOpenClawQueueLoopBindingResult:
     """Build the OpenClaw queue-loop runner from explicit runtime config."""
 
-    requested = str(env.get("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "0")).strip() == "1"
+    requested = resident_queue_runtime_flag_enabled(
+        env,
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER",
+    )
     if not requested:
         return SignedWorkerOpenClawQueueLoopBindingResult(
             accepted=False,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -54,6 +54,46 @@ def test_main_openclaw_signed_worker_claim_loop_passes_when_idle(capsys) -> None
     assert "max_claims=3" in captured
 
 
+def test_main_openclaw_signed_worker_claim_loop_profile_enables_control_plane() -> None:
+    import main
+
+    with patch(
+        CLAIM_LOOP,
+        return_value={
+            "accepted": True,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE",
+            "claimed_count": 0,
+            "completed_task_ids": (),
+            "requeued_task_ids": (),
+            "failed_task_ids": (),
+            "rejection_reasons": ("NO_PENDING_TASK",),
+        },
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {"REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code"},
+            clear=True,
+        ):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_count == 1
+
+
+def test_main_openclaw_signed_worker_claim_loop_explicit_zero_overrides_profile() -> None:
+    import main
+
+    with patch(CLAIM_LOOP, side_effect=AssertionError("claim loop must not run")):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(REPO_ROOT) is True
+
+
 def test_main_openclaw_signed_worker_claim_loop_blocks_when_enforced() -> None:
     import main
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -358,6 +358,45 @@ def test_runtime_binding_builds_runner_from_explicit_env(tmp_path: Path) -> None
     assert bootstrap.calls[0]["work_order_materializer_mode"] == "authority_profile"
 
 
+def test_runtime_binding_profile_enables_runner_without_explicit_runner_flag(tmp_path: Path) -> None:
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=_FakeBootstrap(),
+    )
+
+    assert binding.accepted is True
+    assert binding.status == SIGNED_WORKER_QUEUE_LOOP_BINDING_READY
+    assert binding.runner is not None
+
+
+def test_runtime_binding_explicit_zero_disables_runner_profile(tmp_path: Path) -> None:
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "0",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=_FakeBootstrap(),
+    )
+
+    assert binding.accepted is False
+    assert binding.requested is False
+    assert binding.runner is None
+
+
 def test_runtime_binding_rejects_missing_required_paths(tmp_path: Path) -> None:
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
         repo_root=tmp_path,


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- Extends `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code` to default only two safe control-plane flags:
  - `REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP`
  - `REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER`
- Explicit env values still win; explicit `0` disables both profile defaults.
- The profile still does not enable model execution, shell execution, real worktree runners, draft PR publishing, PatternMemory writes, HoloIndex re-indexing, merge authority, or rewards.

SPECIFIED_NOT_IMPLEMENTED:
- No automatic artifact generation mode.
- No automatic evidence command runner.
- No automatic 0102 bounded-code task inclusion beyond existing OpenClaw stage-ready gates.
- No new worker capability or direct execution path.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 7 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 28 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 36 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 50 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py`
- `git diff --check`

## WSP_15 Placement

This removes another manual operator toggle from the RedDog resident path while keeping all mutation/effect modes separately gated.