### PR TITLE
feat(reddog): bootstrap authority profile source supply

### DIFF
--- a/main.py
+++ b/main.py
@@ -1495,6 +1495,10 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
+        REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY=0    Materialize authority source from seed/principal/snapshot
+        REDDOG_AUTHORITY_PROFILE_SEED_PATH                   Outside-repo authority seed input JSON
+        REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH               Outside-repo principal authority record JSON
+        REDDOG_PERMISSION_SNAPSHOT_PATH                      Outside-repo permission snapshot JSON
         REDDOG_RESIDENT_ARCHITECT_INTENT_ID                  Intent ID for the determined resident cycle
     """
 
@@ -1613,6 +1617,50 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             os.environ["REDDOG_MODEL_SELECTION_RECEIPT_PATH"] = model_selection_receipt_path
         elif model_supply_enforced:
             print("[REDDOG-MODEL-SELECTION] Startup blocked by REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_ENFORCED=1")
+            return False
+
+    authority_supply_requested = os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY", "0") == "1"
+    authority_supply_enforced = os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
+    if authority_supply_requested:
+        try:
+            from modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply_bootstrap import (
+                run_reddog_authority_profile_source_artifact_supply_bootstrap,
+            )
+
+            raw_now = os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_NOW_EPOCH", "").strip()
+            authority_supply = run_reddog_authority_profile_source_artifact_supply_bootstrap(
+                repo_root=repo_root,
+                authority_seed_path=os.getenv("REDDOG_AUTHORITY_PROFILE_SEED_PATH", "") or None,
+                principal_authority_record_path=os.getenv("REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH", "") or None,
+                permission_snapshot_path=os.getenv("REDDOG_PERMISSION_SNAPSHOT_PATH", "") or None,
+                output_path=authority_profile_source_path,
+                now_epoch=(int(raw_now) if raw_now else None),
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-AUTHORITY-SOURCE] Startup artifact supply failed: {exc}")
+            if authority_supply_enforced:
+                print(f"[REDDOG-AUTHORITY-SOURCE] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-AUTHORITY-SOURCE] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        authority_status = "PASS" if authority_supply.accepted else "WARN"
+        authority_reasons = (
+            ",".join(authority_supply.rejection_reasons) if authority_supply.rejection_reasons else "(none)"
+        )
+        print(
+            f"[REDDOG-AUTHORITY-SOURCE] preflight={authority_status} status={authority_supply.status} "
+            f"receipt={authority_supply.authority_profile_source_receipt_id or '(none)'} "
+            f"reasons={authority_reasons}"
+        )
+        if authority_supply.accepted and authority_supply.output_path:
+            authority_profile_source_path = authority_supply.output_path
+            os.environ["REDDOG_AUTHORITY_PROFILE_SOURCE_PATH"] = authority_profile_source_path
+        elif authority_supply_enforced:
+            print(
+                "[REDDOG-AUTHORITY-SOURCE] Startup blocked by "
+                "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_ENFORCED=1"
+            )
             return False
 
     required_inputs_present = all(

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Wired `main.py` to optionally materialize the authority-profile source
+  artifact before architect-FIX promotion when
+  `REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY=1` is set.
+- The preflight consumes outside-repo authority seed, token-verified principal,
+  and permission snapshot JSON files, then feeds the resulting
+  authority-profile source path into the existing promotion bridge.
+- Boundary remains constrained: no signing, signature verification, signer
+  state mutation, work-state mutation, worker spawn, shell, worktree,
+  OpenClaw enqueue, Hermes dispatch, PR creation, PatternMemory write, source
+  mutation, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_authority_profile_source_artifact_supply_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_profile_source_artifact_supply_bootstrap.py
@@ -1,0 +1,166 @@
+"""Main-startup bootstrap for RedDog authority-profile source supply.
+
+Slice: REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads outside-repo authority seed, token-verified principal, and
+permission snapshot JSON inputs, then materializes the authority-profile source
+artifact consumed by the architect FIX promotion bridge.
+
+It does not sign, verify signatures, mutate signer state, mutate work state,
+spawn workers, create worktrees, execute shell commands, enqueue OpenClaw,
+dispatch Hermes, create PRs, settle rewards, write PatternMemory, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply import (
+    AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT,
+    run_reddog_authority_profile_source_artifact_supply,
+)
+
+
+AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED = "AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED"
+AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_NOT_READY = "AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class AuthorityProfileSourceBootstrapResult:
+    accepted: bool
+    status: str
+    authority_profile_source_receipt_id: Optional[str]
+    output_path: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_signing_performed: bool = True
+    no_signature_verification_performed: bool = True
+    no_signer_state_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_worktree_created: bool = True
+    no_shell_command_executed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_work_state_mutation_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_authority_profile_source_artifact_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    authority_seed_path: Path | str | None,
+    principal_authority_record_path: Path | str | None,
+    permission_snapshot_path: Path | str | None,
+    output_path: Path | str | None,
+    now_epoch: int | None = None,
+    leeway_s: int = 60,
+) -> AuthorityProfileSourceBootstrapResult:
+    """Materialize the authority-profile source artifact from runtime files."""
+
+    root = Path(repo_root).resolve()
+    seed, seed_reasons = _read_json_outside_repo(
+        root,
+        authority_seed_path,
+        missing_reason="missing_authority_profile_seed_path",
+        inside_reason="authority_profile_seed_path_inside_repo",
+        malformed_reason="malformed_authority_profile_seed",
+    )
+    principal, principal_reasons = _read_json_outside_repo(
+        root,
+        principal_authority_record_path,
+        missing_reason="missing_principal_authority_record_path",
+        inside_reason="principal_authority_record_path_inside_repo",
+        malformed_reason="malformed_principal_authority_record",
+    )
+    snapshot, snapshot_reasons = _read_json_outside_repo(
+        root,
+        permission_snapshot_path,
+        missing_reason="missing_permission_snapshot_path",
+        inside_reason="permission_snapshot_path_inside_repo",
+        malformed_reason="malformed_permission_snapshot",
+    )
+    reasons = [*seed_reasons, *principal_reasons, *snapshot_reasons]
+    if reasons:
+        return _not_ready(reasons)
+
+    assert seed is not None
+    assert principal is not None
+    assert snapshot is not None
+    supply = run_reddog_authority_profile_source_artifact_supply(
+        repo_root=root,
+        authority_seed=seed,
+        principal_authority_record=principal,
+        permission_snapshot=snapshot,
+        output_path=output_path,
+        now_epoch=int(now_epoch if now_epoch is not None else time.time()),
+        leeway_s=leeway_s,
+    )
+    if not supply.accepted or supply.status != AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT:
+        return _not_ready(supply.rejection_reasons or ("authority_profile_source_supply_rejected",))
+    return AuthorityProfileSourceBootstrapResult(
+        accepted=True,
+        status=AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED,
+        authority_profile_source_receipt_id=supply.authority_profile_source_receipt_id,
+        output_path=supply.output_path,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Mapping[str, Any] | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(reasons: tuple[str, ...] | list[str]) -> AuthorityProfileSourceBootstrapResult:
+    return AuthorityProfileSourceBootstrapResult(
+        accepted=False,
+        status=AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_NOT_READY,
+        authority_profile_source_receipt_id=None,
+        output_path=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED",
+    "AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_NOT_READY",
+    "AuthorityProfileSourceBootstrapResult",
+    "run_reddog_authority_profile_source_artifact_supply_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_source_artifact_supply_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_source_artifact_supply_bootstrap.py
@@ -1,0 +1,133 @@
+"""Tests for REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply_bootstrap import (
+    AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED,
+    AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_NOT_READY,
+    run_reddog_authority_profile_source_artifact_supply_bootstrap,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_authority_profile_source_artifact_supply import (
+    NOW,
+    _principal,
+    _seed,
+    _snapshot,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_authority_profile_source_artifact_supply_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    snapshot = _snapshot()
+    return {
+        "seed": _write_json(runtime, "authority_seed.json", _seed()),
+        "principal": _write_json(runtime, "principal.json", _principal().to_dict()),
+        "snapshot": _write_json(runtime, "permission_snapshot.json", asdict(snapshot)),
+        "output": runtime / "authority_profile_source.json",
+    }
+
+
+def test_bootstrap_materializes_authority_profile_source(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_authority_profile_source_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        authority_seed_path=files["seed"],
+        principal_authority_record_path=files["principal"],
+        permission_snapshot_path=files["snapshot"],
+        output_path=files["output"],
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED
+    assert result.authority_profile_source_receipt_id and result.authority_profile_source_receipt_id.startswith(
+        "sha256:"
+    )
+    profile = json.loads(files["output"].read_text(encoding="utf-8"))
+    assert profile["principal_id"] == "github:mjtrout"
+    assert profile["principal_public_key"] == "pub:principal"
+    assert profile["no_signing_performed"] is True
+    assert profile["no_holoindex_reindex_performed"] is True
+
+
+def test_bootstrap_rejects_missing_principal_record(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_authority_profile_source_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        authority_seed_path=files["seed"],
+        principal_authority_record_path=None,
+        permission_snapshot_path=files["snapshot"],
+        output_path=files["output"],
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_NOT_READY
+    assert "missing_principal_authority_record_path" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_bootstrap_rejects_output_inside_repo(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_authority_profile_source_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        authority_seed_path=files["seed"],
+        principal_authority_record_path=files["principal"],
+        permission_snapshot_path=files["snapshot"],
+        output_path=REPO_ROOT / "authority_profile_source.json",
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert "authority_profile_source_output_path_invalid" in result.rejection_reasons
+    assert not (REPO_ROOT / "authority_profile_source.json").exists()
+
+
+def test_bootstrap_module_has_no_execution_network_signing_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "git",
+        "holo_index",
+        "hmac",
+        "secrets",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -297,6 +297,81 @@ def test_main_preflight_model_selection_supply_runs_before_promotion(tmp_path: P
     assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
 
 
+def test_main_preflight_authority_source_supply_runs_before_promotion(tmp_path: Path) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    model_selection = _write_json(tmp_path, "model_selection_receipt.json", _model_selection())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_supply_result = type(
+        "AuthoritySupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED",
+            "authority_profile_source_receipt_id": "sha256:authority-source",
+            "output_path": str(runtime_root / "authority_profile_source.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply_bootstrap.run_reddog_authority_profile_source_artifact_supply_bootstrap",
+        return_value=authority_supply_result,
+    ) as authority_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(model_selection),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_AUTHORITY_PROFILE_SEED_PATH": str(tmp_path / "seed.json"),
+                    "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": str(tmp_path / "principal.json"),
+                    "REDDOG_PERMISSION_SNAPSHOT_PATH": str(tmp_path / "permission.json"),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_NOW_EPOCH": "1800000000",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_AUTHORITY_PROFILE_SOURCE_PATH"] == str(
+                    runtime_root / "authority_profile_source.json"
+                )
+
+    authority_supply.assert_called_once()
+    authority_kwargs = authority_supply.call_args.kwargs
+    assert authority_kwargs["output_path"] == str(runtime_root / "authority_profile_source.json")
+    assert authority_kwargs["now_epoch"] == 1_800_000_000
+    promote.assert_called_once()
+    promote_kwargs = promote.call_args.kwargs
+    assert promote_kwargs["authority_profile_source_path"] == str(runtime_root / "authority_profile_source.json")
+
+
 def test_main_preflight_disabled_without_requested_or_complete_inputs() -> None:
     import main
 


### PR DESCRIPTION
## WSP_97 Summary

Slice: `REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1`

This wires `main.py` to optionally materialize the authority-profile source artifact before architect-FIX promotion when `REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY=1` is set.

## What changed

- Added `reddog_authority_profile_source_artifact_supply_bootstrap.py`.
- `main.py` now reads outside-repo authority seed, token-verified principal, and permission snapshot inputs, then feeds the resulting `REDDOG_AUTHORITY_PROFILE_SOURCE_PATH` into the existing promotion bridge.
- Added focused bootstrap tests plus a main preflight ordering regression.
- Updated `moltbot_bridge/ModLog.md`.

## Validation

- `python -m py_compile main.py modules\communication\moltbot_bridge\src\reddog_authority_profile_source_artifact_supply_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_authority_profile_source_artifact_supply_bootstrap.py` -> PASS
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_authority_profile_source_artifact_supply_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_authority_profile_source_artifact_supply.py modules\communication\moltbot_bridge\tests\test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 21 passed
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_architect_fix_signed_wsp15_work_order_promotion.py modules\communication\moltbot_bridge\tests\test_reddog_wre_queue_authority_request_dryrun.py -q` -> 23 passed
- `git diff --check` -> PASS (CRLF warnings only)
- New files ASCII/NUL check -> non_ascii=0, nul=0

Note: full `modules\communication\moltbot_bridge\tests` run is not used as the gate here; it cascaded inside pytest capture/tempfile teardown with `ValueError: I/O operation on closed file`, outside the touched slice. Focused promotion/supplier tests are green.

## Truth Boundary

No signing, signature verification, signer state mutation, work-state mutation, worker spawn, shell command, worktree creation, OpenClaw enqueue, Hermes dispatch, PR creation, PatternMemory write, source mutation, or HoloIndex re-indexing was added.