### PR TITLE
feat(reddog): add fusion worktree resident profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1668,6 +1668,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_binding_enabled,
             resident_queue_artifact_generator_mode,
             resident_queue_materializer_mode,
+            resident_queue_worktree_runner_mode,
         )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
             build_reddog_verified_pattern_memory_sink,
@@ -1732,7 +1733,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
                 os.environ,
                 "REDDOG_PILOT_DRYRUN_BINDING",
             ),
-            worktree_runner_mode=os.getenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE", "") or None,
+            worktree_runner_mode=resident_queue_worktree_runner_mode(os.environ) or None,
             worktree_runner_timeout_s=worktree_runner_timeout_s,
             artifact_generator_mode=resident_queue_artifact_generator_mode(os.environ) or None,
             slice_verifier_request_binding_enabled=resident_queue_binding_enabled(

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_FUSION_WORKTREE_PROFILE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree`
+  as a higher-authority resident profile that defaults the isolated worktree
+  runner mode to `real`.
+- Preserved explicit `REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE` override
+  behavior and kept the lower profiles non-worktree.
+- Boundary remains constrained: this profile enables only the existing
+  isolated worktree materializer after signed queue-loop, model artifact, and
+  bounded-code stage gates pass; it does not enable shell execution, draft PR
+  publishing, PatternMemory writes, HoloIndex re-index, merge authority, or
+  rewards.
+
 ## 2026-07-16: REDDOG_RESIDENT_FUSION_ARTIFACT_PROFILE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -4,9 +4,10 @@ Slice: REDDOG_RESIDENT_QUEUE_BINDING_PROFILE_PHASE1
 
 The base profile defaults derivation/request-binding controls and safe
 control-plane loop flags. The fusion profile additionally selects the existing
-`foundups_fusion` artifact generator mode. Neither profile enables shell
-execution, worktree runners, draft PR publishing, PatternMemory writes, reward
-settlement, merge authority, or HoloIndex re-indexing.
+`foundups_fusion` artifact generator mode. The worktree profile additionally
+selects the existing isolated worktree runner. No profile enables shell
+execution, draft PR publishing, PatternMemory writes, reward settlement, merge
+authority, or HoloIndex re-indexing.
 """
 
 from __future__ import annotations
@@ -17,10 +18,12 @@ from typing import Mapping
 ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE = "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"
 PROFILE_SIGNED_0102_BOUNDED_CODE = "signed_0102_bounded_code"
 PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION = "signed_0102_bounded_code_fusion"
+PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE = "signed_0102_bounded_code_fusion_worktree"
 RESIDENT_QUEUE_PROFILES = frozenset(
     {
         PROFILE_SIGNED_0102_BOUNDED_CODE,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
     }
 )
 
@@ -92,8 +95,22 @@ def resident_queue_artifact_generator_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_ARTIFACT_GENERATOR_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION:
+    if resident_queue_binding_profile(env) in {
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
+    }:
         return "foundups_fusion"
+    return ""
+
+
+def resident_queue_worktree_runner_mode(env: Mapping[str, str]) -> str:
+    """Return explicit/default worktree runner mode for the profile."""
+
+    raw = str(env.get("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE:
+        return "real"
     return ""
 
 
@@ -113,6 +130,7 @@ __all__ = [
     "PROFILE_BINDING_FLAGS",
     "PROFILE_RUNTIME_FLAGS",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION",
+    "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE",
     "PROFILE_SIGNED_0102_BOUNDED_CODE",
     "RESIDENT_QUEUE_PROFILES",
     "resident_queue_artifact_generator_mode",
@@ -120,4 +138,5 @@ __all__ = [
     "resident_queue_binding_profile",
     "resident_queue_materializer_mode",
     "resident_queue_runtime_flag_enabled",
+    "resident_queue_worktree_runner_mode",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -27,6 +27,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     resident_queue_binding_enabled,
     resident_queue_materializer_mode,
     resident_queue_runtime_flag_enabled,
+    resident_queue_worktree_runner_mode,
 )
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_queue_serial_loop_runner import (
     RedDogSignedWorkerQueueSerialLoopRunner,
@@ -220,6 +221,7 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
 def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
     materializer_mode = resident_queue_materializer_mode(env)
     artifact_generator_mode = resident_queue_artifact_generator_mode(env)
+    worktree_runner_mode = resident_queue_worktree_runner_mode(env)
     pairs = {
         "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
         "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
@@ -253,6 +255,8 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
             payload[key] = value
     if artifact_generator_mode:
         payload["artifact_generator_mode"] = artifact_generator_mode
+    if worktree_runner_mode:
+        payload["worktree_runner_mode"] = worktree_runner_mode
     for key, env_name in (
         ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
         (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3756,6 +3756,49 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     assert mocked.call_args.kwargs["max_steps"] == 1
 
 
+def test_main_serial_loop_preflight_worktree_profile_derives_model_and_worktree_modes(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "steps_run": 1,
+                "dispatched_stages": ("bounded_worker_pilot",),
+                "next_action": "STOP_QUEUE_CHAIN_COMPLETE",
+                "chain_results_path": str(tmp_path / "chain.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_order_materializer_mode"] == "authority_profile"
+    assert mocked.call_args.kwargs["artifact_generation_request_binding_enabled"] is True
+    assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
+    assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
+
+
 def test_main_serial_loop_preflight_blocks_when_enforced() -> None:
     import main
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -437,6 +437,67 @@ def test_runtime_binding_explicit_artifact_generator_mode_overrides_fusion_profi
     assert bootstrap.calls[0]["artifact_generator_mode"] == "unsafe"
 
 
+def test_runtime_binding_worktree_profile_supplies_worktree_runner_mode(tmp_path: Path) -> None:
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+
+    assert binding.accepted is True
+    assert binding.runner is not None
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
+    assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
+
+
+def test_runtime_binding_explicit_worktree_mode_overrides_worktree_profile(
+    tmp_path: Path,
+) -> None:
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree",
+        "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE": "unsafe",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["worktree_runner_mode"] == "unsafe"
+
+
 def test_runtime_binding_explicit_zero_disables_runner_profile(tmp_path: Path) -> None:
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",


### PR DESCRIPTION
## Summary
- Adds REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree as the next resident profile.
- Defaults the existing isolated worktree runner mode to eal only for that profile.
- Keeps lower profiles non-worktree and preserves explicit REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE override behavior.

## Boundary
- Still requires the signed queue-loop, model artifact, and bounded-code stage gates before materialization.
- Does not enable shell execution, draft PR publishing, PatternMemory writes, HoloIndex re-index, merge authority, reward settlement, or Hermes dispatch.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -> 32 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -> 51 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q -> 39 passed
- pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q -> 21 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_bounded_artifact_generation_runtime.py -q -> 10 passed
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py
- git diff --check

Worker-Lane: RedDog resident runtime
Slice: REDDOG_RESIDENT_FUSION_WORKTREE_PROFILE_PHASE1