### PR TITLE
feat(reddog): add fusion artifact resident profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1666,6 +1666,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         )
         from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
             resident_queue_binding_enabled,
+            resident_queue_artifact_generator_mode,
             resident_queue_materializer_mode,
         )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
@@ -1733,7 +1734,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             ),
             worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
             worktree_runner_timeout_s=worktree_runner_timeout_s,
-            artifact_generator_mode=os.getenv("REDDOG_ARTIFACT_GENERATOR_MODE", "") or None,
+            artifact_generator_mode=resident_queue_artifact_generator_mode(os.environ) or None,
             slice_verifier_request_binding_enabled=resident_queue_binding_enabled(
                 os.environ,
                 "REDDOG_SLICE_VERIFIER_REQUEST_BINDING",

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_FUSION_ARTIFACT_PROFILE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion`
+  as a higher-authority resident profile that defaults the artifact generator
+  mode to `foundups_fusion`.
+- Preserved the base `signed_0102_bounded_code` profile as non-model and
+  preserved explicit `REDDOG_ARTIFACT_GENERATOR_MODE` override behavior.
+- Boundary remains constrained: the fusion profile selects the model artifact
+  generator only after signed queue-loop and bounded-code stage gates pass; it
+  still does not enable shell execution, worktree runners, draft PR publishing,
+  PatternMemory writes, HoloIndex re-index, merge authority, or rewards.
+
 ## 2026-07-16: REDDOG_RESIDENT_PROFILE_0102_BOUNDED_CODE_TASK_DEFAULT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -793,6 +793,7 @@ def _signed_0102_bounded_code_stage_ready_from_env(
     """Return True only when a coding task may safely drive the artifact stage."""
 
     from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+        resident_queue_artifact_generator_mode,
         resident_queue_binding_enabled,
         resident_queue_runtime_flag_enabled,
     )
@@ -801,7 +802,7 @@ def _signed_0102_bounded_code_stage_ready_from_env(
         return False
     if not resident_queue_runtime_flag_enabled(env, "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER"):
         return False
-    if str(env.get("REDDOG_ARTIFACT_GENERATOR_MODE") or "").strip() != "foundups_fusion":
+    if resident_queue_artifact_generator_mode(env) != "foundups_fusion":
         return False
     artifact_request_ready = bool(
         str(env.get("REDDOG_ARTIFACT_GENERATION_REQUEST_PATH") or "").strip()

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -2,9 +2,11 @@
 
 Slice: REDDOG_RESIDENT_QUEUE_BINDING_PROFILE_PHASE1
 
-The profile defaults only derivation/request-binding controls. It does not
-enable model execution, shell execution, worktree runners, draft PR publishing,
-PatternMemory writes, reward settlement, or HoloIndex re-indexing.
+The base profile defaults derivation/request-binding controls and safe
+control-plane loop flags. The fusion profile additionally selects the existing
+`foundups_fusion` artifact generator mode. Neither profile enables shell
+execution, worktree runners, draft PR publishing, PatternMemory writes, reward
+settlement, merge authority, or HoloIndex re-indexing.
 """
 
 from __future__ import annotations
@@ -14,6 +16,13 @@ from typing import Mapping
 
 ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE = "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"
 PROFILE_SIGNED_0102_BOUNDED_CODE = "signed_0102_bounded_code"
+PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION = "signed_0102_bounded_code_fusion"
+RESIDENT_QUEUE_PROFILES = frozenset(
+    {
+        PROFILE_SIGNED_0102_BOUNDED_CODE,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
+    }
+)
 
 PROFILE_BINDING_FLAGS = frozenset(
     {
@@ -40,7 +49,7 @@ def resident_queue_binding_profile(env: Mapping[str, str]) -> str:
     """Return the normalized resident queue binding profile."""
 
     value = str(env.get(ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE) or "").strip().lower()
-    return value if value == PROFILE_SIGNED_0102_BOUNDED_CODE else ""
+    return value if value in RESIDENT_QUEUE_PROFILES else ""
 
 
 def resident_queue_binding_enabled(env: Mapping[str, str], env_name: str) -> bool:
@@ -55,7 +64,7 @@ def resident_queue_binding_enabled(env: Mapping[str, str], env_name: str) -> boo
         return raw == "1"
     return (
         env_name in PROFILE_BINDING_FLAGS
-        and resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE
+        and resident_queue_binding_profile(env) in RESIDENT_QUEUE_PROFILES
     )
 
 
@@ -73,8 +82,19 @@ def resident_queue_runtime_flag_enabled(env: Mapping[str, str], env_name: str) -
         return raw == "1"
     return (
         env_name in PROFILE_RUNTIME_FLAGS
-        and resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE
+        and resident_queue_binding_profile(env) in RESIDENT_QUEUE_PROFILES
     )
+
+
+def resident_queue_artifact_generator_mode(env: Mapping[str, str]) -> str:
+    """Return explicit/default artifact generator mode for the profile."""
+
+    raw = str(env.get("REDDOG_ARTIFACT_GENERATOR_MODE") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION:
+        return "foundups_fusion"
+    return ""
 
 
 def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
@@ -83,7 +103,7 @@ def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_WORK_ORDER_MATERIALIZER_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE:
+    if resident_queue_binding_profile(env) in RESIDENT_QUEUE_PROFILES:
         return "authority_profile"
     return ""
 
@@ -92,7 +112,10 @@ __all__ = [
     "ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE",
     "PROFILE_BINDING_FLAGS",
     "PROFILE_RUNTIME_FLAGS",
+    "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION",
     "PROFILE_SIGNED_0102_BOUNDED_CODE",
+    "RESIDENT_QUEUE_PROFILES",
+    "resident_queue_artifact_generator_mode",
     "resident_queue_binding_enabled",
     "resident_queue_binding_profile",
     "resident_queue_materializer_mode",

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -23,6 +23,7 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker
     SIGNED_WORKER_DISPATCH_TASK_SOURCE,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+    resident_queue_artifact_generator_mode,
     resident_queue_binding_enabled,
     resident_queue_materializer_mode,
     resident_queue_runtime_flag_enabled,
@@ -218,6 +219,7 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
 
 def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
     materializer_mode = resident_queue_materializer_mode(env)
+    artifact_generator_mode = resident_queue_artifact_generator_mode(env)
     pairs = {
         "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
         "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
@@ -249,6 +251,8 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         value = _stripped(env.get(env_name))
         if value:
             payload[key] = value
+    if artifact_generator_mode:
+        payload["artifact_generator_mode"] = artifact_generator_mode
     for key, env_name in (
         ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
         (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -851,6 +851,49 @@ def test_openclaw_claim_profile_enables_0102_bounded_code_when_stage_ready(
     assert runner.calls[0]["task_id"] == task_id
 
 
+def test_openclaw_claim_fusion_profile_supplies_artifact_generator_mode(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task_with_allocation(
+        _allocation(),
+        intent_id="worker_dispatch_intent_coding_worker_1",
+        role="coding_worker_1",
+        worker_runtime="0102",
+        capability="bounded_code_change",
+    )
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    chain = _write_runtime_json(
+        tmp_path,
+        "chain_results.json",
+        _queue_chain_results_through("worktree_create"),
+    )
+    runner = _FakeRunner()
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", "signed_0102_bounded_code_fusion")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(tmp_path / "profile.json"))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+    from modules.communication.moltbot_bridge.src import (
+        reddog_signed_worker_openclaw_queue_loop_runtime_binding as binding_module,
+    )
+
+    monkeypatch.setattr(
+        binding_module,
+        "build_reddog_signed_worker_queue_loop_runner_from_env",
+        lambda *, repo_root, env: _FakeBinding(runner),
+    )
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=tmp_path)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert result["worker_runtime"] == "0102"
+    assert result["capability"] == "bounded_code_change"
+    assert runner.calls[0]["task_id"] == task_id
+
+
 def test_openclaw_claim_explicit_zero_disables_profile_0102_bounded_code(
     tmp_path: Path,
     monkeypatch,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -377,6 +377,66 @@ def test_runtime_binding_profile_enables_runner_without_explicit_runner_flag(tmp
     assert binding.runner is not None
 
 
+def test_runtime_binding_fusion_profile_supplies_artifact_generator_mode(tmp_path: Path) -> None:
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+
+    assert binding.accepted is True
+    assert binding.runner is not None
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
+
+
+def test_runtime_binding_explicit_artifact_generator_mode_overrides_fusion_profile(
+    tmp_path: Path,
+) -> None:
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion",
+        "REDDOG_ARTIFACT_GENERATOR_MODE": "unsafe",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["artifact_generator_mode"] == "unsafe"
+
+
 def test_runtime_binding_explicit_zero_disables_runner_profile(tmp_path: Path) -> None:
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- Adds `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion`.
- The existing `signed_0102_bounded_code` profile remains non-model.
- The fusion profile defaults only `REDDOG_ARTIFACT_GENERATOR_MODE=foundups_fusion` in addition to the existing resident queue control-plane defaults.
- Explicit `REDDOG_ARTIFACT_GENERATOR_MODE` still wins, including unsupported values that the bootstrap rejects.
- OpenClaw bounded-code stage readiness still requires signed queue-loop runner readiness, artifact request binding/source, correct queue stage, and no static artifact contents.

SPECIFIED_NOT_IMPLEMENTED:
- No automatic shell/evidence runner mode.
- No automatic real worktree runner.
- No automatic draft PR runner.
- No PatternMemory sink, HoloIndex re-index, merge authority, reward settlement, or Hermes dispatch.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 30 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 39 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 50 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_bounded_artifact_generation_runtime.py -q` -> 10 passed
- `pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 21 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py`
- `git diff --check`

## WSP_15 Placement

This gives RedDog a single resident profile for signed bounded-code model artifact generation while keeping all mutation surfaces separately gated.