### PR TITLE
feat(reddog): bind backend architect to model selection receipt

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_BACKEND_ARCHITECT_MODEL_SELECTION_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Bound backend architect determination to an optional production
+  model-selection receipt, recording the receipt id and digest on persisted
+  architect determination receipts.
+- Routed FoundUps Fusion backend architect calls through receipt-derived
+  lead/panel topology instead of always using the legacy default model panel
+  when a model-selection binding is supplied.
+- Added bootstrap support for outside-repo architect model-selection receipt
+  supply in production mode while preserving injected-runner test paths.
+
 ## 2026-07-16: REDDOG_ARTIFACT_GENERATION_MODEL_SELECTION_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
@@ -15,10 +15,12 @@ PatternMemory, settle rewards, or re-index HoloIndex.
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 import os
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Mapping, Optional, Protocol, Sequence
 
 from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
@@ -35,6 +37,13 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_colle
 )
 from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
     validate_reddog_wsp15_allocation_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    SelectionDecision,
+    SelectionPurpose,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    rehydrate_model_selection_receipt,
 )
 
 
@@ -79,6 +88,7 @@ class ArchitectDeterminationReason:
     WSP15_RECEIPT_MISMATCH = "REJECT_ARCHITECT_DETERMINATION_WSP15_RECEIPT_MISMATCH"
     STORE_REJECTED = "REJECT_ARCHITECT_DETERMINATION_STORE_REJECTED"
     PROMPT_BUDGET_EXCEEDED = "REJECT_ARCHITECT_DETERMINATION_PROMPT_BUDGET_EXCEEDED"
+    MODEL_SELECTION_RECEIPT = "REJECT_ARCHITECT_DETERMINATION_MODEL_SELECTION_RECEIPT"
 
 
 @dataclass(frozen=True)
@@ -140,32 +150,40 @@ class FoundupsFusionArchitectModelRunner:
         if not api_key:
             return _model_result_reject("missing_openrouter_api_key")
         try:
-            from scripts.advisory_model_once import _run_foundups_fusion
             from modules.communication.moltbot_bridge.src.fusion_redaction_gate import (
                 REDACTION_GATE_PASSED,
                 evaluate_redaction_gate,
             )
+            run_foundups_fusion = _load_foundups_fusion_runner()
         except Exception:
             return _model_result_reject("fusion_bridge_unavailable")
 
         gate = evaluate_redaction_gate(prompt, context, audit_mode=True)
         if gate.status != REDACTION_GATE_PASSED or not gate.redacted_prompt:
             return _model_result_reject("redaction_blocked")
+        model_topology = _runtime_model_topology(
+            binding,
+            default_lead=self.lead_model,
+            default_panel=self.panel_models,
+        )
         redacted_user = gate.redacted_prompt
         if gate.redacted_context:
             redacted_user = gate.redacted_prompt + "\n\n" + gate.redacted_context
         payload = {
             "mode": "foundups_fusion",
-            "lead_model": self.lead_model,
-            "panel_models": list(self.panel_models),
+            "lead_model": model_topology["lead_model"],
+            "panel_models": list(model_topology["panel_models"]),
             "max_tokens": self.max_tokens,
             "temperature": self.temperature,
             "timeout": timeout_seconds,
             "_redacted_evidence_context": gate.redacted_context or "",
-            "bridge_meta": {"architect_binding": dict(binding)},
+            "bridge_meta": {
+                "architect_binding": dict(binding),
+                "model_selection_receipt_id": model_topology["model_selection_receipt_id"],
+            },
         }
         try:
-            result = _run_foundups_fusion(api_key, redacted_user, [], payload)
+            result = run_foundups_fusion(api_key, redacted_user, [], payload)
         except TimeoutError:
             return _model_result_reject(ArchitectDeterminationReason.MODEL_TIMEOUT)
         except Exception:
@@ -230,6 +248,8 @@ class ArchitectDeterminationReceipt:
     audit_report_digests: tuple[str, ...]
     model_result_digest: Optional[str]
     model_receipt_id: Optional[str]
+    model_selection_receipt_id: Optional[str]
+    model_selection_digest: Optional[str]
     fusion_quorum_passed: bool
     wsp15_allocation_receipt_id: Optional[str]
     wsp15_allocation_digest: Optional[str]
