### PR TITLE
feat(reddog): add pattern memory admission resident profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1671,6 +1671,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_evidence_command_runner_mode,
             resident_queue_materializer_mode,
             resident_queue_outcome_ratchet_store_path,
+            resident_queue_pattern_memory_admission_db_path,
             resident_queue_worktree_runner_mode,
         )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
@@ -1679,7 +1680,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
 
         pattern_memory_admission_sink = build_reddog_verified_pattern_memory_sink(
             repo_root=repo_root,
-            db_path=os.getenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", "") or None,
+            db_path=resident_queue_pattern_memory_admission_db_path(os.environ, repo_root)
+            or None,
         )
         draft_pr_runner = None
         draft_pr_runner_mode = resident_queue_draft_pr_runner_mode(os.environ).strip().lower()

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_PATTERN_MEMORY_ADMISSION_PROFILE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added
+  `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree_draft_pr_pattern_memory`
+  as the next resident queue profile above the verified draft-PR profile.
+- The profile preserves the existing fusion, isolated worktree, independent
+  evidence, verified draft-PR, and verified outcome ratchet defaults, then
+  derives an outside-repo PatternMemory admission DB path under
+  `.reddog/pattern_memory/<repo>/pattern_memory.db`.
+- Boundary remains constrained: PatternMemory writes still require the
+  queue-authorized verified draft PR, verified outcome ratchet, held-out gate
+  acceptance, derived admission request, and verified PatternMemory sink guard.
+  The profile does not enable shell execution, HoloIndex re-indexing, merge
+  authority, reward settlement, or Hermes dispatch.
+
 ## 2026-07-16: REDDOG_RESIDENT_FUSION_WORKTREE_DRAFT_PR_PROFILE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -7,7 +7,8 @@ control-plane loop flags. The fusion profile additionally selects the existing
 `foundups_fusion` artifact generator mode. The worktree profile additionally
 selects the existing isolated worktree runner. The draft-PR profile
 additionally selects the existing independent evidence runner and verified
-draft-PR runner. No profile enables shell execution, PatternMemory writes,
+draft-PR runner. The PatternMemory profile additionally selects the existing
+verified PatternMemory admission sink. No profile enables shell execution,
 reward settlement, merge authority, or HoloIndex re-indexing.
 """
 
@@ -25,12 +26,35 @@ PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE = "signed_0102_bounded_code_fus
 PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR = (
     "signed_0102_bounded_code_fusion_worktree_draft_pr"
 )
+PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY = (
+    "signed_0102_bounded_code_fusion_worktree_draft_pr_pattern_memory"
+)
 RESIDENT_QUEUE_PROFILES = frozenset(
     {
         PROFILE_SIGNED_0102_BOUNDED_CODE,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
         PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY,
+    }
+)
+
+_DRAFT_PR_OR_HIGHER_PROFILES = frozenset(
+    {
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY,
+    }
+)
+_WORKTREE_OR_HIGHER_PROFILES = frozenset(
+    {
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
+        *_DRAFT_PR_OR_HIGHER_PROFILES,
+    }
+)
+_FUSION_OR_HIGHER_PROFILES = frozenset(
+    {
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
+        *_WORKTREE_OR_HIGHER_PROFILES,
     }
 )
 
@@ -82,9 +106,9 @@ def resident_queue_runtime_flag_enabled(env: Mapping[str, str], env_name: str) -
     """Return whether a safe resident runtime control-plane flag is enabled.
 
     Explicit environment values win. The profile only enables known
