### PR TITLE
feat(reddog): supply authority profile source artifact

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a bounded authority-profile source supplier that validates an explicit
+  authority seed against a token-verified principal record and fresh permission
+  snapshot, then writes one profile-source JSON artifact outside the source
+  repository.
+- The supplier enforces FoundUp-scoped allowed/denied paths, principal
+  repo/FoundUp scope, permission snapshot freshness/grants, high-authority
+  co-sign evidence, HoloIndex no-gap evidence, non-reused principal/RedDog
+  public keys, and outside-repo output.
+- Boundary remains constrained: no signing, signature verification, signer
+  state mutation, work-state mutation, worker spawn, shell, worktree,
+  OpenClaw enqueue, Hermes dispatch, PatternMemory write, source mutation, or
+  HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_RESIDENT_CYCLE_FIX_PROMOTION_ARTIFACT_HANDOFF_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_authority_profile_source_artifact_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_profile_source_artifact_supply.py
@@ -1,0 +1,443 @@
+"""Authority-profile source artifact supplier for RedDog FIX promotion.
+
+Slice: REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_PHASE1
+
+This module materializes the source authority profile consumed by the existing
+architect FIX promotion bridge. It validates an explicit authority seed against
+token-verified principal evidence and a fresh permission snapshot, then writes
+one JSON artifact outside the source repository.
+
+It does not sign, verify signatures, mutate signer state, mutate work state,
+spawn workers, create worktrees, execute shell commands, enqueue OpenClaw,
+dispatch Hermes, create PRs, settle rewards, write PatternMemory, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    HIGH_AUTHORITY_OPERATIONS,
+    PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PermissionSnapshot,
+)
+
+
+AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT = "AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT"
+AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT = "AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT"
+AUTHORITY_PROFILE_SOURCE_SCHEMA_VERSION = "reddog_authority_profile_source.v1"
+
+_FOUNDUP_PATH_PREFIX = "modules/foundups/"
+
+_REQUIRED_SEED_FIELDS = (
+    "principal_id",
+    "principal_provider",
+    "reddog_id",
+    "reddog_public_key",
+    "repo_full_name",
+    "foundup_id",
+    "allowed_paths",
+    "denied_paths",
+    "requested_operation",
+    "permission_snapshot_digest",
+    "identity_nonce",
+    "work_authority_nonce",
+    "issued_at",
+    "identity_expires_at",
+    "work_authority_expires_at",
+    "valve_state_required",
+    "key_epoch",
+    "required_tests",
+    "required_policy_gates",
+    "holoindex_evidence",
+)
+
+
+class AuthorityProfileSourceSupplyReason:
+    SEED_MISSING = "authority_profile_seed_missing"
+    SEED_NON_ASCII = "authority_profile_seed_non_ascii"
+    REQUIRED_FIELD_MISSING = "authority_profile_seed_required_field_missing"
+    PRINCIPAL_INVALID = "principal_authority_record_invalid"
+    PRINCIPAL_MISMATCH = "principal_authority_record_mismatch"
+    REPO_OUT_OF_SCOPE = "principal_repo_scope_missing"
+    FOUNDUP_OUT_OF_SCOPE = "principal_foundup_scope_missing"
+    PERMISSION_SNAPSHOT_INVALID = "permission_snapshot_invalid"
+    PERMISSION_SNAPSHOT_MISMATCH = "permission_snapshot_digest_mismatch"
+    PERMISSION_SNAPSHOT_STALE = "permission_snapshot_stale"
+    PERMISSION_DENIED = "permission_snapshot_denies_operation"
+    PATH_SCOPE = "authority_profile_path_scope_invalid"
+    UNSUPPORTED_REPO_WIDE = "authority_profile_repo_wide_not_supported"
+    HIGH_AUTHORITY_COSIGN = "authority_profile_high_authority_cosign_missing"
+    HOLOINDEX_EVIDENCE_INVALID = "authority_profile_holoindex_evidence_invalid"
+    TIME_BOUNDS_INVALID = "authority_profile_time_bounds_invalid"
+    KEY_REUSE = "authority_profile_principal_reddog_key_reuse"
+    OUTPUT_PATH_INVALID = "authority_profile_source_output_path_invalid"
+    OUTPUT_WRITE_FAILED = "authority_profile_source_output_write_failed"
+
+
+@dataclass(frozen=True)
+class AuthorityProfileSourceSupplyResult:
+    accepted: bool
+    status: str
+    authority_profile_source_receipt_id: str | None
+    output_path: str | None
+    principal_id: str | None
+    reddog_id: str | None
+    foundup_id: str | None
+    requested_operation: str | None
+    rejection_reasons: tuple[str, ...]
+    no_signing_performed: bool = True
+    no_signature_verification_performed: bool = True
+    no_signer_state_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_work_state_mutation_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_authority_profile_source_artifact_supply(
+    *,
+    repo_root: Path | str,
+    authority_seed: Mapping[str, Any] | None,
+    principal_authority_record: Mapping[str, Any] | PrincipalAuthorityRecord | None,
+    permission_snapshot: Mapping[str, Any] | PermissionSnapshot | None,
+    output_path: Path | str | None,
+    now_epoch: int,
+    leeway_s: int = 60,
+) -> AuthorityProfileSourceSupplyResult:
+    """Validate and materialize one authority-profile source artifact."""
+
+    root = Path(repo_root).resolve()
+    seed = _mapping(authority_seed)
+    reasons: list[str] = []
+    if not seed:
+        reasons.append(AuthorityProfileSourceSupplyReason.SEED_MISSING)
+    elif not _ascii_deep(seed):
+        reasons.append(AuthorityProfileSourceSupplyReason.SEED_NON_ASCII)
+    missing = [field for field in _REQUIRED_SEED_FIELDS if field not in seed or seed.get(field) in (None, "", (), [])]
+    if missing:
+        reasons.extend(
+            f"{AuthorityProfileSourceSupplyReason.REQUIRED_FIELD_MISSING}:{field}" for field in missing
+        )
+
+    principal = _principal(principal_authority_record)
+    if principal is None:
+        reasons.append(AuthorityProfileSourceSupplyReason.PRINCIPAL_INVALID)
+    snapshot = _snapshot(permission_snapshot)
+    if snapshot is None:
+        reasons.append(AuthorityProfileSourceSupplyReason.PERMISSION_SNAPSHOT_INVALID)
+
+    output, output_reasons = _runtime_output_path(output_path, root)
+    reasons.extend(output_reasons)
+    if seed and principal is not None:
+        reasons.extend(_principal_reasons(seed, principal))
+    if seed and snapshot is not None:
+        reasons.extend(_snapshot_reasons(seed, snapshot, now_epoch=now_epoch, leeway_s=leeway_s))
+    if seed:
+        reasons.extend(_seed_policy_reasons(seed, now_epoch=now_epoch, leeway_s=leeway_s))
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert principal is not None
+    assert snapshot is not None
+    assert output is not None
+    profile = _profile(seed, principal, snapshot)
+    try:
+        _write_json_atomic(output, profile)
+    except Exception:
+        return _reject((AuthorityProfileSourceSupplyReason.OUTPUT_WRITE_FAILED,))
+    return AuthorityProfileSourceSupplyResult(
+        accepted=True,
+        status=AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT,
+        authority_profile_source_receipt_id=str(profile["authority_profile_source_receipt_id"]),
+        output_path=str(output),
+        principal_id=str(profile["principal_id"]),
+        reddog_id=str(profile["reddog_id"]),
+        foundup_id=str(profile["foundup_id"]),
+        requested_operation=str(profile["requested_operation"]),
+        rejection_reasons=(),
+    )
+
+
+def _principal_reasons(seed: Mapping[str, Any], principal: PrincipalAuthorityRecord) -> list[str]:
+    reasons: list[str] = []
+    if (
+        str(seed.get("principal_id") or "") != principal.principal_id
+        or str(seed.get("principal_provider") or "") != principal.principal_provider
+    ):
+        reasons.append(AuthorityProfileSourceSupplyReason.PRINCIPAL_MISMATCH)
+    if str(seed.get("repo_full_name") or "") not in set(principal.repo_scope):
+        reasons.append(AuthorityProfileSourceSupplyReason.REPO_OUT_OF_SCOPE)
+    if str(seed.get("foundup_id") or "") not in set(principal.foundup_scope):
+        reasons.append(AuthorityProfileSourceSupplyReason.FOUNDUP_OUT_OF_SCOPE)
+    if str(seed.get("reddog_public_key") or "") == principal.principal_public_key:
+        reasons.append(AuthorityProfileSourceSupplyReason.KEY_REUSE)
+    return reasons
+
+
+def _snapshot_reasons(
+    seed: Mapping[str, Any],
+    snapshot: PermissionSnapshot,
+    *,
+    now_epoch: int,
+    leeway_s: int,
+) -> list[str]:
+    reasons: list[str] = []
+    if snapshot.evidence_digest != str(seed.get("permission_snapshot_digest") or ""):
+        reasons.append(AuthorityProfileSourceSupplyReason.PERMISSION_SNAPSHOT_MISMATCH)
+    if not snapshot.is_fresh(now_epoch, leeway_s):
+        reasons.append(AuthorityProfileSourceSupplyReason.PERMISSION_SNAPSHOT_STALE)
+    if not snapshot.grants(str(seed.get("requested_operation") or ""), str(seed.get("repo_full_name") or "")):
+        reasons.append(AuthorityProfileSourceSupplyReason.PERMISSION_DENIED)
+    return reasons
+
+
+def _seed_policy_reasons(seed: Mapping[str, Any], *, now_epoch: int, leeway_s: int) -> list[str]:
+    reasons: list[str] = []
+    foundup_id = str(seed.get("foundup_id") or "")
+    if not foundup_id or foundup_id in {"*", "repo", "root", "all"}:
+        reasons.append(AuthorityProfileSourceSupplyReason.UNSUPPORTED_REPO_WIDE)
+    allowed_paths = _strings(seed.get("allowed_paths"))
+    denied_paths = _strings(seed.get("denied_paths"))
+    if not allowed_paths or not all(_path_within_foundup(path, foundup_id) for path in allowed_paths):
+        reasons.append(AuthorityProfileSourceSupplyReason.PATH_SCOPE)
+    if not denied_paths or not all(_path_within_foundup(path, foundup_id) for path in denied_paths):
+        reasons.append(AuthorityProfileSourceSupplyReason.PATH_SCOPE)
+    operation = str(seed.get("requested_operation") or "")
+    if operation in HIGH_AUTHORITY_OPERATIONS and not (
+        seed.get("consensus_receipt_digest") and seed.get("sovereign_authorization_digest")
+    ):
+        reasons.append(AuthorityProfileSourceSupplyReason.HIGH_AUTHORITY_COSIGN)
+    if not _valid_holoindex_evidence(_mapping(seed.get("holoindex_evidence"))):
+        reasons.append(AuthorityProfileSourceSupplyReason.HOLOINDEX_EVIDENCE_INVALID)
+    try:
+        issued_at = int(seed.get("issued_at"))
+        identity_expires_at = int(seed.get("identity_expires_at"))
+        work_expires_at = int(seed.get("work_authority_expires_at"))
+    except Exception:
+        reasons.append(AuthorityProfileSourceSupplyReason.TIME_BOUNDS_INVALID)
+        return reasons
+    if issued_at > now_epoch + int(leeway_s) or identity_expires_at <= now_epoch or work_expires_at <= now_epoch:
+        reasons.append(AuthorityProfileSourceSupplyReason.TIME_BOUNDS_INVALID)
+    if not _strings(seed.get("required_tests")) or not _strings(seed.get("required_policy_gates")):
+        reasons.append(AuthorityProfileSourceSupplyReason.REQUIRED_FIELD_MISSING + ":required_execution_gates")
+    return reasons
+
+
+def _profile(
+    seed: Mapping[str, Any],
+    principal: PrincipalAuthorityRecord,
+    snapshot: PermissionSnapshot,
+) -> dict[str, Any]:
+    body = dict(seed)
+    body.update(
+        {
+            "schema_version": AUTHORITY_PROFILE_SOURCE_SCHEMA_VERSION,
+            "principal_public_key": principal.principal_public_key,
+            "permission_snapshot_digest": snapshot.evidence_digest,
+            "allowed_paths": list(_strings(seed.get("allowed_paths"))),
+            "denied_paths": list(_strings(seed.get("denied_paths"))),
+            "required_tests": list(_strings(seed.get("required_tests"))),
+            "required_policy_gates": list(_strings(seed.get("required_policy_gates"))),
+            "source_authority_basis": {
+                "principal_verified_subject_digest": principal.verified_subject_digest,
+                "principal_repo_scope": list(principal.repo_scope),
+                "principal_foundup_scope": list(principal.foundup_scope),
+                "permission_snapshot_digest": snapshot.evidence_digest,
+                "permission_snapshot_expires_at": snapshot.expires_at,
+                "permission_snapshot_can_write": snapshot.can_write,
+                "permission_snapshot_can_admin": snapshot.can_admin,
+            },
+            "no_signing_performed": True,
+            "no_signature_verification_performed": True,
+            "no_signer_state_mutation_performed": True,
+            "no_worker_spawn_performed": True,
+            "no_worktree_created": True,
+            "no_shell_command_executed": True,
+            "no_openclaw_enqueue_performed": True,
+            "no_hermes_dispatch_performed": True,
+            "no_work_state_mutation_performed": True,
+            "no_repo_mutation_performed": True,
+            "no_holoindex_reindex_performed": True,
+            "no_pattern_memory_write_performed": True,
+        }
+    )
+    if principal.reward_account:
+        body["reward_account"] = principal.reward_account
+    if principal.owner_dae:
+        body["owner_dae"] = principal.owner_dae
+    if principal.principal_wallet:
+        body["principal_wallet"] = principal.principal_wallet
+    body["authority_profile_source_receipt_id"] = _digest(body)
+    return body
+
+
+def _principal(value: Mapping[str, Any] | PrincipalAuthorityRecord | None) -> PrincipalAuthorityRecord | None:
+    if isinstance(value, PrincipalAuthorityRecord):
+        return value
+    data = _mapping(value)
+    if not data:
+        return None
+    try:
+        return PrincipalAuthorityRecord(
+            principal_id=str(data["principal_id"]),
+            principal_provider=str(data["principal_provider"]),
+            principal_public_key=str(data["principal_public_key"]),
+            repo_scope=tuple(str(item) for item in _strings(data.get("repo_scope"))),
+            foundup_scope=tuple(str(item) for item in _strings(data.get("foundup_scope"))),
+            verified_subject_digest=str(data["verified_subject_digest"]),
+            reward_account=(str(data["reward_account"]) if data.get("reward_account") else None),
+            owner_dae=(str(data["owner_dae"]) if data.get("owner_dae") else None),
+            principal_wallet=(str(data["principal_wallet"]) if data.get("principal_wallet") else None),
+        )
+    except Exception:
+        return None
+
+
+def _snapshot(value: Mapping[str, Any] | PermissionSnapshot | None) -> PermissionSnapshot | None:
+    if isinstance(value, PermissionSnapshot):
+        return value
+    data = _mapping(value)
+    if not data:
+        return None
+    try:
+        return PermissionSnapshot(
+            evidence_digest=str(data["evidence_digest"]),
+            expires_at=int(data["expires_at"]),
+            can_write=bool(data.get("can_write", False)),
+            can_admin=bool(data.get("can_admin", False)),
+            repo_full_name=str(data.get("repo_full_name") or ""),
+        )
+    except Exception:
+        return None
+
+
+def _runtime_output_path(value: Path | str | None, repo_root: Path) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [AuthorityProfileSourceSupplyReason.OUTPUT_PATH_INVALID]
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root)
+        return None, [AuthorityProfileSourceSupplyReason.OUTPUT_PATH_INVALID]
+    except ValueError:
+        return resolved, []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _path_within_foundup(path: str, foundup_id: str) -> bool:
+    if not isinstance(path, str) or not path or "\\" in path or ":" in path or path.startswith("/") or "\x00" in path:
+        return False
+    if path.startswith("//?/") or path.startswith("//./"):
+        return False
+    prefix = f"{_FOUNDUP_PATH_PREFIX}{foundup_id}/"
+    if not path.startswith(prefix):
+        return False
+    for segment in path.split("/"):
+        if segment.strip(" \t") == ".." or segment.strip(" .\t") == "":
+            return False
+    return True
+
+
+def _valid_holoindex_evidence(evidence: Mapping[str, Any]) -> bool:
+    if not evidence:
+        return False
+    if evidence.get("index_gap_detected") is True:
+        return False
+    if str(evidence.get("retrieval_quality") or "").upper() == "INDEX_GAP":
+        return False
+    refs = evidence.get("evidence_refs")
+    return bool(_strings(refs))
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        try:
+            return value.to_dict()
+        except Exception:
+            return {}
+    return value if isinstance(value, Mapping) else {}
+
+
+def _strings(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value if str(item).strip())
+    return ()
+
+
+def _ascii_deep(value: Any) -> bool:
+    if isinstance(value, str):
+        return all(ord(char) < 128 for char in value)
+    if isinstance(value, Mapping):
+        return all(isinstance(key, str) and _ascii_deep(key) and _ascii_deep(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_ascii_deep(item) for item in value)
+    return True
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _reject(reasons: Sequence[str]) -> AuthorityProfileSourceSupplyResult:
+    return AuthorityProfileSourceSupplyResult(
+        accepted=False,
+        status=AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT,
+        authority_profile_source_receipt_id=None,
+        output_path=None,
+        principal_id=None,
+        reddog_id=None,
+        foundup_id=None,
+        requested_operation=None,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+__all__ = [
+    "AUTHORITY_PROFILE_SOURCE_SCHEMA_VERSION",
+    "AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT",
+    "AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT",
+    "AuthorityProfileSourceSupplyReason",
+    "AuthorityProfileSourceSupplyResult",
+    "run_reddog_authority_profile_source_artifact_supply",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_source_artifact_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_source_artifact_supply.py
@@ -1,0 +1,276 @@
+"""Tests for REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_architect_fix_signed_wsp15_work_order_promotion as promotion,
+)
+from modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply import (
+    AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT,
+    AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT,
+    AuthorityProfileSourceSupplyReason,
+    run_reddog_authority_profile_source_artifact_supply,
+)
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
+    InMemoryAuthoritativeWorkStateStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PermissionSnapshot,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import (
+    VALVE_OPEN_WORKTREE_CREATE,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    _determination,
+    _memex_supply,
+    _model_selection,
+    _work_state,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_authority_profile_source_artifact_supply.py"
+)
+NOW = 1_800_000_000
+
+
+def _principal() -> PrincipalAuthorityRecord:
+    return PrincipalAuthorityRecord(
+        principal_id="github:mjtrout",
+        principal_provider="github",
+        principal_public_key="pub:principal",
+        repo_scope=("FOUNDUPS/Foundups-Agent",),
+        foundup_scope=("paccess_001",),
+        verified_subject_digest="sha256:verified-subject",
+        reward_account="reward:paccess",
+        owner_dae="dae:paccess",
+    )
+
+
+def _snapshot(**overrides) -> PermissionSnapshot:
+    payload = {
+        "evidence_digest": "sha256:permission",
+        "expires_at": NOW + 3600,
+        "can_write": True,
+        "can_admin": False,
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+    }
+    payload.update(overrides)
+    return PermissionSnapshot(**payload)
+
+
+def _seed(**overrides):
+    payload = {
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "reddog_id": "reddog:architect",
+        "reddog_public_key": "pub:reddog",
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/foundups/paccess_001/**"],
+        "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
+        "requested_operation": "create_foundup",
+        "permission_snapshot_digest": "sha256:permission",
+        "identity_nonce": "identity-nonce-0001",
+        "work_authority_nonce": "workauth-nonce-0001",
+        "issued_at": NOW,
+        "identity_expires_at": NOW + 3600,
+        "work_authority_expires_at": NOW + 900,
+        "valve_state_required": VALVE_OPEN_WORKTREE_CREATE,
+        "key_epoch": "epoch-1",
+        "required_tests": ["pytest modules/communication/moltbot_bridge/tests"],
+        "required_policy_gates": ["signed_work_order_authority", "execution_valve"],
+        "consensus_receipt_digest": "sha256:consensus",
+        "sovereign_authorization_digest": "sha256:012-token",
+        "holoindex_evidence": {
+            "holoindex_query": "RedDog architect FIX promotion",
+            "holoindex_status": "bundle_json_ok",
+            "index_gap_detected": False,
+            "retrieval_quality": "HIGH",
+            "applicable_wsps": ["WSP_15", "WSP_97"],
+            "evidence_refs": [
+                "modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py"
+            ],
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_supplier_writes_profile_source_consumable_by_fix_promotion(tmp_path: Path) -> None:
+    output = tmp_path / "runtime" / "authority_profile_source.json"
+
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=_seed(),
+        principal_authority_record=_principal(),
+        permission_snapshot=_snapshot(),
+        output_path=output,
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT
+    assert result.authority_profile_source_receipt_id and result.authority_profile_source_receipt_id.startswith(
+        "sha256:"
+    )
+    profile = json.loads(output.read_text(encoding="utf-8"))
+    assert profile["principal_public_key"] == "pub:principal"
+    assert profile["no_signing_performed"] is True
+    assert profile["no_holoindex_reindex_performed"] is True
+    assert profile["source_authority_basis"]["permission_snapshot_can_write"] is True
+
+    promoted = promotion.promote_reddog_architect_fix_to_signed_wsp15_work_order(
+        architect_determination=_determination(),
+        work_state_store=InMemoryAuthoritativeWorkStateStore(_work_state()),
+        authority_profile=profile,
+        model_selection_receipt=_model_selection(),
+        memex_supply_receipt=_memex_supply(),
+        worker_id="reddog-worker-1",
+        now_iso="2026-07-16T00:00:00+00:00",
+    )
+    assert promoted.accepted is True
+    assert promoted.authority_profile is not None
+    assert promoted.authority_profile["authority_profile_source_receipt_id"] == profile[
+        "authority_profile_source_receipt_id"
+    ]
+
+
+def test_supplier_rejects_output_inside_repo(tmp_path: Path) -> None:
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=_seed(),
+        principal_authority_record=_principal(),
+        permission_snapshot=_snapshot(),
+        output_path=REPO_ROOT / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT
+    assert AuthorityProfileSourceSupplyReason.OUTPUT_PATH_INVALID in result.rejection_reasons
+    assert not (REPO_ROOT / "authority_profile_source.json").exists()
+
+
+def test_supplier_rejects_stale_permission_snapshot(tmp_path: Path) -> None:
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=_seed(),
+        principal_authority_record=_principal(),
+        permission_snapshot=_snapshot(expires_at=NOW - 100),
+        output_path=tmp_path / "runtime" / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSourceSupplyReason.PERMISSION_SNAPSHOT_STALE in result.rejection_reasons
+
+
+def test_supplier_rejects_path_outside_foundup_scope(tmp_path: Path) -> None:
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=_seed(allowed_paths=["modules/communication/moltbot_bridge/**"]),
+        principal_authority_record=_principal(),
+        permission_snapshot=_snapshot(),
+        output_path=tmp_path / "runtime" / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSourceSupplyReason.PATH_SCOPE in result.rejection_reasons
+
+
+def test_supplier_rejects_high_authority_without_cosign(tmp_path: Path) -> None:
+    seed = _seed()
+    seed.pop("consensus_receipt_digest")
+    seed.pop("sovereign_authorization_digest")
+
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=seed,
+        principal_authority_record=_principal(),
+        permission_snapshot=_snapshot(),
+        output_path=tmp_path / "runtime" / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSourceSupplyReason.HIGH_AUTHORITY_COSIGN in result.rejection_reasons
+
+
+def test_supplier_rejects_holoindex_gap_authority(tmp_path: Path) -> None:
+    evidence = dict(_seed()["holoindex_evidence"])
+    evidence["index_gap_detected"] = True
+
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=_seed(holoindex_evidence=evidence),
+        principal_authority_record=_principal(),
+        permission_snapshot=_snapshot(),
+        output_path=tmp_path / "runtime" / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSourceSupplyReason.HOLOINDEX_EVIDENCE_INVALID in result.rejection_reasons
+
+
+def test_supplier_rejects_principal_foundup_scope_mismatch(tmp_path: Path) -> None:
+    principal = PrincipalAuthorityRecord(
+        principal_id="github:mjtrout",
+        principal_provider="github",
+        principal_public_key="pub:principal",
+        repo_scope=("FOUNDUPS/Foundups-Agent",),
+        foundup_scope=("other_foundup",),
+        verified_subject_digest="sha256:verified-subject",
+    )
+
+    result = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=REPO_ROOT,
+        authority_seed=_seed(),
+        principal_authority_record=principal,
+        permission_snapshot=_snapshot(),
+        output_path=tmp_path / "runtime" / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSourceSupplyReason.FOUNDUP_OUT_OF_SCOPE in result.rejection_reasons
+
+
+def test_module_has_no_execution_network_signing_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "git",
+        "holo_index",
+        "hmac",
+        "secrets",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## WSP_97 Truth Boundary

Slice: `REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_PHASE1`

### OBSERVED
- Adds a bounded authority-profile source artifact supplier for the existing architect FIX promotion bridge.
- Validates an explicit authority seed against a token-verified principal record and fresh permission snapshot.
- Enforces FoundUp-scoped allowed/denied paths, principal repo/FoundUp scope, permission snapshot freshness/grants, high-authority co-sign evidence, HoloIndex no-gap evidence, and outside-repo output.
- Positive test feeds the generated source artifact into the existing architect-FIX promotion bridge and proves it is consumable.
- No signing, signature verification, signer-state mutation, work-state mutation, worker spawn, shell, worktree, OpenClaw enqueue, Hermes dispatch, PR creation, PatternMemory write, source mutation, or HoloIndex re-indexing.

### Validation
- `python -m py_compile` on new runtime/test modules -> pass
- `pytest modules\\communication\\moltbot_bridge\\tests\\test_reddog_authority_profile_source_artifact_supply.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_architect_fix_signed_wsp15_work_order_promotion.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_architect_fix_promotion_bootstrap.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_wre_queue_authority_request_dryrun.py -q` -> 38 passed
- `git diff --check` -> clean
- New runtime/test files ASCII/NUL clean

### SPECIFIED_NOT_IMPLEMENTED
- Repo-wide generic authority remains blocked by the existing generic-spine work.
- Actual signing and signer runtime invocation remain downstream gates.
- Worker dispatch, worktree mutation, draft PR publishing, PatternMemory writes, and HoloIndex re-indexing remain out of scope.