### PR TITLE
feat(reddog): supply model runtime binding artifacts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -236,6 +236,41 @@ public-key resolver, uses the configured public signature verifier, and delegate
 receipt creation to `run_reddog_model_selection_artifact_supply`. It is disabled
 unless `REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=1`.
 
+#### RedDog Runtime Binding Artifact Supply
+
+```python
+run_reddog_model_runtime_binding_artifact_supply(...) -> ModelRuntimeBindingArtifactSupplyResult
+```
+
+The supplier rehydrates a catalog snapshot, a production model-selection
+receipt, benchmark evidence receipts, promotion evidence receipts, signed
+production-evidence proof, and a runtime binding policy. It then calls
+`bind_reddog_runtime_models` and atomically writes one
+`RedDogModelRuntimeBindingReceipt` JSON artifact outside the repository.
+
+Serialized signed evidence requires a trusted public-key resolver and signature
+verifier before runtime binding. A binding is emitted only when the production
+selection, benchmark evidence, promotion evidence, verified signed evidence and
+runtime policy agree. Policy mismatches, missing signature verification,
+rejected runtime binding, missing output paths and repository-internal output
+paths fail closed.
+
+```python
+run_reddog_model_runtime_binding_artifact_supply_bootstrap(...) -> ModelRuntimeBindingArtifactBootstrapResult
+```
+
+The bootstrap adapter is the explicit `main.py` preflight surface for runtime
+binding artifacts. It reads outside-repo catalog, selection, benchmark,
+promotion, evidence-bundle, policy and trusted-key JSON inputs, constructs a
+trusted public-key resolver, uses the configured public signature verifier, and
+delegates receipt creation to
+`run_reddog_model_runtime_binding_artifact_supply`.
+
+This API does not call providers, run benchmarks, execute shell commands,
+persist telemetry, mutate extension runtime defaults, dispatch workers, write
+PatternMemory, or re-index HoloIndex. It supplies a receipt artifact only; later
+resident runtime code must explicitly consume that receipt.
+
 ## Configuration
 
 ### Environment Variables

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,48 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - RedDog Runtime Binding Artifact Supply
+
+**Who:** 0102 Codex
+**Type:** Runtime Artifact Bridge
+**Slice:** REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_PHASE1
+
+**What:** Added a bounded supplier and startup adapter that materialize a
+`RedDogModelRuntimeBindingReceipt` JSON artifact from an existing production
+model-selection receipt, benchmark evidence, promotion evidence, signed
+production evidence, and explicit runtime binding policy.
+
+**Why:** After RedDog runtime paths learned to consume runtime-binding receipts,
+the resident runtime needs a receipt artifact producer. This bridge supplies the
+artifact without hard-coding model defaults or trusting catalog-only champion
+fields.
+
+**Files:**
+- `src/model_runtime_binding_artifact_supply.py` - rehydrates source receipts,
+  verifies signed production evidence, binds runtime models, and atomically
+  writes one receipt outside the repository.
+- `src/model_runtime_binding_artifact_supply_bootstrap.py` - outside-repo JSON
+  input loader, trusted model-evidence key resolver construction, public
+  signature verifier selection, and supplier invocation.
+- `tests/test_model_runtime_binding_artifact_supply.py` - serialized and typed
+  evidence acceptance, missing signature-gate rejection, policy-mismatch
+  rejection, repository-output rejection, and AST boundary tests.
+- `tests/test_model_runtime_binding_artifact_supply_bootstrap.py` - positive
+  materialization and missing-key/output/AST boundary tests.
+- `README.md` and `INTERFACE.md` - API and truth-boundary notes.
+
+**Truth Boundary:**
+- IMPLEMENTED: production runtime-binding receipt artifact supply.
+- IMPLEMENTED: serialized evidence requires key resolution and signature
+  verification before runtime binding.
+- IMPLEMENTED: receipt output must live outside the repository.
+- NOT IMPLEMENTED: provider calls, benchmark execution, telemetry persistence,
+  HoloIndex re-indexing, extension runtime default mutation, worker dispatch,
+  PatternMemory writes, or panel runtime promotion.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - RedDog Model Selection Artifact Supply Main Preflight
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -136,6 +136,28 @@ selection receipt path consumed by RedDog FIX promotion. The adapter defaults to
 the existing Ed25519 public verifier and fails closed when trusted keys or
 signed evidence are absent.
 