-    control-plane flags that start existing gated loops; it never enables
-    model, shell, worktree, draft-PR, PatternMemory, HoloIndex, merge, or
-    reward-settlement effect modes.
+    control-plane flags that start existing gated loops; this helper never
+    selects effect modes such as model generation, worktree, draft PR,
+    PatternMemory, HoloIndex, merge, or reward settlement.
     """
 
     raw = str(env.get(env_name) or "").strip()
@@ -102,11 +126,7 @@ def resident_queue_artifact_generator_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_ARTIFACT_GENERATOR_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) in {
-        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION,
-        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
-        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
-    }:
+    if resident_queue_binding_profile(env) in _FUSION_OR_HIGHER_PROFILES:
         return "foundups_fusion"
     return ""
 
@@ -117,10 +137,7 @@ def resident_queue_worktree_runner_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) in {
-        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE,
-        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
-    }:
+    if resident_queue_binding_profile(env) in _WORKTREE_OR_HIGHER_PROFILES:
         return "real"
     return ""
 
@@ -131,7 +148,7 @@ def resident_queue_draft_pr_runner_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_DRAFT_PR_RUNNER_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR:
+    if resident_queue_binding_profile(env) in _DRAFT_PR_OR_HIGHER_PROFILES:
         return "real"
     return ""
 
@@ -142,7 +159,7 @@ def resident_queue_evidence_command_runner_mode(env: Mapping[str, str]) -> str:
     raw = str(env.get("REDDOG_EVIDENCE_COMMAND_RUNNER_MODE") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) == PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR:
+    if resident_queue_binding_profile(env) in _DRAFT_PR_OR_HIGHER_PROFILES:
         return "real"
     return ""
 
@@ -156,7 +173,7 @@ def resident_queue_outcome_ratchet_store_path(
     raw = str(env.get("REDDOG_OUTCOME_RATCHET_STORE_PATH") or "").strip()
     if raw:
         return raw
-    if resident_queue_binding_profile(env) != PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR:
+    if resident_queue_binding_profile(env) not in _DRAFT_PR_OR_HIGHER_PROFILES:
         return ""
     root = Path(repo_root).resolve()
     return str(
@@ -165,6 +182,30 @@ def resident_queue_outcome_ratchet_store_path(
         / "outcome_ratchet"
         / _repo_slug(root)
         / "verified_outcomes.jsonl"
+    )
+
+
+def resident_queue_pattern_memory_admission_db_path(
+    env: Mapping[str, str],
+    repo_root: Path | str,
+) -> str:
+    """Return explicit/default verified PatternMemory admission DB path."""
+
+    raw = str(env.get("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH") or "").strip()
+    if raw:
+        return raw
+    if (
+        resident_queue_binding_profile(env)
+        != PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY
+    ):
+        return ""
+    root = Path(repo_root).resolve()
+    return str(
+        root.parent
+        / ".reddog"
+        / "pattern_memory"
+        / _repo_slug(root)
+        / "pattern_memory.db"
     )
 
 
@@ -190,6 +231,7 @@ __all__ = [
     "PROFILE_BINDING_FLAGS",
     "PROFILE_RUNTIME_FLAGS",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION",
+    "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE",
     "PROFILE_SIGNED_0102_BOUNDED_CODE",
@@ -201,6 +243,7 @@ __all__ = [
     "resident_queue_evidence_command_runner_mode",
     "resident_queue_materializer_mode",
     "resident_queue_outcome_ratchet_store_path",
+    "resident_queue_pattern_memory_admission_db_path",
     "resident_queue_runtime_flag_enabled",
     "resident_queue_worktree_runner_mode",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -8,9 +8,10 @@ environment/configuration, accepts only the OpenClaw candidate queue-review
 capability, and delegates all queue advancement to the existing bounded
 resident queue serial-loop bootstrap.
 
-It does not execute shell commands, mutate repository files, create worktrees,
-publish PRs, dispatch Hermes, settle rewards, write PatternMemory, or re-index
-HoloIndex.
+It does not execute shell commands, mutate repository files, dispatch Hermes,
+settle rewards, or re-index HoloIndex. Higher resident profiles can supply
+existing guarded worktree, draft-PR, outcome-ratchet, and PatternMemory sinks;
+those effects remain downstream of their own queue-stage gates.
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     resident_queue_evidence_command_runner_mode,
     resident_queue_materializer_mode,
     resident_queue_outcome_ratchet_store_path,
+    resident_queue_pattern_memory_admission_db_path,
     resident_queue_runtime_flag_enabled,
     resident_queue_worktree_runner_mode,
 )
@@ -324,7 +326,7 @@ def _build_pattern_memory_admission_sink(
     repo_root: Path | str,
     env: Mapping[str, str],
 ) -> tuple[Any, tuple[str, ...]]:
-    db_path = _stripped(env.get("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH"))
+    db_path = resident_queue_pattern_memory_admission_db_path(env, repo_root)
     if not db_path:
         return None, ()
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3849,8 +3849,73 @@ def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
         / REPO_ROOT.resolve().name
         / "verified_outcomes.jsonl"
     )
+    assert mocked.call_args.kwargs["pattern_memory_admission_sink"] is None
     assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
     assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 91
+
+
+def test_main_serial_loop_preflight_pattern_memory_profile_derives_sink(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "steps_run": 1,
+                "dispatched_stages": ("pattern_memory_admission",),
+                "next_action": "STOP_QUEUE_CHAIN_COMPLETE",
+                "chain_results_path": str(tmp_path / "chain.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": (
+                    "signed_0102_bounded_code_fusion_worktree_draft_pr_pattern_memory"
+                ),
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+                "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "92",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["artifact_generator_mode"] == "foundups_fusion"
+    assert mocked.call_args.kwargs["worktree_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["evidence_command_runner_mode"] == "real"
+    assert mocked.call_args.kwargs["outcome_ratchet_store_path"] == str(
+        REPO_ROOT.resolve().parent
+        / ".reddog"
+        / "outcome_ratchet"
+        / REPO_ROOT.resolve().name
+        / "verified_outcomes.jsonl"
+    )
+    sink = mocked.call_args.kwargs["pattern_memory_admission_sink"]
+    assert sink is not None
+    assert sink.__class__.__name__ == "RedDogVerifiedPatternMemorySink"
+    assert str(sink.db_path) == str(
+        REPO_ROOT.resolve().parent
+        / ".reddog"
+        / "pattern_memory"
+        / REPO_ROOT.resolve().name
+        / "pattern_memory.db"
+    )
+    assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
+    assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 92
 
 
 def test_main_serial_loop_preflight_blocks_when_enforced() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -617,10 +617,71 @@ def test_runtime_binding_draft_pr_profile_supplies_verified_draft_runner(
         / tmp_path.resolve().name
         / "verified_outcomes.jsonl"
     )
+    assert "pattern_memory_admission_sink" not in bootstrap.calls[0]
     draft_runner = bootstrap.calls[0]["draft_pr_runner"]
     assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
     assert draft_runner.repo_root == tmp_path.resolve()
     assert draft_runner.timeout_s == 89
+
+
+def test_runtime_binding_pattern_memory_profile_derives_outside_repo_sink(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from modules.foundups.agent.src import worktree_pr_runner
+
+    monkeypatch.setattr(worktree_pr_runner, "RealWorktreeRunner", _FakeDraftPrRunner)
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": (
+            "signed_0102_bounded_code_fusion_worktree_draft_pr_pattern_memory"
+        ),
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "90",
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=tmp_path,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=tmp_path,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["artifact_generator_mode"] == "foundups_fusion"
+    assert bootstrap.calls[0]["worktree_runner_mode"] == "real"
+    assert bootstrap.calls[0]["evidence_command_runner_mode"] == "real"
+    assert bootstrap.calls[0]["outcome_ratchet_store_path"] == str(
+        tmp_path.resolve().parent
+        / ".reddog"
+        / "outcome_ratchet"
+        / tmp_path.resolve().name
+        / "verified_outcomes.jsonl"
+    )
+    sink = bootstrap.calls[0]["pattern_memory_admission_sink"]
+    assert sink.__class__.__name__ == "RedDogVerifiedPatternMemorySink"
+    assert sink.db_path == (
+        tmp_path.resolve().parent
+        / ".reddog"
+        / "pattern_memory"
+        / tmp_path.resolve().name
+        / "pattern_memory.db"
+    )
+    draft_runner = bootstrap.calls[0]["draft_pr_runner"]
+    assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
+    assert draft_runner.repo_root == tmp_path.resolve()
+    assert draft_runner.timeout_s == 90
 
 
 def test_runtime_binding_rejects_unsupported_draft_pr_runner_mode(tmp_path: Path) -> None:


### PR DESCRIPTION
## Slice
REDDOG_RESIDENT_PATTERN_MEMORY_ADMISSION_PROFILE_PHASE1

## Summary
- adds `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE=signed_0102_bounded_code_fusion_worktree_draft_pr_pattern_memory`
- preserves fusion, isolated worktree, evidence runner, verified draft PR, and outcome ratchet defaults
- derives an outside-repo PatternMemory admission DB path at `.reddog/pattern_memory/<repo>/pattern_memory.db`
- wires the same profile helper through `main.py` preflight and the OpenClaw signed-worker queue-loop runtime binding

## WSP_97 Truth Boundary
OBSERVED:
- lower draft-PR profile still does not supply a PatternMemory admission sink
- new profile supplies the existing verified PatternMemory sink only with an outside-repo DB path
- existing guarded admission path remains downstream of verified draft PR, outcome ratchet, held-out gate, derived admission request, and sink validation

NOT IMPLEMENTED / NOT EXPANDED:
- no shell execution
- no HoloIndex re-index
- no merge authority
- no reward settlement
- no Hermes dispatch
- no PatternMemory write without the existing downstream admission gates

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 34 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 53 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_pattern_memory_admission_handler.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_pattern_memory_admission_invoke.py -q` -> 18 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 39 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/src/reddog_resident_queue_pattern_memory_admission_handler.py modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_pattern_memory_admission_invoke.py modules/communication/moltbot_bridge/src/reddog_verified_pattern_memory_sink.py`
- `git diff --check`