### PR TITLE
feat(reddog): hand off resident FIX promotion artifacts

### DIFF
--- a/main.py
+++ b/main.py
@@ -1489,6 +1489,8 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_AUTHORITY_PROFILE_SOURCE_PATH                 Outside-repo authority seed JSON
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo promoted profile JSON
         REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional profile-derived output path
+        REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=0              Materialize determination/Memex from AgentDB cycle
+        REDDOG_RESIDENT_ARCHITECT_INTENT_ID                  Intent ID for the determined resident cycle
     """
 
     try:
@@ -1499,19 +1501,80 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         logger.error(f"[REDDOG-FIX-PROMOTION] profile helper import failed: {exc}")
         return True
 
+    work_state_path = resident_queue_runtime_file_path(os.environ, repo_root, "REDDOG_AUTHORITATIVE_WORK_STATE_PATH")
+    architect_determination_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH",
+    )
+    model_selection_receipt_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_SELECTION_RECEIPT_PATH",
+    )
+    memex_supply_receipt_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH",
+    )
+    authority_profile_source_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH",
+    )
     authority_profile_path = resident_queue_runtime_file_path(
         os.environ,
         repo_root,
         "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
     )
+    handoff_requested = os.getenv("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF", "0") == "1"
+    handoff_enforced = os.getenv("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF_ENFORCED", "0") != "0"
+    if handoff_requested:
+        try:
+            from modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_artifact_handoff import (
+                run_reddog_resident_fix_promotion_artifact_handoff,
+            )
+
+            handoff = run_reddog_resident_fix_promotion_artifact_handoff(
+                repo_root=repo_root,
+                intent_id=os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", ""),
+                architect_determination_output_path=architect_determination_path,
+                memex_supply_receipt_output_path=memex_supply_receipt_path,
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-FIX-HANDOFF] Startup handoff failed: {exc}")
+            if handoff_enforced:
+                print(f"[REDDOG-FIX-HANDOFF] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-FIX-HANDOFF] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        handoff_status = "PASS" if handoff.accepted else "WARN"
+        handoff_reasons = ",".join(handoff.rejection_reasons) if handoff.rejection_reasons else "(none)"
+        print(
+            f"[REDDOG-FIX-HANDOFF] preflight={handoff_status} status={handoff.status} "
+            f"architect_determination={handoff.architect_determination_id or '(none)'} "
+            f"reasons={handoff_reasons}"
+        )
+        if handoff.accepted:
+            if handoff.architect_determination_path:
+                architect_determination_path = handoff.architect_determination_path
+                os.environ["REDDOG_ARCHITECT_FIX_DETERMINATION_PATH"] = architect_determination_path
+            if handoff.memex_supply_receipt_path:
+                memex_supply_receipt_path = handoff.memex_supply_receipt_path
+                os.environ["REDDOG_MEMEX_SUPPLY_RECEIPT_PATH"] = memex_supply_receipt_path
+        elif handoff_enforced:
+            print("[REDDOG-FIX-HANDOFF] Startup blocked by REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF_ENFORCED=1")
+            return False
+
     required_inputs_present = all(
-        str(os.getenv(name) or "").strip()
-        for name in (
-            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
-            "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH",
-            "REDDOG_MODEL_SELECTION_RECEIPT_PATH",
-            "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH",
-            "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH",
+        str(value or "").strip()
+        for value in (
+            work_state_path,
+            architect_determination_path,
+            model_selection_receipt_path,
+            memex_supply_receipt_path,
+            authority_profile_source_path,
         )
     ) and bool(authority_profile_path)
     raw_requested = os.getenv("REDDOG_ARCHITECT_FIX_PROMOTION_RUNTIME")
@@ -1528,11 +1591,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
 
         result = run_reddog_main_architect_fix_promotion_bootstrap(
             repo_root=repo_root,
-            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
-            architect_determination_path=os.getenv("REDDOG_ARCHITECT_FIX_DETERMINATION_PATH", ""),
-            model_selection_receipt_path=os.getenv("REDDOG_MODEL_SELECTION_RECEIPT_PATH", ""),
-            memex_supply_receipt_path=os.getenv("REDDOG_MEMEX_SUPPLY_RECEIPT_PATH", ""),
-            authority_profile_source_path=os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_PATH", ""),
+            work_state_path=work_state_path,
+            architect_determination_path=architect_determination_path,
+            model_selection_receipt_path=model_selection_receipt_path,
+            memex_supply_receipt_path=memex_supply_receipt_path,
+            authority_profile_source_path=authority_profile_source_path,
             authority_profile_output_path=authority_profile_path,
             worker_id=os.getenv(
                 "REDDOG_ARCHITECT_FIX_PROMOTION_WORKER_ID",

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_CYCLE_FIX_PROMOTION_ARTIFACT_HANDOFF_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a resident-cycle handoff runtime that materializes backend architect
+  determination and cycle-level Memex supply receipt JSON artifacts outside
+  the source repository for the existing architect-FIX promotion bridge.
+- Extended the operational Memex supplier to emit one aggregate
+  cycle-level supply receipt while preserving per-assignment worker receipts.
+- Wired `main.py` behind explicit `REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=1`
+  so a determined resident cycle can feed promotion without manual Copy-MD
+  artifact handling. The boundary remains read/serialize-only: no signing,
+  worker spawn, shell, worktree, OpenClaw enqueue, Hermes dispatch, PR,
+  PatternMemory, source mutation, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_ARCHITECT_FIX_PROMOTION_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -138,6 +138,7 @@ class RedDogMainReadonlyBootstrapResult:
     memex_snapshot_supply_attempted: bool = False
     memex_snapshot_supply_status: Optional[str] = None
     memex_snapshot_supply_view_id: Optional[str] = None
+    memex_snapshot_supply_receipt: Optional[Mapping[str, Any]] = None
     memex_snapshot_supply_rejection_reasons: tuple[str, ...] = ()
     no_model_call_performed: bool = True
     no_worker_spawn_performed: bool = True
@@ -569,6 +570,9 @@ def _ready(
         memex_snapshot_supply_attempted=memex_supply_result is not None,
         memex_snapshot_supply_status=memex_supply_result.status if memex_supply_result else None,
         memex_snapshot_supply_view_id=memex_supply_result.memex_view_id if memex_supply_result else None,
+        memex_snapshot_supply_receipt=(
+            dict(memex_supply_result.supply_receipt or {}) if memex_supply_result else None
+        ),
         memex_snapshot_supply_rejection_reasons=(
             memex_supply_result.rejection_reasons if memex_supply_result else ()
         ),
@@ -692,6 +696,9 @@ def _not_ready(
         memex_snapshot_supply_attempted=memex_supply_result is not None,
         memex_snapshot_supply_status=memex_supply_result.status if memex_supply_result else None,
         memex_snapshot_supply_view_id=memex_supply_result.memex_view_id if memex_supply_result else None,
+        memex_snapshot_supply_receipt=(
+            dict(memex_supply_result.supply_receipt or {}) if memex_supply_result else None
+        ),
         memex_snapshot_supply_rejection_reasons=(
             memex_supply_result.rejection_reasons if memex_supply_result else ()
         ),

--- a/modules/communication/moltbot_bridge/src/reddog_operational_memex_snapshot_supplier.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_memex_snapshot_supplier.py
@@ -61,6 +61,7 @@ class OperationalMemexTaskEnrichmentResult:
     tasks: tuple[ReadOnlyAuditTaskSpec, ...]
     memex_view_id: str | None
     rejection_reasons: tuple[str, ...]
+    supply_receipt: Mapping[str, Any] | None = None
     no_memex_write_performed: bool = True
     no_holoindex_reindex_performed: bool = True
     no_repo_mutation_performed: bool = True
@@ -73,6 +74,7 @@ class OperationalMemexTaskEnrichmentResult:
             "status": self.status,
             "tasks": [task.to_dict() for task in self.tasks],
             "memex_view_id": self.memex_view_id,
+            "supply_receipt": dict(self.supply_receipt or {}),
             "rejection_reasons": list(self.rejection_reasons),
             "no_memex_write_performed": self.no_memex_write_performed,
             "no_holoindex_reindex_performed": self.no_holoindex_reindex_performed,
@@ -201,6 +203,7 @@ def enrich_readonly_audit_tasks_with_operational_memex(
     memex_view = assembly.view.to_dict()
     view_id = _clean(memex_view.get("foundup_brain_view_id"))
     enriched: list[ReadOnlyAuditTaskSpec] = []
+    assignment_receipts: list[Mapping[str, Any]] = []
     for task in tasks:
         context = dict(task.context)
         assignment = dict(context.get("assignment") or {})
@@ -221,7 +224,7 @@ def enrich_readonly_audit_tasks_with_operational_memex(
         context.update(binding)
         context["assignment"] = assignment
         context["memex_view"] = memex_view
-        context["memex_snapshot_supply_receipt"] = {
+        assignment_receipt = {
             "schema_version": "reddog_operational_memex_snapshot_supply_receipt.v1",
             "foundup_id": cfg.foundup_id,
             "principal_id": cfg.principal_id,
@@ -249,13 +252,28 @@ def enrich_readonly_audit_tasks_with_operational_memex(
             "no_holoindex_reindex_performed": True,
             "no_repo_mutation_performed": True,
         }
+        context["memex_snapshot_supply_receipt"] = assignment_receipt
+        assignment_receipts.append(assignment_receipt)
         enriched.append(replace(task, context=context))
+
+    supply_receipt = _cycle_supply_receipt(
+        config=cfg,
+        snapshot=snapshot,
+        memex_view_id=view_id,
+        generation_id=generation_id,
+        source_revision=source_revision,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        tasks=enriched,
+        assignment_receipts=assignment_receipts,
+    )
 
     return OperationalMemexTaskEnrichmentResult(
         accepted=True,
         status=OPERATIONAL_MEMEX_SUPPLY_ACCEPT,
         tasks=tuple(enriched),
         memex_view_id=view_id,
+        supply_receipt=supply_receipt,
         rejection_reasons=(),
     )
 
@@ -284,6 +302,55 @@ def _validate_snapshot_memory_sources(snapshot: OperationalContextSnapshot) -> l
     if int(snapshot.breadcrumbs_state.get("record_count") or 0) <= 0:
         reasons.append("breadcrumbs_source_empty")
     return reasons
+
+
+def _cycle_supply_receipt(
+    *,
+    config: OperationalMemexSnapshotSupplyConfig,
+    snapshot: OperationalContextSnapshot,
+    memex_view_id: str,
+    generation_id: str,
+    source_revision: str,
+    issued_at: str,
+    expires_at: str,
+    tasks: Sequence[ReadOnlyAuditTaskSpec],
+    assignment_receipts: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any]:
+    """Return one cycle-level receipt for all assignment-bound Memex supplies."""
+
+    assignment_ids: list[str] = []
+    lane_ids: list[str] = []
+    task_ids: list[str] = []
+    assignment_receipt_ids: list[str] = []
+    for task, receipt in zip(tasks, assignment_receipts):
+        assignment = task.context.get("assignment") if isinstance(task.context, Mapping) else {}
+        assignment_ids.append(_clean(assignment.get("assignment_id")) or task.task_id)
+        lane_ids.append(_clean(assignment.get("lane_id")) or "unknown_lane")
+        task_ids.append(task.task_id)
+        assignment_receipt_ids.append(_clean(receipt.get("receipt_id")))
+
+    body = {
+        "schema_version": "reddog_operational_memex_snapshot_supply_receipt.v1",
+        "foundup_id": config.foundup_id,
+        "principal_id": config.principal_id,
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+        "snapshot_content_digest": snapshot.snapshot_content_digest,
+        "memex_view_id": memex_view_id,
+        "holoindex_generation_id": generation_id,
+        "source_revision": source_revision,
+        "policy_issued_at": issued_at,
+        "policy_expires_at": expires_at,
+        "assignment_count": len(assignment_ids),
+        "assignment_ids": tuple(assignment_ids),
+        "lane_ids": tuple(lane_ids),
+        "task_ids": tuple(task_ids),
+        "assignment_receipt_ids": tuple(assignment_receipt_ids),
+        "max_records": config.max_records,
+        "no_memex_write_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+    return {**body, "receipt_id": _digest(body)}
 
 
 def _reject(*reasons: Any) -> OperationalMemexTaskEnrichmentResult:

--- a/modules/communication/moltbot_bridge/src/reddog_resident_fix_promotion_artifact_handoff.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_fix_promotion_artifact_handoff.py
@@ -1,0 +1,304 @@
+"""Resident-cycle artifact handoff for architect FIX promotion.
+
+Slice: REDDOG_RESIDENT_CYCLE_FIX_PROMOTION_ARTIFACT_HANDOFF_PHASE1
+
+This module bridges an accepted durable resident RedDog architect cycle into
+the existing architect-FIX promotion preflight by materializing two runtime
+artifacts outside the repository:
+
+* backend architect determination JSON
+* cycle-level operational Memex supply receipt JSON
+
+It does not create model-selection receipts, authority profiles, signatures,
+work orders, workers, shells, worktrees, PRs, PatternMemory entries, or
+HoloIndex indexes. Those remain independently gated downstream.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ACTION_FIX,
+    ARCHITECT_DETERMINATION_ACCEPT,
+    AgentDbArchitectDeterminationStore,
+    ArchitectDeterminationStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    AgentDbResidentArchitectCycleStore,
+    ResidentArchitectCycleStore,
+    STATUS_DETERMINED,
+)
+
+
+RESIDENT_FIX_HANDOFF_APPLIED = "RESIDENT_FIX_HANDOFF_APPLIED"
+RESIDENT_FIX_HANDOFF_NOT_READY = "RESIDENT_FIX_HANDOFF_NOT_READY"
+
+
+class ResidentFixHandoffReason:
+    MISSING_INTENT_ID = "missing_intent_id"
+    CYCLE_NOT_FOUND = "resident_cycle_not_found"
+    CYCLE_NOT_DETERMINED = "resident_cycle_not_determined"
+    CYCLE_NOT_FIX = "resident_cycle_not_fix"
+    DETERMINATION_NOT_FOUND = "architect_determination_not_found"
+    DETERMINATION_NOT_ACCEPTED = "architect_determination_not_accepted"
+    DETERMINATION_ID_MISMATCH = "architect_determination_id_mismatch"
+    MISSING_MEMEX_SUPPLY_RECEIPT = "missing_memex_supply_receipt"
+    MEMEX_SUPPLY_INVALID = "memex_supply_receipt_invalid"
+    MEMEX_SNAPSHOT_MISMATCH = "memex_supply_snapshot_mismatch"
+    DETERMINATION_OUTPUT_INVALID = "architect_determination_output_invalid"
+    MEMEX_OUTPUT_INVALID = "memex_supply_output_invalid"
+    OUTPUT_WRITE_FAILED = "artifact_output_write_failed"
+
+
+@dataclass(frozen=True)
+class ResidentFixPromotionArtifactHandoffResult:
+    accepted: bool
+    status: str
+    intent_id: str
+    cycle_id: str | None
+    architect_determination_id: str | None
+    architect_determination_path: str | None
+    memex_supply_receipt_path: str | None
+    rejection_reasons: tuple[str, ...]
+    no_signing_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_pattern_memory_promotion_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_resident_fix_promotion_artifact_handoff(
+    *,
+    repo_root: Path | str,
+    intent_id: str,
+    architect_determination_output_path: Path | str | None,
+    memex_supply_receipt_output_path: Path | str | None,
+    cycle_store: ResidentArchitectCycleStore | None = None,
+    architect_store: ArchitectDeterminationStore | None = None,
+) -> ResidentFixPromotionArtifactHandoffResult:
+    """Materialize promotion input artifacts from one determined resident cycle."""
+
+    root = Path(repo_root).resolve()
+    cleaned_intent = _clean(intent_id)
+    if not cleaned_intent:
+        return _reject(cleaned_intent, None, None, (ResidentFixHandoffReason.MISSING_INTENT_ID,))
+
+    cycle_reader = cycle_store or AgentDbResidentArchitectCycleStore()
+    architect_reader = architect_store or AgentDbArchitectDeterminationStore()
+    cycle = cycle_reader.load_cycle_by_intent(cleaned_intent)
+    if not isinstance(cycle, Mapping) or not cycle:
+        return _reject(cleaned_intent, None, None, (ResidentFixHandoffReason.CYCLE_NOT_FOUND,))
+
+    cycle_id = _clean(cycle.get("cycle_id"))
+    architect_id = _clean(cycle.get("architect_determination_id"))
+    reasons = _validate_cycle(cycle)
+    determination_record: Mapping[str, Any] | None = None
+    determination_payload: Mapping[str, Any] | None = None
+    if cycle_id and not reasons:
+        determination_record = architect_reader.load_architect_determination_by_cycle(cycle_id)
+        determination_payload = _mapping(determination_record, "determination")
+        reasons.extend(_validate_determination(determination_payload, expected_id=architect_id))
+    else:
+        reasons.append(ResidentFixHandoffReason.DETERMINATION_NOT_FOUND)
+
+    memex_supply = _memex_supply_receipt(cycle)
+    reasons.extend(_validate_memex_supply(memex_supply, determination_payload))
+    determination_path, determination_reasons = _runtime_output_path(
+        architect_determination_output_path,
+        root,
+        ResidentFixHandoffReason.DETERMINATION_OUTPUT_INVALID,
+    )
+    memex_path, memex_reasons = _runtime_output_path(
+        memex_supply_receipt_output_path,
+        root,
+        ResidentFixHandoffReason.MEMEX_OUTPUT_INVALID,
+    )
+    reasons.extend(determination_reasons)
+    reasons.extend(memex_reasons)
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(cleaned_intent, cycle_id, architect_id, deduped)
+
+    assert determination_payload is not None
+    assert memex_supply is not None
+    assert determination_path is not None
+    assert memex_path is not None
+    try:
+        _write_json_atomic(determination_path, determination_payload)
+        _write_json_atomic(memex_path, memex_supply)
+    except Exception:
+        return _reject(
+            cleaned_intent,
+            cycle_id,
+            architect_id,
+            (ResidentFixHandoffReason.OUTPUT_WRITE_FAILED,),
+        )
+
+    return ResidentFixPromotionArtifactHandoffResult(
+        accepted=True,
+        status=RESIDENT_FIX_HANDOFF_APPLIED,
+        intent_id=cleaned_intent,
+        cycle_id=cycle_id,
+        architect_determination_id=architect_id,
+        architect_determination_path=str(determination_path),
+        memex_supply_receipt_path=str(memex_path),
+        rejection_reasons=(),
+    )
+
+
+def _validate_cycle(cycle: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if _clean(cycle.get("status")) != STATUS_DETERMINED:
+        reasons.append(ResidentFixHandoffReason.CYCLE_NOT_DETERMINED)
+    if _clean(cycle.get("architect_action")) != ACTION_FIX:
+        reasons.append(ResidentFixHandoffReason.CYCLE_NOT_FIX)
+    if not _clean(cycle.get("cycle_id")) or not _clean(cycle.get("architect_determination_id")):
+        reasons.append(ResidentFixHandoffReason.DETERMINATION_NOT_FOUND)
+    return reasons
+
+
+def _validate_determination(
+    determination: Mapping[str, Any] | None,
+    *,
+    expected_id: str,
+) -> list[str]:
+    if not isinstance(determination, Mapping) or not determination:
+        return [ResidentFixHandoffReason.DETERMINATION_NOT_FOUND]
+    reasons: list[str] = []
+    if determination.get("accepted") is not True or _clean(determination.get("status")) != ARCHITECT_DETERMINATION_ACCEPT:
+        reasons.append(ResidentFixHandoffReason.DETERMINATION_NOT_ACCEPTED)
+    if _clean(determination.get("action")) != ACTION_FIX:
+        reasons.append(ResidentFixHandoffReason.CYCLE_NOT_FIX)
+    if _clean(determination.get("determination_receipt_id")) != expected_id:
+        reasons.append(ResidentFixHandoffReason.DETERMINATION_ID_MISMATCH)
+    return reasons
+
+
+def _memex_supply_receipt(cycle: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    for key in ("initial_bootstrap", "final_bootstrap"):
+        bootstrap = cycle.get(key)
+        if isinstance(bootstrap, Mapping):
+            receipt = bootstrap.get("memex_snapshot_supply_receipt")
+            if isinstance(receipt, Mapping) and receipt:
+                return receipt
+    return None
+
+
+def _validate_memex_supply(
+    receipt: Mapping[str, Any] | None,
+    determination: Mapping[str, Any] | None,
+) -> list[str]:
+    if not isinstance(receipt, Mapping) or not receipt:
+        return [ResidentFixHandoffReason.MISSING_MEMEX_SUPPLY_RECEIPT]
+    reasons: list[str] = []
+    required = (
+        "schema_version",
+        "receipt_id",
+        "snapshot_receipt_id",
+        "snapshot_content_digest",
+        "memex_view_id",
+        "holoindex_generation_id",
+        "source_revision",
+        "no_holoindex_reindex_performed",
+    )
+    missing = [field for field in required if receipt.get(field) in (None, "", ())]
+    if missing or receipt.get("schema_version") != "reddog_operational_memex_snapshot_supply_receipt.v1":
+        reasons.append(ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID)
+    if receipt.get("no_holoindex_reindex_performed") is not True:
+        reasons.append(ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID)
+    if isinstance(determination, Mapping) and determination:
+        if _clean(receipt.get("snapshot_receipt_id")) != _clean(determination.get("snapshot_receipt_id")):
+            reasons.append(ResidentFixHandoffReason.MEMEX_SNAPSHOT_MISMATCH)
+        if _clean(receipt.get("snapshot_content_digest")) != _clean(determination.get("snapshot_content_digest")):
+            reasons.append(ResidentFixHandoffReason.MEMEX_SNAPSHOT_MISMATCH)
+    return reasons
+
+
+def _runtime_output_path(
+    value: Path | str | None,
+    repo_root: Path,
+    reason: str,
+) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root)
+        return None, [reason]
+    except ValueError:
+        pass
+    if resolved.name == "":
+        return None, [reason]
+    return resolved, []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _mapping(value: Any, key: str) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+    nested = value.get(key)
+    return nested if isinstance(nested, Mapping) else None
+
+
+def _reject(
+    intent_id: str,
+    cycle_id: str | None,
+    architect_id: str | None,
+    reasons: tuple[str, ...] | list[str],
+) -> ResidentFixPromotionArtifactHandoffResult:
+    return ResidentFixPromotionArtifactHandoffResult(
+        accepted=False,
+        status=RESIDENT_FIX_HANDOFF_NOT_READY,
+        intent_id=intent_id,
+        cycle_id=cycle_id,
+        architect_determination_id=architect_id,
+        architect_determination_path=None,
+        memex_supply_receipt_path=None,
+        rejection_reasons=tuple(_dedupe(reasons)),
+    )
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _dedupe(values: Any) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+__all__ = [
+    "RESIDENT_FIX_HANDOFF_APPLIED",
+    "RESIDENT_FIX_HANDOFF_NOT_READY",
+    "ResidentFixHandoffReason",
+    "ResidentFixPromotionArtifactHandoffResult",
+    "run_reddog_resident_fix_promotion_artifact_handoff",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -81,6 +81,10 @@ PROFILE_RUNTIME_FLAGS = frozenset(
 
 PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "authoritative_work_state.json",
+    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": "architect_determination.json",
+    "REDDOG_MODEL_SELECTION_RECEIPT_PATH": "model_selection_receipt.json",
+    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
+    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": "authority_profile_source.json",
     "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": "resident_queue_chain_results.json",
     "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": "authority_profile.json",
 }

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -146,6 +146,81 @@ def test_main_preflight_auto_runs_when_all_artifacts_are_present(tmp_path: Path)
     assert (runtime_root / "authority_profile.json").exists()
 
 
+def test_main_preflight_handoff_materializes_resident_cycle_artifacts_before_promotion(tmp_path: Path) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    model_selection = _write_json(tmp_path, "model_selection_receipt.json", _model_selection())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    handoff_result = type(
+        "HandoffResult",
+        (),
+        {
+            "accepted": True,
+            "status": "RESIDENT_FIX_HANDOFF_APPLIED",
+            "architect_determination_id": "sha256:architect-determination-1",
+            "architect_determination_path": str(runtime_root / "architect_determination.json"),
+            "memex_supply_receipt_path": str(runtime_root / "memex_supply_receipt.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_artifact_handoff.run_reddog_resident_fix_promotion_artifact_handoff",
+        return_value=handoff_result,
+    ) as handoff:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-handoff",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(model_selection),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+
+    handoff.assert_called_once()
+    handoff_kwargs = handoff.call_args.kwargs
+    assert handoff_kwargs["intent_id"] == "sha256:intent-handoff"
+    assert handoff_kwargs["architect_determination_output_path"] == str(
+        runtime_root / "architect_determination.json"
+    )
+    assert handoff_kwargs["memex_supply_receipt_output_path"] == str(runtime_root / "memex_supply_receipt.json")
+    promote.assert_called_once()
+    promote_kwargs = promote.call_args.kwargs
+    assert promote_kwargs["architect_determination_path"] == str(runtime_root / "architect_determination.json")
+    assert promote_kwargs["memex_supply_receipt_path"] == str(runtime_root / "memex_supply_receipt.json")
+    assert promote_kwargs["model_selection_receipt_path"] == str(model_selection)
+    assert promote_kwargs["authority_profile_source_path"] == str(authority_source)
+    assert promote_kwargs["authority_profile_output_path"] == str(runtime_root / "authority_profile.json")
+
+
 def test_main_preflight_disabled_without_requested_or_complete_inputs() -> None:
     import main
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -568,6 +568,13 @@ def test_bootstrap_memex_supply_enriches_enqueued_readonly_audit_tasks() -> None
     assert result.memex_snapshot_supply_attempted is True
     assert result.memex_snapshot_supply_status == "OPERATIONAL_MEMEX_SUPPLY_ACCEPT"
     assert result.memex_snapshot_supply_view_id
+    assert result.memex_snapshot_supply_receipt is not None
+    assert result.memex_snapshot_supply_receipt["schema_version"] == (
+        "reddog_operational_memex_snapshot_supply_receipt.v1"
+    )
+    assert result.memex_snapshot_supply_receipt["snapshot_receipt_id"] == result.snapshot_receipt_id
+    assert result.memex_snapshot_supply_receipt["assignment_count"] == result.assignment_count
+    assert result.memex_snapshot_supply_receipt["receipt_id"].startswith("sha256:")
     assert result.memex_snapshot_supply_rejection_reasons == ()
     task_context = writer.calls[0][0][0].context
     assignment = task_context["assignment"]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py
@@ -205,6 +205,60 @@ def test_enriches_task_with_snapshot_bound_memex_view_and_worker_bindings() -> N
     assert assignment["memex_source_revision"] == REVISION
     assert assignment["memex_holoindex_generation_id"] == GENERATION_ID
     assert enriched["memex_snapshot_supply_receipt"]["no_holoindex_reindex_performed"] is True
+    assert result.supply_receipt is not None
+    assert result.supply_receipt["schema_version"] == "reddog_operational_memex_snapshot_supply_receipt.v1"
+    assert result.supply_receipt["receipt_id"].startswith("sha256:")
+    assert result.supply_receipt["snapshot_receipt_id"] == snapshot.snapshot_receipt_id
+    assert result.supply_receipt["assignment_count"] == 1
+    assert result.supply_receipt["assignment_receipt_ids"] == (
+        enriched["memex_snapshot_supply_receipt"]["receipt_id"],
+    )
+    assert result.supply_receipt["no_holoindex_reindex_performed"] is True
+
+
+def test_cycle_supply_receipt_aggregates_assignment_receipts() -> None:
+    snapshot = _snapshot()
+    first = _task("repo_code_audit")
+    second = replace(
+        _task("external_research"),
+        task_id="task-2",
+        context={
+            "assignment": {
+                "assignment_id": "assignment-2",
+                "lane_id": "external_research",
+                "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+                "snapshot_content_digest": snapshot.snapshot_content_digest,
+            }
+        },
+    )
+    first = replace(
+        first,
+        context={
+            **first.context,
+            "assignment": {
+                **first.context["assignment"],
+                "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+                "snapshot_content_digest": snapshot.snapshot_content_digest,
+            },
+        },
+    )
+
+    result = enrich_readonly_audit_tasks_with_operational_memex(
+        tasks=(first, second),
+        snapshot=snapshot,
+        config=_config(),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.supply_receipt is not None
+    assert result.supply_receipt["assignment_count"] == 2
+    assert result.supply_receipt["assignment_ids"] == ("assignment-1", "assignment-2")
+    assert result.supply_receipt["lane_ids"] == ("repo_code_audit", "external_research")
+    assert result.supply_receipt["task_ids"] == ("task-1", "task-2")
+    assert result.supply_receipt["assignment_receipt_ids"] == tuple(
+        task.context["memex_snapshot_supply_receipt"]["receipt_id"] for task in result.tasks
+    )
 
 
 def test_rejects_before_enqueue_when_memex_sources_are_not_fresh() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py
@@ -1,0 +1,203 @@
+"""Tests for REDDOG_RESIDENT_CYCLE_FIX_PROMOTION_ARTIFACT_HANDOFF_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ACTION_RESEARCH_MORE,
+    InMemoryArchitectDeterminationStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    STATUS_DETERMINED,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_artifact_handoff import (
+    RESIDENT_FIX_HANDOFF_APPLIED,
+    RESIDENT_FIX_HANDOFF_NOT_READY,
+    ResidentFixHandoffReason,
+    run_reddog_resident_fix_promotion_artifact_handoff,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    _determination,
+    _memex_supply,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_fix_promotion_artifact_handoff.py"
+)
+INTENT_ID = "sha256:intent-handoff"
+CYCLE_ID = "sha256:cycle-1"
+
+
+class _CycleStore:
+    def __init__(self, record: Optional[Mapping[str, Any]]) -> None:
+        self.record = dict(record) if record else None
+
+    def load_cycle_by_intent(self, intent_id: str) -> Optional[Mapping[str, Any]]:
+        return self.record if intent_id == INTENT_ID else None
+
+    def upsert_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        raise AssertionError("not used")
+
+    def update_cycle(self, intent_id: str, updates: Mapping[str, Any]) -> Mapping[str, Any]:
+        raise AssertionError("not used")
+
+    def load_task_ids(self, determination_id: str) -> tuple[str, ...]:
+        raise AssertionError("not used")
+
+    def load_task_status_counts(self, task_ids) -> Mapping[str, int]:
+        raise AssertionError("not used")
+
+    def delete_cycle_tasks(self, task_ids) -> None:
+        raise AssertionError("not used")
+
+
+def _cycle(**overrides: Any) -> dict[str, Any]:
+    record = {
+        "schema_version": "reddog_resident_architect_cycle.v1",
+        "intent_id": INTENT_ID,
+        "cycle_id": CYCLE_ID,
+        "status": STATUS_DETERMINED,
+        "architect_action": "FIX",
+        "architect_determination_id": "sha256:architect-determination-1",
+        "initial_bootstrap": {
+            "memex_snapshot_supply_receipt": _memex_supply(),
+        },
+    }
+    record.update(overrides)
+    return record
+
+
+def _architect_store(determination: Mapping[str, Any] | None = None) -> InMemoryArchitectDeterminationStore:
+    determination = determination or _determination()
+    return InMemoryArchitectDeterminationStore(
+        (
+            {
+                "cycle_id": CYCLE_ID,
+                "determination": dict(determination),
+            },
+        )
+    )
+
+
+def test_handoff_writes_determination_and_memex_artifacts_outside_repo(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+
+    result = run_reddog_resident_fix_promotion_artifact_handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=runtime / "architect_determination.json",
+        memex_supply_receipt_output_path=runtime / "memex_supply_receipt.json",
+        cycle_store=_CycleStore(_cycle()),
+        architect_store=_architect_store(),
+    )
+
+    assert result.accepted is True
+    assert result.status == RESIDENT_FIX_HANDOFF_APPLIED
+    assert result.architect_determination_path == str((runtime / "architect_determination.json").resolve())
+    assert result.memex_supply_receipt_path == str((runtime / "memex_supply_receipt.json").resolve())
+    determination = json.loads(Path(result.architect_determination_path).read_text(encoding="utf-8"))
+    memex = json.loads(Path(result.memex_supply_receipt_path).read_text(encoding="utf-8"))
+    assert determination["determination_receipt_id"] == "sha256:architect-determination-1"
+    assert memex["schema_version"] == "reddog_operational_memex_snapshot_supply_receipt.v1"
+    assert memex["receipt_id"] == "sha256:memex-supply"
+    assert result.no_signing_performed is True
+    assert result.no_openclaw_enqueue_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert not (REPO_ROOT / "architect_determination.json").exists()
+
+
+def test_handoff_rejects_non_fix_cycle_without_writes(tmp_path: Path) -> None:
+    result = run_reddog_resident_fix_promotion_artifact_handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=tmp_path / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        cycle_store=_CycleStore(_cycle(architect_action=ACTION_RESEARCH_MORE)),
+        architect_store=_architect_store(),
+    )
+
+    assert result.accepted is False
+    assert result.status == RESIDENT_FIX_HANDOFF_NOT_READY
+    assert ResidentFixHandoffReason.CYCLE_NOT_FIX in result.rejection_reasons
+    assert not (tmp_path / "runtime" / "architect.json").exists()
+
+
+def test_handoff_rejects_missing_memex_supply_receipt(tmp_path: Path) -> None:
+    cycle = _cycle(initial_bootstrap={})
+
+    result = run_reddog_resident_fix_promotion_artifact_handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=tmp_path / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        cycle_store=_CycleStore(cycle),
+        architect_store=_architect_store(),
+    )
+
+    assert result.accepted is False
+    assert ResidentFixHandoffReason.MISSING_MEMEX_SUPPLY_RECEIPT in result.rejection_reasons
+    assert not (tmp_path / "runtime" / "memex.json").exists()
+
+
+def test_handoff_rejects_memex_snapshot_mismatch(tmp_path: Path) -> None:
+    memex = _memex_supply(snapshot_receipt_id="sha256:other-snapshot")
+
+    result = run_reddog_resident_fix_promotion_artifact_handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=tmp_path / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        cycle_store=_CycleStore(_cycle(initial_bootstrap={"memex_snapshot_supply_receipt": memex})),
+        architect_store=_architect_store(),
+    )
+
+    assert result.accepted is False
+    assert ResidentFixHandoffReason.MEMEX_SNAPSHOT_MISMATCH in result.rejection_reasons
+
+
+def test_handoff_rejects_outputs_inside_repo(tmp_path: Path) -> None:
+    result = run_reddog_resident_fix_promotion_artifact_handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=REPO_ROOT / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        cycle_store=_CycleStore(_cycle()),
+        architect_store=_architect_store(),
+    )
+
+    assert result.accepted is False
+    assert ResidentFixHandoffReason.DETERMINATION_OUTPUT_INVALID in result.rejection_reasons
+
+
+def test_handoff_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "holo_index",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary
- Add a resident-cycle FIX promotion artifact handoff that writes backend architect determination and cycle-level Memex supply receipt JSON outside the repo.
- Add aggregate cycle-level Memex supply receipts while preserving per-assignment worker receipts.
- Wire main.py behind explicit REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=1 and extend resident profile runtime paths for promotion artifacts.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q (114 passed)
- python -m py_compile main.py and changed modules/tests
- git diff --check

## WSP_97 Boundary
No signing, worker spawn, shell execution, worktree operation, OpenClaw enqueue, Hermes dispatch, PR creation, PatternMemory promotion, source mutation, reward settlement, or HoloIndex re-indexing is added.
