### PR TITLE
test(reddog): prove auto-published worker complete chain

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MAIN_OPENCLAW_AUTOPUBLISHED_WORKER_COMPLETE_CHAIN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Tightened signed worker dispatch planning so resident code chains publish only
+  currently executable AgentDB worker tasks: one `0102/bounded_code_change`
+  materializer and one `openclaw/queue_stage_progress` continuation worker.
+- Preserved the legacy OpenClaw candidate-review task for non-code worker
+  plans, but stopped publishing unclaimable Fusion/critic/verifier task roles
+  into the resident execution queue until those runtimes exist.
+- Converted the `main.py` OpenClaw complete-chain regression from manually
+  seeded worker tasks to tasks created by `worker_dispatch_runtime` through
+  `AgentDbSignedWorkerDispatchTaskWriter`, and proved the generated artifact
+  chain drains with no leftover signed worker tasks.
+
 ## 2026-07-16: REDDOG_SIGNED_WORKER_QUEUE_STAGE_PUBLICATION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
@@ -209,16 +209,10 @@ def _build_intents(
     }
 
     roles: List[tuple[str, str, str]] = []
-    if worker_plan.get("fusion_required") is True:
-        roles.append(("fusion_lead", "0102", "architect_review"))
-    critic_count = int(worker_plan.get("critic_count") or 0)
-    for index in range(max(0, critic_count)):
-        roles.append((f"critic_{index + 1}", "0102", "adversarial_review"))
     coding_count = int(worker_plan.get("coding_worker_count") or 0)
-    for index in range(max(0, coding_count)):
+    active_bounded_code_workers = 1 if coding_count > 0 else 0
+    for index in range(active_bounded_code_workers):
         roles.append((f"coding_worker_{index + 1}", "0102", "bounded_code_change"))
