### PR TITLE
fix(reddog): let resident profile plan before chain exists

### DIFF
--- a/main.py
+++ b/main.py
@@ -1501,6 +1501,17 @@ def run_reddog_resident_queue_orchestration_plan_preflight(repo_root: Path) -> b
             resident_queue_runtime_file_path,
         )
 
+        explicit_chain_results_path = str(
+            os.getenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH") or ""
+        ).strip()
+        chain_results_path = resident_queue_runtime_file_path(
+            os.environ,
+            repo_root,
+            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+        )
+        if not explicit_chain_results_path and chain_results_path:
+            chain_results_path = chain_results_path if Path(chain_results_path).exists() else ""
+
         result = run_reddog_main_resident_queue_orchestration_plan_bootstrap(
             repo_root=repo_root,
             work_state_path=resident_queue_runtime_file_path(
@@ -1508,12 +1519,7 @@ def run_reddog_resident_queue_orchestration_plan_preflight(repo_root: Path) -> b
                 repo_root,
                 "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
             ),
-            chain_results_path=resident_queue_runtime_file_path(
-                os.environ,
-                repo_root,
-                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
-            )
-            or None,
+            chain_results_path=chain_results_path or None,
             requested_queue_item_id=os.getenv("REDDOG_WRE_QUEUE_ITEM_ID", "") or None,
         )
     except Exception as exc:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_QUEUE_PLAN_OPTIONAL_PROFILE_CHAIN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Fixed the resident orchestration-plan preflight so a profile-derived default
+  `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH` is optional until the serial loop
+  creates the chain-results file.
+- Preserved strict behavior for an explicit `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH`;
+  if the operator supplies a path, the planner still validates it.
+- Added real-path and mocked regressions proving the first resident profile
+  plan does not warn on a missing default chain file, while existing chain
+  files and explicit paths are still passed through.
+
 ## 2026-07-16: REDDOG_RESIDENT_PROFILE_SERIAL_LOOP_DEFAULT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py
@@ -260,10 +260,123 @@ def test_main_resident_queue_plan_preflight_profile_derives_runtime_paths(
     assert mocked.call_args.kwargs["work_state_path"] == str(
         runtime_root / "authoritative_work_state.json"
     )
-    assert mocked.call_args.kwargs["chain_results_path"] == str(
-        runtime_root / "resident_queue_chain_results.json"
-    )
+    assert mocked.call_args.kwargs["chain_results_path"] is None
     assert not runtime_root.exists()
+
+
+def test_main_resident_queue_plan_preflight_profile_uses_existing_chain_file(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    chain_path = runtime_root / "resident_queue_chain_results.json"
+    chain_path.parent.mkdir(parents=True)
+    chain_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "reddog_resident_queue_chain_results.v1",
+                "stage_results": {},
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap.run_reddog_main_resident_queue_orchestration_plan_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": True,
+                "status": REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY,
+                "plan_id": "plan-1",
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "current_stage": "authority_request",
+                "next_action": NEXT_QUEUE_AUTHORITY_REQUEST_DRYRUN,
+                "accepted_stage_count": 1,
+                "chain_complete": False,
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_orchestration_plan_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["chain_results_path"] == str(chain_path)
+
+
+def test_main_resident_queue_plan_preflight_preserves_explicit_chain_path(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    explicit_chain = tmp_path / "runtime" / "missing-chain-results.json"
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap.run_reddog_main_resident_queue_orchestration_plan_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "ready": True,
+                "status": REDDOG_RESIDENT_QUEUE_PLAN_BOOTSTRAP_READY,
+                "plan_id": "plan-1",
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "current_stage": "authority_request",
+                "next_action": NEXT_QUEUE_AUTHORITY_REQUEST_DRYRUN,
+                "accepted_stage_count": 1,
+                "chain_complete": False,
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(tmp_path / "resident-runtime"),
+                "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(explicit_chain),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_orchestration_plan_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["chain_results_path"] == str(explicit_chain)
+
+
+def test_main_resident_queue_plan_preflight_profile_missing_chain_file_still_plans(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    state_path = runtime_root / "authoritative_work_state.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps(_snapshot(), sort_keys=True), encoding="utf-8")
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_RESIDENT_QUEUE_ORCHESTRATION_PLAN": "1",
+            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+        },
+        clear=True,
+    ):
+        assert main.run_reddog_resident_queue_orchestration_plan_preflight(REPO_ROOT) is True
+
+    assert not (runtime_root / "resident_queue_chain_results.json").exists()
 
 
 def test_main_resident_queue_plan_preflight_blocks_when_enforced() -> None:


### PR DESCRIPTION
## Summary
- Treat a profile-derived default `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH` as optional for the first resident orchestration-plan preflight.
- Keep explicit `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH` strict and pass it through unchanged.
- Add mocked and real-path regressions proving the first profile-selected resident plan no longer warns before the serial loop has created chain results.

## WSP_97 Truth Boundary
- OBSERVED: A resident profile can now plan the first queue bridge before a chain-results file exists.
- OBSERVED: Existing chain-results files are still consumed when present.
- OBSERVED: Explicit operator-provided chain paths are still treated as explicit inputs.
- OBSERVED: No shell execution, HoloIndex re-index, OpenClaw enqueue, Hermes dispatch, PR creation, merge authority, or reward settlement was added.

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py -q` -> 13 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py`
- `git diff --check` -> clean (CRLF warnings only)