@@ -456,6 +476,7 @@ def run_reddog_backend_architect_determination_runtime(
     wsp15_allocation_receipt: Mapping[str, Any],
     store: ArchitectDeterminationStore | None = None,
     model_runner: ArchitectModelRunner | None = None,
+    model_selection_receipt: Mapping[str, Any] | None = None,
     now_iso: str | None = None,
     timeout_seconds: int = 60,
 ) -> BackendArchitectDeterminationResult:
@@ -480,11 +501,15 @@ def run_reddog_backend_architect_determination_runtime(
     report_digests = _report_digests(reports)
     allocation_receipt_id = str(wsp15_allocation_receipt.get("receipt_id") or "").strip() or None
     allocation_digest = _digest(wsp15_allocation_receipt) if isinstance(wsp15_allocation_receipt, Mapping) else None
+    model_selection = _model_selection_binding(model_selection_receipt, reasons)
+    model_selection_receipt_id = str(model_selection.get("receipt_id") or "").strip() or None
+    model_selection_digest = str(model_selection.get("digest") or "").strip() or None
     cycle_id = _cycle_id(
         snapshot=snapshot,
         report_bundle_id=report_bundle_id,
         report_digests=report_digests,
         wsp15_allocation_digest=allocation_digest,
+        model_selection_digest=model_selection_digest,
     )
     writer = store if store is not None else AgentDbArchitectDeterminationStore()
     if cycle_id and not reasons:
@@ -512,6 +537,8 @@ def run_reddog_backend_architect_determination_runtime(
             cycle_id=cycle_id or "sha256:" + "0" * 64,
             decision_reasons=(),
             rejection_reasons=_dedupe(reasons),
+            model_selection_receipt_id=model_selection_receipt_id,
+            model_selection_digest=model_selection_digest,
         )
         persist_result = _persist_rejected(receipt)
         return _result(receipt=receipt, persist_result=persist_result)
@@ -553,9 +580,13 @@ def run_reddog_backend_architect_determination_runtime(
             cycle_id=cycle_id,
             decision_reasons=(),
             rejection_reasons=(ArchitectDeterminationReason.PROMPT_BUDGET_EXCEEDED,),
+            model_selection_receipt_id=model_selection_receipt_id,
+            model_selection_digest=model_selection_digest,
         )
         return _result(receipt=receipt, persist_result=_persist_rejected(receipt))
     binding = fusion_gate.determination_binding.to_dict() if fusion_gate.determination_binding else {}
+    if model_selection:
+        binding = {**binding, "model_selection": dict(model_selection)}
     try:
         model_result = runner.run_architect_determination(
             prompt=prompt,
@@ -588,6 +619,8 @@ def run_reddog_backend_architect_determination_runtime(
             cycle_id=cycle_id,
             decision_reasons=(),
             rejection_reasons=_dedupe(reasons),
+            model_selection_receipt_id=model_selection_receipt_id,
+            model_selection_digest=model_selection_digest,
         )
         persist_result = _persist_rejected(receipt)
         return _result(receipt=receipt, persist_result=persist_result)
@@ -625,6 +658,8 @@ def run_reddog_backend_architect_determination_runtime(
             cycle_id=cycle_id,
             decision_reasons=(),
             rejection_reasons=_dedupe(reasons),
+            model_selection_receipt_id=model_selection_receipt_id,
+            model_selection_digest=model_selection_digest,
         )
         persist_result = _persist_rejected(receipt)
         return _result(receipt=receipt, persist_result=persist_result)
@@ -640,6 +675,7 @@ def run_reddog_backend_architect_determination_runtime(
             "action": action,
             "next_slice_name": next_slice_name,
             "model_result_digest": model_result.model_result_digest,
+            "model_selection_digest": model_selection_digest,
         }
     )
     if action == ACTION_FIX:
@@ -668,6 +704,8 @@ def run_reddog_backend_architect_determination_runtime(
         cycle_id=cycle_id,
         decision_reasons=decision_reasons,
         rejection_reasons=(),
+        model_selection_receipt_id=model_selection_receipt_id,
+        model_selection_digest=model_selection_digest,
         queue_candidate=queue_candidate,
         determination_receipt_id=receipt_stub_id,
     )
@@ -690,6 +728,8 @@ def run_reddog_backend_architect_determination_runtime(
             cycle_id=cycle_id,
             decision_reasons=decision_reasons,
             rejection_reasons=(ArchitectDeterminationReason.STORE_REJECTED, *persist_result.rejection_reasons),
+            model_selection_receipt_id=model_selection_receipt_id,
+            model_selection_digest=model_selection_digest,
         )
         return _result(receipt=failed, persist_result=persist_result)
     return _result(receipt=receipt, persist_result=persist_result)
@@ -761,6 +801,82 @@ def _validate_wsp15_allocation(allocation: Mapping[str, Any], reasons: list[str]
         reasons.append(ArchitectDeterminationReason.MISSING_WSP15_ALLOCATION)
     else:
         reasons.append(ArchitectDeterminationReason.MALFORMED_WSP15_ALLOCATION)
+
+
+def _model_selection_binding(value: Any, reasons: list[str]) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        reasons.append(ArchitectDeterminationReason.MODEL_SELECTION_RECEIPT)
+        return {}
+    selection = _json_compatible_mapping(value)
+    if not selection:
+        reasons.append(ArchitectDeterminationReason.MODEL_SELECTION_RECEIPT)
+        return {}
+    try:
+        receipt = rehydrate_model_selection_receipt(selection)
+    except Exception:
+        reasons.append(ArchitectDeterminationReason.MODEL_SELECTION_RECEIPT)
+        return {}
+    if (
+        receipt.decision != SelectionDecision.SELECTED
+        or not receipt.selected_model_ids
+        or receipt.requirements.purpose != SelectionPurpose.PRODUCTION
+    ):
+        reasons.append(ArchitectDeterminationReason.MODEL_SELECTION_RECEIPT)
+        return {}
+    lead_model = ""
+    panel_models: list[str] = []
+    assignments = [asdict(item) for item in receipt.role_assignments]
+    for assignment in assignments:
+        role = str(assignment.get("role") or "")
+        model_id = str(assignment.get("canonical_model_id") or "")
+        if role == "principal" and model_id:
+            lead_model = model_id
+        elif role != "verifier" and model_id:
+            panel_models.append(model_id)
+    if not lead_model:
+        lead_model = str(receipt.selected_model_ids[0])
+        panel_models = [str(item) for item in receipt.selected_model_ids[1:]]
+    return {
+        "receipt_id": receipt.receipt_id,
+        "digest": _digest(selection),
+        "catalog_snapshot_id": receipt.catalog_snapshot_id,
+        "task_family": receipt.requirements.task_family,
+        "selection_mode": receipt.requirements.selection_mode.value,
+        "purpose": receipt.requirements.purpose.value,
+        "selected_model_ids": [str(item) for item in receipt.selected_model_ids],
+        "role_assignments": assignments,
+        "panel_topology_digest": receipt.panel_topology_digest,
+        "lead_model": lead_model,
+        "panel_models": panel_models,
+    }
+
+
+def _json_compatible_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    try:
+        normalized = json.loads(json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True))
+    except (TypeError, ValueError):
+        return {}
+    return normalized if isinstance(normalized, Mapping) else {}
+
+
+def _runtime_model_topology(
+    binding: Mapping[str, Any],
+    *,
+    default_lead: str,
+    default_panel: Sequence[str],
+) -> Mapping[str, Any]:
+    selection = binding.get("model_selection")
+    selection = selection if isinstance(selection, Mapping) else {}
+    lead = str(selection.get("lead_model") or default_lead)
+    raw_panel = selection.get("panel_models")
+    panel = [str(item) for item in raw_panel] if isinstance(raw_panel, list) else list(default_panel)
+    return {
+        "lead_model": lead,
+        "panel_models": tuple(item for item in panel if item),
+        "model_selection_receipt_id": str(selection.get("receipt_id") or ""),
+    }
 
 
 def _parse_model_output(content: str) -> Mapping[str, Any]:
@@ -942,6 +1058,8 @@ def _receipt(
     cycle_id: str,
     decision_reasons: Sequence[str],
     rejection_reasons: Sequence[str],
+    model_selection_receipt_id: Optional[str] = None,
+    model_selection_digest: Optional[str] = None,
     queue_candidate: ArchitectQueueCandidate | None = None,
     determination_receipt_id: Optional[str] = None,
 ) -> ArchitectDeterminationReceipt:
@@ -960,6 +1078,8 @@ def _receipt(
         "audit_report_digests": tuple(report_digests),
         "model_result_digest": model_result.model_result_digest if model_result else None,
         "model_receipt_id": model_result.model_receipt_id if model_result else None,
+        "model_selection_receipt_id": model_selection_receipt_id,
+        "model_selection_digest": model_selection_digest,
         "fusion_quorum_passed": _fusion_quorum_passed(model_result.review_packet) if model_result else False,
         "wsp15_allocation_receipt_id": allocation_receipt_id,
         "wsp15_allocation_digest": allocation_digest,
@@ -986,6 +1106,8 @@ def _receipt(
         audit_report_digests=tuple(report_digests),
         model_result_digest=model_result.model_result_digest if model_result else None,
         model_receipt_id=model_result.model_receipt_id if model_result else None,
+        model_selection_receipt_id=model_selection_receipt_id,
+        model_selection_digest=model_selection_digest,
         fusion_quorum_passed=_fusion_quorum_passed(model_result.review_packet) if model_result else False,
         wsp15_allocation_receipt_id=allocation_receipt_id,
         wsp15_allocation_digest=allocation_digest,
@@ -1079,12 +1201,31 @@ def _model_result_reject(reason: str) -> ArchitectModelResult:
     )
 
 
+def _load_foundups_fusion_runner():
+    try:
+        from scripts.advisory_model_once import _run_foundups_fusion
+
+        return _run_foundups_fusion
+    except Exception:
+        bridge_path = Path(__file__).resolve().parents[4] / "scripts" / "advisory_model_once.py"
+        spec = importlib.util.spec_from_file_location("reddog_advisory_model_once_backend", bridge_path)
+        if spec is None or spec.loader is None:
+            raise ImportError("advisory_model_once_unavailable")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        runner = getattr(module, "_run_foundups_fusion", None)
+        if not callable(runner):
+            raise ImportError("foundups_fusion_runner_unavailable")
+        return runner
+
+
 def _cycle_id(
     *,
     snapshot: OperationalContextSnapshot | None,
     report_bundle_id: Optional[str],
     report_digests: Sequence[str],
     wsp15_allocation_digest: Optional[str],
+    model_selection_digest: Optional[str],
 ) -> Optional[str]:
     if snapshot is None or not report_bundle_id or not wsp15_allocation_digest:
         return None
@@ -1095,6 +1236,7 @@ def _cycle_id(
             "report_bundle_id": report_bundle_id,
             "report_digests": tuple(report_digests),
             "wsp15_allocation_digest": wsp15_allocation_digest,
+            "model_selection_digest": model_selection_digest,
         }
     )
 

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -181,10 +181,13 @@ def run_reddog_main_readonly_operational_bootstrap(
     decision_store: ReadOnlyAuditDecisionStore | None = None,
     run_backend_architect_determination: bool = False,
     architect_model_runner: ArchitectModelRunner | None = None,
+    architect_model_selection_receipt_path: Path | str | None = None,
+    architect_model_selection_receipt_override: Mapping[str, Any] | None = None,
     architect_determination_store: ArchitectDeterminationStore | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     """Build a read-only startup plan or explain why it is not ready."""
 
+    root = Path(repo_root).resolve()
     paths = _normalize_paths(changed_paths)
     targets = _normalize_paths(allowed_read_targets)
     wsp15_allocation_receipt = allocate_reddog_wsp15_receipt(
@@ -194,6 +197,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         allowed_read_targets=targets,
     ).to_dict()
     reasons: list[str] = []
+    architect_model_selection_receipt = architect_model_selection_receipt_override
 
     work_state_snapshot = work_state_snapshot_override
     if work_state_snapshot is None:
@@ -234,7 +238,7 @@ def run_reddog_main_readonly_operational_bootstrap(
         )
 
     assert work_state_snapshot is not None
-    repo_state = dict(repo_state_override) if repo_state_override is not None else observe_repo_state(Path(repo_root))
+    repo_state = dict(repo_state_override) if repo_state_override is not None else observe_repo_state(root)
     snapshot_result = build_operational_context_snapshot(
         repo_state=repo_state,
         work_state_snapshot=work_state_snapshot,
@@ -370,6 +374,46 @@ def run_reddog_main_readonly_operational_bootstrap(
                         architect_result=architect_result,
                     )
             if run_backend_architect_determination:
+                if architect_model_selection_receipt is None:
+                    if architect_model_selection_receipt_path:
+                        architect_model_selection_receipt, model_reasons = _read_json_outside_repo(
+                            root,
+                            architect_model_selection_receipt_path,
+                            missing_reason="missing_architect_model_selection_receipt",
+                            inside_reason="architect_model_selection_receipt_path_inside_repo",
+                            unreadable_reason="malformed_architect_model_selection_receipt",
+                            required=True,
+                        )
+                        if model_reasons:
+                            return _not_ready(
+                                reasons=tuple(model_reasons),
+                                changed_paths=paths,
+                                allowed_read_targets=targets,
+                                wsp15_allocation_receipt=wsp15_allocation_receipt,
+                                snapshot=snapshot,
+                                evidence_bundle=evidence_bundle,
+                                gate=gate,
+                                swarm_plan=plan,
+                                collection_result=collection_result,
+                                decision_result=decision_result,
+                                decision_persist_result=decision_persist_result,
+                                architect_result=architect_result,
+                            )
+                    elif architect_model_runner is None:
+                        return _not_ready(
+                            reasons=("missing_architect_model_selection_receipt_path",),
+                            changed_paths=paths,
+                            allowed_read_targets=targets,
+                            wsp15_allocation_receipt=wsp15_allocation_receipt,
+                            snapshot=snapshot,
+                            evidence_bundle=evidence_bundle,
+                            gate=gate,
+                            swarm_plan=plan,
+                            collection_result=collection_result,
+                            decision_result=decision_result,
+                            decision_persist_result=decision_persist_result,
+                            architect_result=architect_result,
+                        )
                 architect_store = (
                     architect_determination_store
                     if architect_determination_store is not None
@@ -385,6 +429,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                     wsp15_allocation_receipt=wsp15_allocation_receipt,
                     store=architect_store,
                     model_runner=architect_model_runner,
+                    model_selection_receipt=architect_model_selection_receipt,
                     now_iso=now_iso,
                 )
                 if not architect_result.accepted:
@@ -613,6 +658,38 @@ def _resolve_holoindex_receipt_path(
     if ssd_path:
         return freshness_receipt_path(ssd_path)
     return None
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    unreadable_reason: str,
+    required: bool = True,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,) if required else ()
+    path = Path(value)
+    if not path.is_absolute():
+        path = (repo_root / path).resolve()
+    else:
+        path = path.resolve()
+    try:
+        path.relative_to(repo_root)
+        return None, (inside_reason,)
+    except ValueError:
+        pass
+    if not path.exists() or not path.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (unreadable_reason,)
+    if not isinstance(payload, Mapping):
+        return None, (unreadable_reason,)
+    return payload, ()
 
 
 def _not_ready(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -40,6 +40,9 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_report_colle
 from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
     allocate_reddog_wsp15_receipt,
 )
+from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    _model_selection,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -326,6 +329,50 @@ def test_research_more_persists_without_queue_candidate() -> None:
     assert result.queue_candidate_count == 0
 
 
+def test_model_selection_receipt_is_bound_to_backend_runner_and_receipt() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    selection = _model_selection()
+    runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref))
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        model_selection_receipt=selection,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.receipt.model_selection_receipt_id == selection["receipt_id"]
+    assert result.receipt.model_selection_digest
+    binding = runner.calls[0]["binding"]["model_selection"]
+    assert binding["receipt_id"] == selection["receipt_id"]
+    assert binding["lead_model"] == "openai/gpt-5.6-code"
+    assert binding["purpose"] == "production"
+
+
+def test_tampered_model_selection_receipt_rejects_before_backend_model_call() -> None:
+    inputs = _build_inputs()
+    selection = _model_selection()
+    selection["selected_model_ids"] = ["attacker/model"]
+    runner = FakeArchitectRunner({})
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=runner,
+        model_selection_receipt=selection,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.MODEL_SELECTION_RECEIPT in result.rejection_reasons
+    assert runner.calls == []
+
+
 def test_missing_reports_fail_before_model_call() -> None:
     inputs = _build_inputs(include_reports=False)
     runner = FakeArchitectRunner({})
@@ -548,6 +595,53 @@ def test_production_runner_is_explicit_mode_only_without_network(monkeypatch) ->
     assert result.ok is False
     assert result.made_network_call is False
     assert result.rejection_reasons == ("runtime_mode_not_enabled",)
+
+
+def test_production_runner_uses_model_selection_topology(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_fusion(api_key, user_payload, messages, payload):
+        calls.append(dict(payload))
+        return {
+            "ok": True,
+            "content": json.dumps(
+                {
+                    "action": ACTION_RESEARCH_MORE,
+                    "next_slice_name": "REDDOG_NEXT_RUNTIME_SLICE_PHASE1",
+                    "summary": "ok",
+                    "decision_reasons": ["test"],
+                    "evidence_refs": ["file:test.md:1"],
+                    "wsp15_allocation_receipt_id": "wsp15:test",
+                },
+                sort_keys=True,
+            ),
+            "review_packet": {"receipt_id": "fusion-receipt-1"},
+        }
+
+    monkeypatch.setenv("REDDOG_BACKEND_ARCHITECT_RUNTIME_MODE", "foundups_fusion")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(backend_runtime, "_load_foundups_fusion_runner", lambda: fake_fusion)
+
+    result = FoundupsFusionArchitectModelRunner(
+        lead_model="legacy/lead",
+        panel_models=("legacy/panel",),
+    ).run_architect_determination(
+        prompt="Return JSON.",
+        context="public evidence",
+        binding={
+            "model_selection": {
+                "receipt_id": "model_selection_receipt:test",
+                "lead_model": "openai/gpt-5.6-code",
+                "panel_models": ["anthropic/claude-opus-5"],
+            }
+        },
+        timeout_seconds=1,
+    )
+
+    assert result.ok is True
+    assert calls[0]["lead_model"] == "openai/gpt-5.6-code"
+    assert calls[0]["panel_models"] == ["anthropic/claude-opus-5"]
+    assert calls[0]["bridge_meta"]["model_selection_receipt_id"] == "model_selection_receipt:test"
 
 
 def test_module_ast_denies_execution_and_mutation_surfaces() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -43,6 +43,9 @@ from modules.communication.moltbot_bridge.src.reddog_backend_architect_determina
     ArchitectModelResult,
     InMemoryArchitectDeterminationStore,
 )
+from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    _model_selection,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -412,6 +415,66 @@ def test_bootstrap_runs_backend_architect_determination_when_enabled() -> None:
     assert len(architect_store.records) == 1
     assert result.no_openclaw_enqueue_performed is True
     assert result.no_queue_mutation_performed is True
+
+
+def test_bootstrap_passes_architect_model_selection_receipt_override_to_backend_runner() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+    architect_store = InMemoryArchitectDeterminationStore()
+    architect_runner = _FakeArchitectRunner()
+    model_selection = _model_selection()
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=report_store,
+        run_backend_architect_determination=True,
+        architect_model_runner=architect_runner,
+        architect_model_selection_receipt_override=model_selection,
+        architect_determination_store=architect_store,
+    )
+
+    assert result.ready is True
+    assert architect_runner.calls[0]["binding"]["model_selection"]["receipt_id"] == model_selection["receipt_id"]
+    assert architect_store.records[0].determination["model_selection_receipt_id"] == model_selection["receipt_id"]
+
+
+def test_bootstrap_requires_architect_model_selection_for_production_runner() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=report_store,
+        run_backend_architect_determination=True,
+        architect_model_runner=None,
+        architect_determination_store=InMemoryArchitectDeterminationStore(),
+    )
+
+    assert result.ready is False
+    assert "missing_architect_model_selection_receipt_path" in result.rejection_reasons
+    assert result.backend_architect_determination_attempted is False
 
 
 def test_bootstrap_fails_closed_when_decision_persistence_rejects() -> None:


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- Backend architect determination accepts an optional production `ModelSelectionReceipt` and rehydrates it before model invocation.
- Valid supplied receipts are bound into the architect runner binding and persisted on `ArchitectDeterminationReceipt` as receipt id + digest.
- Tampered supplied receipts reject before model invocation.
- The FoundUps Fusion backend architect runner resolves the Fusion bridge with a repo-path fallback and uses receipt-derived lead/panel topology when supplied.
- `main.py` read-only bootstrap can pass an outside-repo architect model-selection receipt into the backend architect runtime, and production runner usage fails closed when no receipt path is supplied.

SPECIFIED_NOT_IMPLEMENTED / unchanged:
- No model benchmark/catalog rebuild in this slice.
- No OpenClaw enqueue, Hermes dispatch, shell execution, worktree creation, PR publish, PatternMemory promotion, HoloIndex re-index, or extension runtime change.
- Injected model runners remain supported for deterministic tests and dry-run paths.

## Verification

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py modules/communication/moltbot_bridge/tests/test_reddog_bounded_artifact_generation_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 82 passed
- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py`
- `git diff --check`

## WSP_15 Placement

P0 operational bridge: this removes another hard-coded model panel from the resident RedDog decision path before worker dispatch broadens.