### PR TITLE
feat(reddog): derive resident runtime paths from profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1672,6 +1672,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_materializer_mode,
             resident_queue_outcome_ratchet_store_path,
             resident_queue_pattern_memory_admission_db_path,
+            resident_queue_runtime_file_path,
             resident_queue_worktree_runner_mode,
         )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
@@ -1699,9 +1700,23 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
 
         result = run_reddog_main_resident_queue_serial_loop_bootstrap(
             repo_root=repo_root,
-            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
-            chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
-            authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
+            work_state_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+            ),
+            chain_results_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+            )
+            or None,
+            authority_profile_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+            )
+            or None,
             work_orders_path=os.getenv("REDDOG_WORK_ORDERS_PATH", "") or None,
             work_order_materializer_mode=resident_queue_materializer_mode(os.environ) or None,
             valve_environment_path=os.getenv("REDDOG_EXECUTION_VALVE_ENV_PATH", "") or None,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_RUNTIME_PATH_DEFAULTS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added profile-derived mandatory resident runtime paths under
+  `.reddog/resident/<repo>/` or explicit `REDDOG_RESIDENT_RUNTIME_ROOT`.
+- `main.py` preflight and the OpenClaw signed-worker queue-loop runtime now
+  derive work-state, chain-results, and authority-profile paths when a
+  resident profile is active and the explicit env vars are absent.
+- Explicit path env vars still win, and the helper only returns paths; it does
+  not create files, write runtime state, re-index HoloIndex, dispatch Hermes,
+  merge, settle rewards, or grant additional authority.
+
 ## 2026-07-16: REDDOG_RESIDENT_FULL_RECURSIVE_PROFILE_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -78,6 +78,12 @@ PROFILE_RUNTIME_FLAGS = frozenset(
     }
 )
 
+PROFILE_RUNTIME_PATH_FILENAMES = {
+    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "authoritative_work_state.json",
+    "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": "resident_queue_chain_results.json",
+    "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": "authority_profile.json",
+}
+
 
 def resident_queue_binding_profile(env: Mapping[str, str]) -> str:
     """Return the normalized resident queue binding profile."""
@@ -118,6 +124,40 @@ def resident_queue_runtime_flag_enabled(env: Mapping[str, str], env_name: str) -
         env_name in PROFILE_RUNTIME_FLAGS
         and resident_queue_binding_profile(env) in RESIDENT_QUEUE_PROFILES
     )
+
+
+def resident_queue_runtime_root_path(env: Mapping[str, str], repo_root: Path | str) -> str:
+    """Return explicit/default outside-repo resident runtime root for profiles."""
+
+    root = Path(repo_root).resolve()
+    raw = str(env.get("REDDOG_RESIDENT_RUNTIME_ROOT") or "").strip()
+    if raw:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = root.parent / path
+        return str(path.resolve())
+    if resident_queue_binding_profile(env) not in RESIDENT_QUEUE_PROFILES:
+        return ""
+    return str(root.parent / ".reddog" / "resident" / _repo_slug(root))
+
+
+def resident_queue_runtime_file_path(
+    env: Mapping[str, str],
+    repo_root: Path | str,
+    env_name: str,
+) -> str:
+    """Return an explicit env path or a profile-derived runtime file path."""
+
+    raw = str(env.get(env_name) or "").strip()
+    if raw:
+        return raw
+    filename = PROFILE_RUNTIME_PATH_FILENAMES.get(env_name)
+    if not filename:
+        return ""
+    root = resident_queue_runtime_root_path(env, repo_root)
+    if not root:
+        return ""
+    return str(Path(root) / filename)
 
 
 def resident_queue_artifact_generator_mode(env: Mapping[str, str]) -> str:
