### PR TITLE
feat(reddog): enable artifact supply from resident profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1504,6 +1504,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
 
     try:
         from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_flag_enabled,
             resident_queue_runtime_file_path,
         )
     except Exception as exc:
@@ -1536,7 +1537,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         repo_root,
         "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
     )
-    handoff_requested = os.getenv("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF", "0") == "1"
+    handoff_requested = resident_queue_runtime_flag_enabled(os.environ, "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF")
     handoff_enforced = os.getenv("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF_ENFORCED", "0") != "0"
     if handoff_requested:
         try:
@@ -1576,7 +1577,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print("[REDDOG-FIX-HANDOFF] Startup blocked by REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF_ENFORCED=1")
             return False
 
-    model_supply_requested = os.getenv("REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY", "0") == "1"
+    model_supply_requested = resident_queue_runtime_flag_enabled(os.environ, "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY")
     model_supply_enforced = os.getenv("REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
     if model_supply_requested:
         try:
@@ -1619,7 +1620,10 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print("[REDDOG-MODEL-SELECTION] Startup blocked by REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_ENFORCED=1")
             return False
 
-    authority_supply_requested = os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY", "0") == "1"
+    authority_supply_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY",
+    )
     authority_supply_enforced = os.getenv("REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
     if authority_supply_requested:
         try:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_PROFILE_ARTIFACT_SUPPLY_DEFAULTS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Extended the resident queue binding profile so the
+  `signed_0102_bounded_code` profile enables the safe artifact-supply
+  preflights for resident fix-promotion handoff, model-selection receipt
+  supply, and authority-profile source supply.
+- Updated `main.py` to use the profile helper for those preflight toggles,
+  preserving explicit environment overrides (`0` still disables a profile
+  default).
+- Boundary remains constrained: the profile only materializes outside-repo
+  receipts already required by the promotion bridge; it does not sign, spawn
+  workers, create worktrees, execute shell commands, enqueue OpenClaw, dispatch
+  Hermes, publish PRs, mutate source files, write PatternMemory, settle
+  rewards, or re-index HoloIndex.
+
 ## 2026-07-16: REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -72,6 +72,9 @@ PROFILE_BINDING_FLAGS = frozenset(
 
 PROFILE_RUNTIME_FLAGS = frozenset(
     {
+        "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF",
+        "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY",
+        "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY",
         "OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED",
         "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP",
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER",
@@ -117,9 +120,10 @@ def resident_queue_runtime_flag_enabled(env: Mapping[str, str], env_name: str) -
     """Return whether a safe resident runtime control-plane flag is enabled.
 
     Explicit environment values win. The profile only enables known
-    control-plane flags that start existing gated loops; this helper never
-    selects effect modes such as model generation, worktree, draft PR,
-    PatternMemory, HoloIndex, merge, or reward settlement.
+    control-plane flags that start existing gated loops or materialize
+    outside-repo receipts needed by those loops; this helper never selects
+    effect modes such as model generation, worktree, draft PR, PatternMemory,
+    HoloIndex, merge, or reward settlement.
     """
 
     raw = str(env.get(env_name) or "").strip()

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -372,6 +372,146 @@ def test_main_preflight_authority_source_supply_runs_before_promotion(tmp_path: 
     assert promote_kwargs["authority_profile_source_path"] == str(runtime_root / "authority_profile_source.json")
 
 
+def test_main_preflight_profile_runs_artifact_supply_chain_before_promotion(tmp_path: Path) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = runtime_root / "authoritative_work_state.json"
+    handoff_result = type(
+        "HandoffResult",
+        (),
+        {
+            "accepted": True,
+            "status": "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF_APPLIED",
+            "architect_determination_id": "architect_determination:profile",
+            "architect_determination_path": str(runtime_root / "architect_determination.json"),
+            "memex_supply_receipt_path": str(runtime_root / "memex_supply_receipt.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    model_supply_result = type(
+        "ModelSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_SELECTION_BOOTSTRAP_APPLIED",
+            "model_selection_receipt_id": "model_selection_receipt:profile",
+            "output_path": str(runtime_root / "model_selection_receipt.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    authority_supply_result = type(
+        "AuthoritySupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "AUTHORITY_PROFILE_SOURCE_BOOTSTRAP_APPLIED",
+            "authority_profile_source_receipt_id": "sha256:authority-source-profile",
+            "output_path": str(runtime_root / "authority_profile_source.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_artifact_handoff.run_reddog_resident_fix_promotion_artifact_handoff",
+        return_value=handoff_result,
+    ) as handoff:
+        with patch(
+            "modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap.run_reddog_model_selection_artifact_supply_bootstrap",
+            return_value=model_supply_result,
+        ) as model_supply:
+            with patch(
+                "modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply_bootstrap.run_reddog_authority_profile_source_artifact_supply_bootstrap",
+                return_value=authority_supply_result,
+            ) as authority_supply:
+                with patch(
+                    "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+                    return_value=promotion_result,
+                ) as promote:
+                    with patch.dict(
+                        "os.environ",
+                        {
+                            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                            "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "intent-profile",
+                            "REDDOG_MODEL_CATALOG_SNAPSHOT_PATH": str(tmp_path / "catalog.json"),
+                            "REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH": str(tmp_path / "evidence.json"),
+                            "REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH": str(tmp_path / "requirements.json"),
+                            "REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH": str(tmp_path / "keys.json"),
+                            "REDDOG_AUTHORITY_PROFILE_SEED_PATH": str(tmp_path / "seed.json"),
+                            "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": str(tmp_path / "principal.json"),
+                            "REDDOG_PERMISSION_SNAPSHOT_PATH": str(tmp_path / "permission.json"),
+                        },
+                        clear=True,
+                    ):
+                        assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+
+    handoff.assert_called_once()
+    handoff_kwargs = handoff.call_args.kwargs
+    assert handoff_kwargs["architect_determination_output_path"] == str(
+        runtime_root / "architect_determination.json"
+    )
+    assert handoff_kwargs["memex_supply_receipt_output_path"] == str(
+        runtime_root / "memex_supply_receipt.json"
+    )
+    model_supply.assert_called_once()
+    assert model_supply.call_args.kwargs["output_path"] == str(runtime_root / "model_selection_receipt.json")
+    authority_supply.assert_called_once()
+    assert authority_supply.call_args.kwargs["output_path"] == str(runtime_root / "authority_profile_source.json")
+    promote.assert_called_once()
+    promote_kwargs = promote.call_args.kwargs
+    assert promote_kwargs["architect_determination_path"] == str(runtime_root / "architect_determination.json")
+    assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
+    assert promote_kwargs["memex_supply_receipt_path"] == str(runtime_root / "memex_supply_receipt.json")
+    assert promote_kwargs["authority_profile_source_path"] == str(runtime_root / "authority_profile_source.json")
+
+
+def test_main_preflight_explicit_zero_overrides_profile_artifact_supply(tmp_path: Path) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_artifact_handoff.run_reddog_resident_fix_promotion_artifact_handoff",
+        side_effect=AssertionError("handoff supply must not run"),
+    ):
+        with patch(
+            "modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap.run_reddog_model_selection_artifact_supply_bootstrap",
+            side_effect=AssertionError("model supply must not run"),
+        ):
+            with patch(
+                "modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply_bootstrap.run_reddog_authority_profile_source_artifact_supply_bootstrap",
+                side_effect=AssertionError("authority supply must not run"),
+            ):
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                        "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                        "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                        "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    },
+                    clear=True,
+                ):
+                    assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+
+
 def test_main_preflight_disabled_without_requested_or_complete_inputs() -> None:
     import main
 


### PR DESCRIPTION
## WSP_97 Summary

Slice: `REDDOG_RESIDENT_PROFILE_ARTIFACT_SUPPLY_DEFAULTS_PHASE1`

This makes the `signed_0102_bounded_code` resident profile enable the safe artifact-supply preflights that are now required before architect-FIX promotion. The goal is to reduce operator mode-setting and make RedDog startup deterministic from its resident profile.

## What changed

- Added profile defaults for:
  - `REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF`
  - `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY`
  - `REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY`
- Updated `main.py` to use `resident_queue_runtime_flag_enabled()` for those toggles.
- Preserved explicit override semantics: setting any of those env vars to `0` disables the profile default.
- Added main-preflight regression coverage for the full profile-driven artifact chain and the explicit-zero override.
- Updated `moltbot_bridge/ModLog.md`.

## Validation

- `python -m py_compile main.py modules\communication\moltbot_bridge\src\reddog_resident_queue_binding_profile.py modules\communication\moltbot_bridge\tests\test_reddog_main_architect_fix_promotion_bootstrap.py` -> PASS
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_main_architect_fix_promotion_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_main_resident_queue_serial_loop_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 75 passed
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_authority_profile_source_artifact_supply_bootstrap.py modules\communication\moltbot_bridge\tests\test_reddog_authority_profile_source_artifact_supply.py modules\ai_intelligence\ai_gateway\tests\test_model_selection_artifact_supply_bootstrap.py modules\ai_intelligence\ai_gateway\tests\test_model_selection_artifact_supply.py -q` -> 23 passed
- `pytest modules\communication\moltbot_bridge\tests\test_reddog_signed_worker_queue_serial_loop_runner.py modules\communication\moltbot_bridge\tests\test_reddog_main_resident_queue_orchestration_plan_bootstrap.py -q` -> 48 passed
- `git diff --check` -> PASS (CRLF warnings only)
- NUL check on modified source/test files -> 0 NUL bytes

## Truth Boundary

This does not sign, verify signatures, spawn workers, create worktrees, execute shell commands, enqueue OpenClaw, dispatch Hermes, publish PRs, mutate source files, write PatternMemory, settle rewards, or re-index HoloIndex. It only profile-enables already-built outside-repo receipt materialization preflights.