### PR TITLE
feat(reddog): derive verified outcome ratchet store path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1670,6 +1670,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_draft_pr_runner_mode,
             resident_queue_evidence_command_runner_mode,
             resident_queue_materializer_mode,
+            resident_queue_outcome_ratchet_store_path,
             resident_queue_worktree_runner_mode,
         )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
@@ -1721,7 +1722,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             evidence_producer_request_path=os.getenv("REDDOG_EVIDENCE_PRODUCER_REQUEST_PATH", "") or None,
             publish_request_path=os.getenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", "") or None,
             ratchet_request_path=os.getenv("REDDOG_OUTCOME_RATCHET_REQUEST_PATH", "") or None,
-            outcome_ratchet_store_path=os.getenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", "") or None,
+            outcome_ratchet_store_path=resident_queue_outcome_ratchet_store_path(
+                os.environ,
+                repo_root,
+            )
+            or None,
             held_out_gate_request_path=os.getenv("REDDOG_HELD_OUT_GATE_REQUEST_PATH", "") or None,
             admission_request_path=os.getenv("REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH", "") or None,
             authority_state_path=os.getenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -9,12 +9,17 @@
 - The profile derives `foundups_fusion`, the isolated worktree runner, the
   independent evidence command runner, and the existing verified draft-PR
   runner while preserving explicit env overrides.
+- The same profile also derives an outside-repo verified outcome ratchet JSONL
+  store under `.reddog/outcome_ratchet/<repo>/verified_outcomes.jsonl`, so the
+  queue chain can persist verified outcomes without writing into the source
+  checkout.
 - Boundary remains constrained: draft PR publishing is still downstream of the
   queue-authorized slice verifier, evidence production, exact-head checks,
   draft-only guard, and branch policy; the evidence runner uses argv execution
-  with `shell=False`, and this profile does not enable shell execution,
-  PatternMemory writes, HoloIndex re-index, merge authority, reward settlement,
-  or Hermes dispatch.
+  with `shell=False`, verified outcome ratchet writes only to the outside-repo
+  JSONL store, and this profile does not enable shell execution, PatternMemory
+  writes, HoloIndex re-index, merge authority, reward settlement, or Hermes
+  dispatch.
 
 ## 2026-07-16: REDDOG_RESIDENT_FUSION_WORKTREE_PROFILE_PHASE1
 

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -13,6 +13,8 @@ reward settlement, merge authority, or HoloIndex re-indexing.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from typing import Mapping
 
 
@@ -145,6 +147,27 @@ def resident_queue_evidence_command_runner_mode(env: Mapping[str, str]) -> str:
     return ""
 
 
+def resident_queue_outcome_ratchet_store_path(
+    env: Mapping[str, str],
+    repo_root: Path | str,
+) -> str:
+    """Return explicit/default verified outcome ratchet store path."""
+
+    raw = str(env.get("REDDOG_OUTCOME_RATCHET_STORE_PATH") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) != PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR:
+        return ""
+    root = Path(repo_root).resolve()
+    return str(
+        root.parent
+        / ".reddog"
+        / "outcome_ratchet"
+        / _repo_slug(root)
+        / "verified_outcomes.jsonl"
+    )
+
+
 def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
     """Return explicit/default work-order materializer mode for the profile."""
 
@@ -154,6 +177,12 @@ def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
     if resident_queue_binding_profile(env) in RESIDENT_QUEUE_PROFILES:
         return "authority_profile"
     return ""
+
+
+def _repo_slug(root: Path) -> str:
+    raw = root.name or "repo"
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw).strip(".-_")
+    return slug or "repo"
 
 
 __all__ = [
@@ -171,6 +200,7 @@ __all__ = [
     "resident_queue_draft_pr_runner_mode",
     "resident_queue_evidence_command_runner_mode",
     "resident_queue_materializer_mode",
+    "resident_queue_outcome_ratchet_store_path",
     "resident_queue_runtime_flag_enabled",
     "resident_queue_worktree_runner_mode",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -28,6 +28,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     resident_queue_draft_pr_runner_mode,
     resident_queue_evidence_command_runner_mode,
     resident_queue_materializer_mode,
+    resident_queue_outcome_ratchet_store_path,
     resident_queue_runtime_flag_enabled,
     resident_queue_worktree_runner_mode,
 )
@@ -191,7 +192,7 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
             max_steps=max_steps,
         )
 
-    bootstrap_kwargs = _bootstrap_kwargs(env)
+    bootstrap_kwargs = _bootstrap_kwargs(env, repo_root=repo_root)
     if draft_pr_runner is not None:
         bootstrap_kwargs["draft_pr_runner"] = draft_pr_runner
     if pattern_memory_admission_sink is not None:
