### PR TITLE
feat(reddog): derive evidence runner for verified draft PR profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1668,6 +1668,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_binding_enabled,
             resident_queue_artifact_generator_mode,
             resident_queue_draft_pr_runner_mode,
+            resident_queue_evidence_command_runner_mode,
             resident_queue_materializer_mode,
             resident_queue_worktree_runner_mode,
         )
@@ -1741,7 +1742,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
                 os.environ,
                 "REDDOG_SLICE_VERIFIER_REQUEST_BINDING",
             ),
-            evidence_command_runner_mode=os.getenv("REDDOG_EVIDENCE_COMMAND_RUNNER_MODE", "") or None,
+            evidence_command_runner_mode=resident_queue_evidence_command_runner_mode(os.environ)
+            or None,
             draft_pr_publish_request_binding_enabled=resident_queue_binding_enabled(
                 os.environ,
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING",

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -6,13 +6,15 @@
 
 - Added `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree_draft_pr`
   as the highest resident coding profile for the current chain.
-- The profile derives `foundups_fusion`, the isolated worktree runner, and the
-  existing verified draft-PR runner while preserving explicit env overrides.
+- The profile derives `foundups_fusion`, the isolated worktree runner, the
+  independent evidence command runner, and the existing verified draft-PR
+  runner while preserving explicit env overrides.
 - Boundary remains constrained: draft PR publishing is still downstream of the
-  queue-authorized slice verifier, exact-head checks, draft-only guard, and
-  branch policy; this profile does not enable shell execution, PatternMemory
-  writes, HoloIndex re-index, merge authority, reward settlement, or Hermes
-  dispatch.
+  queue-authorized slice verifier, evidence production, exact-head checks,
+  draft-only guard, and branch policy; the evidence runner uses argv execution
+  with `shell=False`, and this profile does not enable shell execution,
+  PatternMemory writes, HoloIndex re-index, merge authority, reward settlement,
+  or Hermes dispatch.
 
 ## 2026-07-16: REDDOG_RESIDENT_FUSION_WORKTREE_PROFILE_PHASE1
 

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -6,9 +6,9 @@ The base profile defaults derivation/request-binding controls and safe
 control-plane loop flags. The fusion profile additionally selects the existing
 `foundups_fusion` artifact generator mode. The worktree profile additionally
 selects the existing isolated worktree runner. The draft-PR profile
-additionally selects the existing verified draft-PR runner. No profile enables
-shell execution, PatternMemory writes, reward settlement, merge authority, or
-HoloIndex re-indexing.
+additionally selects the existing independent evidence runner and verified
+draft-PR runner. No profile enables shell execution, PatternMemory writes,
+reward settlement, merge authority, or HoloIndex re-indexing.
 """
 
 from __future__ import annotations
@@ -134,6 +134,17 @@ def resident_queue_draft_pr_runner_mode(env: Mapping[str, str]) -> str:
     return ""
 
 
+def resident_queue_evidence_command_runner_mode(env: Mapping[str, str]) -> str:
+    """Return explicit/default independent evidence command runner mode."""
+
+    raw = str(env.get("REDDOG_EVIDENCE_COMMAND_RUNNER_MODE") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR:
+        return "real"
+    return ""
+
+
 def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
     """Return explicit/default work-order materializer mode for the profile."""
 
@@ -158,6 +169,7 @@ __all__ = [
     "resident_queue_binding_enabled",
     "resident_queue_binding_profile",
     "resident_queue_draft_pr_runner_mode",
+    "resident_queue_evidence_command_runner_mode",
     "resident_queue_materializer_mode",
     "resident_queue_runtime_flag_enabled",
     "resident_queue_worktree_runner_mode",

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -26,6 +26,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     resident_queue_artifact_generator_mode,
     resident_queue_binding_enabled,
     resident_queue_draft_pr_runner_mode,
+    resident_queue_evidence_command_runner_mode,
     resident_queue_materializer_mode,
     resident_queue_runtime_flag_enabled,
     resident_queue_worktree_runner_mode,
@@ -223,6 +224,7 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
     materializer_mode = resident_queue_materializer_mode(env)
     artifact_generator_mode = resident_queue_artifact_generator_mode(env)
     worktree_runner_mode = resident_queue_worktree_runner_mode(env)
+    evidence_command_runner_mode = resident_queue_evidence_command_runner_mode(env)
     pairs = {
         "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
         "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
@@ -258,6 +260,8 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         payload["artifact_generator_mode"] = artifact_generator_mode
     if worktree_runner_mode:
         payload["worktree_runner_mode"] = worktree_runner_mode
+    if evidence_command_runner_mode:
+        payload["evidence_command_runner_mode"] = evidence_command_runner_mode
     for key, env_name in (
         ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
         (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3797,6 +3797,7 @@ def test_main_serial_loop_preflight_worktree_profile_derives_model_and_worktree_
     assert mocked.call_args.kwargs["artifact_generation_request_binding_enabled"] is True
     assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
     assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["evidence_command_runner_mode"] is None
 
 
 def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
@@ -3839,6 +3840,7 @@ def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
 
     assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
     assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["evidence_command_runner_mode"] == "real"
     assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
     assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 91
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -465,6 +465,7 @@ def test_runtime_binding_worktree_profile_supplies_worktree_runner_mode(tmp_path
     assert result["accepted"] is True
     assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
     assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
+    assert "evidence_command_runner_mode" not in bootstrap.calls[0]
 
 
 def test_runtime_binding_explicit_worktree_mode_overrides_worktree_profile(
@@ -607,6 +608,7 @@ def test_runtime_binding_draft_pr_profile_supplies_verified_draft_runner(
     assert result["accepted"] is True
     assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
     assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
+    assert bootstrap.calls[0]["evidence_command_runner_mode"] == "real"
     draft_runner = bootstrap.calls[0]["draft_pr_runner"]
     assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
     assert draft_runner.repo_root == tmp_path.resolve()


### PR DESCRIPTION
## Summary
- Extends signed_0102_bounded_code_fusion_worktree_draft_pr to derive the existing independent evidence command runner mode.
- Keeps lower resident profiles non-evidence-runner and preserves explicit REDDOG_EVIDENCE_COMMAND_RUNNER_MODE overrides.
- Wires profile-derived evidence runner mode through main.py and OpenClaw queue-loop runtime binding.

## Boundary
- Evidence production remains inside the existing independent verifier path.
- The evidence runner uses argv execution with shell=False, reads the isolated worktree, and enforces the existing protected-path, secret, HoloIndex-gap, exact-head, and allowlisted-check gates.
- This does not enable source editing, shell execution, PatternMemory writes, HoloIndex re-index, merge authority, reward settlement, or Hermes dispatch.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -> 33 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -> 52 passed
- pytest modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py -q -> 23 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q -> 39 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py -q -> 21 passed
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_resident_queue_slice_verifier_handler.py modules/infrastructure/wre_core/src/wre_independent_evidence_producer_runtime.py
- git diff --check

Worker-Lane: RedDog resident runtime
Slice: REDDOG_RESIDENT_VERIFIED_DRAFT_PR_EVIDENCE_PROFILE_PHASE1