### PR TITLE
test(reddog): prove main signed worker complete chain

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MAIN_OPENCLAW_SIGNED_WORKER_COMPLETE_CHAIN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a `main.py` startup-preflight regression proving the RedDog OpenClaw
+  signed-worker claim loop can drain an env-bound signed worker task through
+  bounded worker pilot, slice verification, draft-PR request, outcome ratchet,
+  held-out gate, and PatternMemory admission.
+- Boundary remains constrained to governed runtime artifacts and an isolated
+  worktree: no source repo mutation, no shell execution, no Hermes dispatch,
+  no live OpenClaw enqueue, no real PR publication, no reward settlement, and
+  no HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_MAIN_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_E2E_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from modules.communication.moltbot_bridge.src import (
+    reddog_openclaw_hermes_0102_worker_dispatch_runtime as runtime,
+)
 from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_serial_loop_bootstrap import (
     NOW as BOOTSTRAP_NOW,
     PILOT_ARTIFACT,
     PILOT_OPERATION,
     REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+    _draft_pr_publish_request,
     _ed25519_signing_material,
     _FakeWorkerDispatchTaskWriter,
     _FakeWorktreeRunner,
@@ -25,12 +30,14 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     _repo,
     _snapshot as _bootstrap_snapshot,
     _snapshots,
+    _slice_verifier_request,
     _valve_environment,
     _work_order,
     _write_runtime_json,
     run_reddog_main_resident_queue_serial_loop_bootstrap,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_signed_worker_dispatch_task_executor import (
+    _FakeEnvDraftPrRunner,
     _publish_agentdb_task,
 )
 from modules.infrastructure.database.src.agent_db import AgentDB
@@ -308,3 +315,160 @@ def test_main_openclaw_signed_worker_claim_loop_runs_real_agentdb_queue_stage(
         "# Resident Queue Pilot"
     )
     assert not (repo / PILOT_ARTIFACT).exists()
+
+
+def test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+    from modules.foundups.agent.src import worktree_pr_runner
+
+    _FakeEnvDraftPrRunner.instances.clear()
+    monkeypatch.setattr(worktree_pr_runner, "RealWorktreeRunner", _FakeEnvDraftPrRunner)
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_runtime_json(tmp_path, "work_state.json", _bootstrap_snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _bootstrap_profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    work_order = _work_order(**pilot_overrides)
+    work_orders = _write_runtime_json(
+        tmp_path,
+        "work_orders.json",
+        {"work_orders": {str(work_order["work_order_id"]): work_order}},
+    )
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    worktree_runner = _FakeWorktreeRunner()
+    worktree = _pilot_worktree_path(repo, work_order)
+
+    seed = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worktree_runner=worktree_runner,
+        now_iso=BOOTSTRAP_NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=9,
+    )
+    assert seed.accepted is True
+    assert seed.dispatched_stages[-1] == "worktree_create"
+
+    pilot_payloads = _pilot_payloads(repo, worktree, work_order)
+    generic_writer = _write_runtime_json(
+        tmp_path,
+        "generic_writer.json",
+        pilot_payloads["generic_writer_dryrun_result"],
+    )
+    governed_shell = _write_runtime_json(
+        tmp_path,
+        "governed_shell.json",
+        pilot_payloads["governed_shell_dryrun_result"],
+    )
+    artifacts = _write_runtime_json(
+        tmp_path,
+        "artifact_contents.json",
+        pilot_payloads["artifact_contents"],
+    )
+    holoindex = _write_runtime_json(
+        tmp_path,
+        "holoindex_evidence.json",
+        pilot_payloads["holoindex_evidence"],
+    )
+    verifier_request = _write_runtime_json(
+        tmp_path,
+        "verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_runtime_json(
+        tmp_path,
+        "publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+    outcome_store = tmp_path / "runtime" / "outcomes" / "signed-worker-ratchet.jsonl"
+    pattern_memory_db = tmp_path / "runtime" / "pattern_memory.db"
+
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP", "1")
+    monkeypatch.setenv("OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS", "7")
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER", "1")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH", str(chain))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(profile))
+    monkeypatch.setenv("REDDOG_WORK_ORDERS_PATH", str(work_orders))
+    monkeypatch.setenv("REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH", str(generic_writer))
+    monkeypatch.setenv("REDDOG_GOVERNED_SHELL_DRYRUN_RESULT_PATH", str(governed_shell))
+    monkeypatch.setenv("REDDOG_ARTIFACT_CONTENTS_PATH", str(artifacts))
+    monkeypatch.setenv("REDDOG_HOLOINDEX_EVIDENCE_PATH", str(holoindex))
+    monkeypatch.setenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", str(verifier_request))
+    monkeypatch.setenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", str(publish_request))
+    monkeypatch.setenv("REDDOG_DRAFT_PR_RUNNER_MODE", "real")
+    monkeypatch.setenv("REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S", "88")
+    monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_REQUEST_BINDING", "1")
+    monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", str(outcome_store))
+    monkeypatch.setenv("REDDOG_HELD_OUT_GATE_REQUEST_BINDING", "1")
+    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING", "1")
+    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", str(pattern_memory_db))
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+
+    assert main.run_reddog_openclaw_signed_worker_claim_loop_preflight(repo) is True
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=PASS" in captured
+    assert "status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT" in captured
+    assert "claimed_count=6" in captured
+    assert f"completed={task_id}" in captured
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    for stage_name in (
+        "bounded_worker_pilot",
+        "slice_verifier",
+        "verified_draft_pr_publish",
+        "verified_outcome_ratchet",
+        "held_out_regression_gate",
+        "pattern_memory_admission",
+    ):
+        assert stage_name in stored["stage_results"]
+    assert stored["receipts"][-1]["next_action"] == "STOP_QUEUE_CHAIN_COMPLETE"
+    assert (worktree / PILOT_ARTIFACT).exists()
+    assert not (repo / PILOT_ARTIFACT).exists()
+    draft_pr_calls = [
+        call[0]
+        for instance in _FakeEnvDraftPrRunner.instances
+        for call in instance.calls
+    ]
+    assert draft_pr_calls == ["push_branch", "create_draft_pr"]
+    assert outcome_store.exists()
+    with sqlite3.connect(pattern_memory_db) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM skill_outcomes").fetchone()[0]
+    assert count == 1
+    assert not (repo / "runtime" / "pattern_memory.db").exists()


### PR DESCRIPTION
## Summary
- Add a `main.py` startup-preflight regression that drains an env-bound signed worker task through the full resident queue chain.
- Prove bounded worker pilot, slice verifier, draft-PR request, verified outcome ratchet, held-out gate, and PatternMemory admission run through repeated OpenClaw claim-loop requeues.
- Record the WSP_97 boundary in the moltbot_bridge ModLog.

## Boundaries
- No source repo mutation.
- No shell execution.
- No Hermes dispatch.
- No live OpenClaw enqueue.
- No real PR publication.
- No reward settlement.
- No HoloIndex re-indexing.
- Runtime artifacts, isolated worktree, outcome store, and test PatternMemory DB stay outside the source repo.

## Validation
- `python -m py_compile modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py`
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 9 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 74 passed
- `git diff --check`