### PR TITLE
feat(reddog): bootstrap model selection artifact supply

### DIFF
--- a/main.py
+++ b/main.py
@@ -1490,6 +1490,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo promoted profile JSON
         REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional profile-derived output path
         REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=0              Materialize determination/Memex from AgentDB cycle
+        REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=0             Materialize model selection receipt from signed evidence
+        REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
+        REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
+        REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
+        REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
         REDDOG_RESIDENT_ARCHITECT_INTENT_ID                  Intent ID for the determined resident cycle
     """
 
@@ -1565,6 +1570,49 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
                 os.environ["REDDOG_MEMEX_SUPPLY_RECEIPT_PATH"] = memex_supply_receipt_path
         elif handoff_enforced:
             print("[REDDOG-FIX-HANDOFF] Startup blocked by REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF_ENFORCED=1")
+            return False
+
+    model_supply_requested = os.getenv("REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY", "0") == "1"
+    model_supply_enforced = os.getenv("REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
+    if model_supply_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap import (
+                run_reddog_model_selection_artifact_supply_bootstrap,
+            )
+
+            raw_now = os.getenv("REDDOG_MODEL_SELECTION_EVIDENCE_NOW_EPOCH", "").strip()
+            model_supply = run_reddog_model_selection_artifact_supply_bootstrap(
+                repo_root=repo_root,
+                catalog_snapshot_path=os.getenv("REDDOG_MODEL_CATALOG_SNAPSHOT_PATH", "") or None,
+                evidence_bundle_path=os.getenv("REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH", "") or None,
+                requirements_path=os.getenv("REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH", "") or None,
+                trusted_keys_path=os.getenv("REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH", "") or None,
+                output_path=model_selection_receipt_path,
+                signature_verifier_backend=os.getenv(
+                    "REDDOG_MODEL_EVIDENCE_SIGNATURE_VERIFIER_BACKEND",
+                    "ed25519",
+                ),
+                now_epoch=(int(raw_now) if raw_now else None),
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-SELECTION] Startup artifact supply failed: {exc}")
+            if model_supply_enforced:
+                print(f"[REDDOG-MODEL-SELECTION] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-SELECTION] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        model_status = "PASS" if model_supply.accepted else "WARN"
+        model_reasons = ",".join(model_supply.rejection_reasons) if model_supply.rejection_reasons else "(none)"
+        print(
+            f"[REDDOG-MODEL-SELECTION] preflight={model_status} status={model_supply.status} "
+            f"receipt={model_supply.model_selection_receipt_id or '(none)'} reasons={model_reasons}"
+        )
+        if model_supply.accepted and model_supply.output_path:
+            model_selection_receipt_path = model_supply.output_path
+            os.environ["REDDOG_MODEL_SELECTION_RECEIPT_PATH"] = model_selection_receipt_path
+        elif model_supply_enforced:
+            print("[REDDOG-MODEL-SELECTION] Startup blocked by REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_ENFORCED=1")
             return False
 
     required_inputs_present = all(

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -226,6 +226,16 @@ repository-internal output paths fail closed. The API does not call providers,
 run benchmarks, execute commands, persist telemetry, re-index HoloIndex, bind
 runtime defaults, mutate the extension, dispatch workers, or write PatternMemory.
 
+```python
+run_reddog_model_selection_artifact_supply_bootstrap(...) -> ModelSelectionArtifactBootstrapResult
+```
+
+The bootstrap adapter is the explicit `main.py` preflight surface. It reads
+outside-repo catalog/evidence/requirements/key JSON inputs, constructs a trusted
+public-key resolver, uses the configured public signature verifier, and delegates
+receipt creation to `run_reddog_model_selection_artifact_supply`. It is disabled
+unless `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=1`.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,40 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - RedDog Model Selection Artifact Supply Main Preflight
+
+**Who:** 0102 Codex
+**Type:** Runtime Artifact Bridge
+**Slice:** REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**What:** Added an optional `main.py` startup adapter that materializes the
+production `ModelSelectionReceipt` path from outside-repo catalog, signed
+evidence, requirements, and trusted public-key JSON inputs.
+
+**Why:** The resident RedDog architect FIX promotion path should not require a
+manual model-selection receipt when the signed benchmark/promotion evidence is
+already available. The bridge still must fail closed instead of trusting catalog
+champion fields or raw evidence mappings.
+
+**Files:**
+- `src/model_selection_artifact_supply_bootstrap.py` - outside-repo input
+  loader, trusted model-evidence key resolver construction, public signature
+  verifier selection, and supplier invocation.
+- `tests/test_model_selection_artifact_supply_bootstrap.py` - positive
+  materialization and missing-key/output/backend/AST boundary tests.
+- `README.md` and `INTERFACE.md` - API and startup-boundary notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: explicit main-startup model-selection artifact supply.
+- IMPLEMENTED: trusted public keys and signed evidence are required before
+  production selection.
+- NOT IMPLEMENTED: provider calls, benchmark execution, runtime model default
+  binding, telemetry persistence, worker dispatch, source mutation,
+  PatternMemory writes, or HoloIndex re-indexing.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - RedDog Model Selection Artifact Supply
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -128,6 +128,14 @@ write artifacts inside the repository. It does not call providers, run
 benchmarks, execute commands, persist telemetry, re-index HoloIndex, bind
 runtime model defaults, mutate `extension.js`, or dispatch workers.
 
+`src/model_selection_artifact_supply_bootstrap.py` is the optional `main.py`
+startup adapter for that supplier. When explicitly enabled, it reads the model
+catalog snapshot, signed production-evidence bundle, selection requirements and
+trusted public-key records from outside-repo runtime files, then writes the
+selection receipt path consumed by RedDog FIX promotion. The adapter defaults to
+the existing Ed25519 public verifier and fails closed when trusted keys or
+signed evidence are absent.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_selection_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_selection_artifact_supply_bootstrap.py
@@ -1,0 +1,225 @@
+"""Main-startup bootstrap for RedDog model-selection artifact supply.
+
+Slice: REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads outside-repo runtime JSON inputs, constructs a trusted
+model-evidence key resolver, verifies signed benchmark/promotion evidence, and
+materializes the production ``ModelSelectionReceipt`` JSON expected by the
+RedDog architect FIX promotion bridge.
+
+It does not call models, run benchmarks, execute commands, mutate catalogs,
+persist telemetry, bind runtime defaults, mutate the extension, spawn workers,
+write PatternMemory, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply import (
+    MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT,
+    run_reddog_model_selection_artifact_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    StaticModelEvidenceKeyResolver,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+
+MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED = "MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED"
+MODEL_SELECTION_ARTIFACT_BOOTSTRAP_NOT_READY = "MODEL_SELECTION_ARTIFACT_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class ModelSelectionArtifactBootstrapResult:
+    accepted: bool
+    status: str
+    model_selection_receipt_id: Optional[str]
+    output_path: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_telemetry_persistence_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_selection_artifact_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    catalog_snapshot_path: Path | str | None,
+    evidence_bundle_path: Path | str | None,
+    requirements_path: Path | str | None,
+    trusted_keys_path: Path | str | None,
+    output_path: Path | str | None,
+    signature_verifier_backend: str = "ed25519",
+    signature_verifier: SignatureVerifier | None = None,
+    now_epoch: int | None = None,
+) -> ModelSelectionArtifactBootstrapResult:
+    """Materialize the model-selection artifact from configured runtime files."""
+
+    root = Path(repo_root).resolve()
+    catalog, catalog_reasons = _read_json_outside_repo(
+        root,
+        catalog_snapshot_path,
+        missing_reason="missing_model_catalog_snapshot_path",
+        inside_reason="model_catalog_snapshot_path_inside_repo",
+        malformed_reason="malformed_model_catalog_snapshot",
+    )
+    evidence, evidence_reasons = _read_json_outside_repo(
+        root,
+        evidence_bundle_path,
+        missing_reason="missing_model_evidence_bundle_path",
+        inside_reason="model_evidence_bundle_path_inside_repo",
+        malformed_reason="malformed_model_evidence_bundle",
+    )
+    requirements, requirements_reasons = _read_json_outside_repo(
+        root,
+        requirements_path,
+        missing_reason="missing_model_selection_requirements_path",
+        inside_reason="model_selection_requirements_path_inside_repo",
+        malformed_reason="malformed_model_selection_requirements",
+    )
+    trusted_keys, key_reasons = _read_json_outside_repo(
+        root,
+        trusted_keys_path,
+        missing_reason="missing_model_evidence_trusted_keys_path",
+        inside_reason="model_evidence_trusted_keys_path_inside_repo",
+        malformed_reason="malformed_model_evidence_trusted_keys",
+    )
+    reasons = [*catalog_reasons, *evidence_reasons, *requirements_reasons, *key_reasons]
+    key_resolver = None
+    if trusted_keys is not None:
+        key_resolver, resolver_reasons = _key_resolver(trusted_keys)
+        reasons.extend(resolver_reasons)
+    verifier = signature_verifier
+    if verifier is None:
+        verifier, verifier_reasons = _signature_verifier(signature_verifier_backend)
+        reasons.extend(verifier_reasons)
+    if reasons:
+        return _not_ready(reasons)
+
+    assert catalog is not None
+    assert evidence is not None
+    assert requirements is not None
+    assert key_resolver is not None
+    assert verifier is not None
+    supply = run_reddog_model_selection_artifact_supply(
+        repo_root=root,
+        catalog_snapshot=catalog,
+        verified_evidence_bundle=evidence,
+        requirements=requirements,
+        output_path=output_path,
+        key_resolver=key_resolver,
+        signature_verifier=verifier,
+        now=int(now_epoch if now_epoch is not None else time.time()),
+    )
+    if not supply.accepted or supply.status != MODEL_SELECTION_ARTIFACT_SUPPLY_ACCEPT:
+        return _not_ready(supply.rejection_reasons or ("model_selection_artifact_supply_rejected",))
+    return ModelSelectionArtifactBootstrapResult(
+        accepted=True,
+        status=MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED,
+        model_selection_receipt_id=supply.selection_receipt_id,
+        output_path=supply.output_path,
+        rejection_reasons=(),
+    )
+
+
+def _signature_verifier(backend: str | None) -> tuple[SignatureVerifier | None, tuple[str, ...]]:
+    normalized = str(backend or "").strip().lower()
+    if normalized != "ed25519":
+        return None, ("unsupported_model_evidence_signature_verifier_backend",)
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+            Ed25519SignatureVerifier,
+        )
+    except Exception:
+        return None, ("model_evidence_signature_verifier_unavailable",)
+    return Ed25519SignatureVerifier(), ()
+
+
+def _key_resolver(payload: Mapping[str, Any]) -> tuple[StaticModelEvidenceKeyResolver | None, tuple[str, ...]]:
+    raw = payload.get("trusted_public_keys", payload)
+    keys: dict[object, str] = {}
+    if isinstance(raw, Mapping):
+        keys.update({str(role): str(public_key) for role, public_key in raw.items() if str(role) and str(public_key)})
+    elif isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                return None, ("malformed_model_evidence_trusted_keys",)
+            role = str(item.get("signer_role") or "")
+            fingerprint = str(item.get("signer_key_fingerprint") or "")
+            epoch = str(item.get("key_epoch") or "")
+            public_key = str(item.get("public_key") or "")
+            if not (role and fingerprint and epoch and public_key):
+                return None, ("malformed_model_evidence_trusted_keys",)
+            keys[(role, fingerprint, epoch)] = public_key
+    else:
+        return None, ("malformed_model_evidence_trusted_keys",)
+    if not keys:
+        return None, ("missing_model_evidence_trusted_keys",)
+    return StaticModelEvidenceKeyResolver(keys), ()
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(reasons: tuple[str, ...] | list[str]) -> ModelSelectionArtifactBootstrapResult:
+    return ModelSelectionArtifactBootstrapResult(
+        accepted=False,
+        status=MODEL_SELECTION_ARTIFACT_BOOTSTRAP_NOT_READY,
+        model_selection_receipt_id=None,
+        output_path=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED",
+    "MODEL_SELECTION_ARTIFACT_BOOTSTRAP_NOT_READY",
+    "ModelSelectionArtifactBootstrapResult",
+    "run_reddog_model_selection_artifact_supply_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_selection_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_selection_artifact_supply_bootstrap.py
@@ -1,0 +1,180 @@
+"""Tests for REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap import (
+    MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED,
+    MODEL_SELECTION_ARTIFACT_BOOTSTRAP_NOT_READY,
+    run_reddog_model_selection_artifact_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.tests.model_signed_evidence_test_helpers import (
+    BENCHMARK_FINGERPRINT,
+    BENCHMARK_PUBLIC_KEY,
+    KEY_EPOCH,
+    PROMOTION_FINGERPRINT,
+    PROMOTION_PUBLIC_KEY,
+    DeterministicSignatureVerifier,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_selection_artifact_supply import (
+    _requirements,
+    _serialized_evidence_bundle,
+    _snapshot,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_selection_artifact_supply_bootstrap.py"
+)
+NOW = 1_800_000_000
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _keys() -> dict[str, object]:
+    return {
+        "trusted_public_keys": [
+            {
+                "signer_role": "benchmark_verifier",
+                "signer_key_fingerprint": BENCHMARK_FINGERPRINT,
+                "key_epoch": KEY_EPOCH,
+                "public_key": BENCHMARK_PUBLIC_KEY,
+            },
+            {
+                "signer_role": "promotion_authority",
+                "signer_key_fingerprint": PROMOTION_FINGERPRINT,
+                "key_epoch": KEY_EPOCH,
+                "public_key": PROMOTION_PUBLIC_KEY,
+            },
+        ]
+    }
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    snapshot = _snapshot()
+    return {
+        "catalog": _write_json(runtime, "catalog.json", snapshot.to_dict()),
+        "evidence": _write_json(runtime, "evidence.json", _serialized_evidence_bundle(snapshot)),
+        "requirements": _write_json(runtime, "requirements.json", _requirements()),
+        "keys": _write_json(runtime, "keys.json", _keys()),
+        "output": runtime / "model_selection_receipt.json",
+    }
+
+
+def test_bootstrap_materializes_model_selection_receipt(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_selection_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        evidence_bundle_path=files["evidence"],
+        requirements_path=files["requirements"],
+        trusted_keys_path=files["keys"],
+        output_path=files["output"],
+        signature_verifier=DeterministicSignatureVerifier(),
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED
+    assert result.model_selection_receipt_id and result.model_selection_receipt_id.startswith(
+        "model_selection_receipt:"
+    )
+    receipt = json.loads(files["output"].read_text(encoding="utf-8"))
+    assert receipt["requirements"]["purpose"] == "production"
+    assert result.no_model_call_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_bootstrap_rejects_missing_trusted_keys(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_selection_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        evidence_bundle_path=files["evidence"],
+        requirements_path=files["requirements"],
+        trusted_keys_path=None,
+        output_path=files["output"],
+        signature_verifier=DeterministicSignatureVerifier(),
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == MODEL_SELECTION_ARTIFACT_BOOTSTRAP_NOT_READY
+    assert "missing_model_evidence_trusted_keys_path" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_bootstrap_rejects_output_inside_repo(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_selection_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        evidence_bundle_path=files["evidence"],
+        requirements_path=files["requirements"],
+        trusted_keys_path=files["keys"],
+        output_path=REPO_ROOT / "model_selection_receipt.json",
+        signature_verifier=DeterministicSignatureVerifier(),
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert "model_selection_output_path_invalid" in result.rejection_reasons
+    assert not (REPO_ROOT / "model_selection_receipt.json").exists()
+
+
+def test_bootstrap_rejects_unsupported_signature_verifier_backend(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_selection_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        evidence_bundle_path=files["evidence"],
+        requirements_path=files["requirements"],
+        trusted_keys_path=files["keys"],
+        output_path=files["output"],
+        signature_verifier_backend="none",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert "unsupported_model_evidence_signature_verifier_backend" in result.rejection_reasons
+
+
+def test_bootstrap_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "holo_index",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Wired `main.py` to optionally run the AI Gateway model-selection artifact
+  supplier before architect-FIX promotion when
+  `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=1` is set.
+- The preflight consumes outside-repo catalog snapshot, signed production
+  evidence bundle, selection requirements, and trusted public-key files, then
+  feeds the resulting model-selection receipt path into the existing promotion
+  bridge.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  runtime model default binding, worker spawn, shell, worktree, source
+  mutation, PatternMemory write, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -221,6 +221,82 @@ def test_main_preflight_handoff_materializes_resident_cycle_artifacts_before_pro
     assert promote_kwargs["authority_profile_output_path"] == str(runtime_root / "authority_profile.json")
 
 
+def test_main_preflight_model_selection_supply_runs_before_promotion(tmp_path: Path) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    model_supply_result = type(
+        "ModelSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED",
+            "model_selection_receipt_id": "model_selection_receipt:runtime",
+            "output_path": str(runtime_root / "model_selection_receipt.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap.run_reddog_model_selection_artifact_supply_bootstrap",
+        return_value=model_supply_result,
+    ) as model_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_MODEL_CATALOG_SNAPSHOT_PATH": str(tmp_path / "catalog.json"),
+                    "REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH": str(tmp_path / "evidence.json"),
+                    "REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH": str(tmp_path / "requirements.json"),
+                    "REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH": str(tmp_path / "keys.json"),
+                    "REDDOG_MODEL_SELECTION_EVIDENCE_NOW_EPOCH": "1800000000",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_MODEL_SELECTION_RECEIPT_PATH"] == str(
+                    runtime_root / "model_selection_receipt.json"
+                )
+
+    model_supply.assert_called_once()
+    model_kwargs = model_supply.call_args.kwargs
+    assert model_kwargs["output_path"] == str(runtime_root / "model_selection_receipt.json")
+    assert model_kwargs["now_epoch"] == 1_800_000_000
+    promote.assert_called_once()
+    promote_kwargs = promote.call_args.kwargs
+    assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
+
+
 def test_main_preflight_disabled_without_requested_or_complete_inputs() -> None:
     import main
 


### PR DESCRIPTION
## WSP_97 Truth Boundary

Slice: `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1`

### OBSERVED
- Adds an explicit `main.py` preflight gate: `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=1`.
- The preflight reads outside-repo catalog snapshot, signed production-evidence bundle, selection requirements, and trusted public-key JSON inputs.
- It uses the existing model-selection artifact supplier and the configured public signature verifier backend, defaulting to Ed25519.
- On success, it materializes `REDDOG_MODEL_SELECTION_RECEIPT_PATH` before architect-FIX promotion, so promotion consumes the runtime receipt path instead of a manual artifact.
- Default startup is unchanged when the flag is not set.
- No model/provider calls, benchmark execution, command execution, telemetry persistence, runtime model default binding, extension mutation, worker dispatch, PatternMemory write, source mutation, or HoloIndex re-index.

### Validation
- `python -m py_compile` on new bootstrap, test, and `main.py` -> pass
- `pytest modules\\ai_intelligence\\ai_gateway\\tests modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_architect_fix_promotion_bootstrap.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_architect_fix_signed_wsp15_work_order_promotion.py -q` -> 94 passed
- `git diff --check` -> clean
- New bootstrap runtime/test files ASCII/NUL clean

### SPECIFIED_NOT_IMPLEMENTED
- Automatic production evidence generation.
- Authority profile source supply main preflight.
- Signer runtime invocation and worker dispatch.
- Runtime model default persistence.