### PR TITLE
feat(ai-gateway): supply RedDog model selection artifact

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -207,6 +207,25 @@ crypto signing library. Nonces are consumed only when admission explicitly
 requests it. Downstream selection and runtime checks validate immutable verified
 evidence and do not consume single-use nonces again.
 
+#### RedDog Model Selection Artifact Supply
+
+```python
+run_reddog_model_selection_artifact_supply(...) -> ModelSelectionArtifactSupplyResult
+```
+
+The supplier rehydrates a catalog snapshot, verifies serialized signed
+benchmark/promotion evidence into `VerifiedModelProductionEvidence`, runs
+production model selection, and atomically writes one `ModelSelectionReceipt`
+JSON artifact outside the repository. It is intended for the resident RedDog
+architect FIX promotion bridge, where the promotion layer expects a file path
+rather than an in-memory object.
+
+Evaluation requirements, raw serialized evidence without a key resolver and
+signature verifier, rejected model selections, missing output paths, and
+repository-internal output paths fail closed. The API does not call providers,
+run benchmarks, execute commands, persist telemetry, re-index HoloIndex, bind
+runtime defaults, mutate the extension, dispatch workers, or write PatternMemory.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,42 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - RedDog Model Selection Artifact Supply
+
+**Who:** 0102 Codex
+**Type:** Runtime Artifact Bridge
+**Slice:** REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_PHASE1
+
+**What:** Added a bounded supplier that materializes a production
+`ModelSelectionReceipt` JSON artifact from a catalog snapshot and signed
+benchmark/promotion evidence.
+
+**Why:** The resident RedDog architect FIX promotion bridge expects a
+model-selection receipt path. After signed production-evidence hardening,
+production model selection must be created from verified evidence, not raw
+mappings or catalog-only champion fields.
+
+**Files:**
+- `src/model_selection_artifact_supply.py` - rehydrates the catalog snapshot,
+  verifies serialized signed evidence, runs production model selection, and
+  atomically writes one receipt outside the repository.
+- `tests/test_model_selection_artifact_supply.py` - serialized and typed
+  evidence acceptance, missing signature-gate rejection, non-production
+  rejection, repository-output rejection, and AST boundary tests.
+- `README.md` and `INTERFACE.md` - API and truth-boundary notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: production model-selection receipt artifact supply.
+- IMPLEMENTED: serialized evidence requires key resolution and signature
+  verification before production selection.
+- IMPLEMENTED: receipt output must live outside the repository.
+- NOT IMPLEMENTED: provider calls, benchmark execution, telemetry persistence,
+  HoloIndex re-indexing, runtime model default binding, extension mutation,
+  worker dispatch, PatternMemory writes, or panel runtime promotion.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Model Intelligence Receipt Rehydration and Signed Evidence
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -113,6 +113,21 @@ verification. Runtime binding also requires that verified object before a bridge
 payload can be emitted. Single-model chains can pass; panel runtime binding is
 still deferred until topology-bound panel evidence is signed and verified.
 
