### PR TITLE
feat(reddog): bridge architect fix promotion into startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1475,6 +1475,99 @@ def run_reddog_wre_queue_consumer_preflight(repo_root: Path) -> bool:
     return True
 
 
+def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
+    """
+    Optionally promote a backend architect FIX determination into the resident queue.
+
+    Env:
+        REDDOG_ARCHITECT_FIX_PROMOTION_RUNTIME=0             Enable promotion bridge
+        REDDOG_ARCHITECT_FIX_PROMOTION_ENFORCED=0            Block startup if rejected
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
+        REDDOG_ARCHITECT_FIX_DETERMINATION_PATH              Outside-repo determination JSON
+        REDDOG_MODEL_SELECTION_RECEIPT_PATH                  Outside-repo model receipt JSON
+        REDDOG_MEMEX_SUPPLY_RECEIPT_PATH                     Outside-repo Memex supply JSON
+        REDDOG_AUTHORITY_PROFILE_SOURCE_PATH                 Outside-repo authority seed JSON
+        REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo promoted profile JSON
+        REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional profile-derived output path
+    """
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_file_path,
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-FIX-PROMOTION] profile helper import failed: {exc}")
+        return True
+
+    authority_profile_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+    )
+    required_inputs_present = all(
+        str(os.getenv(name) or "").strip()
+        for name in (
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+            "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH",
+            "REDDOG_MODEL_SELECTION_RECEIPT_PATH",
+            "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH",
+            "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH",
+        )
+    ) and bool(authority_profile_path)
+    raw_requested = os.getenv("REDDOG_ARCHITECT_FIX_PROMOTION_RUNTIME")
+    requested = raw_requested == "1" or (raw_requested is None and required_inputs_present)
+    if not requested:
+        logger.info("[REDDOG-FIX-PROMOTION] Startup promotion bridge disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_ARCHITECT_FIX_PROMOTION_ENFORCED", "0") != "0"
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap import (
+            run_reddog_main_architect_fix_promotion_bootstrap,
+        )
+
+        result = run_reddog_main_architect_fix_promotion_bootstrap(
+            repo_root=repo_root,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            architect_determination_path=os.getenv("REDDOG_ARCHITECT_FIX_DETERMINATION_PATH", ""),
+            model_selection_receipt_path=os.getenv("REDDOG_MODEL_SELECTION_RECEIPT_PATH", ""),
+            memex_supply_receipt_path=os.getenv("REDDOG_MEMEX_SUPPLY_RECEIPT_PATH", ""),
+            authority_profile_source_path=os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_PATH", ""),
+            authority_profile_output_path=authority_profile_path,
+            worker_id=os.getenv(
+                "REDDOG_ARCHITECT_FIX_PROMOTION_WORKER_ID",
+                "reddog-main-architect-fix-promotion",
+            ),
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-FIX-PROMOTION] Startup promotion bridge failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-FIX-PROMOTION] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-FIX-PROMOTION] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.accepted else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    print(
+        f"[REDDOG-FIX-PROMOTION] preflight={status} status={result.status} "
+        f"queue_item={result.queue_item_id or '(none)'} "
+        f"selected_slice={result.selected_slice or '(none)'} reasons={reasons}"
+    )
+    if result.accepted and result.authority_profile_path:
+        os.environ["REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH"] = result.authority_profile_path
+        print(
+            f"[REDDOG-FIX-PROMOTION] receipt={result.promotion_receipt_id} "
+            f"revision={result.committed_revision}"
+        )
+        return True
+
+    if enforced:
+        print("[REDDOG-FIX-PROMOTION] Startup blocked by REDDOG_ARCHITECT_FIX_PROMOTION_ENFORCED=1")
+        return False
+    return True
+
+
 def run_reddog_resident_queue_orchestration_plan_preflight(repo_root: Path) -> bool:
     """
     Plan the next resident RedDog queue bridge from the authoritative snapshot.
@@ -2127,6 +2220,8 @@ def main():
     if not run_git_main_merge_sentinel_preflight(repo_root):
         return
     if not run_reddog_authoritative_work_state_refresh_preflight(repo_root):
+        return
+    if not run_reddog_architect_fix_promotion_preflight(repo_root):
         return
     if not run_reddog_wre_queue_consumer_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_ARCHITECT_FIX_PROMOTION_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a `main.py` promotion bridge that consumes outside-repo backend
+  architect FIX, model-selection, Memex-supply, and authority-profile receipts.
+- The bridge calls the existing signed WSP_15 promotion runtime, atomically
+  updates the outside-repo authoritative work-state snapshot, and writes the
+  promoted authority profile consumed by the resident serial loop.
+- Boundary remains constrained: no signing, worker spawn, worktree creation,
+  shell execution, OpenClaw enqueue, Hermes dispatch, PR creation,
+  PatternMemory write, reward settlement, source-repo mutation, or HoloIndex
+  re-indexing was added.
+
 ## 2026-07-16: REDDOG_RESIDENT_QUEUE_PLAN_OPTIONAL_PROFILE_CHAIN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
@@ -1,0 +1,298 @@
+"""Main-startup bridge for RedDog architect FIX promotion.
+
+Slice: REDDOG_ARCHITECT_FIX_PROMOTION_MAIN_PREFLIGHT_PHASE1
+
+This adapter consumes already-produced backend architect, model-selection,
+Memex-supply, and authority-profile receipts from outside-repo runtime files.
+It promotes one FIX determination into the authoritative work-state queue and
+writes the promoted authority profile consumed by the resident serial loop.
+
+It does not sign authority, spawn workers, create worktrees, run shell commands,
+enqueue OpenClaw, dispatch Hermes, publish PRs, admit PatternMemory, settle
+rewards, mutate source files, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT,
+    promote_reddog_architect_fix_to_signed_wsp15_work_order,
+)
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
+    AtomicJsonAuthoritativeWorkStateStore,
+)
+
+
+REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED = (
+    "REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED"
+)
+REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY = (
+    "REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY"
+)
+
+
+@dataclass(frozen=True)
+class RedDogMainArchitectFixPromotionBootstrapResult:
+    """Result returned to ``main.py`` for startup reporting."""
+
+    accepted: bool
+    status: str
+    promotion_receipt_id: Optional[str]
+    queue_item_id: Optional[str]
+    claim_id: Optional[str]
+    selected_slice: Optional[str]
+    authority_profile_path: Optional[str]
+    committed_revision: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_signing_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_main_architect_fix_promotion_bootstrap(
+    *,
+    repo_root: Path | str,
+    work_state_path: Path | str | None,
+    architect_determination_path: Path | str | None,
+    model_selection_receipt_path: Path | str | None,
+    memex_supply_receipt_path: Path | str | None,
+    authority_profile_source_path: Path | str | None,
+    authority_profile_output_path: Path | str | None,
+    worker_id: str = "reddog-main-architect-fix-promotion",
+    now_iso: str | None = None,
+) -> RedDogMainArchitectFixPromotionBootstrapResult:
+    """Promote one backend architect FIX determination into the resident queue."""
+
+    root = Path(repo_root).resolve()
+    reasons: list[str] = []
+
+    work_state_file, work_state_reasons = _resolve_existing_file_outside_repo(
+        root,
+        work_state_path,
+        missing_reason="missing_authoritative_work_state_path",
+        inside_reason="work_state_path_inside_repo",
+    )
+    reasons.extend(work_state_reasons)
+    determination, determination_reasons = _read_json_outside_repo(
+        root,
+        architect_determination_path,
+        missing_reason="missing_architect_determination_path",
+        inside_reason="architect_determination_path_inside_repo",
+        unreadable_reason="malformed_architect_determination",
+    )
+    reasons.extend(determination_reasons)
+    model_selection, model_reasons = _read_json_outside_repo(
+        root,
+        model_selection_receipt_path,
+        missing_reason="missing_model_selection_receipt_path",
+        inside_reason="model_selection_receipt_path_inside_repo",
+        unreadable_reason="malformed_model_selection_receipt",
+    )
+    reasons.extend(model_reasons)
+    memex_supply, memex_reasons = _read_json_outside_repo(
+        root,
+        memex_supply_receipt_path,
+        missing_reason="missing_memex_supply_receipt_path",
+        inside_reason="memex_supply_receipt_path_inside_repo",
+        unreadable_reason="malformed_memex_supply_receipt",
+    )
+    reasons.extend(memex_reasons)
+    authority_profile, profile_reasons = _read_json_outside_repo(
+        root,
+        authority_profile_source_path,
+        missing_reason="missing_authority_profile_source_path",
+        inside_reason="authority_profile_source_path_inside_repo",
+        unreadable_reason="malformed_authority_profile_source",
+    )
+    reasons.extend(profile_reasons)
+    output_path, output_reasons = _resolve_output_outside_repo(
+        root,
+        authority_profile_output_path,
+        missing_reason="missing_authority_profile_output_path",
+        inside_reason="authority_profile_output_path_inside_repo",
+    )
+    reasons.extend(output_reasons)
+
+    if reasons:
+        return _not_ready(reasons)
+
+    assert work_state_file is not None
+    assert output_path is not None
+    assert determination is not None
+    assert model_selection is not None
+    assert memex_supply is not None
+    assert authority_profile is not None
+
+    output_probe_reasons = _probe_atomic_output(output_path)
+    if output_probe_reasons:
+        return _not_ready(output_probe_reasons)
+
+    store = AtomicJsonAuthoritativeWorkStateStore(work_state_file)
+    result = promote_reddog_architect_fix_to_signed_wsp15_work_order(
+        architect_determination=determination,
+        work_state_store=store,
+        authority_profile=authority_profile,
+        model_selection_receipt=model_selection,
+        memex_supply_receipt=memex_supply,
+        worker_id=worker_id,
+        now_iso=now_iso or datetime.now(timezone.utc).isoformat(),
+    )
+    if not result.accepted or result.status != ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT:
+        return _not_ready(result.rejection_reasons or ("architect_fix_promotion_rejected",))
+    if result.authority_profile is None or result.receipt is None:
+        return _not_ready(("architect_fix_promotion_missing_profile",))
+
+    try:
+        _write_json_atomic(output_path, result.authority_profile)
+    except Exception:
+        return _not_ready(("authority_profile_output_write_failed",))
+
+    return RedDogMainArchitectFixPromotionBootstrapResult(
+        accepted=True,
+        status=REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+        promotion_receipt_id=result.receipt.promotion_receipt_id,
+        queue_item_id=result.receipt.queue_item_id,
+        claim_id=result.receipt.claim_id,
+        selected_slice=result.receipt.selected_slice,
+        authority_profile_path=str(output_path),
+        committed_revision=result.receipt.committed_revision,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    unreadable_reason: str,
+) -> tuple[Optional[Mapping[str, Any]], list[str]]:
+    path, reasons = _resolve_existing_file_outside_repo(
+        repo_root,
+        value,
+        missing_reason=missing_reason,
+        inside_reason=inside_reason,
+    )
+    if reasons:
+        return None, reasons
+    assert path is not None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, [unreadable_reason]
+    if not isinstance(payload, Mapping):
+        return None, [unreadable_reason]
+    return payload, []
+
+
+def _resolve_existing_file_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+) -> tuple[Optional[Path], list[str]]:
+    if not value:
+        return None, [missing_reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, [inside_reason]
+    if not path.exists() or not path.is_file():
+        return None, [missing_reason]
+    return path, []
+
+
+def _resolve_output_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+) -> tuple[Optional[Path], list[str]]:
+    if not value:
+        return None, [missing_reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    if _is_inside(path, repo_root):
+        return None, [inside_reason]
+    return path, []
+
+
+def _probe_atomic_output(path: Path) -> list[str]:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".probe", dir=str(path.parent))
+        os.close(fd)
+        os.replace(tmp_name, tmp_name)
+        os.unlink(tmp_name)
+    except Exception:
+        return ["authority_profile_output_not_writable"]
+    return []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _not_ready(reasons: tuple[str, ...] | list[str]) -> RedDogMainArchitectFixPromotionBootstrapResult:
+    return RedDogMainArchitectFixPromotionBootstrapResult(
+        accepted=False,
+        status=REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY,
+        promotion_receipt_id=None,
+        queue_item_id=None,
+        claim_id=None,
+        selected_slice=None,
+        authority_profile_path=None,
+        committed_revision=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED",
+    "REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY",
+    "RedDogMainArchitectFixPromotionBootstrapResult",
+    "run_reddog_main_architect_fix_promotion_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -1,0 +1,235 @@
+"""Tests for REDDOG_ARCHITECT_FIX_PROMOTION_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap import (
+    REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+    REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY,
+    run_reddog_main_architect_fix_promotion_bootstrap,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    _authority_profile,
+    _determination,
+    _memex_supply,
+    _model_selection,
+    _work_state,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_main_architect_fix_promotion_bootstrap.py"
+)
+NOW = "2026-07-16T00:00:00+00:00"
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _write_json(tmp_path: Path, name: str, payload: object) -> Path:
+    path = tmp_path / "runtime" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _runtime_files(tmp_path: Path) -> dict[str, Path]:
+    return {
+        "work_state": _write_json(tmp_path, "authoritative_work_state.json", _work_state()),
+        "determination": _write_json(tmp_path, "architect_determination.json", _determination()),
+        "model_selection": _write_json(tmp_path, "model_selection.json", _model_selection()),
+        "memex_supply": _write_json(tmp_path, "memex_supply.json", _memex_supply()),
+        "authority_profile_source": _write_json(
+            tmp_path,
+            "authority_profile_source.json",
+            _authority_profile(),
+        ),
+        "authority_profile_output": tmp_path / "runtime" / "authority_profile.json",
+    }
+
+
+def test_bootstrap_promotes_fix_and_writes_authority_profile(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+
+    result = run_reddog_main_architect_fix_promotion_bootstrap(
+        repo_root=repo,
+        work_state_path=files["work_state"],
+        architect_determination_path=files["determination"],
+        model_selection_receipt_path=files["model_selection"],
+        memex_supply_receipt_path=files["memex_supply"],
+        authority_profile_source_path=files["authority_profile_source"],
+        authority_profile_output_path=files["authority_profile_output"],
+        worker_id="reddog-main-test",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED
+    assert result.queue_item_id
+    assert result.claim_id
+    assert result.selected_slice == "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+    assert result.authority_profile_path == str(files["authority_profile_output"].resolve())
+    assert result.no_signing_performed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+    promoted_profile = json.loads(files["authority_profile_output"].read_text(encoding="utf-8"))
+    assert promoted_profile["operational_context_binding"]["queue_item_id"] == result.queue_item_id
+    assert promoted_profile["operational_context_binding"]["claim_id"] == result.claim_id
+
+    work_state = json.loads(files["work_state"].read_text(encoding="utf-8"))
+    assert work_state["wre_queue_items"][0]["queue_item_id"] == result.queue_item_id
+    assert work_state["worker_claims"][0]["claim_id"] == result.claim_id
+    assert not (repo / ".reddog").exists()
+
+
+def test_bootstrap_rejects_authority_profile_output_inside_repo(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+
+    result = run_reddog_main_architect_fix_promotion_bootstrap(
+        repo_root=repo,
+        work_state_path=files["work_state"],
+        architect_determination_path=files["determination"],
+        model_selection_receipt_path=files["model_selection"],
+        memex_supply_receipt_path=files["memex_supply"],
+        authority_profile_source_path=files["authority_profile_source"],
+        authority_profile_output_path=repo / "authority_profile.json",
+        worker_id="reddog-main-test",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY
+    assert "authority_profile_output_path_inside_repo" in result.rejection_reasons
+
+
+def test_main_preflight_auto_runs_when_all_artifacts_are_present(tmp_path: Path) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+    runtime_root = tmp_path / "runtime"
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(files["work_state"]),
+            "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(files["determination"]),
+            "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(files["model_selection"]),
+            "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(files["memex_supply"]),
+            "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(files["authority_profile_source"]),
+            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+        },
+        clear=True,
+    ):
+        assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+        assert main.os.environ["REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH"] == str(
+            runtime_root / "authority_profile.json"
+        )
+
+    assert (runtime_root / "authority_profile.json").exists()
+
+
+def test_main_preflight_disabled_without_requested_or_complete_inputs() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+    ) as mocked:
+        with patch.dict("os.environ", {}, clear=True):
+            assert main.run_reddog_architect_fix_promotion_preflight(REPO_ROOT) is True
+
+    assert mocked.called is False
+
+
+def test_main_preflight_enforced_blocks_rejection() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": False,
+                "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY,
+                "promotion_receipt_id": None,
+                "queue_item_id": None,
+                "claim_id": None,
+                "selected_slice": None,
+                "authority_profile_path": None,
+                "committed_revision": None,
+                "rejection_reasons": ("missing_architect_determination_path",),
+            },
+        )(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_ARCHITECT_FIX_PROMOTION_RUNTIME": "1",
+                "REDDOG_ARCHITECT_FIX_PROMOTION_ENFORCED": "1",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(REPO_ROOT) is False
+
+
+def test_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    banned_attrs = {
+        "system",
+        "popen",
+        "spawn",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "replace",
+        "unlink",
+        "remove",
+        "rmdir",
+        "rename",
+    }
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".")[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                if isinstance(node.func.value, ast.Name):
+                    assert not (
+                        node.func.value.id in banned_import_roots
+                        and node.func.attr in banned_attrs
+                    )


### PR DESCRIPTION
## Summary
- Add a main-startup bridge for `REDDOG_ARCHITECT_FIX_PROMOTION_MAIN_PREFLIGHT_PHASE1`.
- Consume outside-repo backend architect FIX, model-selection, Memex-supply, and authority-profile receipts.
- Call the existing signed WSP_15 promotion runtime, update the outside-repo authoritative work-state snapshot, and write the promoted authority profile for the resident serial loop.

## WSP_97 Truth Boundary
- OBSERVED: The bridge is a real runtime adapter, not a docs/contract slice.
- OBSERVED: It writes only caller-provided outside-repo runtime files: authoritative work state and promoted authority profile.
- OBSERVED: It does not sign authority, spawn workers, create worktrees, execute shell commands, enqueue OpenClaw, dispatch Hermes, create PRs, admit PatternMemory, settle rewards, mutate source repo files, or re-index HoloIndex.
- SPECIFIED_NOT_IMPLEMENTED: Automatic production of the source receipts remains upstream; this bridge consumes receipts that already exist.

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 6 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 16 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py -q` -> 70 passed
- Combined focused run -> 86 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py`
- `git diff --check` / staged check -> clean (CRLF warnings only)