@@ -220,11 +221,15 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
     )
 
 
-def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
+def _bootstrap_kwargs(env: Mapping[str, str], *, repo_root: Path | str) -> dict[str, Any]:
     materializer_mode = resident_queue_materializer_mode(env)
     artifact_generator_mode = resident_queue_artifact_generator_mode(env)
     worktree_runner_mode = resident_queue_worktree_runner_mode(env)
     evidence_command_runner_mode = resident_queue_evidence_command_runner_mode(env)
+    outcome_ratchet_store_path = resident_queue_outcome_ratchet_store_path(
+        env,
+        repo_root,
+    )
     pairs = {
         "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
         "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
@@ -262,6 +267,8 @@ def _bootstrap_kwargs(env: Mapping[str, str]) -> dict[str, Any]:
         payload["worktree_runner_mode"] = worktree_runner_mode
     if evidence_command_runner_mode:
         payload["evidence_command_runner_mode"] = evidence_command_runner_mode
+    if outcome_ratchet_store_path:
+        payload["outcome_ratchet_store_path"] = outcome_ratchet_store_path
     for key, env_name in (
         ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
         (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3798,6 +3798,7 @@ def test_main_serial_loop_preflight_worktree_profile_derives_model_and_worktree_
     assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
     assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
     assert mocked.call_args.kwargs["evidence_command_runner_mode"] is None
+    assert mocked.call_args.kwargs["outcome_ratchet_store_path"] is None
 
 
 def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
@@ -3841,6 +3842,13 @@ def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
     assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
     assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
     assert mocked.call_args.kwargs["evidence_command_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["outcome_ratchet_store_path"] == str(
+        REPO_ROOT.resolve().parent
+        / ".reddog"
+        / "outcome_ratchet"
+        / REPO_ROOT.resolve().name
+        / "verified_outcomes.jsonl"
+    )
     assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
     assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 91
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -466,6 +466,7 @@ def test_runtime_binding_worktree_profile_supplies_worktree_runner_mode(tmp_path
     assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
     assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
     assert "evidence_command_runner_mode" not in bootstrap.calls[0]
+    assert "outcome_ratchet_store_path" not in bootstrap.calls[0]
 
 
 def test_runtime_binding_explicit_worktree_mode_overrides_worktree_profile(
@@ -609,6 +610,13 @@ def test_runtime_binding_draft_pr_profile_supplies_verified_draft_runner(
     assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
     assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
     assert bootstrap.calls[0]["evidence_command_runner_mode"] == "real"
+    assert bootstrap.calls[0]["outcome_ratchet_store_path"] == str(
+        tmp_path.resolve().parent
+        / ".reddog"
+        / "outcome_ratchet"
+        / tmp_path.resolve().name
+        / "verified_outcomes.jsonl"
+    )
     draft_runner = bootstrap.calls[0]["draft_pr_runner"]
     assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
     assert draft_runner.repo_root == tmp_path.resolve()


### PR DESCRIPTION
## Summary
- Extends the highest resident coding profile with an outside-repo verified outcome ratchet JSONL store path.
- Defaults to .reddog/outcome_ratchet/<repo>/verified_outcomes.jsonl beside the repository parent, never inside the source checkout.
- Wires the derived path through main.py and OpenClaw queue-loop runtime binding.
- Lower profiles remain non-ratchet-store by default, and explicit REDDOG_OUTCOME_RATCHET_STORE_PATH still wins.

## Boundary
- This only provides persistence for the existing verified outcome ratchet stage.
- PatternMemory writes remain disabled unless separately and explicitly requested by the guarded ratchet path.
- No shell execution, source editing, HoloIndex re-index, merge authority, reward settlement, or Hermes dispatch is enabled.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -> 33 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q -> 52 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_outcome_ratchet_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py -q -> 33 passed
- pytest modules/infrastructure/wre_core/tests/test_wre_independent_evidence_producer_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_slice_verifier_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py -q -> 44 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q -> 39 passed
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_resident_queue_slice_verifier_handler.py modules/infrastructure/wre_core/src/wre_independent_evidence_producer_runtime.py modules/communication/moltbot_bridge/src/reddog_resident_queue_verified_outcome_ratchet_handler.py modules/infrastructure/wre_core/src/reddog_verified_outcome_ratchet.py
- git diff --check

Worker-Lane: RedDog resident runtime
Slice: REDDOG_RESIDENT_OUTCOME_RATCHET_STORE_PROFILE_PHASE1