+## RedDog Runtime Binding Artifact Supply
+
+`src/model_runtime_binding_artifact_supply.py` materializes a
+`RedDogModelRuntimeBindingReceipt` JSON artifact from the production
+`ModelSelectionReceipt`, matching benchmark evidence, matching promotion
+evidence, signed verified production evidence, and an explicit runtime binding
+policy.
+
+This closes the handoff after model selection: resident RedDog can now consume a
+receipt-bound runtime model topology instead of hard-coded GLM/DeepSeek/Kimi
+defaults. The supplier rehydrates and digest-checks every source receipt before
+binding, rejects mismatched policy evidence, and refuses to write artifacts
+inside the repository. It does not call providers, run benchmarks, execute
+commands, mutate catalogs, persist telemetry, re-index HoloIndex, mutate
+`extension.js`, dispatch workers, or write PatternMemory.
+
+`src/model_runtime_binding_artifact_supply_bootstrap.py` is the optional
+`main.py` startup adapter for that supplier. It reads outside-repo catalog,
+selection, benchmark, promotion, signed-evidence, policy and trusted-key JSON
+inputs, then writes the runtime-binding receipt path for later resident runtime
+consumption. It remains disabled unless explicitly configured.
+
 **Usage Examples**:
 ```python
 from modules.ai_intelligence.ai_gateway import AIGateway

--- a/modules/ai_intelligence/ai_gateway/src/model_runtime_binding_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_runtime_binding_artifact_supply.py
@@ -1,0 +1,356 @@
+"""Production runtime-binding receipt artifact supplier for RedDog.
+
+Slice: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_PHASE1
+
+This module materializes a ``RedDogModelRuntimeBindingReceipt`` from an
+existing production model-selection receipt and its signed benchmark/promotion
+evidence. It is a bounded bridge for resident RedDog runtime inputs. It does
+not call providers, benchmark models, execute commands, mutate catalogs, bind
+extension runtime defaults, spawn workers, write PatternMemory, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelBenchmarkEvidenceReceipt,
+    ModelPromotionEvidenceReceipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import (
+    ModelRuntimeBindingDecision,
+    ModelRuntimeBindingPolicy,
+    bind_reddog_runtime_models,
+)
+from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply import (
+    _rehydrate_verified_evidence_bundle,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    ModelEvidenceKeyResolver,
+    VerifiedModelProductionEvidence,
+    rehydrate_model_benchmark_evidence_receipt,
+    rehydrate_model_catalog_snapshot,
+    rehydrate_model_promotion_evidence_receipt,
+    rehydrate_model_selection_receipt,
+)
+
+
+MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT = "MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT"
+MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_REJECT = "MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_REJECT"
+
+
+class ModelRuntimeBindingArtifactSupplyReason:
+    CATALOG_MISSING = "model_catalog_snapshot_missing"
+    CATALOG_INVALID = "model_catalog_snapshot_invalid"
+    SELECTION_MISSING = "model_selection_receipt_missing"
+    SELECTION_INVALID = "model_selection_receipt_invalid"
+    BENCHMARKS_MISSING = "model_benchmark_evidence_receipts_missing"
+    BENCHMARKS_INVALID = "model_benchmark_evidence_receipts_invalid"
+    PROMOTIONS_MISSING = "model_promotion_evidence_receipts_missing"
+    PROMOTIONS_INVALID = "model_promotion_evidence_receipts_invalid"
+    EVIDENCE_MISSING = "verified_production_evidence_missing"
+    EVIDENCE_INVALID = "verified_production_evidence_invalid"
+    KEY_RESOLVER_MISSING = "model_evidence_key_resolver_missing"
+    SIGNATURE_VERIFIER_MISSING = "model_evidence_signature_verifier_missing"
+    POLICY_MISSING = "model_runtime_binding_policy_missing"
+    POLICY_INVALID = "model_runtime_binding_policy_invalid"
+    RUNTIME_BINDING_REJECTED = "model_runtime_binding_rejected"
+    OUTPUT_PATH_INVALID = "model_runtime_binding_output_path_invalid"
+    OUTPUT_WRITE_FAILED = "model_runtime_binding_output_write_failed"
+
+
+@dataclass(frozen=True)
+class ModelRuntimeBindingArtifactSupplyResult:
+    accepted: bool
+    status: str
+    runtime_binding_receipt_id: str | None
+    catalog_snapshot_id: str | None
+    selection_receipt_id: str | None
+    runtime_surface: str | None
+    principal_model: str | None
+    panel_models: tuple[str, ...]
+    output_path: str | None
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_extension_runtime_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_telemetry_persistence_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_runtime_binding_artifact_supply(
+    *,
+    repo_root: Path | str,
+    catalog_snapshot: Mapping[str, Any] | None,
+    model_selection_receipt: Mapping[str, Any] | None,
+    benchmark_evidence_receipts: Sequence[Mapping[str, Any] | ModelBenchmarkEvidenceReceipt] | None,
+    promotion_evidence_receipts: Sequence[Mapping[str, Any] | ModelPromotionEvidenceReceipt] | None,
+    verified_evidence_bundle: Mapping[str, Any] | VerifiedModelProductionEvidence | None,
+    runtime_policy: Mapping[str, Any] | ModelRuntimeBindingPolicy | None,
+    output_path: Path | str | None,
+    key_resolver: ModelEvidenceKeyResolver | None = None,
+    signature_verifier: SignatureVerifier | None = None,
+    now: int | None = None,
+    consume_nonces: bool = False,
+) -> ModelRuntimeBindingArtifactSupplyResult:
+    """Verify model evidence, bind runtime models, and write one receipt."""
+
+    root = Path(repo_root).resolve()
+    reasons: list[str] = []
+
+    snapshot = None
+    if not isinstance(catalog_snapshot, Mapping) or not catalog_snapshot:
+        reasons.append(ModelRuntimeBindingArtifactSupplyReason.CATALOG_MISSING)
+    else:
+        try:
+            snapshot = rehydrate_model_catalog_snapshot(catalog_snapshot)
+        except Exception:
+            reasons.append(ModelRuntimeBindingArtifactSupplyReason.CATALOG_INVALID)
+
+    selection = None
+    if not isinstance(model_selection_receipt, Mapping) or not model_selection_receipt:
+        reasons.append(ModelRuntimeBindingArtifactSupplyReason.SELECTION_MISSING)
+    else:
+        try:
+            selection = rehydrate_model_selection_receipt(model_selection_receipt)
+        except Exception:
+            reasons.append(ModelRuntimeBindingArtifactSupplyReason.SELECTION_INVALID)
+
+    benchmarks: tuple[ModelBenchmarkEvidenceReceipt, ...] = ()
+    benchmark_reasons: list[str] = []
+    if not benchmark_evidence_receipts:
+        benchmark_reasons.append(ModelRuntimeBindingArtifactSupplyReason.BENCHMARKS_MISSING)
+    else:
+        try:
+            benchmarks = tuple(_benchmark_receipts(benchmark_evidence_receipts))
+        except Exception:
+            benchmark_reasons.append(ModelRuntimeBindingArtifactSupplyReason.BENCHMARKS_INVALID)
+    reasons.extend(benchmark_reasons)
+
+    promotions: tuple[ModelPromotionEvidenceReceipt, ...] = ()
+    promotion_reasons: list[str] = []
+    if not promotion_evidence_receipts:
+        promotion_reasons.append(ModelRuntimeBindingArtifactSupplyReason.PROMOTIONS_MISSING)
+    else:
+        try:
+            promotions = tuple(_promotion_receipts(promotion_evidence_receipts, benchmarks))
+        except Exception:
+            promotion_reasons.append(ModelRuntimeBindingArtifactSupplyReason.PROMOTIONS_INVALID)
+    reasons.extend(promotion_reasons)
+
+    evidence = None
+    if verified_evidence_bundle is None:
+        reasons.append(ModelRuntimeBindingArtifactSupplyReason.EVIDENCE_MISSING)
+    elif isinstance(verified_evidence_bundle, VerifiedModelProductionEvidence):
+        evidence = verified_evidence_bundle
+    else:
+        if key_resolver is None:
+            reasons.append(ModelRuntimeBindingArtifactSupplyReason.KEY_RESOLVER_MISSING)
+        if signature_verifier is None:
+            reasons.append(ModelRuntimeBindingArtifactSupplyReason.SIGNATURE_VERIFIER_MISSING)
+        if key_resolver is not None and signature_verifier is not None:
+            try:
+                evidence = _rehydrate_verified_evidence_bundle(
+                    verified_evidence_bundle,
+                    key_resolver=key_resolver,
+                    signature_verifier=signature_verifier,
+                    now=now,
+                    consume_nonces=consume_nonces,
+                )
+            except Exception:
+                reasons.append(ModelRuntimeBindingArtifactSupplyReason.EVIDENCE_INVALID)
+
+    policy = None
+    if runtime_policy is None:
+        reasons.append(ModelRuntimeBindingArtifactSupplyReason.POLICY_MISSING)
+    else:
+        try:
+            policy = _policy(runtime_policy)
+        except Exception:
+            reasons.append(ModelRuntimeBindingArtifactSupplyReason.POLICY_INVALID)
+
+    resolved_output, output_reasons = _runtime_output_path(
+        output_path,
+        root,
+        ModelRuntimeBindingArtifactSupplyReason.OUTPUT_PATH_INVALID,
+    )
+    reasons.extend(output_reasons)
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert snapshot is not None
+    assert selection is not None
+    assert evidence is not None
+    assert policy is not None
+    assert resolved_output is not None
+    receipt = bind_reddog_runtime_models(
+        catalog_snapshot=snapshot,
+        selection_receipt=selection,
+        benchmark_evidence_receipts=benchmarks,
+        promotion_evidence_receipts=promotions,
+        policy=policy,
+        verified_production_evidence=evidence,
+    )
+    if receipt.decision != ModelRuntimeBindingDecision.BOUND:
+        return _reject((ModelRuntimeBindingArtifactSupplyReason.RUNTIME_BINDING_REJECTED, *receipt.rejection_reasons))
+
+    try:
+        _write_json_atomic(resolved_output, receipt.to_dict())
+    except Exception:
+        return _reject((ModelRuntimeBindingArtifactSupplyReason.OUTPUT_WRITE_FAILED,))
+
+    return ModelRuntimeBindingArtifactSupplyResult(
+        accepted=True,
+        status=MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT,
+        runtime_binding_receipt_id=receipt.receipt_id,
+        catalog_snapshot_id=receipt.catalog_snapshot_id,
+        selection_receipt_id=receipt.selection_receipt_id,
+        runtime_surface=receipt.runtime_surface,
+        principal_model=receipt.principal_model,
+        panel_models=receipt.panel_models,
+        output_path=str(resolved_output),
+        rejection_reasons=(),
+    )
+
+
+def _benchmark_receipts(
+    values: Sequence[Mapping[str, Any] | ModelBenchmarkEvidenceReceipt],
+) -> tuple[ModelBenchmarkEvidenceReceipt, ...]:
+    receipts: list[ModelBenchmarkEvidenceReceipt] = []
+    for value in values:
+        if isinstance(value, ModelBenchmarkEvidenceReceipt):
+            receipts.append(value)
+        elif isinstance(value, Mapping):
+            receipts.append(rehydrate_model_benchmark_evidence_receipt(value))
+        else:
+            raise ValueError("invalid_benchmark_receipt")
+    return tuple(receipts)
+
+
+def _promotion_receipts(
+    values: Sequence[Mapping[str, Any] | ModelPromotionEvidenceReceipt],
+    benchmarks: Sequence[ModelBenchmarkEvidenceReceipt],
+) -> tuple[ModelPromotionEvidenceReceipt, ...]:
+    by_id = {receipt.receipt_id: receipt for receipt in benchmarks}
+    receipts: list[ModelPromotionEvidenceReceipt] = []
+    for value in values:
+        if isinstance(value, ModelPromotionEvidenceReceipt):
+            receipts.append(value)
+            continue
+        if not isinstance(value, Mapping):
+            raise ValueError("invalid_promotion_receipt")
+        benchmark = by_id.get(str(value.get("benchmark_evidence_receipt_id") or ""))
+        if benchmark is None:
+            raise ValueError("promotion_benchmark_receipt_missing")
+        receipts.append(rehydrate_model_promotion_evidence_receipt(value, benchmark_receipt=benchmark))
+    return tuple(receipts)
+
+
+def _policy(value: Mapping[str, Any] | ModelRuntimeBindingPolicy) -> ModelRuntimeBindingPolicy:
+    if isinstance(value, ModelRuntimeBindingPolicy):
+        return value.normalized()
+    if not isinstance(value, Mapping):
+        raise ValueError("policy_not_mapping")
+    return ModelRuntimeBindingPolicy(
+        task_family=_required(value.get("task_family"), "task_family"),
+        runtime_surface=_required(value.get("runtime_surface"), "runtime_surface"),
+        min_verifier_pass_rate=float(value.get("min_verifier_pass_rate")),
+        required_task_set_digest=_required(value.get("required_task_set_digest"), "required_task_set_digest"),
+        required_held_out_split_digest=_required(
+            value.get("required_held_out_split_digest"),
+            "required_held_out_split_digest",
+        ),
+        required_verifier_digest=_required(value.get("required_verifier_digest"), "required_verifier_digest"),
+        max_panel_models=int(value.get("max_panel_models", 4)),
+        required_panel_topology_digest=_optional(value.get("required_panel_topology_digest")),
+        authority_receipt_id=_optional(value.get("authority_receipt_id")),
+    ).normalized()
+
+
+def _runtime_output_path(
+    value: Path | str | None,
+    repo_root: Path,
+    reason: str,
+) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root)
+        return None, [reason]
+    except ValueError:
+        pass
+    return resolved, []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _required(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(name + "_missing")
+    return text
+
+
+def _optional(value: Any) -> str | None:
+    text = str(value or "").strip() if value is not None else ""
+    return text or None
+
+
+def _reject(reasons: Sequence[str]) -> ModelRuntimeBindingArtifactSupplyResult:
+    return ModelRuntimeBindingArtifactSupplyResult(
+        accepted=False,
+        status=MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_REJECT,
+        runtime_binding_receipt_id=None,
+        catalog_snapshot_id=None,
+        selection_receipt_id=None,
+        runtime_surface=None,
+        principal_model=None,
+        panel_models=(),
+        output_path=None,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+__all__ = [
+    "MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT",
+    "MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_REJECT",
+    "ModelRuntimeBindingArtifactSupplyReason",
+    "ModelRuntimeBindingArtifactSupplyResult",
+    "run_reddog_model_runtime_binding_artifact_supply",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_runtime_binding_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_runtime_binding_artifact_supply_bootstrap.py
@@ -1,0 +1,243 @@
+"""Main-startup bootstrap for RedDog runtime-binding artifact supply.
+
+Slice: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads outside-repo runtime JSON inputs and materializes a
+``RedDogModelRuntimeBindingReceipt``. It does not call providers, execute
+commands, mutate catalogs, bind extension defaults, spawn workers, re-index
+HoloIndex, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding_artifact_supply import (
+    MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT,
+    run_reddog_model_runtime_binding_artifact_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap import (
+    _key_resolver,
+    _signature_verifier,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+
+MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED = "MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED"
+MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY = "MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY"
+
+
+@dataclass(frozen=True)
+class ModelRuntimeBindingArtifactBootstrapResult:
+    accepted: bool
+    status: str
+    runtime_binding_receipt_id: Optional[str]
+    output_path: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_extension_runtime_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_telemetry_persistence_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_runtime_binding_artifact_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    catalog_snapshot_path: Path | str | None,
+    model_selection_receipt_path: Path | str | None,
+    benchmark_evidence_receipts_path: Path | str | None,
+    promotion_evidence_receipts_path: Path | str | None,
+    evidence_bundle_path: Path | str | None,
+    runtime_policy_path: Path | str | None,
+    trusted_keys_path: Path | str | None,
+    output_path: Path | str | None,
+    signature_verifier_backend: str = "ed25519",
+    signature_verifier: SignatureVerifier | None = None,
+    now_epoch: int | None = None,
+) -> ModelRuntimeBindingArtifactBootstrapResult:
+    """Materialize the runtime-binding artifact from configured runtime files."""
+
+    root = Path(repo_root).resolve()
+    catalog, catalog_reasons = _read_json_outside_repo(
+        root,
+        catalog_snapshot_path,
+        missing_reason="missing_model_catalog_snapshot_path",
+        inside_reason="model_catalog_snapshot_path_inside_repo",
+        malformed_reason="malformed_model_catalog_snapshot",
+    )
+    selection, selection_reasons = _read_json_outside_repo(
+        root,
+        model_selection_receipt_path,
+        missing_reason="missing_model_selection_receipt_path",
+        inside_reason="model_selection_receipt_path_inside_repo",
+        malformed_reason="malformed_model_selection_receipt",
+    )
+    benchmark_payload, benchmark_reasons = _read_json_outside_repo(
+        root,
+        benchmark_evidence_receipts_path,
+        missing_reason="missing_model_benchmark_evidence_receipts_path",
+        inside_reason="model_benchmark_evidence_receipts_path_inside_repo",
+        malformed_reason="malformed_model_benchmark_evidence_receipts",
+    )
+    promotion_payload, promotion_reasons = _read_json_outside_repo(
+        root,
+        promotion_evidence_receipts_path,
+        missing_reason="missing_model_promotion_evidence_receipts_path",
+        inside_reason="model_promotion_evidence_receipts_path_inside_repo",
+        malformed_reason="malformed_model_promotion_evidence_receipts",
+    )
+    evidence, evidence_reasons = _read_json_outside_repo(
+        root,
+        evidence_bundle_path,
+        missing_reason="missing_model_evidence_bundle_path",
+        inside_reason="model_evidence_bundle_path_inside_repo",
+        malformed_reason="malformed_model_evidence_bundle",
+    )
+    policy, policy_reasons = _read_json_outside_repo(
+        root,
+        runtime_policy_path,
+        missing_reason="missing_model_runtime_binding_policy_path",
+        inside_reason="model_runtime_binding_policy_path_inside_repo",
+        malformed_reason="malformed_model_runtime_binding_policy",
+    )
+    trusted_keys, key_reasons = _read_json_outside_repo(
+        root,
+        trusted_keys_path,
+        missing_reason="missing_model_evidence_trusted_keys_path",
+        inside_reason="model_evidence_trusted_keys_path_inside_repo",
+        malformed_reason="malformed_model_evidence_trusted_keys",
+    )
+    reasons = [
+        *catalog_reasons,
+        *selection_reasons,
+        *benchmark_reasons,
+        *promotion_reasons,
+        *evidence_reasons,
+        *policy_reasons,
+        *key_reasons,
+    ]
+    key_resolver = None
+    if trusted_keys is not None:
+        key_resolver, resolver_reasons = _key_resolver(trusted_keys)
+        reasons.extend(resolver_reasons)
+    verifier = signature_verifier
+    if verifier is None:
+        verifier, verifier_reasons = _signature_verifier(signature_verifier_backend)
+        reasons.extend(verifier_reasons)
+    benchmarks = _receipt_list(benchmark_payload, "benchmark_evidence_receipts")
+    promotions = _receipt_list(promotion_payload, "promotion_evidence_receipts")
+    if benchmark_payload is not None and benchmarks is None:
+        reasons.append("malformed_model_benchmark_evidence_receipts")
+    if promotion_payload is not None and promotions is None:
+        reasons.append("malformed_model_promotion_evidence_receipts")
+    if reasons:
+        return _not_ready(reasons)
+
+    assert catalog is not None
+    assert selection is not None
+    assert evidence is not None
+    assert policy is not None
+    assert key_resolver is not None
+    assert verifier is not None
+    assert benchmarks is not None
+    assert promotions is not None
+    supply = run_reddog_model_runtime_binding_artifact_supply(
+        repo_root=root,
+        catalog_snapshot=catalog,
+        model_selection_receipt=selection,
+        benchmark_evidence_receipts=benchmarks,
+        promotion_evidence_receipts=promotions,
+        verified_evidence_bundle=evidence,
+        runtime_policy=policy,
+        output_path=output_path,
+        key_resolver=key_resolver,
+        signature_verifier=verifier,
+        now=int(now_epoch if now_epoch is not None else time.time()),
+    )
+    if not supply.accepted or supply.status != MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT:
+        return _not_ready(supply.rejection_reasons or ("model_runtime_binding_artifact_supply_rejected",))
+    return ModelRuntimeBindingArtifactBootstrapResult(
+        accepted=True,
+        status=MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED,
+        runtime_binding_receipt_id=supply.runtime_binding_receipt_id,
+        output_path=supply.output_path,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _receipt_list(value: Any, key: str) -> tuple[Mapping[str, Any], ...] | None:
+    raw = value
+    if isinstance(value, Mapping):
+        raw = value.get(key)
+    if not isinstance(raw, list) or not raw:
+        return None
+    records: list[Mapping[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            return None
+        records.append(item)
+    return tuple(records)
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(reasons: tuple[str, ...] | list[str]) -> ModelRuntimeBindingArtifactBootstrapResult:
+    return ModelRuntimeBindingArtifactBootstrapResult(
+        accepted=False,
+        status=MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY,
+        runtime_binding_receipt_id=None,
+        output_path=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED",
+    "MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY",
+    "ModelRuntimeBindingArtifactBootstrapResult",
+    "run_reddog_model_runtime_binding_artifact_supply_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply.py
@@ -1,0 +1,283 @@
+"""Tests for REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionPurpose,
+    select_models_for_task,
+)
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding_artifact_supply import (
+    MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT,
+    MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_REJECT,
+    ModelRuntimeBindingArtifactSupplyReason,
+    run_reddog_model_runtime_binding_artifact_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply import (
+    EVIDENCE_BUNDLE_SCHEMA_VERSION,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    ModelEvidenceSignerRole,
+    StaticModelEvidenceKeyResolver,
+)
+from modules.ai_intelligence.ai_gateway.tests.model_signed_evidence_test_helpers import (
+    BENCHMARK_FINGERPRINT,
+    BENCHMARK_PUBLIC_KEY,
+    PROMOTION_FINGERPRINT,
+    PROMOTION_PUBLIC_KEY,
+    DeterministicSignatureVerifier,
+    make_signed_evidence_receipt,
+    make_verified_production_evidence,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_selection_artifact_supply import (
+    MODEL_ID,
+    NOW,
+    REPO_ROOT,
+    TASK,
+    _benchmark,
+    _promotion,
+    _snapshot,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_runtime_binding_artifact_supply.py"
+)
+
+
+def _selection_chain():
+    snapshot = _snapshot()
+    benchmark = _benchmark()
+    promotion = _promotion(benchmark)
+    provisional = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=snapshot.snapshot_id,
+    )
+    requirements = ModelTaskRequirements(
+        task_family=TASK,
+        purpose=SelectionPurpose.PRODUCTION,
+        min_verifier_pass_rate=0.8,
+        require_structured_output=True,
+        require_reasoning=True,
+    )
+    first = select_models_for_task(snapshot, requirements, production_evidence=provisional)
+    verified = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=snapshot.snapshot_id,
+        selection_receipt_id=first.receipt_id,
+    )
+    selection = select_models_for_task(snapshot, requirements, production_evidence=verified)
+    assert selection.receipt_id == first.receipt_id
+    return snapshot, selection, benchmark, promotion, verified
+
+
+def _policy(**overrides):
+    values = {
+        "task_family": TASK,
+        "runtime_surface": "reddog_backend_architect",
+        "min_verifier_pass_rate": 0.8,
+        "required_task_set_digest": "sha256:task-set",
+        "required_held_out_split_digest": "sha256:held-out",
+        "required_verifier_digest": "sha256:verifier",
+        "authority_receipt_id": "runtime-authority:1",
+    }
+    values.update(overrides)
+    return values
+
+
+def _serialized_evidence_bundle(snapshot, selection, benchmark, promotion):
+    benchmark_sig = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.BENCHMARK_VERIFIER,
+        public_key=BENCHMARK_PUBLIC_KEY,
+        fingerprint=BENCHMARK_FINGERPRINT,
+        model_id=MODEL_ID,
+        catalog_snapshot_id=snapshot.snapshot_id,
+        selection_receipt_id=selection.receipt_id,
+        benchmark_run_receipt_id="model_combination_benchmark_run:test",
+        benchmark_receipt=benchmark,
+        nonce=f"nonce:benchmark:{benchmark.receipt_id}:{selection.receipt_id}",
+    )
+    promotion_sig = make_signed_evidence_receipt(
+        signer_role=ModelEvidenceSignerRole.PROMOTION_AUTHORITY,
+        public_key=PROMOTION_PUBLIC_KEY,
+        fingerprint=PROMOTION_FINGERPRINT,
+        model_id=MODEL_ID,
+        catalog_snapshot_id=snapshot.snapshot_id,
+        selection_receipt_id=selection.receipt_id,
+        benchmark_run_receipt_id="model_combination_benchmark_run:test",
+        benchmark_receipt=benchmark,
+        promotion_receipt=promotion,
+        promotion_policy_digest="sha256:promotion-policy",
+        nonce=f"nonce:promotion:{promotion.receipt_id}:{selection.receipt_id}",
+    )
+    return {
+        "schema_version": EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        "catalog_snapshot_id": snapshot.snapshot_id,
+        "selection_receipt_id": selection.receipt_id,
+        "benchmark_run_receipt_id": "model_combination_benchmark_run:test",
+        "entries": [
+            {
+                "benchmark_receipt": benchmark.to_dict(),
+                "promotion_receipt": promotion.to_dict(),
+                "benchmark_signature_receipt": benchmark_sig.to_dict(),
+                "promotion_signature_receipt": promotion_sig.to_dict(),
+            }
+        ],
+    }
+
+
+def _key_resolver():
+    return StaticModelEvidenceKeyResolver(
+        {
+            ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY,
+            ModelEvidenceSignerRole.PROMOTION_AUTHORITY.value: PROMOTION_PUBLIC_KEY,
+        }
+    )
+
+
+def _artifact(value):
+    return json.loads(json.dumps(value, sort_keys=True))
+
+
+def test_runtime_supplier_verifies_serialized_evidence_and_writes_bound_receipt(tmp_path: Path) -> None:
+    snapshot, selection, benchmark, promotion, _verified = _selection_chain()
+    output = tmp_path / "runtime" / "model_runtime_binding_receipt.json"
+
+    result = run_reddog_model_runtime_binding_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=_artifact(snapshot.to_dict()),
+        model_selection_receipt=_artifact(selection.to_dict()),
+        benchmark_evidence_receipts=(_artifact(benchmark.to_dict()),),
+        promotion_evidence_receipts=(_artifact(promotion.to_dict()),),
+        verified_evidence_bundle=_serialized_evidence_bundle(snapshot, selection, benchmark, promotion),
+        runtime_policy=_policy(),
+        output_path=output,
+        key_resolver=_key_resolver(),
+        signature_verifier=DeterministicSignatureVerifier(),
+        now=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ACCEPT
+    assert result.runtime_binding_receipt_id and result.runtime_binding_receipt_id.startswith(
+        "reddog_model_runtime_binding:"
+    )
+    assert result.output_path == str(output.resolve())
+    assert result.principal_model == MODEL_ID
+    receipt = json.loads(output.read_text(encoding="utf-8"))
+    assert receipt["decision"] == "bound"
+    assert receipt["runtime_surface"] == "reddog_backend_architect"
+    assert receipt["selection_receipt_id"] == selection.receipt_id
+    assert result.no_model_call_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_runtime_supplier_accepts_typed_verified_evidence_object(tmp_path: Path) -> None:
+    snapshot, selection, benchmark, promotion, verified = _selection_chain()
+
+    result = run_reddog_model_runtime_binding_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=_artifact(snapshot.to_dict()),
+        model_selection_receipt=_artifact(selection.to_dict()),
+        benchmark_evidence_receipts=(_artifact(benchmark.to_dict()),),
+        promotion_evidence_receipts=(_artifact(promotion.to_dict()),),
+        verified_evidence_bundle=verified,
+        runtime_policy=_policy(),
+        output_path=tmp_path / "runtime" / "model_runtime_binding_receipt.json",
+    )
+
+    assert result.accepted is True
+    assert result.selection_receipt_id == selection.receipt_id
+
+
+def test_runtime_supplier_rejects_serialized_evidence_without_signature_gate(tmp_path: Path) -> None:
+    snapshot, selection, benchmark, promotion, _verified = _selection_chain()
+
+    result = run_reddog_model_runtime_binding_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=_artifact(snapshot.to_dict()),
+        model_selection_receipt=_artifact(selection.to_dict()),
+        benchmark_evidence_receipts=(_artifact(benchmark.to_dict()),),
+        promotion_evidence_receipts=(_artifact(promotion.to_dict()),),
+        verified_evidence_bundle=_serialized_evidence_bundle(snapshot, selection, benchmark, promotion),
+        runtime_policy=_policy(),
+        output_path=tmp_path / "runtime" / "model_runtime_binding_receipt.json",
+    )
+
+    assert result.accepted is False
+    assert result.status == MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_REJECT
+    assert ModelRuntimeBindingArtifactSupplyReason.KEY_RESOLVER_MISSING in result.rejection_reasons
+    assert ModelRuntimeBindingArtifactSupplyReason.SIGNATURE_VERIFIER_MISSING in result.rejection_reasons
+
+
+def test_runtime_supplier_rejects_binding_policy_mismatch_without_writing(tmp_path: Path) -> None:
+    snapshot, selection, benchmark, promotion, verified = _selection_chain()
+    output = tmp_path / "runtime" / "model_runtime_binding_receipt.json"
+
+    result = run_reddog_model_runtime_binding_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=_artifact(snapshot.to_dict()),
+        model_selection_receipt=_artifact(selection.to_dict()),
+        benchmark_evidence_receipts=(_artifact(benchmark.to_dict()),),
+        promotion_evidence_receipts=(_artifact(promotion.to_dict()),),
+        verified_evidence_bundle=verified,
+        runtime_policy=_policy(required_task_set_digest="sha256:wrong"),
+        output_path=output,
+    )
+
+    assert result.accepted is False
+    assert ModelRuntimeBindingArtifactSupplyReason.RUNTIME_BINDING_REJECTED in result.rejection_reasons
+    assert "task_set_digest_mismatch" in result.rejection_reasons
+    assert not output.exists()
+
+
+def test_runtime_supplier_rejects_output_inside_repo() -> None:
+    snapshot, selection, benchmark, promotion, verified = _selection_chain()
+
+    result = run_reddog_model_runtime_binding_artifact_supply(
+        repo_root=REPO_ROOT,
+        catalog_snapshot=_artifact(snapshot.to_dict()),
+        model_selection_receipt=_artifact(selection.to_dict()),
+        benchmark_evidence_receipts=(_artifact(benchmark.to_dict()),),
+        promotion_evidence_receipts=(_artifact(promotion.to_dict()),),
+        verified_evidence_bundle=verified,
+        runtime_policy=_policy(),
+        output_path=REPO_ROOT / "model_runtime_binding_receipt.json",
+    )
+
+    assert result.accepted is False
+    assert ModelRuntimeBindingArtifactSupplyReason.OUTPUT_PATH_INVALID in result.rejection_reasons
+    assert not (REPO_ROOT / "model_runtime_binding_receipt.json").exists()
+
+
+def test_runtime_supplier_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "holo_index",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply_bootstrap.py
@@ -1,0 +1,187 @@
+"""Tests for REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding_artifact_supply_bootstrap import (
+    MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED,
+    MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY,
+    run_reddog_model_runtime_binding_artifact_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.tests.model_signed_evidence_test_helpers import (
+    BENCHMARK_FINGERPRINT,
+    BENCHMARK_PUBLIC_KEY,
+    KEY_EPOCH,
+    PROMOTION_FINGERPRINT,
+    PROMOTION_PUBLIC_KEY,
+    DeterministicSignatureVerifier,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_runtime_binding_artifact_supply import (
+    REPO_ROOT,
+    _policy,
+    _selection_chain,
+    _serialized_evidence_bundle,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_runtime_binding_artifact_supply_bootstrap.py"
+)
+NOW = 1_800_000_000
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _keys() -> dict[str, object]:
+    return {
+        "trusted_public_keys": [
+            {
+                "signer_role": "benchmark_verifier",
+                "signer_key_fingerprint": BENCHMARK_FINGERPRINT,
+                "key_epoch": KEY_EPOCH,
+                "public_key": BENCHMARK_PUBLIC_KEY,
+            },
+            {
+                "signer_role": "promotion_authority",
+                "signer_key_fingerprint": PROMOTION_FINGERPRINT,
+                "key_epoch": KEY_EPOCH,
+                "public_key": PROMOTION_PUBLIC_KEY,
+            },
+        ]
+    }
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    snapshot, selection, benchmark, promotion, _verified = _selection_chain()
+    return {
+        "catalog": _write_json(runtime, "catalog.json", snapshot.to_dict()),
+        "selection": _write_json(runtime, "selection.json", selection.to_dict()),
+        "benchmarks": _write_json(
+            runtime,
+            "benchmarks.json",
+            {"benchmark_evidence_receipts": [benchmark.to_dict()]},
+        ),
+        "promotions": _write_json(
+            runtime,
+            "promotions.json",
+            {"promotion_evidence_receipts": [promotion.to_dict()]},
+        ),
+        "evidence": _write_json(
+            runtime,
+            "evidence.json",
+            _serialized_evidence_bundle(snapshot, selection, benchmark, promotion),
+        ),
+        "policy": _write_json(runtime, "policy.json", _policy()),
+        "keys": _write_json(runtime, "keys.json", _keys()),
+        "output": runtime / "model_runtime_binding_receipt.json",
+    }
+
+
+def test_bootstrap_materializes_runtime_binding_receipt(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_runtime_binding_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        model_selection_receipt_path=files["selection"],
+        benchmark_evidence_receipts_path=files["benchmarks"],
+        promotion_evidence_receipts_path=files["promotions"],
+        evidence_bundle_path=files["evidence"],
+        runtime_policy_path=files["policy"],
+        trusted_keys_path=files["keys"],
+        output_path=files["output"],
+        signature_verifier=DeterministicSignatureVerifier(),
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED
+    assert result.runtime_binding_receipt_id and result.runtime_binding_receipt_id.startswith(
+        "reddog_model_runtime_binding:"
+    )
+    receipt = json.loads(files["output"].read_text(encoding="utf-8"))
+    assert receipt["decision"] == "bound"
+    assert receipt["runtime_surface"] == "reddog_backend_architect"
+    assert result.no_model_call_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+
+def test_bootstrap_rejects_missing_trusted_keys(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_runtime_binding_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        model_selection_receipt_path=files["selection"],
+        benchmark_evidence_receipts_path=files["benchmarks"],
+        promotion_evidence_receipts_path=files["promotions"],
+        evidence_bundle_path=files["evidence"],
+        runtime_policy_path=files["policy"],
+        trusted_keys_path=None,
+        output_path=files["output"],
+        signature_verifier=DeterministicSignatureVerifier(),
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert result.status == MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY
+    assert "missing_model_evidence_trusted_keys_path" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_bootstrap_rejects_output_inside_repo(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_runtime_binding_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        catalog_snapshot_path=files["catalog"],
+        model_selection_receipt_path=files["selection"],
+        benchmark_evidence_receipts_path=files["benchmarks"],
+        promotion_evidence_receipts_path=files["promotions"],
+        evidence_bundle_path=files["evidence"],
+        runtime_policy_path=files["policy"],
+        trusted_keys_path=files["keys"],
+        output_path=REPO_ROOT / "model_runtime_binding_receipt.json",
+        signature_verifier=DeterministicSignatureVerifier(),
+        now_epoch=NOW,
+    )
+
+    assert result.accepted is False
+    assert "model_runtime_binding_output_path_invalid" in result.rejection_reasons
+    assert not (REPO_ROOT / "model_runtime_binding_receipt.json").exists()
+
+
+def test_bootstrap_module_has_no_execution_network_or_reindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "git",
+        "holo_index",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary
- add a bounded runtime-binding artifact supplier that rehydrates catalog, selection, benchmark, promotion and signed production-evidence receipts
- add a main-startup bootstrap adapter that reads outside-repo JSON inputs and writes one RedDogModelRuntimeBindingReceipt outside the repository
- document the truth boundary in ai_gateway README, INTERFACE and ModLog

## WSP_97 Evidence
- focused tests: python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply_bootstrap.py -q -> 10 passed
- connected ai_gateway suite: python -m pytest modules/ai_intelligence/ai_gateway/tests -q -> 86 passed
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_runtime_binding_artifact_supply.py modules/ai_intelligence/ai_gateway/src/model_runtime_binding_artifact_supply_bootstrap.py
- git diff --check
- byte scan: 0 non-ASCII / 0 NUL in new code/tests

## Truth Boundary
- IMPLEMENTED: production runtime-binding receipt artifact supply from receipt-bound model evidence
- IMPLEMENTED: serialized evidence requires trusted key resolution and signature verification before runtime binding
- IMPLEMENTED: runtime-binding output must live outside the repository
- NOT IMPLEMENTED: provider calls, benchmark execution, telemetry persistence, HoloIndex re-indexing, extension runtime default mutation, worker dispatch, PatternMemory writes, or panel runtime promotion

Slice: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_PHASE1
Worker-Lane: model-intelligence-runtime-binding