@@ -235,6 +275,7 @@ __all__ = [
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR",
     "PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE",
     "PROFILE_SIGNED_0102_BOUNDED_CODE",
+    "PROFILE_RUNTIME_PATH_FILENAMES",
     "RESIDENT_QUEUE_PROFILES",
     "resident_queue_artifact_generator_mode",
     "resident_queue_binding_enabled",
@@ -244,6 +285,8 @@ __all__ = [
     "resident_queue_materializer_mode",
     "resident_queue_outcome_ratchet_store_path",
     "resident_queue_pattern_memory_admission_db_path",
+    "resident_queue_runtime_file_path",
     "resident_queue_runtime_flag_enabled",
+    "resident_queue_runtime_root_path",
     "resident_queue_worktree_runner_mode",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -31,6 +31,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     resident_queue_materializer_mode,
     resident_queue_outcome_ratchet_store_path,
     resident_queue_pattern_memory_admission_db_path,
+    resident_queue_runtime_file_path,
     resident_queue_runtime_flag_enabled,
     resident_queue_worktree_runner_mode,
 )
@@ -142,9 +143,15 @@ def build_reddog_signed_worker_queue_loop_runner_from_env(
             rejection_reasons=(SignedWorkerOpenClawQueueLoopBindingReason.NOT_REQUESTED,),
         )
 
-    work_state_path = _stripped(env.get("REDDOG_AUTHORITATIVE_WORK_STATE_PATH"))
-    chain_results_path = _stripped(env.get("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH"))
-    authority_profile_path = _stripped(env.get("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH"))
+    work_state_path = _stripped(
+        resident_queue_runtime_file_path(env, repo_root, "REDDOG_AUTHORITATIVE_WORK_STATE_PATH")
+    )
+    chain_results_path = _stripped(
+        resident_queue_runtime_file_path(env, repo_root, "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH")
+    )
+    authority_profile_path = _stripped(
+        resident_queue_runtime_file_path(env, repo_root, "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH")
+    )
     reasons: list[str] = []
     if not work_state_path:
         reasons.append(SignedWorkerOpenClawQueueLoopBindingReason.WORK_STATE_PATH_MISSING)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -3801,6 +3801,56 @@ def test_main_serial_loop_preflight_worktree_profile_derives_model_and_worktree_
     assert mocked.call_args.kwargs["outcome_ratchet_store_path"] is None
 
 
+def test_main_serial_loop_preflight_profile_derives_mandatory_runtime_paths(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "steps_run": 1,
+                "dispatched_stages": ("authority_request",),
+                "next_action": "RUN_QUEUE_AUTHORITY_RUNTIME_INVOKE",
+                "chain_results_path": str(runtime_root / "resident_queue_chain_results.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(
+        runtime_root / "authoritative_work_state.json"
+    )
+    assert mocked.call_args.kwargs["chain_results_path"] == str(
+        runtime_root / "resident_queue_chain_results.json"
+    )
+    assert mocked.call_args.kwargs["authority_profile_path"] == str(
+        runtime_root / "authority_profile.json"
+    )
+    assert mocked.call_args.kwargs["work_order_materializer_mode"] == "authority_profile"
+    assert mocked.call_args.kwargs["artifact_generator_mode"] is None
+    assert not runtime_root.exists()
+
+
 def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
     tmp_path: Path,
 ) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -785,6 +785,41 @@ def test_runtime_binding_profile_defaults_derivation_flags(tmp_path: Path) -> No
     assert "draft_pr_runner" not in call
 
 
+def test_runtime_binding_profile_derives_mandatory_paths_from_runtime_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime_root = tmp_path / "resident-runtime"
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+    assert binding.work_state_path == str(runtime_root / "authoritative_work_state.json")
+    assert binding.chain_results_path == str(runtime_root / "resident_queue_chain_results.json")
+    assert binding.authority_profile_path == str(runtime_root / "authority_profile.json")
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=repo,
+    )
+
+    assert result["accepted"] is True
+    assert not runtime_root.exists()
+
+
 def test_runtime_binding_profile_respects_explicit_binding_disable(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Slice
REDDOG_RESIDENT_RUNTIME_PATH_DEFAULTS_PHASE1

## Summary
- adds profile-derived mandatory resident runtime paths under `.reddog/resident/<repo>/`
- supports explicit `REDDOG_RESIDENT_RUNTIME_ROOT`
- wires `main.py` preflight and the OpenClaw signed-worker queue-loop binding to derive work-state, chain-results, and authority-profile paths when explicit env vars are absent
- preserves explicit env path precedence

## WSP_97 Truth Boundary
OBSERVED:
- profile-derived paths reduce manual 012 env setup for resident queue loop startup
- helper only returns paths and does not create files
- explicit `REDDOG_AUTHORITATIVE_WORK_STATE_PATH`, `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH`, and `REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH` still win

NOT IMPLEMENTED / NOT EXPANDED:
- no runtime state creation
- no source write
- no HoloIndex re-index
- no Hermes dispatch
- no merge authority
- no reward settlement
- no new authority grant

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 90 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py`
- `git diff --check`