+## RedDog Model Selection Artifact Supply
+
+`src/model_selection_artifact_supply.py` materializes a production
+`ModelSelectionReceipt` JSON artifact from a model catalog snapshot and signed
+benchmark/promotion evidence. It is a bounded bridge for RedDog architect FIX
+promotion: the resident cycle can write the receipt path expected by the
+promotion bridge without calling models or trusting raw production-evidence
+mappings.
+
+The supplier verifies serialized evidence through the signed-evidence gate
+before production selection, rejects non-production requirements, and refuses to
+write artifacts inside the repository. It does not call providers, run
+benchmarks, execute commands, persist telemetry, re-index HoloIndex, bind
+runtime model defaults, mutate `extension.js`, or dispatch workers.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_selection_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_selection_artifact_supply.py
@@ -1,0 +1,328 @@
+"""Production model-selection receipt artifact supplier for RedDog runtime.
+
+Slice: REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_PHASE1
+
+This module materializes a production ``ModelSelectionReceipt`` from an
+already-built catalog snapshot and signed benchmark/promotion evidence. It is a
+bounded bridge for downstream RedDog work-order promotion. It does not call
+models, benchmark models, mutate catalogs, persist telemetry, execute commands,
+spawn workers, re-index HoloIndex, or bind the selection into live runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionDecision,
+    SelectionMode,
+    SelectionPurpose,
+    select_models_for_task,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    ModelEvidenceKeyResolver,
+    VerifiedModelEvidenceEntry,
+    VerifiedModelProductionEvidence,
+    build_verified_model_production_evidence,
+    rehydrate_model_catalog_snapshot,
+)
+
+
+MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT = "MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT"
+MODEL_SELECTION_ARTIFACT_SUPPLY_REJECT = "MODEL_SELECTION_ARTIFACT_SUPPLY_REJECT"
+EVIDENCE_BUNDLE_SCHEMA_VERSION = "reddog_model_verified_production_evidence_bundle.v1"
+
+
+class ModelSelectionArtifactSupplyReason:
+    CATALOG_MISSING = "model_catalog_snapshot_missing"
+    CATALOG_INVALID = "model_catalog_snapshot_invalid"
+    EVIDENCE_MISSING = "verified_production_evidence_missing"
+    EVIDENCE_INVALID = "verified_production_evidence_invalid"
+    KEY_RESOLVER_MISSING = "model_evidence_key_resolver_missing"
+    SIGNATURE_VERIFIER_MISSING = "model_evidence_signature_verifier_missing"
+    REQUIREMENTS_INVALID = "model_selection_requirements_invalid"
+    NON_PRODUCTION_REQUIREMENTS = "model_selection_requirements_not_production"
+    SELECTION_REJECTED = "model_selection_rejected"
+    OUTPUT_PATH_INVALID = "model_selection_output_path_invalid"
+    OUTPUT_WRITE_FAILED = "model_selection_output_write_failed"
+
+
+@dataclass(frozen=True)
+class ModelSelectionArtifactSupplyResult:
+    accepted: bool
+    status: str
+    selection_receipt_id: str | None
+    catalog_snapshot_id: str | None
+    selected_model_ids: tuple[str, ...]
+    output_path: str | None
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_telemetry_persistence_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_selection_artifact_supply(
+    *,
+    repo_root: Path | str,
+    catalog_snapshot: Mapping[str, Any] | None,
+    verified_evidence_bundle: Mapping[str, Any] | VerifiedModelProductionEvidence | None,
+    requirements: Mapping[str, Any] | ModelTaskRequirements,
+    output_path: Path | str | None,
+    key_resolver: ModelEvidenceKeyResolver | None = None,
+    signature_verifier: SignatureVerifier | None = None,
+    now: int | None = None,
+    consume_nonces: bool = False,
+) -> ModelSelectionArtifactSupplyResult:
+    """Verify evidence, select a production model, and write one receipt."""
+
+    root = Path(repo_root).resolve()
+    reasons: list[str] = []
+    snapshot = None
+    if not isinstance(catalog_snapshot, Mapping) or not catalog_snapshot:
+        reasons.append(ModelSelectionArtifactSupplyReason.CATALOG_MISSING)
+    else:
+        try:
+            snapshot = rehydrate_model_catalog_snapshot(catalog_snapshot)
+        except Exception:
+            reasons.append(ModelSelectionArtifactSupplyReason.CATALOG_INVALID)
+
+    normalized_requirements = None
+    try:
+        normalized_requirements = _requirements(requirements)
+    except Exception:
+        reasons.append(ModelSelectionArtifactSupplyReason.REQUIREMENTS_INVALID)
+    if normalized_requirements is not None and normalized_requirements.purpose != SelectionPurpose.PRODUCTION:
+        reasons.append(ModelSelectionArtifactSupplyReason.NON_PRODUCTION_REQUIREMENTS)
+
+    evidence = None
+    if verified_evidence_bundle is None:
+        reasons.append(ModelSelectionArtifactSupplyReason.EVIDENCE_MISSING)
+    elif isinstance(verified_evidence_bundle, VerifiedModelProductionEvidence):
+        evidence = verified_evidence_bundle
+    else:
+        if key_resolver is None:
+            reasons.append(ModelSelectionArtifactSupplyReason.KEY_RESOLVER_MISSING)
+        if signature_verifier is None:
+            reasons.append(ModelSelectionArtifactSupplyReason.SIGNATURE_VERIFIER_MISSING)
+        if key_resolver is not None and signature_verifier is not None:
+            try:
+                evidence = _rehydrate_verified_evidence_bundle(
+                    verified_evidence_bundle,
+                    key_resolver=key_resolver,
+                    signature_verifier=signature_verifier,
+                    now=now,
+                    consume_nonces=consume_nonces,
+                )
+            except Exception:
+                reasons.append(ModelSelectionArtifactSupplyReason.EVIDENCE_INVALID)
+
+    resolved_output, output_reasons = _runtime_output_path(
+        output_path,
+        root,
+        ModelSelectionArtifactSupplyReason.OUTPUT_PATH_INVALID,
+    )
+    reasons.extend(output_reasons)
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert snapshot is not None
+    assert normalized_requirements is not None
+    assert evidence is not None
+    assert resolved_output is not None
+    receipt = select_models_for_task(
+        snapshot,
+        normalized_requirements,
+        production_evidence=evidence,
+    )
+    if receipt.decision != SelectionDecision.SELECTED or not receipt.selected_model_ids:
+        return _reject((ModelSelectionArtifactSupplyReason.SELECTION_REJECTED, *receipt.rejection_reasons))
+    try:
+        _write_json_atomic(resolved_output, receipt.to_dict())
+    except Exception:
+        return _reject((ModelSelectionArtifactSupplyReason.OUTPUT_WRITE_FAILED,))
+    return ModelSelectionArtifactSupplyResult(
+        accepted=True,
+        status=MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT,
+        selection_receipt_id=receipt.receipt_id,
+        catalog_snapshot_id=receipt.catalog_snapshot_id,
+        selected_model_ids=receipt.selected_model_ids,
+        output_path=str(resolved_output),
+        rejection_reasons=(),
+    )
+
+
+def _rehydrate_verified_evidence_bundle(
+    bundle: Mapping[str, Any],
+    *,
+    key_resolver: ModelEvidenceKeyResolver,
+    signature_verifier: SignatureVerifier,
+    now: int | None,
+    consume_nonces: bool,
+) -> VerifiedModelProductionEvidence:
+    if bundle.get("schema_version") != EVIDENCE_BUNDLE_SCHEMA_VERSION:
+        raise ValueError("invalid_evidence_bundle_schema")
+    catalog_snapshot_id = _required(bundle.get("catalog_snapshot_id"), "catalog_snapshot_id")
+    selection_receipt_id = _required(bundle.get("selection_receipt_id"), "selection_receipt_id")
+    benchmark_run_receipt_id = _required(bundle.get("benchmark_run_receipt_id"), "benchmark_run_receipt_id")
+    entries = bundle.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("missing_evidence_entries")
+    verified_entries: list[VerifiedModelEvidenceEntry] = []
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            raise ValueError("invalid_evidence_entry")
+        evidence = build_verified_model_production_evidence(
+            catalog_snapshot_id=catalog_snapshot_id,
+            selection_receipt_id=selection_receipt_id,
+            benchmark_run_receipt_id=benchmark_run_receipt_id,
+            benchmark_receipt=_mapping(entry.get("benchmark_receipt"), "benchmark_receipt"),
+            promotion_receipt=_mapping(entry.get("promotion_receipt"), "promotion_receipt"),
+            benchmark_signature_receipt=_mapping(
+                entry.get("benchmark_signature_receipt"),
+                "benchmark_signature_receipt",
+            ),
+            promotion_signature_receipt=_mapping(
+                entry.get("promotion_signature_receipt"),
+                "promotion_signature_receipt",
+            ),
+            key_resolver=key_resolver,
+            signature_verifier=signature_verifier,
+            now=int(now if now is not None else bundle.get("now", 0)),
+            consume_nonces=consume_nonces,
+        )
+        verified_entries.extend(evidence.entries)
+    return VerifiedModelProductionEvidence(entries=tuple(verified_entries))
+
+
+def _requirements(value: Mapping[str, Any] | ModelTaskRequirements) -> ModelTaskRequirements:
+    if isinstance(value, ModelTaskRequirements):
+        return value.normalized()
+    if not isinstance(value, Mapping):
+        raise ValueError("requirements_not_mapping")
+    return ModelTaskRequirements(
+        task_family=_required(value.get("task_family"), "task_family"),
+        selection_mode=SelectionMode(str(value.get("selection_mode") or SelectionMode.SINGLE.value)),
+        purpose=SelectionPurpose(str(value.get("purpose") or SelectionPurpose.PRODUCTION.value)),
+        required_modalities=tuple(str(item) for item in _list(value.get("required_modalities")) or ("text",)),
+        min_context_window=_int_or_none(value.get("min_context_window")),
+        require_tools=bool(value.get("require_tools", False)),
+        require_structured_output=bool(value.get("require_structured_output", False)),
+        require_reasoning=bool(value.get("require_reasoning", False)),
+        max_input_cost_per_million=_float_or_none(value.get("max_input_cost_per_million")),
+        max_output_cost_per_million=_float_or_none(value.get("max_output_cost_per_million")),
+        allowed_providers=tuple(str(item) for item in _list(value.get("allowed_providers"))),
+        denied_providers=tuple(str(item) for item in _list(value.get("denied_providers"))),
+        max_candidates=int(value.get("max_candidates") or 1),
+        min_verifier_pass_rate=_float_or_none(value.get("min_verifier_pass_rate")),
+        panel_roles=tuple(str(item) for item in _list(value.get("panel_roles"))),
+        panel_topology_digest=str(value.get("panel_topology_digest") or "") or None,
+    ).normalized()
+
+
+def _runtime_output_path(
+    value: Path | str | None,
+    repo_root: Path,
+    reason: str,
+) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root)
+        return None, [reason]
+    except ValueError:
+        pass
+    return resolved, []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name}_missing")
+    return value
+
+
+def _required(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(name + "_missing")
+    return text
+
+
+def _list(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return (value,)
+
+
+def _int_or_none(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    parsed = int(value)
+    return parsed if parsed > 0 else None
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)
+
+
+def _reject(reasons: Sequence[str]) -> ModelSelectionArtifactSupplyResult:
+    return ModelSelectionArtifactSupplyResult(
+        accepted=False,
+        status=MODEL_SELECTION_ARTIFACT_SUPPLY_REJECT,
+        selection_receipt_id=None,
+        catalog_snapshot_id=None,
+        selected_model_ids=(),
+        output_path=None,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+__all__ = [
+    "EVIDENCE_BUNDLE_SCHEMA_VERSION",
+    "MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT",
+    "MODEL_SELECTION_ARTIFACT_SUPPLY_REJECT",
+    "ModelSelectionArtifactSupplyReason",
+    "ModelSelectionArtifactSupplyResult",
+    "run_reddog_model_selection_artifact_supply",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_selection_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_selection_artifact_supply.py
@@ -1,0 +1,288 @@
+"""Tests for REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    Availability,
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply import (
+    EVIDENCE_BUNDLE_SCHEMA_VERSION,
+    MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT,
+    MODEL_SELECTION_ARTIFACT_SUPPLY_REJECT,
+    ModelSelectionArtifactSupplyReason,
+    run_reddog_model_selection_artifact_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    ModelEvidenceSignerRole,
+    StaticModelEvidenceKeyResolver,
+)
+from model_signed_evidence_test_helpers import (
+    BENCHMARK_PUBLIC_KEY,
+    PROMOTION_PUBLIC_KEY,
+    DeterministicSignatureVerifier,
+    make_signed_evidence_receipt,
+    make_verified_production_evidence,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT / "modules" / "ai_intelligence" / "ai_gateway" / "src" / "model_selection_artifact_supply.py"
+)
+NOW = 1_800_000_000
+MODEL_ID = "openai/gpt-5.6-code"
+TASK = "reddog_architect_fix_promotion"
+
+
+def _card() -> ModelCapabilityCard:
+    return ModelCapabilityCard(
+        provider="openai",
+        model_id=MODEL_ID,
+        canonical_model_id=MODEL_ID,
+        source="test",
+        availability=Availability.AVAILABLE,
+        promotion_state=PromotionState.CHAMPION,
+        task_families=(TASK,),
+        context_window=256000,
+        supports_structured_output=True,
+        supports_reasoning=True,
+        verifier_pass_rate=1.0,
+        benchmark_scores={TASK: 1.0},
+    ).normalized()
+
+
+def _snapshot():
+    return build_model_catalog_snapshot((_card(),), generated_at="2026-07-16T00:00:00+00:00")
+
+
+def _benchmark():
+    return build_model_benchmark_evidence_receipt(
+        model_id=MODEL_ID,
+        task_family=TASK,
+        task_set_digest="sha256:task-set",
+        held_out_split_digest="sha256:held-out",
+        prompt_topology_digest="sha256:topology",
+        verifier_digest="sha256:verifier",
+        verifier_receipt_id="sha256:verifier-receipt",
+        sample_count=12,
+        accepted_count=12,
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=20),
+    )
+
+
+def _promotion(benchmark):
+    return build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id="sha256:promotion-authority",
+        signed_promotion_receipt_id="signature:promotion",
+        min_verifier_pass_rate=0.8,
+    )
+
+
+def _requirements(**overrides):
+    payload = {
+        "task_family": TASK,
+        "purpose": "production",
+        "selection_mode": "single",
+        "require_structured_output": True,
+        "require_reasoning": True,
+        "min_verifier_pass_rate": 0.8,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _serialized_evidence_bundle(snapshot):
+    benchmark = _benchmark()
+    promotion = _promotion(benchmark)
+    benchmark_sig = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint="fingerprint:benchmark",
+        model_id=MODEL_ID,
+        catalog_snapshot_id=snapshot.snapshot_id,
+        selection_receipt_id="model_selection_receipt:pending",
+        benchmark_run_receipt_id="model_combination_benchmark_run:test",
+        benchmark_receipt=benchmark,
+        nonce="nonce:benchmark",
+    )
+    promotion_sig = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.PROMOTION_AUTHORITY,
+        public_key=PROMOTION_PUBLIC_KEY,
+        fingerprint="fingerprint:promotion",
+        model_id=MODEL_ID,
+        catalog_snapshot_id=snapshot.snapshot_id,
+        selection_receipt_id="model_selection_receipt:pending",
+        benchmark_run_receipt_id="model_combination_benchmark_run:test",
+        benchmark_receipt=benchmark,
+        promotion_receipt=promotion,
+        promotion_policy_digest="sha256:promotion-policy",
+        nonce="nonce:promotion",
+    )
+    return {
+        "schema_version": EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        "catalog_snapshot_id": snapshot.snapshot_id,
+        "selection_receipt_id": "model_selection_receipt:pending",
+        "benchmark_run_receipt_id": "model_combination_benchmark_run:test",
+        "entries": [
+            {
+                "benchmark_receipt": benchmark.to_dict(),
+                "promotion_receipt": promotion.to_dict(),
+                "benchmark_signature_receipt": benchmark_sig.to_dict(),
+                "promotion_signature_receipt": promotion_sig.to_dict(),
+            }
+        ],
+    }
+
+
+def _key_resolver():
+    return StaticModelEvidenceKeyResolver(
+        {
+            ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY,
+            ModelEvidenceSignerRole.PROMOTION_AUTHORITY.value: PROMOTION_PUBLIC_KEY,
+        }
+    )
+
+
+def test_supplier_verifies_serialized_evidence_and_writes_selection_receipt(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+    output = tmp_path / "runtime" / "model_selection_receipt.json"
+
+    result = run_reddog_model_selection_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=snapshot.to_dict(),
+        verified_evidence_bundle=_serialized_evidence_bundle(snapshot),
+        requirements=_requirements(),
+        output_path=output,
+        key_resolver=_key_resolver(),
+        signature_verifier=DeterministicSignatureVerifier(),
+        now=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT
+    assert result.output_path == str(output.resolve())
+    assert result.selection_receipt_id and result.selection_receipt_id.startswith("model_selection_receipt:")
+    receipt = json.loads(output.read_text(encoding="utf-8"))
+    assert receipt["decision"] == "selected"
+    assert receipt["selected_model_ids"] == [MODEL_ID]
+    assert receipt["requirements"]["purpose"] == "production"
+    assert result.no_model_call_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_supplier_accepts_typed_verified_evidence_object(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+    benchmark = _benchmark()
+    promotion = _promotion(benchmark)
+    verified = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=snapshot.snapshot_id,
+    )
+
+    result = run_reddog_model_selection_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=snapshot.to_dict(),
+        verified_evidence_bundle=verified,
+        requirements=_requirements(),
+        output_path=tmp_path / "runtime" / "model_selection_receipt.json",
+    )
+
+    assert result.accepted is True
+    assert result.selected_model_ids == (MODEL_ID,)
+
+
+def test_supplier_rejects_serialized_evidence_without_signature_gate(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+
+    result = run_reddog_model_selection_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=snapshot.to_dict(),
+        verified_evidence_bundle=_serialized_evidence_bundle(snapshot),
+        requirements=_requirements(),
+        output_path=tmp_path / "runtime" / "model_selection_receipt.json",
+    )
+
+    assert result.accepted is False
+    assert result.status == MODEL_SELECTION_ARTIFACT_SUPPLY_REJECT
+    assert ModelSelectionArtifactSupplyReason.KEY_RESOLVER_MISSING in result.rejection_reasons
+    assert ModelSelectionArtifactSupplyReason.SIGNATURE_VERIFIER_MISSING in result.rejection_reasons
+
+
+def test_supplier_rejects_evaluation_requirements(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+    benchmark = _benchmark()
+    promotion = _promotion(benchmark)
+
+    result = run_reddog_model_selection_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=snapshot.to_dict(),
+        verified_evidence_bundle=make_verified_production_evidence(
+            benchmark,
+            promotion,
+            catalog_snapshot_id=snapshot.snapshot_id,
+        ),
+        requirements=_requirements(purpose="evaluation"),
+        output_path=tmp_path / "runtime" / "model_selection_receipt.json",
+    )
+
+    assert result.accepted is False
+    assert ModelSelectionArtifactSupplyReason.NON_PRODUCTION_REQUIREMENTS in result.rejection_reasons
+
+
+def test_supplier_rejects_output_inside_repo(tmp_path: Path) -> None:
+    snapshot = _snapshot()
+    benchmark = _benchmark()
+    promotion = _promotion(benchmark)
+
+    result = run_reddog_model_selection_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=snapshot.to_dict(),
+        verified_evidence_bundle=make_verified_production_evidence(
+            benchmark,
+            promotion,
+            catalog_snapshot_id=snapshot.snapshot_id,
+        ),
+        requirements=_requirements(),
+        output_path=REPO_ROOT / "model_selection_receipt.json",
+    )
+
+    assert result.accepted is False
+    assert ModelSelectionArtifactSupplyReason.OUTPUT_PATH_INVALID in result.rejection_reasons
+    assert not (REPO_ROOT / "model_selection_receipt.json").exists()
+
+
+def test_supplier_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "holo_index",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## WSP_97 Truth Boundary

Slice: `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_PHASE1`

### OBSERVED
- Adds `model_selection_artifact_supply.py`, a bounded supplier that materializes one production `ModelSelectionReceipt` JSON artifact outside the repository.
- Serialized evidence must pass the signed benchmark/promotion evidence gate via key resolver + signature verifier before production selection.
- Typed `VerifiedModelProductionEvidence` remains accepted for already-verified in-memory callers.
- Non-production requirements, missing signature gate, rejected selection, missing output path, and repository-internal output path fail closed.
- No provider/model calls, benchmark execution, command execution, telemetry persistence, HoloIndex re-index, extension runtime mutation, runtime default binding, worker dispatch, or PatternMemory writes.

### Validation
- `pytest modules\\ai_intelligence\\ai_gateway\\tests -q` -> 71 passed
- `git diff --check` -> clean
- New runtime/test files ASCII/NUL clean

### SPECIFIED_NOT_IMPLEMENTED
- Authority profile source artifact supply.
- Full main.py promotion run with determination + Memex + model selection + authority seed.
- Runtime model default binding and provider/model invocation.
- Panel runtime promotion.