### PR TITLE
feat(reddog): align queue preflights with resident profile paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -1435,10 +1435,17 @@ def run_reddog_wre_queue_consumer_preflight(repo_root: Path) -> bool:
         from modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap import (
             run_reddog_main_wre_queue_consumer_bootstrap,
         )
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_file_path,
+        )
 
         result = run_reddog_main_wre_queue_consumer_bootstrap(
             repo_root=repo_root,
-            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            work_state_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+            ),
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
         )
     except Exception as exc:
@@ -1490,11 +1497,23 @@ def run_reddog_resident_queue_orchestration_plan_preflight(repo_root: Path) -> b
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap import (
             run_reddog_main_resident_queue_orchestration_plan_bootstrap,
         )
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_file_path,
+        )
 
         result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
             repo_root=repo_root,
-            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
-            chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
+            work_state_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+            ),
+            chain_results_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+            )
+            or None,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
         )
     except Exception as exc:
@@ -1553,12 +1572,29 @@ def run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root: Path) -> 
         from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_next_stage_dispatch_bootstrap import (
             run_reddog_main_resident_queue_next_stage_dispatch_bootstrap,
         )
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_file_path,
+        )
 
         result = run_reddog_main_resident_queue_next_stage_dispatch_bootstrap(
             repo_root=repo_root,
-            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
-            chain_results_path=os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", "") or None,
-            authority_profile_path=os.getenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", "") or None,
+            work_state_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+            ),
+            chain_results_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+            )
+            or None,
+            authority_profile_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+            )
+            or None,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
         )
     except Exception as exc:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MIDDLE_PREFLIGHTS_PROFILE_PATHS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Aligned the WRE queue consumer, resident orchestration-plan, and
+  next-stage dispatch `main.py` preflights with the resident profile runtime
+  path helper.
+- These preflights now consume the same profile-derived work-state,
+  chain-results, and authority-profile paths as the refresh producer and
+  serial-loop runner when explicit env vars are absent.
+- Added regression tests proving the derived paths are passed without creating
+  runtime files or writing inside the source checkout.
+
 ## 2026-07-16: REDDOG_WORK_STATE_REFRESH_PROFILE_PATH_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py
@@ -258,6 +258,53 @@ def test_main_next_stage_dispatch_preflight_passes_when_bootstrap_applies(tmp_pa
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
 
 
+def test_main_next_stage_dispatch_preflight_profile_derives_runtime_paths(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_next_stage_dispatch_bootstrap.run_reddog_main_resident_queue_next_stage_dispatch_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_DISPATCH_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "dispatched_stage": AUTHORITY_REQUEST_STAGE_KEY,
+                "next_action": NEXT_QUEUE_AUTHORITY_RUNTIME_INVOKE,
+                "chain_results_path": str(runtime_root / "resident_queue_chain_results.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_NEXT_STAGE_DISPATCH": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_next_stage_dispatch_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(
+        runtime_root / "authoritative_work_state.json"
+    )
+    assert mocked.call_args.kwargs["chain_results_path"] == str(
+        runtime_root / "resident_queue_chain_results.json"
+    )
+    assert mocked.call_args.kwargs["authority_profile_path"] == str(
+        runtime_root / "authority_profile.json"
+    )
+    assert not runtime_root.exists()
+
+
 def test_main_next_stage_dispatch_preflight_blocks_when_enforced() -> None:
     import main
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py
@@ -221,6 +221,51 @@ def test_main_resident_queue_plan_preflight_passes_when_bootstrap_ready(tmp_path
     assert mocked.call_args.kwargs["requested_queue_item_id"] == "queue-1"
 
 
+def test_main_resident_queue_plan_preflight_profile_derives_runtime_paths(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap.run_reddog_main_resident_queue_orchestration_plan_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": True,
+                "status": REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY,
+                "plan_id": "plan-1",
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "current_stage": "authority_request",
+                "next_action": NEXT_QUEUE_AUTHORITY_REQUEST_DRYRUN,
+                "accepted_stage_count": 1,
+                "chain_complete": False,
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_orchestration_plan_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(
+        runtime_root / "authoritative_work_state.json"
+    )
+    assert mocked.call_args.kwargs["chain_results_path"] == str(
+        runtime_root / "resident_queue_chain_results.json"
+    )
+    assert not runtime_root.exists()
+
+
 def test_main_resident_queue_plan_preflight_blocks_when_enforced() -> None:
     import main
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
@@ -295,6 +295,44 @@ def test_main_queue_consumer_preflight_passes_when_bootstrap_ready(tmp_path: Pat
     assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
 
 
+def test_main_queue_consumer_preflight_profile_derives_work_state_path(tmp_path: Path) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap.run_reddog_main_wre_queue_consumer_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": True,
+                "status": REDDOG_WRE_QUEUE_BOOTSTRAP_READY,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_SAMPLE_SLICE_PHASE1",
+                "next_required_gate": consumer.NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
+                "execution_ready": False,
+                "rejection_reasons": (),
+                "receipt_id": "receipt-1",
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_wre_queue_consumer_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["work_state_path"] == str(
+        runtime_root / "authoritative_work_state.json"
+    )
+    assert not runtime_root.exists()
+
+
 def test_main_queue_consumer_preflight_blocks_when_enforced() -> None:
     import main
 


### PR DESCRIPTION
## Slice
REDDOG_MIDDLE_PREFLIGHTS_PROFILE_PATHS_PHASE1

## Summary
- aligns WRE queue consumer, resident queue orchestration-plan, and next-stage dispatch `main.py` preflights with resident profile runtime path defaults
- these middle preflights now consume the same derived work-state, chain-results, and authority-profile paths used by the refresh producer and serial-loop runner
- explicit env paths remain authoritative

## WSP_97 Truth Boundary
OBSERVED:
- profile-derived paths are passed to middle preflights without creating runtime files
- this removes more manual 012 env glue between refresh, plan, dispatch, and serial-loop stages

NOT IMPLEMENTED / NOT EXPANDED:
- no runtime state creation in these preflights
- no shell execution
- no HoloIndex re-index
- no Hermes dispatch
- no merge authority
- no reward settlement
- no new authority grant

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py -q` -> 37 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py`
- `git diff --check`