### PR TITLE
feat(reddog): derive optional resident runtime paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -2371,6 +2371,20 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         if signer_socket_path and not signature_verifier_backend:
             signature_verifier_backend = "ed25519"
 
+        explicit_valve_environment_path = str(
+            os.getenv("REDDOG_EXECUTION_VALVE_ENV_PATH") or ""
+        ).strip()
+        profile_valve_environment_path = resident_queue_runtime_file_path(
+            os.environ,
+            repo_root,
+            "REDDOG_EXECUTION_VALVE_ENV_PATH",
+        )
+        valve_environment_path = explicit_valve_environment_path
+        if not valve_environment_path and profile_valve_environment_path:
+            candidate_valve_path = Path(profile_valve_environment_path)
+            if candidate_valve_path.exists():
+                valve_environment_path = profile_valve_environment_path
+
         result = run_reddog_main_resident_queue_serial_loop_bootstrap(
             repo_root=repo_root,
             work_state_path=resident_queue_runtime_file_path(
@@ -2392,7 +2406,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             or None,
             work_orders_path=os.getenv("REDDOG_WORK_ORDERS_PATH", "") or None,
             work_order_materializer_mode=resident_queue_materializer_mode(os.environ) or None,
-            valve_environment_path=os.getenv("REDDOG_EXECUTION_VALVE_ENV_PATH", "") or None,
+            valve_environment_path=valve_environment_path or None,
             generic_writer_dryrun_result_path=os.getenv(
                 "REDDOG_GENERIC_WRITER_DRYRUN_RESULT_PATH", ""
             )

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,19 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_RESIDENT_PROFILE_OPTIONAL_RUNTIME_PATHS_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_EXECUTION_VALVE_ENV_PATH` to the resident binding profile's
+  outside-repo runtime path map so profile-based resident chains can discover
+  the execution-valve environment without hand-setting another path.
+- Hardened optional profile-derived paths: explicit env paths remain strict,
+  but profile defaults are passed to the bootstrap only when the artifact
+  exists, preventing resumed later-stage chains from failing on unused missing
+  optional files.
+- Added focused regressions at both the direct OpenClaw queue-loop binding and
+  `main.py` serial-loop preflight layers.
+
 ## 2026-07-16: REDDOG_MAIN_OPENCLAW_AUTOPUBLISHED_WORKER_COMPLETE_CHAIN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -102,6 +102,7 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_PERMISSION_SNAPSHOT_PATH": "permission_snapshot.json",
     "REDDOG_AUTHORITY_PROFILE_SEED_PATH": "authority_profile_seed.json",
     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": "authority_profile_source.json",
+    "REDDOG_EXECUTION_VALVE_ENV_PATH": "execution_valve_env.json",
     "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": "authority_runtime_state.json",
     "REDDOG_PERMISSION_SNAPSHOTS_PATH": "permission_snapshots.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": "principal_authority_records.json",

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -281,7 +281,7 @@ def _bootstrap_kwargs(env: Mapping[str, str], *, repo_root: Path | str) -> dict[
     if materializer_mode:
         payload["work_order_materializer_mode"] = materializer_mode
     for key, env_name in pairs.items():
-        value = _stripped(env.get(env_name))
+        value = _optional_runtime_file_path(env, repo_root=repo_root, env_name=env_name)
         if value:
             payload[key] = value
     if artifact_generator_mode:
@@ -369,6 +369,21 @@ def _build_pattern_memory_admission_sink(
 
 def _stripped(value: Any) -> str:
     return str(value or "").strip()
+
+
+def _optional_runtime_file_path(
+    env: Mapping[str, str],
+    *,
+    repo_root: Path | str,
+    env_name: str,
+) -> str:
+    explicit = _stripped(env.get(env_name))
+    if explicit:
+        return explicit
+    value = _stripped(resident_queue_runtime_file_path(env, repo_root, env_name))
+    if value and Path(value).exists():
+        return value
+    return ""
 
 
 __all__ = [

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -4178,9 +4178,52 @@ def test_main_serial_loop_preflight_profile_derives_mandatory_runtime_paths(
     assert mocked.call_args.kwargs["authority_profile_path"] == str(
         runtime_root / "authority_profile.json"
     )
+    assert mocked.call_args.kwargs["valve_environment_path"] is None
     assert mocked.call_args.kwargs["work_order_materializer_mode"] == "authority_profile"
     assert mocked.call_args.kwargs["artifact_generator_mode"] is None
     assert not runtime_root.exists()
+
+
+def test_main_serial_loop_preflight_profile_derives_existing_valve_environment_path(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "resident-runtime"
+    runtime_root.mkdir(parents=True)
+    valve_env = runtime_root / "execution_valve_env.json"
+    valve_env.write_text("{}", encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap.run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=type(
+            "Result",
+            (),
+            {
+                "accepted": True,
+                "status": REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
+                "queue_item_id": "queue-1",
+                "selected_slice": "REDDOG_TEST_SLICE_PHASE1",
+                "steps_run": 1,
+                "dispatched_stages": ("execution_valve",),
+                "next_action": "RUN_QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE",
+                "chain_results_path": str(runtime_root / "resident_queue_chain_results.json"),
+                "store_revision": "sha256:revision",
+                "rejection_reasons": (),
+            },
+        )(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_queue_serial_loop_preflight(REPO_ROOT) is True
+
+    assert mocked.call_args.kwargs["valve_environment_path"] == str(valve_env)
 
 
 def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -847,7 +847,65 @@ def test_runtime_binding_profile_derives_mandatory_paths_from_runtime_root(
     )
 
     assert result["accepted"] is True
+    assert "valve_environment_path" not in bootstrap.calls[0]
+    assert "authority_state_path" not in bootstrap.calls[0]
+    assert "permission_snapshots_path" not in bootstrap.calls[0]
+    assert "principal_authority_records_path" not in bootstrap.calls[0]
+    assert "signer_socket_path" not in bootstrap.calls[0]
     assert not runtime_root.exists()
+
+
+def test_runtime_binding_profile_derives_existing_optional_runtime_paths(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime_root = tmp_path / "resident-runtime"
+    runtime_root.mkdir(parents=True)
+    for filename in (
+        "execution_valve_env.json",
+        "authority_runtime_state.json",
+        "permission_snapshots.json",
+        "principal_authority_records.json",
+        "reddog_signer.sock",
+    ):
+        (runtime_root / filename).write_text("{}", encoding="utf-8")
+    bootstrap = _FakeBootstrap()
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo,
+        env=env,
+        bootstrap=bootstrap,
+    )
+    assert binding.accepted is True
+    assert binding.runner is not None
+
+    result = binding.runner.run_signed_worker_dispatch_task(
+        task_id="task-1",
+        task_context=_context(),
+        worker_dispatch_intent=_context()["worker_dispatch_intent"],
+        signed_authority_receipt=_context()["signed_authority_worker_dispatch_receipt"],
+        repo_root=repo,
+    )
+
+    assert result["accepted"] is True
+    assert bootstrap.calls[0]["valve_environment_path"] == str(
+        runtime_root / "execution_valve_env.json"
+    )
+    assert bootstrap.calls[0]["authority_state_path"] == str(
+        runtime_root / "authority_runtime_state.json"
+    )
+    assert bootstrap.calls[0]["permission_snapshots_path"] == str(
+        runtime_root / "permission_snapshots.json"
+    )
+    assert bootstrap.calls[0]["principal_authority_records_path"] == str(
+        runtime_root / "principal_authority_records.json"
+    )
+    assert bootstrap.calls[0]["signer_socket_path"] == str(runtime_root / "reddog_signer.sock")
 
 
 def test_runtime_binding_profile_respects_explicit_binding_disable(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds profile-derived REDDOG_EXECUTION_VALVE_ENV_PATH outside-repo runtime path support.
- Keeps explicit optional paths strict, but only supplies profile-derived optional paths when the artifact exists so resumed later-stage chains do not fail on unused missing defaults.
- Applies the same rule in main.py and the OpenClaw signed-worker queue-loop binding.

## WSP_97 Evidence
- OBSERVED: resident profile already derives mandatory state/profile/chain paths and control-plane flags.
- OBSERVED: execution-valve environment was still a manually supplied path in profile-driven chains.
- OBSERVED: missing optional profile defaults can break resumed later-stage chains if passed as strict paths.
- SPECIFIED_NOT_IMPLEMENTED: no new shell, Hermes dispatch, HoloIndex re-index, merge authority, or reward settlement.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q -> 107 passed, 1 skipped
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
- git diff --check -> clean

## Boundary
No extension runtime change, no source repo mutation path, no HoloIndex mutation, no OpenClaw enqueue creation, no Hermes dispatch.
