### PR TITLE
feat(reddog): add fusion worktree draft PR resident profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1667,6 +1667,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
             resident_queue_binding_enabled,
             resident_queue_artifact_generator_mode,
+            resident_queue_draft_pr_runner_mode,
             resident_queue_materializer_mode,
             resident_queue_worktree_runner_mode,
         )
@@ -1679,7 +1680,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             db_path=os.getenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", "") or None,
         )
         draft_pr_runner = None
-        draft_pr_runner_mode = os.getenv("REDDOG_DRAFT_PR_RUNNER_MODE", "").strip().lower()
+        draft_pr_runner_mode = resident_queue_draft_pr_runner_mode(os.environ).strip().lower()
         if draft_pr_runner_mode:
             if draft_pr_runner_mode != "real":
                 raise ValueError("unsupported_draft_pr_runner_mode")

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_FUSION_WORKTREE_DRAFT_PR_PROFILE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree_draft_pr`
+  as the highest resident coding profile for the current chain.
+- The profile derives `foundups_fusion`, the isolated worktree runner, and the
+  existing verified draft-PR runner while preserving explicit env overrides.
+- Boundary remains constrained: draft PR publishing is still downstream of the
+  queue-authorized slice verifier, exact-head checks, draft-only guard, and
+  branch policy; this profile does not enable shell execution, PatternMemory
+  writes, HoloIndex re-index, merge authority, reward settlement, or Hermes
+  dispatch.
+
 ## 2026-07-16: REDDOG_RESIDENT_FUSION_WORKTREE_PROFILE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -5,9 +5,10 @@ Slice: REDDOG_RESIDENT_QUEUE_BINDING_PROFILE_PHASE1
 The base profile defaults derivation/request-binding controls and safe
 control-plane loop flags. The fusion profile additionally selects the existing
 `foundups_fusion` artifact generator mode. The worktree profile additionally
-selects the existing isolated worktree runner. No profile enables shell
-execution, draft PR publishing, PatternMemory writes, reward settlement, merge
-authority, or HoloIndex re-indexing.
+selects the existing isolated worktree runner. The draft-PR profile
+additionally selects the existing verified draft-PR runner. No profile enables
+shell execution, PatternMemory writes, reward settlement, merge authority, or
+HoloIndex re-indexing.
 """
 
 from __future__ import annotations
@@ -19,11 +20,15 @@ ENV_REDDOG_RESIDENT_QUEUE_BINDING_PROFILE = "REDDOG_RESIDENT_QUEUE_BINDING_PROFI
 PROFILE_SIGNED_0102_BOUNDED_CODE = "signed_0102_bounded_code"
 PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION = "signed_0102_bounded_code_fusion"
 PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE = "signed_0102_bounded_code_fusion_worktree"
+PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR = (
+    "signed_0102_bounded_code_fusion_worktree_draft_pr"
+)
 RESIDENT_QUEUE_PROFILES = frozenset(
     {
         PROFILE_SIGNED_0102_BOUNDED_CODE,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
     }
 )
 
@@ -98,6 +103,7 @@ def resident_queue_artifact_generator_mode(env: Mapping[str, str]) -> str:
     if resident_queue_binding_profile(env) in {
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
     }:
         return "foundups_fusion"
     return ""
@@ -109,7 +115,21 @@ def resident_queue_worktree_runner_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE:
+    if resident_queue_binding_profile(env) in {
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
+    }:
+        return "real"
+    return ""
+
+
+def resident_queue_draft_pr_runner_mode(env: Mapping[str, str]) -> str:
+    """Return explicit/default verified draft-PR runner mode for the profile."""
+
+    raw = str(env.get("REDDOG_DRAFT_PR_RUNNER_MODE") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR:
         return "real"
     return ""
 
@@ -130,12 +150,14 @@ __all__ = [
     "PROFILE_BINDING_FLAGS",
     "PROFILE_RUNTIME_FLAGS",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION",
+    "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE",
     "PROFILE_SIGNED_0102_BOUNDED_CODE",
     "RESIDENT_QUEUE_PROFILES",
     "resident_queue_artifact_generator_mode",
     "resident_queue_binding_enabled",
     "resident_queue_binding_profile",
+    "resident_queue_draft_pr_runner_mode",
     "resident_queue_materializer_mode",
     "resident_queue_runtime_flag_enabled",
     "resident_queue_worktree_runner_mode",

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -25,6 +25,7 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
     resident_queue_artifact_generator_mode,
     resident_queue_binding_enabled,
+    resident_queue_draft_pr_runner_mode,
     resident_queue_materializer_mode,
     resident_queue_runtime_flag_enabled,
     resident_queue_worktree_runner_mode,
@@ -282,7 +283,7 @@ def _build_draft_pr_runner(
     repo_root: Path | str,
     env: Mapping[str, str],
 ) -> tuple[Any, tuple[str, ...]]:
-    mode = _stripped(env.get("REDDOG_DRAFT_PR_RUNNER_MODE")).lower()
+    mode = resident_queue_draft_pr_runner_mode(env).strip().lower()
     if not mode:
         return None, ()
     if mode != "real":

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3799,6 +3799,50 @@ def test_main_serial_loop_preflight_worktree_profile_derives_model_and_worktree_
     assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
 
 
+def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "steps_run": 1,
+                "dispatched_stages": ("verified_draft_pr_publish",),
+                "next_action": "STOP_QUEUE_CHAIN_COMPLETE",
+                "chain_results_path": str(tmp_path / "chain.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+                "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "91",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
+    assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
+    assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 91
+
+
 def test_main_serial_loop_preflight_blocks_when_enforced() -> None:
     import main
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -572,6 +572,47 @@ def test_runtime_binding_builds_draft_pr_runner_when_requested(
     assert draft_runner.timeout_s == 88
 
 
+def test_runtime_binding_draft_pr_profile_supplies_verified_draft_runner(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from modules.foundups.agent.src import worktree_pr_runner
+
+    monkeypatch.setattr(worktree_pr_runner, "RealWorktreeRunner", _FakeDraftPrRunner)
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "89",
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
+    assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
+    draft_runner = bootstrap.calls[0]["draft_pr_runner"]
+    assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
+    assert draft_runner.repo_root == tmp_path.resolve()
+    assert draft_runner.timeout_s == 89
+
+
 def test_runtime_binding_rejects_unsupported_draft_pr_runner_mode(tmp_path: Path) -> None:
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
         repo_root=tmp_path,


### PR DESCRIPTION
## Summary
- Adds REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree_draft_pr.
- Defaults the existing verified draft-PR runner mode to eal only for that highest profile.
- Inherits the fusion artifact mode and isolated worktree runner defaults from the lower profiles.
- Preserves explicit REDDOG_DRAFT_PR_RUNNER_MODE overrides, including fail-closed unsupported values.

## Boundary
- Draft PR publishing remains downstream of the queue-authorized slice verifier, autonomous verifier acceptance, exact-head check, draft-only guard, and branch policy.
- This profile does not enable shell execution, PatternMemory writes, HoloIndex re-index, merge authority, reward settlement, or Hermes dispatch.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -> 33 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -> 52 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py -q -> 10 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py -q -> 21 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q -> 39 passed
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_resident_queue_verified_draft_pr_publish_handler.py modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/src/reddog_verified_draft_pr_publish.py
- git diff --check

Worker-Lane: RedDog resident runtime
Slice: REDDOG_RESIDENT_FUSION_WORKTREE_DRAFT_PR_PROFILE_PHASE1