-    if worker_plan.get("independent_verifier_required") is True:
-        roles.append(("independent_verifier", "0102", "diff_verification"))
     if worker_plan.get("openclaw_candidate") is True and coding_count <= 0:
         roles.append(("openclaw_candidate", "openclaw", "candidate_queue_review"))
     if coding_count > 0:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -551,7 +551,7 @@ def test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain(
         signer_socket_path=socket_path,
         signer_socket_connector=connector,
         signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
-        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worker_dispatch_writer=runtime.AgentDbSignedWorkerDispatchTaskWriter(),
         worktree_runner=worktree_runner,
         now_iso=BOOTSTRAP_NOW,
         now_epoch=1000,
@@ -575,20 +575,24 @@ def test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain(
     outcome_store = tmp_path / "runtime" / "outcomes" / "signed-worker-ratchet.jsonl"
     pattern_memory_db = tmp_path / "runtime" / "pattern_memory.db"
 
-    allocation = _allocation()
-    coding_task_id = _publish_agentdb_task_with_allocation(
-        allocation,
-        intent_id="worker_dispatch_intent_coding_worker_1",
-        role="coding_worker_1",
-        worker_runtime="0102",
-        capability="bounded_code_change",
+    pending = AgentDB().get_autonomous_tasks(status="pending", limit=10)
+    signed_tasks = [
+        task
+        for task in pending
+        if task.get("discovered_by") == runtime.SIGNED_WORKER_DISPATCH_TASK_SOURCE
+    ]
+    assert len(signed_tasks) == 2
+    coding_task_id = next(
+        task["task_id"]
+        for task in signed_tasks
+        if task["context"]["worker_runtime"] == "0102"
+        and task["context"]["capability"] == "bounded_code_change"
     )
-    queue_stage_task_id = _publish_agentdb_task_with_allocation(
-        allocation,
-        intent_id="worker_dispatch_intent_queue_stage_progress",
-        role="queue_stage_worker",
-        worker_runtime="openclaw",
-        capability="queue_stage_progress",
+    queue_stage_task_id = next(
+        task["task_id"]
+        for task in signed_tasks
+        if task["context"]["worker_runtime"] == "openclaw"
+        and task["context"]["capability"] == "queue_stage_progress"
     )
     monkeypatch.setenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP", "1")
     monkeypatch.setenv("OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED", "1")
@@ -624,6 +628,12 @@ def test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain(
     assert f"completed={coding_task_id},{queue_stage_task_id}" in captured
     assert AgentDB().get_autonomous_task_by_id(coding_task_id)["status"] == "completed"
     assert AgentDB().get_autonomous_task_by_id(queue_stage_task_id)["status"] == "completed"
+    remaining_signed = [
+        task
+        for task in AgentDB().get_autonomous_tasks(status="pending", limit=10)
+        if task.get("discovered_by") == runtime.SIGNED_WORKER_DISPATCH_TASK_SOURCE
+    ]
+    assert remaining_signed == []
     assert calls
     assert calls[0]["api_key"] == "test-openrouter-key"
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -1509,7 +1509,7 @@ def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_
     assert result.no_pr_created is True
     assert worker_dispatch_writer.calls
     published_tasks = worker_dispatch_writer.calls[0]["task_ids"]
-    assert len(published_tasks) == 7
+    assert len(published_tasks) == 2
 
     stored = json.loads(chain.read_text(encoding="utf-8"))
     stage_results = stored["stage_results"]
@@ -1520,6 +1520,7 @@ def test_bootstrap_serial_loop_reaches_execution_valve_with_explicit_work_order_
         and intent["capability"] == "queue_stage_progress"
         for intent in dispatch_intents
     )
+    assert sum(1 for intent in dispatch_intents if intent["capability"] == "bounded_code_change") == 1
     assert not any(intent["role"] == "openclaw_candidate" for intent in dispatch_intents)
     assert stage_results["work_order_invocation"]["decision"] == "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"
     assert stage_results["executor_plan"]["decision"] == "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
@@ -108,7 +108,6 @@ def _intent(role: str, runtime_name: str, capability: str, allocation=None, **ov
 def _dryrun_result(allocation=None, intents=None, **overrides):
     allocation = allocation or _allocation()
     intents = intents or (
-        _intent("fusion_lead", "0102", "architect_review", allocation),
         _intent("coding_worker_1", "0102", "bounded_code_change", allocation),
         _intent("queue_stage_worker", "openclaw", "queue_stage_progress", allocation),
     )
@@ -175,8 +174,8 @@ def test_publishes_signed_worker_dispatch_intents_as_pending_tasks() -> None:
     assert result.receipt.agentdb_tasks_enqueued is True
     assert result.receipt.no_worker_process_started is True
     assert result.receipt.no_hermes_execution_performed is True
-    assert len(result.tasks) == 3
-    assert writer.calls and len(writer.calls[0][0]) == 3
+    assert len(result.tasks) == 2
+    assert writer.calls and len(writer.calls[0][0]) == 2
     assert {task.context["worker_runtime"] for task in result.tasks} == {"0102", "openclaw"}
     assert all(task.context["execution_allowed_by_dispatch_runtime"] is False for task in result.tasks)
     assert all(runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL in task.required_skills for task in result.tasks)
@@ -192,7 +191,7 @@ def test_agentdb_writer_publishes_tasks_atomically() -> None:
 
     assert result.accepted is True
     pending = AgentDB().get_autonomous_tasks(status="pending", limit=10)
-    assert len(pending) == 3
+    assert len(pending) == 2
     assert {task["task_id"] for task in pending} == set(result.receipt.task_ids)
     for task in pending:
         assert task["context"]["source"] == runtime.SIGNED_WORKER_DISPATCH_TASK_SOURCE
@@ -218,7 +217,7 @@ def test_agentdb_writer_rejects_duplicate_without_second_batch() -> None:
     assert first.accepted is True
     assert second.accepted is False
     assert second.rejection_reasons == (runtime.WorkerDispatchRuntimeReason.WRITER_REJECTED,)
-    assert len(AgentDB().get_autonomous_tasks(status="pending", limit=10)) == 3
+    assert len(AgentDB().get_autonomous_tasks(status="pending", limit=10)) == 2
 
 
 def test_rejects_missing_writer_and_unaccepted_dryrun() -> None:
@@ -278,7 +277,7 @@ def test_rejects_wsp15_queue_binding_mismatch_and_seen_replay() -> None:
         work_state_snapshot=_snapshot(allocation),
         queue_item_id="queue-1",
         writer=_FakeWriter(),
-        seen_intent_ids={"worker_dispatch_intent_fusion_lead"},
+        seen_intent_ids={"worker_dispatch_intent_coding_worker_1"},
     )
 
     assert mismatch.accepted is False

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_dryrun_handler.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_dryrun_handler.py
@@ -226,7 +226,15 @@ def test_dispatcher_records_worker_dispatch_dryrun_and_advances_to_work_order_in
     stage = store.load()["stage_results"][WORKER_DISPATCH_DRYRUN_STAGE_KEY]
     assert stage["accepted"] is True
     assert stage["decision"] == SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT
-    assert stage["receipt"]["dispatch_intent_count"] == 7
+    assert stage["receipt"]["dispatch_intent_count"] == 2
+    intents = stage["receipt"]["dispatch_intents"]
+    assert sum(1 for intent in intents if intent["capability"] == "bounded_code_change") == 1
+    assert any(
+        intent["role"] == "queue_stage_worker"
+        and intent["worker_runtime"] == "openclaw"
+        and intent["capability"] == "queue_stage_progress"
+        for intent in intents
+    )
     assert stage["receipt"]["no_worker_spawn_performed"] is True
     assert stage["receipt"]["no_openclaw_enqueue_performed"] is True
     assert stage["receipt"]["no_hermes_dispatch_performed"] is True

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
@@ -134,17 +134,14 @@ def test_accepts_verified_signed_authority_and_emits_wsp15_worker_intents() -> N
     assert result.accepted is True
     assert result.decision == dispatch.SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT
     assert result.receipt is not None
-    assert result.receipt.dispatch_intent_count == 7
+    assert result.receipt.dispatch_intent_count == 2
     roles = [intent.role for intent in result.receipt.dispatch_intents]
     assert roles == [
-        "fusion_lead",
-        "critic_1",
-        "critic_2",
         "coding_worker_1",
-        "coding_worker_2",
-        "independent_verifier",
         "queue_stage_worker",
     ]
+    assert roles.count("coding_worker_1") == 1
+    assert "coding_worker_2" not in roles
     assert result.receipt.dispatch_intents[-1].worker_runtime == "openclaw"
     assert result.receipt.dispatch_intents[-1].capability == "queue_stage_progress"
     assert {intent.worker_runtime for intent in result.receipt.dispatch_intents} == {"0102", "openclaw"}


### PR DESCRIPTION
## WSP_97 Summary

This slice proves the resident RedDog chain no longer depends on manually seeded signed worker tasks.

- signed worker dispatch now publishes only currently executable AgentDB tasks for a code-bearing chain: one `0102/bounded_code_change` task and one `openclaw/queue_stage_progress` task
- Fusion/critic/verifier task roles are no longer published into AgentDB until their runtime claim paths exist, preventing stale unclaimable tasks
- the `main.py` OpenClaw complete-chain regression now uses `AgentDbSignedWorkerDispatchTaskWriter`, drains the generated artifact chain, and asserts no signed worker tasks remain pending

## Validation

- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/src/reddog_openclaw_hermes_0102_worker_dispatch_runtime.py`
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_dryrun_handler.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py -q` -> 31 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 58 passed, 1 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 86 passed
- `git diff --check` -> clean

## Boundary

No shell execution is added. No HoloIndex re-indexing is added. No Hermes execution is enabled. No source-repo mutation authority is broadened. This is an operational proof that already-built resident queue pieces compose through AgentDB-published signed worker tasks.