### PR TITLE
feat(reddog): align work-state refresh with resident profile path

### DIFF
--- a/main.py
+++ b/main.py
@@ -1366,6 +1366,9 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
         from modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap import (
             run_reddog_main_authoritative_work_state_refresh_bootstrap,
         )
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_file_path,
+        )
 
         result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
             repo_root=repo_root,
@@ -1373,7 +1376,11 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
             work_ledger_json_path=os.getenv("REDDOG_WORK_LEDGER_JSON_PATH", ""),
             github_pr_records_path=os.getenv("REDDOG_GITHUB_PR_RECORDS_PATH", ""),
             w10_report_records_path=os.getenv("REDDOG_W10_REPORT_RECORDS_PATH", ""),
-            work_state_output_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            work_state_output_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+            ),
             worker_id=os.getenv("REDDOG_WORK_STATE_REFRESH_WORKER_ID", "reddog-main-bootstrap"),
             use_latest_readonly_audit_decision=use_latest_decision,
         )

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_WORK_STATE_REFRESH_PROFILE_PATH_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Aligned `main.py` authoritative work-state refresh with the resident profile
+  runtime path helper, so an active resident profile writes the authoritative
+  work-state snapshot to the same outside-repo runtime root consumed by the
+  serial queue loop.
+- Preserved the existing explicit `REDDOG_AUTHORITATIVE_WORK_STATE_PATH`
+  override and the legacy non-profile default path.
+- Added a regression proving the profile-derived work-state output is created
+  outside the source checkout and exported back to `os.environ` for downstream
+  RedDog preflights.
+
 ## 2026-07-16: REDDOG_RESIDENT_RUNTIME_PATH_DEFAULTS_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
@@ -432,6 +432,37 @@ def test_main_preflight_sets_work_state_path_after_success(tmp_path: Path) -> No
         assert os.environ["REDDOG_AUTHORITATIVE_WORK_STATE_PATH"] == str(paths["output"].resolve())
 
 
+def test_main_preflight_profile_derives_work_state_output_path(tmp_path: Path) -> None:
+    import main
+
+    paths = _write_sources(tmp_path)
+    runtime_root = tmp_path / "resident-runtime"
+    expected_output = runtime_root / "authoritative_work_state.json"
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+            "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED": "0",
+            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            "REDDOG_ACTIVE_SLICE_LEDGER_PATH": str(paths["active"]),
+            "REDDOG_WORK_LEDGER_JSON_PATH": str(paths["ledger"]),
+            "REDDOG_GITHUB_PR_RECORDS_PATH": str(paths["github"]),
+            "REDDOG_W10_REPORT_RECORDS_PATH": str(paths["w10"]),
+        },
+        clear=True,
+    ):
+        assert main.run_reddog_authoritative_work_state_refresh_preflight(paths["repo"]) is True
+        import os
+
+        assert os.environ["REDDOG_AUTHORITATIVE_WORK_STATE_PATH"] == str(
+            expected_output.resolve()
+        )
+
+    assert expected_output.exists()
+    assert not (paths["repo"] / ".reddog").exists()
+
+
 def test_main_preflight_enables_latest_decision_bridge_with_openclaw_auto_tasks(tmp_path: Path) -> None:
     import main
 


### PR DESCRIPTION
## Slice
REDDOG_WORK_STATE_REFRESH_PROFILE_PATH_PHASE1

## Summary
- aligns `main.py` authoritative work-state refresh with resident profile runtime path defaults
- when a resident profile is active, the refresh writes `authoritative_work_state.json` under the same outside-repo runtime root consumed by the serial queue loop
- explicit `REDDOG_AUTHORITATIVE_WORK_STATE_PATH` remains authoritative
- non-profile legacy default remains unchanged

## WSP_97 Truth Boundary
OBSERVED:
- producer and consumer now share the profile-derived authoritative state path
- work-state refresh still reads only already-observed source artifacts
- output path remains outside the source checkout

NOT IMPLEMENTED / NOT EXPANDED:
- no GitHub/W10 fetch
- no worker spawn
- no OpenClaw enqueue
- no Hermes dispatch
- no source mutation
- no HoloIndex re-index
- no merge/reward authority

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py -q` -> 14 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py`
- `git diff --check`