### PR TITLE
feat(reddog): supply authoritative work-state source records

### DIFF
--- a/main.py
+++ b/main.py
@@ -1343,6 +1343,8 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
     Env:
         REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH=1          Enable check (default ON)
         REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH_ENFORCED=0 Block startup if not ready
+        REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY=0           Materialize PR/W10 source records
+        REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY_ENFORCED=0  Block startup if supply fails
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Output/read path for snapshot JSON
         REDDOG_ACTIVE_SLICE_LEDGER_PATH                    Optional active ledger source
         REDDOG_WORK_LEDGER_JSON_PATH                       Optional work ledger source
@@ -1367,15 +1369,65 @@ def run_reddog_authoritative_work_state_refresh_preflight(repo_root: Path) -> bo
             run_reddog_main_authoritative_work_state_refresh_bootstrap,
         )
         from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_flag_enabled,
             resident_queue_runtime_file_path,
         )
+
+        github_pr_records_path = resident_queue_runtime_file_path(
+            os.environ,
+            repo_root,
+            "REDDOG_GITHUB_PR_RECORDS_PATH",
+        )
+        w10_report_records_path = resident_queue_runtime_file_path(
+            os.environ,
+            repo_root,
+            "REDDOG_W10_REPORT_RECORDS_PATH",
+        )
+        source_supply_requested = resident_queue_runtime_flag_enabled(
+            os.environ,
+            "REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY",
+        )
+        source_supply_enforced = os.getenv("REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY_ENFORCED", "0") != "0"
+        if source_supply_requested:
+            from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_source_record_supply_bootstrap import (
+                run_reddog_authoritative_work_state_source_record_supply_bootstrap,
+            )
+
+            supply = run_reddog_authoritative_work_state_source_record_supply_bootstrap(
+                repo_root=repo_root,
+                github_pr_records_output_path=github_pr_records_path,
+                w10_report_records_output_path=w10_report_records_path,
+                work_ledger_json_path=os.getenv("REDDOG_WORK_LEDGER_JSON_PATH", "") or None,
+                github_repo_full_name=os.getenv("REDDOG_GITHUB_REPO_FULL_NAME", "FOUNDUPS/Foundups-Agent"),
+                github_state=os.getenv("REDDOG_GITHUB_PR_SOURCE_STATE", "open"),
+            )
+            supply_status = "PASS" if supply.accepted else "WARN"
+            supply_reasons = ",".join(supply.rejection_reasons) if supply.rejection_reasons else "(none)"
+            print(
+                f"[REDDOG-WORK-STATE-SOURCES] preflight={supply_status} status={supply.status} "
+                f"github_records={supply.github_record_count} w10_records={supply.w10_record_count} "
+                f"reasons={supply_reasons}"
+            )
+            if supply.accepted:
+                if supply.github_pr_records_path:
+                    github_pr_records_path = supply.github_pr_records_path
+                    os.environ["REDDOG_GITHUB_PR_RECORDS_PATH"] = github_pr_records_path
+                if supply.w10_report_records_path:
+                    w10_report_records_path = supply.w10_report_records_path
+                    os.environ["REDDOG_W10_REPORT_RECORDS_PATH"] = w10_report_records_path
+            elif source_supply_enforced:
+                print(
+                    "[REDDOG-WORK-STATE-SOURCES] Startup blocked by "
+                    "REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY_ENFORCED=1"
+                )
+                return False
 
         result = run_reddog_main_authoritative_work_state_refresh_bootstrap(
             repo_root=repo_root,
             active_slice_ledger_path=os.getenv("REDDOG_ACTIVE_SLICE_LEDGER_PATH", ""),
             work_ledger_json_path=os.getenv("REDDOG_WORK_LEDGER_JSON_PATH", ""),
-            github_pr_records_path=os.getenv("REDDOG_GITHUB_PR_RECORDS_PATH", ""),
-            w10_report_records_path=os.getenv("REDDOG_W10_REPORT_RECORDS_PATH", ""),
+            github_pr_records_path=github_pr_records_path,
+            w10_report_records_path=w10_report_records_path,
             work_state_output_path=resident_queue_runtime_file_path(
                 os.environ,
                 repo_root,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_AUTHORITATIVE_WORK_STATE_SOURCE_RECORD_SUPPLY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a bounded source-record supplier that materializes GitHub PR records
+  and W10 report records outside the repository for the existing
+  authoritative work-state refresh runtime.
+- Wired the `signed_0102_bounded_code` resident profile to derive source
+  record paths and optionally run the supplier before work-state refresh,
+  preserving explicit environment overrides (`0` still disables profile
+  default source supply).
+- Boundary remains constrained: no work-state commit, worker spawn, shell
+  execution, OpenClaw enqueue, Hermes dispatch, source mutation, merge, reward
+  settlement, PatternMemory write, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_RESIDENT_PROFILE_ARTIFACT_SUPPLY_DEFAULTS_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_authoritative_work_state_source_record_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authoritative_work_state_source_record_supply.py
@@ -1,0 +1,383 @@
+"""RedDog authoritative work-state source-record supplier.
+
+Slice: REDDOG_AUTHORITATIVE_WORK_STATE_SOURCE_RECORD_SUPPLY_PHASE1
+
+This module materializes the GitHub PR and W10 report source-record JSON files
+that the authoritative work-state refresh runtime already consumes. It is a
+read-only source collector: it does not refresh work state, claim workers,
+enqueue OpenClaw, dispatch Hermes, mutate HoloIndex, execute shell commands, or
+write repository files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import tempfile
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Protocol, Sequence, Tuple
+
+
+SOURCE_RECORD_SUPPLY_APPLIED = "SOURCE_RECORD_SUPPLY_APPLIED"
+SOURCE_RECORD_SUPPLY_NOT_READY = "SOURCE_RECORD_SUPPLY_NOT_READY"
+
+_SLICE_ID_RE = r"[A-Z][A-Z0-9]+(?:_[A-Z0-9]+){2,}_PHASE[0-9]+"
+
+
+class GitHubPullRequestSourceProvider(Protocol):
+    """Read-only provider for GitHub pull request records."""
+
+    def collect_pull_request_records(self, *, now_iso: str) -> Sequence[Mapping[str, Any]]:
+        """Return refresh-runtime-compatible GitHub PR records."""
+
+
+class W10ReportSourceProvider(Protocol):
+    """Read-only provider for W10 report records."""
+
+    def collect_w10_report_records(self, *, now_iso: str) -> Sequence[Mapping[str, Any]]:
+        """Return refresh-runtime-compatible W10 report records."""
+
+
+@dataclass(frozen=True)
+class SourceRecordSupplyReceipt:
+    """Receipt for a materialized source-record supply operation."""
+
+    receipt_id: str
+    generated_at: str
+    github_pr_records_path: str
+    w10_report_records_path: str
+    github_record_count: int
+    w10_record_count: int
+    github_source_mode: str
+    w10_source_mode: str
+    rejection_reasons: Tuple[str, ...]
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SourceRecordSupplyResult:
+    """Result returned by source-record materialization."""
+
+    accepted: bool
+    status: str
+    receipt: SourceRecordSupplyReceipt
+    github_pr_records_path: str | None = None
+    w10_report_records_path: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "receipt": self.receipt.to_dict(),
+            "github_pr_records_path": self.github_pr_records_path,
+            "w10_report_records_path": self.w10_report_records_path,
+        }
+
+
+class GitHubRestPullRequestSourceProvider:
+    """Read-only GitHub REST source provider for open PR records."""
+
+    def __init__(
+        self,
+        *,
+        repo_full_name: str,
+        token: str | None = None,
+        state: str = "open",
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        if "/" not in repo_full_name:
+            raise ValueError("repo_full_name must be owner/repo")
+        self.repo_full_name = repo_full_name.strip()
+        self.token = token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN") or ""
+        self.state = state.strip().lower() or "open"
+        self.timeout_seconds = timeout_seconds
+
+    def collect_pull_request_records(self, *, now_iso: str) -> Sequence[Mapping[str, Any]]:
+        url = (
+            f"https://api.github.com/repos/{self.repo_full_name}/pulls"
+            f"?state={self.state}&per_page=100"
+        )
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "Foundups-Agent-RedDog-WorkState-Source-Supply",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"github_pr_source_failed:{exc.__class__.__name__}") from exc
+        if not isinstance(payload, list):
+            raise RuntimeError("github_pr_source_failed:response_not_list")
+        return tuple(_github_pr_to_record(item, now_iso=now_iso) for item in payload if isinstance(item, Mapping))
+
+
+class WorkLedgerProjectionW10ReportProvider:
+    """Project work-ledger slices into conservative W10 report records.
+
+    This is a bridge until a real W10 report service is attached. The evidence
+    reference is intentionally labeled as a ledger projection so consumers do
+    not confuse it with independent W10 review.
+    """
+
+    def __init__(self, *, work_ledger_json_path: Path | str) -> None:
+        self.work_ledger_json_path = Path(work_ledger_json_path)
+
+    def collect_w10_report_records(self, *, now_iso: str) -> Sequence[Mapping[str, Any]]:
+        try:
+            payload = json.loads(self.work_ledger_json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"w10_projection_source_failed:{exc.__class__.__name__}") from exc
+        if not isinstance(payload, Mapping):
+            raise RuntimeError("w10_projection_source_failed:root_not_object")
+        records: list[dict[str, Any]] = []
+        for item in payload.get("slices") or []:
+            if not isinstance(item, Mapping):
+                continue
+            slice_id = _normalize_slice_id(item.get("slice_id"))
+            if not slice_id:
+                continue
+            score = item.get("wsp15_score")
+            evidence_refs = [str(ref) for ref in (item.get("evidence_docs") or []) if ref]
+            records.append(
+                {
+                    "slice_id": slice_id,
+                    "status": str(item.get("status") or "PROPOSED").strip().upper(),
+                    "priority": item.get("priority"),
+                    "lane": item.get("lane"),
+                    "branch": item.get("branch"),
+                    "pr_number": item.get("pr_number"),
+                    "head_commit": item.get("head_commit") or item.get("merge_commit") or item.get("base_commit"),
+                    "evidence_refs": (
+                        *evidence_refs,
+                        f"w10:ledger_projection:{_digest({'slice_id': slice_id, 'now': now_iso})}",
+                    ),
+                    "wsp15_score": score if isinstance(score, Mapping) else {},
+                }
+            )
+        return tuple(records)
+
+
+def supply_authoritative_work_state_source_records(
+    *,
+    repo_root: Path | str,
+    github_pr_records_output_path: Path | str,
+    w10_report_records_output_path: Path | str,
+    github_provider: GitHubPullRequestSourceProvider,
+    w10_provider: W10ReportSourceProvider,
+    now_iso: str | None = None,
+) -> SourceRecordSupplyResult:
+    """Materialize fresh GitHub/W10 source-record files outside the repo."""
+
+    root = Path(repo_root).resolve()
+    now = now_iso or datetime.now(timezone.utc).isoformat()
+    github_path = Path(github_pr_records_output_path).resolve()
+    w10_path = Path(w10_report_records_output_path).resolve()
+    reasons: list[str] = []
+
+    if _is_inside(github_path, root):
+        reasons.append("github_pr_records_output_inside_repo")
+    if _is_inside(w10_path, root):
+        reasons.append("w10_report_records_output_inside_repo")
+    if github_path == w10_path:
+        reasons.append("source_record_outputs_must_be_distinct")
+
+    github_records: tuple[Mapping[str, Any], ...] = ()
+    w10_records: tuple[Mapping[str, Any], ...] = ()
+    if not reasons:
+        try:
+            github_records = tuple(_valid_record(item) for item in github_provider.collect_pull_request_records(now_iso=now))
+        except Exception as exc:  # noqa: BLE001 - provider errors fail closed.
+            reasons.append(str(exc) or exc.__class__.__name__)
+        try:
+            w10_records = tuple(_valid_record(item) for item in w10_provider.collect_w10_report_records(now_iso=now))
+        except Exception as exc:  # noqa: BLE001 - provider errors fail closed.
+            reasons.append(str(exc) or exc.__class__.__name__)
+
+    github_records = tuple(item for item in github_records if item)
+    w10_records = tuple(item for item in w10_records if item)
+    if not github_records:
+        reasons.append("no_github_pr_records")
+    if not w10_records:
+        reasons.append("no_w10_report_records")
+
+    if reasons:
+        return _result(
+            accepted=False,
+            status=SOURCE_RECORD_SUPPLY_NOT_READY,
+            now_iso=now,
+            github_path=github_path,
+            w10_path=w10_path,
+            github_count=len(github_records),
+            w10_count=len(w10_records),
+            reasons=tuple(dict.fromkeys(reasons)),
+        )
+
+    _atomic_write_json(github_path, list(github_records))
+    _atomic_write_json(w10_path, list(w10_records))
+    return _result(
+        accepted=True,
+        status=SOURCE_RECORD_SUPPLY_APPLIED,
+        now_iso=now,
+        github_path=github_path,
+        w10_path=w10_path,
+        github_count=len(github_records),
+        w10_count=len(w10_records),
+        reasons=(),
+    )
+
+
+def _github_pr_to_record(item: Mapping[str, Any], *, now_iso: str) -> Mapping[str, Any]:
+    slice_id = _extract_slice_id(
+        " ".join(
+            str(value or "")
+            for value in (
+                item.get("title"),
+                _nested(item, "head", "ref"),
+                item.get("body"),
+            )
+        )
+    )
+    if not slice_id:
+        return {}
+    labels = item.get("labels") if isinstance(item.get("labels"), list) else []
+    return {
+        "slice_id": slice_id,
+        "status": "PR_OPEN" if str(item.get("state") or "").lower() == "open" else "CLOSED",
+        "priority": _label_value(labels, prefix="P") or None,
+        "lane": _label_value(labels, prefix="lane:") or None,
+        "pr_number": item.get("number") if isinstance(item.get("number"), int) else None,
+        "branch": _nested(item, "head", "ref"),
+        "head_commit": _nested(item, "head", "sha"),
+        "evidence_refs": [f"github:pr:{item.get('number')}", f"github:observed:{now_iso}"],
+        "wsp15_score": {},
+    }
+
+
+def _valid_record(item: Mapping[str, Any]) -> Mapping[str, Any]:
+    if not isinstance(item, Mapping):
+        return {}
+    slice_id = _normalize_slice_id(item.get("slice_id"))
+    if not slice_id:
+        return {}
+    record = dict(item)
+    record["slice_id"] = slice_id
+    record["status"] = str(item.get("status") or item.get("state") or "PROPOSED").strip().upper()
+    return record
+
+
+def _extract_slice_id(text: str) -> str:
+    match = re.search(_SLICE_ID_RE, str(text or "").upper())
+    return match.group(0) if match else ""
+
+
+def _normalize_slice_id(value: object) -> str:
+    return _extract_slice_id(str(value or ""))
+
+
+def _label_value(labels: Sequence[Any], *, prefix: str) -> str:
+    wanted = prefix.lower()
+    for item in labels:
+        name = item.get("name") if isinstance(item, Mapping) else item
+        text = str(name or "").strip()
+        lowered = text.lower()
+        if wanted == "p" and lowered in {"p0", "p1", "p2", "p3", "p4"}:
+            return lowered.upper()
+        if lowered.startswith(wanted):
+            return text.split(":", 1)[1].strip().upper() if ":" in text else text.strip().upper()
+    return ""
+
+
+def _nested(item: Mapping[str, Any], key: str, subkey: str) -> Any:
+    value = item.get(key)
+    return value.get(subkey) if isinstance(value, Mapping) else None
+
+
+def _is_inside(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=str(path.parent), delete=False) as handle:
+        json.dump(payload, handle, sort_keys=True, indent=2)
+        handle.write("\n")
+        tmp_name = handle.name
+    Path(tmp_name).replace(path)
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+def _result(
+    *,
+    accepted: bool,
+    status: str,
+    now_iso: str,
+    github_path: Path,
+    w10_path: Path,
+    github_count: int,
+    w10_count: int,
+    reasons: Tuple[str, ...],
+) -> SourceRecordSupplyResult:
+    payload = {
+        "generated_at": now_iso,
+        "github_pr_records_path": str(github_path),
+        "w10_report_records_path": str(w10_path),
+        "github_record_count": github_count,
+        "w10_record_count": w10_count,
+        "rejection_reasons": reasons,
+    }
+    receipt = SourceRecordSupplyReceipt(
+        receipt_id=_digest(payload),
+        generated_at=now_iso,
+        github_pr_records_path=str(github_path),
+        w10_report_records_path=str(w10_path),
+        github_record_count=github_count,
+        w10_record_count=w10_count,
+        github_source_mode="github_rest_or_injected",
+        w10_source_mode="work_ledger_projection_or_injected",
+        rejection_reasons=reasons,
+    )
+    return SourceRecordSupplyResult(
+        accepted=accepted,
+        status=status,
+        receipt=receipt,
+        github_pr_records_path=str(github_path) if accepted else None,
+        w10_report_records_path=str(w10_path) if accepted else None,
+    )
+
+
+__all__ = [
+    "GitHubPullRequestSourceProvider",
+    "GitHubRestPullRequestSourceProvider",
+    "SOURCE_RECORD_SUPPLY_APPLIED",
+    "SOURCE_RECORD_SUPPLY_NOT_READY",
+    "SourceRecordSupplyReceipt",
+    "SourceRecordSupplyResult",
+    "W10ReportSourceProvider",
+    "WorkLedgerProjectionW10ReportProvider",
+    "supply_authoritative_work_state_source_records",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_authoritative_work_state_source_record_supply_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authoritative_work_state_source_record_supply_bootstrap.py
@@ -1,0 +1,146 @@
+"""Main bootstrap for RedDog work-state source-record supply."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_source_record_supply import (
+    GitHubPullRequestSourceProvider,
+    GitHubRestPullRequestSourceProvider,
+    SOURCE_RECORD_SUPPLY_NOT_READY,
+    SourceRecordSupplyResult,
+    W10ReportSourceProvider,
+    WorkLedgerProjectionW10ReportProvider,
+    supply_authoritative_work_state_source_records,
+)
+from modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap import (
+    DEFAULT_WORK_LEDGER_JSON,
+)
+
+
+@dataclass(frozen=True)
+class RedDogWorkStateSourceRecordSupplyBootstrapResult:
+    """Result returned to main.py after source-record supply."""
+
+    accepted: bool
+    status: str
+    github_pr_records_path: Optional[str]
+    w10_report_records_path: Optional[str]
+    receipt_id: Optional[str]
+    github_record_count: int
+    w10_record_count: int
+    rejection_reasons: tuple[str, ...]
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_execution_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_authoritative_work_state_source_record_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    github_pr_records_output_path: Path | str | None,
+    w10_report_records_output_path: Path | str | None,
+    work_ledger_json_path: Path | str | None = None,
+    github_repo_full_name: str = "FOUNDUPS/Foundups-Agent",
+    github_state: str = "open",
+    now_iso: str | None = None,
+    github_provider: GitHubPullRequestSourceProvider | None = None,
+    w10_provider: W10ReportSourceProvider | None = None,
+) -> RedDogWorkStateSourceRecordSupplyBootstrapResult:
+    """Materialize GitHub and W10 source-record files for work-state refresh."""
+
+    root = Path(repo_root).resolve()
+    now = now_iso or datetime.now(timezone.utc).isoformat()
+    reasons: list[str] = []
+    github_path = _resolve_required_output(github_pr_records_output_path, "missing_github_pr_records_output_path", reasons)
+    w10_path = _resolve_required_output(w10_report_records_output_path, "missing_w10_report_records_output_path", reasons)
+    ledger_path = _resolve_read_path(root, work_ledger_json_path or DEFAULT_WORK_LEDGER_JSON)
+
+    if github_provider is None:
+        github_provider = GitHubRestPullRequestSourceProvider(
+            repo_full_name=github_repo_full_name,
+            state=github_state,
+            token=os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN") or "",
+        )
+    if w10_provider is None:
+        w10_provider = WorkLedgerProjectionW10ReportProvider(work_ledger_json_path=ledger_path)
+
+    if reasons:
+        return _not_ready(reasons=tuple(reasons), github_path=github_path, w10_path=w10_path)
+
+    assert github_path is not None and w10_path is not None
+    result = supply_authoritative_work_state_source_records(
+        repo_root=root,
+        github_pr_records_output_path=github_path,
+        w10_report_records_output_path=w10_path,
+        github_provider=github_provider,
+        w10_provider=w10_provider,
+        now_iso=now,
+    )
+    return _from_supply_result(result)
+
+
+def _resolve_read_path(repo_root: Path, value: Path | str) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root / path
+    return path.resolve()
+
+
+def _resolve_required_output(
+    value: Path | str | None,
+    reason: str,
+    reasons: list[str],
+) -> Path | None:
+    raw = str(value or "").strip()
+    if not raw:
+        reasons.append(reason)
+        return None
+    return Path(raw).resolve()
+
+
+def _from_supply_result(result: SourceRecordSupplyResult) -> RedDogWorkStateSourceRecordSupplyBootstrapResult:
+    return RedDogWorkStateSourceRecordSupplyBootstrapResult(
+        accepted=result.accepted,
+        status=result.status,
+        github_pr_records_path=result.github_pr_records_path,
+        w10_report_records_path=result.w10_report_records_path,
+        receipt_id=result.receipt.receipt_id if result.receipt else None,
+        github_record_count=result.receipt.github_record_count,
+        w10_record_count=result.receipt.w10_record_count,
+        rejection_reasons=result.receipt.rejection_reasons,
+    )
+
+
+def _not_ready(
+    *,
+    reasons: tuple[str, ...],
+    github_path: Path | None,
+    w10_path: Path | None,
+) -> RedDogWorkStateSourceRecordSupplyBootstrapResult:
+    return RedDogWorkStateSourceRecordSupplyBootstrapResult(
+        accepted=False,
+        status=SOURCE_RECORD_SUPPLY_NOT_READY,
+        github_pr_records_path=str(github_path) if github_path else None,
+        w10_report_records_path=str(w10_path) if w10_path else None,
+        receipt_id=None,
+        github_record_count=0,
+        w10_record_count=0,
+        rejection_reasons=reasons,
+    )
+
+
+__all__ = [
+    "RedDogWorkStateSourceRecordSupplyBootstrapResult",
+    "run_reddog_authoritative_work_state_source_record_supply_bootstrap",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -72,6 +72,7 @@ PROFILE_BINDING_FLAGS = frozenset(
 
 PROFILE_RUNTIME_FLAGS = frozenset(
     {
+        "REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY",
         "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF",
         "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY",
         "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY",
@@ -84,6 +85,8 @@ PROFILE_RUNTIME_FLAGS = frozenset(
 
 PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "authoritative_work_state.json",
+    "REDDOG_GITHUB_PR_RECORDS_PATH": "github_pr_records.json",
+    "REDDOG_W10_REPORT_RECORDS_PATH": "w10_report_records.json",
     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": "architect_determination.json",
     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": "model_selection_receipt.json",
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_source_record_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authoritative_work_state_source_record_supply.py
@@ -1,0 +1,219 @@
+"""Tests for REDDOG_AUTHORITATIVE_WORK_STATE_SOURCE_RECORD_SUPPLY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_source_record_supply import (
+    SOURCE_RECORD_SUPPLY_APPLIED,
+    SOURCE_RECORD_SUPPLY_NOT_READY,
+    WorkLedgerProjectionW10ReportProvider,
+    supply_authoritative_work_state_source_records,
+)
+from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_source_record_supply_bootstrap import (
+    run_reddog_authoritative_work_state_source_record_supply_bootstrap,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_authoritative_work_state_source_record_supply.py"
+)
+NOW = "2026-07-16T00:00:00+00:00"
+SLICE_ID = "REDDOG_AUTHORITATIVE_WORK_STATE_SOURCE_RECORD_SUPPLY_PHASE1"
+
+
+class _GitHubProvider:
+    def __init__(self, records):
+        self.records = records
+        self.called = False
+
+    def collect_pull_request_records(self, *, now_iso: str):
+        self.called = True
+        return self.records
+
+
+class _W10Provider:
+    def __init__(self, records):
+        self.records = records
+        self.called = False
+
+    def collect_w10_report_records(self, *, now_iso: str):
+        self.called = True
+        return self.records
+
+
+def _github_records() -> list[dict[str, object]]:
+    return [
+        {
+            "slice_id": SLICE_ID,
+            "status": "PR_OPEN",
+            "priority": "P0",
+            "lane": "A",
+            "pr_number": 1179,
+            "head_commit": "a" * 40,
+            "evidence_refs": ["github:pr:1179"],
+            "wsp15_score": {"total": 18},
+        }
+    ]
+
+
+def _w10_records() -> list[dict[str, object]]:
+    return [
+        {
+            "slice_id": SLICE_ID,
+            "status": "PR_OPEN",
+            "priority": "P0",
+            "lane": "A",
+            "evidence_refs": ["w10:fixture"],
+            "wsp15_score": {"total": 18},
+        }
+    ]
+
+
+def _work_ledger(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0.0",
+                "last_updated": NOW,
+                "slices": [
+                    {
+                        "slice_id": SLICE_ID,
+                        "status": "PR_OPEN",
+                        "priority": "P0",
+                        "lane": "A",
+                        "branch": "feat/reddog-authoritative-work-state-source-record-supply-phase1",
+                        "pr_number": 1179,
+                        "head_commit": "a" * 40,
+                        "evidence_docs": ["docs/audits/example.md"],
+                        "wsp15_score": {"total": 18},
+                    }
+                ],
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_supply_writes_github_and_w10_source_records_outside_repo(tmp_path: Path) -> None:
+    github_path = tmp_path / "runtime" / "github_pr_records.json"
+    w10_path = tmp_path / "runtime" / "w10_report_records.json"
+
+    result = supply_authoritative_work_state_source_records(
+        repo_root=REPO_ROOT,
+        github_pr_records_output_path=github_path,
+        w10_report_records_output_path=w10_path,
+        github_provider=_GitHubProvider(_github_records()),
+        w10_provider=_W10Provider(_w10_records()),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == SOURCE_RECORD_SUPPLY_APPLIED
+    assert result.receipt.github_record_count == 1
+    assert result.receipt.w10_record_count == 1
+    assert json.loads(github_path.read_text(encoding="utf-8"))[0]["slice_id"] == SLICE_ID
+    assert json.loads(w10_path.read_text(encoding="utf-8"))[0]["slice_id"] == SLICE_ID
+    assert result.receipt.no_repo_mutation_performed is True
+    assert result.receipt.no_holoindex_reindex_performed is True
+    assert result.receipt.no_execution_performed is True
+
+
+def test_supply_rejects_outputs_inside_repo(tmp_path: Path) -> None:
+    result = supply_authoritative_work_state_source_records(
+        repo_root=REPO_ROOT,
+        github_pr_records_output_path=REPO_ROOT / "github_records.json",
+        w10_report_records_output_path=tmp_path / "w10_records.json",
+        github_provider=_GitHubProvider(_github_records()),
+        w10_provider=_W10Provider(_w10_records()),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == SOURCE_RECORD_SUPPLY_NOT_READY
+    assert "github_pr_records_output_inside_repo" in result.receipt.rejection_reasons
+    assert not (REPO_ROOT / "github_records.json").exists()
+
+
+def test_supply_rejects_empty_sources_without_writing(tmp_path: Path) -> None:
+    github_path = tmp_path / "runtime" / "github_pr_records.json"
+    w10_path = tmp_path / "runtime" / "w10_report_records.json"
+
+    result = supply_authoritative_work_state_source_records(
+        repo_root=REPO_ROOT,
+        github_pr_records_output_path=github_path,
+        w10_report_records_output_path=w10_path,
+        github_provider=_GitHubProvider([]),
+        w10_provider=_W10Provider(_w10_records()),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "no_github_pr_records" in result.receipt.rejection_reasons
+    assert not github_path.exists()
+    assert not w10_path.exists()
+
+
+def test_work_ledger_projection_w10_provider_marks_projection_evidence(tmp_path: Path) -> None:
+    ledger = tmp_path / "work_ledger.json"
+    _work_ledger(ledger)
+
+    provider = WorkLedgerProjectionW10ReportProvider(work_ledger_json_path=ledger)
+    records = list(provider.collect_w10_report_records(now_iso=NOW))
+
+    assert len(records) == 1
+    assert records[0]["slice_id"] == SLICE_ID
+    assert records[0]["status"] == "PR_OPEN"
+    assert any(str(ref).startswith("w10:ledger_projection:") for ref in records[0]["evidence_refs"])
+
+
+def test_bootstrap_uses_injected_providers_and_returns_paths(tmp_path: Path) -> None:
+    ledger = tmp_path / "repo" / "work_ledger.json"
+    ledger.parent.mkdir()
+    _work_ledger(ledger)
+    github_path = tmp_path / "runtime" / "github_pr_records.json"
+    w10_path = tmp_path / "runtime" / "w10_report_records.json"
+
+    result = run_reddog_authoritative_work_state_source_record_supply_bootstrap(
+        repo_root=ledger.parent,
+        github_pr_records_output_path=github_path,
+        w10_report_records_output_path=w10_path,
+        work_ledger_json_path=ledger,
+        github_provider=_GitHubProvider(_github_records()),
+        w10_provider=_W10Provider(_w10_records()),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.github_pr_records_path == str(github_path.resolve())
+    assert result.w10_report_records_path == str(w10_path.resolve())
+    assert result.github_record_count == 1
+    assert result.w10_record_count == 1
+
+
+def test_module_has_no_shell_execution_or_holoindex_mutation_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {"subprocess", "socket", "holo_index"}
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".")[0] not in banned_import_roots
+        elif isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".")[0] not in banned_import_roots
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                assert func.id not in banned_calls
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                assert func.value.id not in banned_import_roots

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py
@@ -463,6 +463,123 @@ def test_main_preflight_profile_derives_work_state_output_path(tmp_path: Path) -
     assert not (paths["repo"] / ".reddog").exists()
 
 
+def test_main_preflight_profile_runs_source_record_supply_before_refresh(tmp_path: Path) -> None:
+    import main
+
+    paths = _write_sources(tmp_path)
+    runtime_root = tmp_path / "resident-runtime"
+    github_path = runtime_root / "github_pr_records.json"
+    w10_path = runtime_root / "w10_report_records.json"
+
+    source_result = type(
+        "SourceResult",
+        (),
+        {
+            "accepted": True,
+            "status": "SOURCE_RECORD_SUPPLY_APPLIED",
+            "github_pr_records_path": str(github_path),
+            "w10_report_records_path": str(w10_path),
+            "receipt_id": "sha256:source-records",
+            "github_record_count": 1,
+            "w10_record_count": 1,
+            "rejection_reasons": (),
+        },
+    )()
+    refresh_result = type(
+        "RefreshResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_WORK_STATE_BOOTSTRAP_APPLIED,
+            "work_state_path": str(runtime_root / "authoritative_work_state.json"),
+            "refresh_id": "refresh",
+            "committed_revision": "revision",
+            "selected_slice": SLICE_ID,
+            "queue_item_count": 1,
+            "rejection_reasons": (),
+            "latest_decision_attempted": False,
+            "latest_decision_next_slice": None,
+        },
+    )()
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_source_record_supply_bootstrap.run_reddog_authoritative_work_state_source_record_supply_bootstrap",
+        return_value=source_result,
+    ) as supply_mock:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap.run_reddog_main_authoritative_work_state_refresh_bootstrap",
+            return_value=refresh_result,
+        ) as refresh_mock:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_ACTIVE_SLICE_LEDGER_PATH": str(paths["active"]),
+                    "REDDOG_WORK_LEDGER_JSON_PATH": str(paths["ledger"]),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_authoritative_work_state_refresh_preflight(paths["repo"]) is True
+
+    assert supply_mock.called is True
+    assert supply_mock.call_args.kwargs["github_pr_records_output_path"] == str(github_path)
+    assert supply_mock.call_args.kwargs["w10_report_records_output_path"] == str(w10_path)
+    assert refresh_mock.call_args.kwargs["github_pr_records_path"] == str(github_path)
+    assert refresh_mock.call_args.kwargs["w10_report_records_path"] == str(w10_path)
+
+
+def test_main_preflight_explicit_zero_disables_profile_source_supply(tmp_path: Path) -> None:
+    import main
+
+    paths = _write_sources(tmp_path)
+    runtime_root = tmp_path / "resident-runtime"
+    refresh_result = type(
+        "RefreshResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_WORK_STATE_BOOTSTRAP_APPLIED,
+            "work_state_path": str(runtime_root / "authoritative_work_state.json"),
+            "refresh_id": "refresh",
+            "committed_revision": "revision",
+            "selected_slice": SLICE_ID,
+            "queue_item_count": 1,
+            "rejection_reasons": (),
+            "latest_decision_attempted": False,
+            "latest_decision_next_slice": None,
+        },
+    )()
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_source_record_supply_bootstrap.run_reddog_authoritative_work_state_source_record_supply_bootstrap",
+        side_effect=AssertionError("source supply should not run"),
+    ):
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_authoritative_work_state_refresh_bootstrap.run_reddog_main_authoritative_work_state_refresh_bootstrap",
+            return_value=refresh_result,
+        ) as refresh_mock:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_REFRESH": "1",
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_WORK_STATE_SOURCE_RECORD_SUPPLY": "0",
+                    "REDDOG_ACTIVE_SLICE_LEDGER_PATH": str(paths["active"]),
+                    "REDDOG_WORK_LEDGER_JSON_PATH": str(paths["ledger"]),
+                    "REDDOG_GITHUB_PR_RECORDS_PATH": str(paths["github"]),
+                    "REDDOG_W10_REPORT_RECORDS_PATH": str(paths["w10"]),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_authoritative_work_state_refresh_preflight(paths["repo"]) is True
+
+    assert refresh_mock.call_args.kwargs["github_pr_records_path"] == str(paths["github"])
+    assert refresh_mock.call_args.kwargs["w10_report_records_path"] == str(paths["w10"])
+
+
 def test_main_preflight_enables_latest_decision_bridge_with_openclaw_auto_tasks(tmp_path: Path) -> None:
     import main
 


### PR DESCRIPTION
## Summary
- Add REDDOG_AUTHORITATIVE_WORK_STATE_SOURCE_RECORD_SUPPLY_PHASE1 source-record supplier for GitHub PR and W10 report JSON files.
- Wire the resident profile/main startup preflight to materialize those source records before the existing authoritative work-state refresh.
- Keep the boundary read-only: no work-state commit in the supplier, no worker spawn, no OpenClaw enqueue, no Hermes dispatch, no shell execution, no source mutation, no HoloIndex re-index.

## Validation
- python -m py_compile main.py modules\\communication\\moltbot_bridge\\src\\reddog_authoritative_work_state_source_record_supply.py modules\\communication\\moltbot_bridge\\src\\reddog_authoritative_work_state_source_record_supply_bootstrap.py modules\\communication\\moltbot_bridge\\src\\reddog_resident_queue_binding_profile.py
- pytest modules\\communication\\moltbot_bridge\\tests\\test_reddog_authoritative_work_state_source_record_supply.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_authoritative_work_state_refresh_runtime.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_architect_fix_promotion_bootstrap.py -q
- pytest modules\\communication\\moltbot_bridge\\tests\\test_reddog_main_resident_queue_serial_loop_bootstrap.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_resident_queue_serial_loop.py modules\\communication\\moltbot_bridge\\tests\\test_reddog_signed_worker_queue_serial_loop_runner.py -q
- git diff --check

## Truth Boundary
- WSP_97 OBSERVED: supplier writes source-record artifacts outside the repo and profile can derive paths.
- WSP_97 OBSERVED: tests use injected providers; CI does not depend on GitHub network.
- SPECIFIED_NOT_IMPLEMENTED: independent W10 service; current W10 provider is explicitly labeled ledger projection until a real W10 source is attached.
