### PR TITLE
feat(reddog): publish queue-stage signed workers

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_SIGNED_WORKER_QUEUE_STAGE_PUBLICATION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Specialized signed worker dispatch dry-run output for code-bearing resident
+  queue plans: `openclaw_candidate/candidate_queue_review` is no longer
+  emitted for coding chains; the planner emits
+  `queue_stage_worker/openclaw/queue_stage_progress` instead.
+- Preserved the legacy OpenClaw candidate-review task for non-code worker
+  plans so advisory/review-only flows remain compatible.
+- Strengthened the resident queue bootstrap regression to prove
+  `worker_dispatch_runtime` publishes the queue-stage worker directly from the
+  WSP_15 worker plan, without manually seeding a second AgentDB task.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_STAGE_OWNERSHIP_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
@@ -219,8 +219,10 @@ def _build_intents(
         roles.append((f"coding_worker_{index + 1}", "0102", "bounded_code_change"))
     if worker_plan.get("independent_verifier_required") is True:
         roles.append(("independent_verifier", "0102", "diff_verification"))
-    if worker_plan.get("openclaw_candidate") is True:
+    if worker_plan.get("openclaw_candidate") is True and coding_count <= 0:
         roles.append(("openclaw_candidate", "openclaw", "candidate_queue_review"))
+    if coding_count > 0:
+        roles.append(("queue_stage_worker", "openclaw", "queue_stage_progress"))
 
     for role, runtime, capability in roles:
         seed = {

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -1323,7 +1323,7 @@ def test_bootstrap_serial_loop_verifies_ed25519_authority_when_configured(tmp_pa
         signer_socket_path=socket_path,
         signer_socket_connector=connector,
         signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
-            worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
         now_iso=NOW,
         now_epoch=1000,
         requested_queue_item_id="queue-1",
@@ -1462,6 +1462,7 @@ def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_
     chain = tmp_path / "runtime" / "chain_results.json"
     authority_state = tmp_path / "runtime" / "authority_state.json"
     socket_path = tmp_path / "runtime" / "signer.sock"
+    worker_dispatch_writer = _FakeWorkerDispatchTaskWriter()
 
     result = run_reddog_main_resident_queue_serial_loop_bootstrap(
         repo_root=repo,
@@ -1476,7 +1477,7 @@ def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_
         signer_socket_path=socket_path,
         signer_socket_connector=connector,
         signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
-            worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worker_dispatch_writer=worker_dispatch_writer,
         now_iso=NOW,
         now_epoch=1000,
         requested_queue_item_id="queue-1",
@@ -1506,9 +1507,20 @@ def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_
     assert result.no_repo_mutation_performed is True
     assert result.no_holoindex_reindex_performed is True
     assert result.no_pr_created is True
+    assert worker_dispatch_writer.calls
+    published_tasks = worker_dispatch_writer.calls[0]["task_ids"]
+    assert len(published_tasks) == 7
 
     stored = json.loads(chain.read_text(encoding="utf-8"))
     stage_results = stored["stage_results"]
+    dispatch_intents = stage_results["worker_dispatch_dryrun"]["receipt"]["dispatch_intents"]
+    assert any(
+        intent["role"] == "queue_stage_worker"
+        and intent["worker_runtime"] == "openclaw"
+        and intent["capability"] == "queue_stage_progress"
+        for intent in dispatch_intents
+    )
+    assert not any(intent["role"] == "openclaw_candidate" for intent in dispatch_intents)
     assert stage_results["work_order_invocation"]["decision"] == "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"
     assert stage_results["executor_plan"]["decision"] == "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"
     valve = stage_results["execution_valve"]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
@@ -110,7 +110,7 @@ def _dryrun_result(allocation=None, intents=None, **overrides):
     intents = intents or (
         _intent("fusion_lead", "0102", "architect_review", allocation),
         _intent("coding_worker_1", "0102", "bounded_code_change", allocation),
-        _intent("openclaw_candidate", "openclaw", "candidate_queue_review", allocation),
+        _intent("queue_stage_worker", "openclaw", "queue_stage_progress", allocation),
     )
     receipt = {
         "receipt_id": "signed_authority_worker_dispatch_abc",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
@@ -143,13 +143,31 @@ def test_accepts_verified_signed_authority_and_emits_wsp15_worker_intents() -> N
         "coding_worker_1",
         "coding_worker_2",
         "independent_verifier",
-        "openclaw_candidate",
+        "queue_stage_worker",
     ]
+    assert result.receipt.dispatch_intents[-1].worker_runtime == "openclaw"
+    assert result.receipt.dispatch_intents[-1].capability == "queue_stage_progress"
     assert {intent.worker_runtime for intent in result.receipt.dispatch_intents} == {"0102", "openclaw"}
     assert result.receipt.wsp15_allocation_digest == _digest(_allocation())
     assert result.receipt.no_worker_spawn_performed is True
     assert result.receipt.no_openclaw_enqueue_performed is True
     assert result.receipt.no_hermes_dispatch_performed is True
+
+
+def test_preserves_legacy_openclaw_candidate_for_non_code_worker_plan() -> None:
+    allocation = _allocation()
+    allocation["worker_plan"] = dict(allocation["worker_plan"], coding_worker_count=0)
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=_runtime_result(allocation))
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    roles = [intent.role for intent in result.receipt.dispatch_intents]
+    assert "openclaw_candidate" in roles
+    assert "queue_stage_worker" not in roles
+    intent = next(value for value in result.receipt.dispatch_intents if value.role == "openclaw_candidate")
+    assert intent.worker_runtime == "openclaw"
+    assert intent.capability == "candidate_queue_review"
 
 
 def test_explicit_request_is_required() -> None:


### PR DESCRIPTION
## WSP_97 Summary

This slice moves the queue-stage worker from a manually seeded test artifact into the signed worker dispatch plan.

- code-bearing WSP_15 worker plans now emit `queue_stage_worker/openclaw/queue_stage_progress`
- legacy `openclaw_candidate/candidate_queue_review` remains available for non-code worker plans
- the resident queue bootstrap regression now proves `worker_dispatch_runtime` publishes the queue-stage worker directly from the generated dry-run dispatch receipt

## Validation

- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/src/reddog_openclaw_hermes_0102_worker_dispatch_runtime.py`
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py -q` -> 22 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 58 passed, 1 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 47 passed
- `git diff --check` -> clean

## Boundary

No runtime worker process is spawned by dispatch. No shell execution is added. No HoloIndex re-indexing is added. No Hermes execution is enabled. This only changes which signed AgentDB task shape is produced for code-bearing resident queue chains.