### PR TITLE
feat(reddog): wire runtime binding artifact preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -1595,15 +1595,20 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH                 Existing work-state snapshot
         REDDOG_ARCHITECT_FIX_DETERMINATION_PATH              Outside-repo determination JSON
         REDDOG_MODEL_SELECTION_RECEIPT_PATH                  Outside-repo model receipt JSON
+        REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH            Outside-repo runtime binding receipt JSON
         REDDOG_MEMEX_SUPPLY_RECEIPT_PATH                     Outside-repo Memex supply JSON
         REDDOG_AUTHORITY_PROFILE_SOURCE_PATH                 Outside-repo authority seed JSON
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo promoted profile JSON
         REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional profile-derived output path
         REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=0              Materialize determination/Memex from AgentDB cycle
         REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=0             Materialize model selection receipt from signed evidence
+        REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY=0       Materialize runtime binding receipt from signed evidence
         REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
+        REDDOG_MODEL_BENCHMARK_EVIDENCE_RECEIPTS_PATH        Outside-repo benchmark evidence receipts JSON
+        REDDOG_MODEL_PROMOTION_EVIDENCE_RECEIPTS_PATH        Outside-repo promotion evidence receipts JSON
+        REDDOG_MODEL_RUNTIME_BINDING_POLICY_PATH             Outside-repo runtime binding policy JSON
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY=0 Materialize principal/snapshot from GitHub probe
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY_ENFORCED=0 Block startup if rejected
@@ -1648,6 +1653,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         os.environ,
         repo_root,
         "REDDOG_MODEL_SELECTION_RECEIPT_PATH",
+    )
+    model_runtime_binding_receipt_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH",
     )
     memex_supply_receipt_path = resident_queue_runtime_file_path(
         os.environ,
@@ -1750,6 +1760,77 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             os.environ["REDDOG_MODEL_SELECTION_RECEIPT_PATH"] = model_selection_receipt_path
         elif model_supply_enforced:
             print("[REDDOG-MODEL-SELECTION] Startup blocked by REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY_ENFORCED=1")
+            return False
+
+    runtime_binding_supply_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY",
+    )
+    runtime_binding_supply_enforced = (
+        os.getenv("REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
+    )
+    if runtime_binding_supply_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_runtime_binding_artifact_supply_bootstrap import (
+                run_reddog_model_runtime_binding_artifact_supply_bootstrap,
+            )
+
+            raw_now = os.getenv(
+                "REDDOG_MODEL_RUNTIME_BINDING_EVIDENCE_NOW_EPOCH",
+                os.getenv("REDDOG_MODEL_SELECTION_EVIDENCE_NOW_EPOCH", ""),
+            ).strip()
+            runtime_binding_supply = run_reddog_model_runtime_binding_artifact_supply_bootstrap(
+                repo_root=repo_root,
+                catalog_snapshot_path=os.getenv("REDDOG_MODEL_CATALOG_SNAPSHOT_PATH", "") or None,
+                model_selection_receipt_path=model_selection_receipt_path,
+                benchmark_evidence_receipts_path=os.getenv(
+                    "REDDOG_MODEL_BENCHMARK_EVIDENCE_RECEIPTS_PATH",
+                    "",
+                )
+                or None,
+                promotion_evidence_receipts_path=os.getenv(
+                    "REDDOG_MODEL_PROMOTION_EVIDENCE_RECEIPTS_PATH",
+                    "",
+                )
+                or None,
+                evidence_bundle_path=os.getenv("REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH", "") or None,
+                runtime_policy_path=os.getenv("REDDOG_MODEL_RUNTIME_BINDING_POLICY_PATH", "") or None,
+                trusted_keys_path=os.getenv("REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH", "") or None,
+                output_path=model_runtime_binding_receipt_path,
+                signature_verifier_backend=os.getenv(
+                    "REDDOG_MODEL_EVIDENCE_SIGNATURE_VERIFIER_BACKEND",
+                    "ed25519",
+                ),
+                now_epoch=(int(raw_now) if raw_now else None),
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-RUNTIME-BINDING] Startup artifact supply failed: {exc}")
+            if runtime_binding_supply_enforced:
+                print(f"[REDDOG-MODEL-RUNTIME-BINDING] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-RUNTIME-BINDING] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        runtime_binding_status = "PASS" if runtime_binding_supply.accepted else "WARN"
+        runtime_binding_reasons = (
+            ",".join(runtime_binding_supply.rejection_reasons)
+            if runtime_binding_supply.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-RUNTIME-BINDING] preflight={runtime_binding_status} "
+            f"status={runtime_binding_supply.status} "
+            f"receipt={runtime_binding_supply.runtime_binding_receipt_id or '(none)'} "
+            f"reasons={runtime_binding_reasons}"
+        )
+        if runtime_binding_supply.accepted and runtime_binding_supply.output_path:
+            model_runtime_binding_receipt_path = runtime_binding_supply.output_path
+            os.environ["REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] = model_runtime_binding_receipt_path
+        elif runtime_binding_supply_enforced:
+            print(
+                "[REDDOG-MODEL-RUNTIME-BINDING] Startup blocked by "
+                "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ENFORCED=1"
+            )
             return False
 
     principal_snapshot_supply_requested = resident_queue_runtime_flag_enabled(

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Wired `main.py` to optionally run the AI Gateway runtime-binding artifact
+  supplier before architect-FIX promotion when
+  `REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY=1` is set.
+- The preflight consumes outside-repo catalog, model-selection, benchmark,
+  promotion, signed evidence, policy, and trusted public-key files, then
+  writes a `RedDogModelRuntimeBindingReceipt` path for later resident runtime
+  consumption.
+- Added a profile-derived output path for
+  `REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH` while keeping the supply flag
+  explicit/default-off to avoid breaking existing startup profiles without
+  runtime-binding evidence inputs.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  runtime model default mutation, worker spawn, shell, worktree, source
+  mutation, PatternMemory write, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_CONSUMPTION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -97,6 +97,7 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_W10_REPORT_RECORDS_PATH": "w10_report_records.json",
     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": "architect_determination.json",
     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": "model_selection_receipt.json",
+    "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH": "model_runtime_binding_receipt.json",
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": "principal_authority_record.json",
     "REDDOG_PERMISSION_SNAPSHOT_PATH": "permission_snapshot.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -307,6 +307,172 @@ def test_main_preflight_model_selection_supply_runs_before_promotion(tmp_path: P
     assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
 
 
+def test_main_preflight_model_runtime_binding_supply_runs_after_model_selection(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    model_supply_result = type(
+        "ModelSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_SELECTION_ARTIFACT_BOOTSTRAP_APPLIED",
+            "model_selection_receipt_id": "model_selection_receipt:runtime",
+            "output_path": str(runtime_root / "model_selection_receipt.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    runtime_binding_supply_result = type(
+        "RuntimeBindingSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_APPLIED",
+            "runtime_binding_receipt_id": "reddog_model_runtime_binding:runtime",
+            "output_path": str(runtime_root / "model_runtime_binding_receipt.json"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_selection_artifact_supply_bootstrap.run_reddog_model_selection_artifact_supply_bootstrap",
+        return_value=model_supply_result,
+    ) as model_supply:
+        with patch(
+            "modules.ai_intelligence.ai_gateway.src.model_runtime_binding_artifact_supply_bootstrap.run_reddog_model_runtime_binding_artifact_supply_bootstrap",
+            return_value=runtime_binding_supply_result,
+        ) as runtime_binding_supply:
+            with patch(
+                "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+                return_value=promotion_result,
+            ) as promote:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "1",
+                        "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "1",
+                        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                        "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                        "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                        "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                        "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                        "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                        "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                        "REDDOG_MODEL_CATALOG_SNAPSHOT_PATH": str(tmp_path / "catalog.json"),
+                        "REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH": str(tmp_path / "evidence.json"),
+                        "REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH": str(tmp_path / "requirements.json"),
+                        "REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH": str(tmp_path / "keys.json"),
+                        "REDDOG_MODEL_BENCHMARK_EVIDENCE_RECEIPTS_PATH": str(tmp_path / "benchmarks.json"),
+                        "REDDOG_MODEL_PROMOTION_EVIDENCE_RECEIPTS_PATH": str(tmp_path / "promotions.json"),
+                        "REDDOG_MODEL_RUNTIME_BINDING_POLICY_PATH": str(tmp_path / "policy.json"),
+                        "REDDOG_MODEL_RUNTIME_BINDING_EVIDENCE_NOW_EPOCH": "1800000001",
+                    },
+                    clear=True,
+                ):
+                    assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                    assert main.os.environ["REDDOG_MODEL_SELECTION_RECEIPT_PATH"] == str(
+                        runtime_root / "model_selection_receipt.json"
+                    )
+                    assert main.os.environ["REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] == str(
+                        runtime_root / "model_runtime_binding_receipt.json"
+                    )
+
+    model_supply.assert_called_once()
+    runtime_binding_supply.assert_called_once()
+    runtime_kwargs = runtime_binding_supply.call_args.kwargs
+    assert runtime_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
+    assert runtime_kwargs["output_path"] == str(runtime_root / "model_runtime_binding_receipt.json")
+    assert runtime_kwargs["now_epoch"] == 1_800_000_001
+    promote.assert_called_once()
+    promote_kwargs = promote.call_args.kwargs
+    assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
+
+
+def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    model_selection = _write_json(tmp_path, "model_selection_receipt.json", _model_selection())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    runtime_binding_supply_result = type(
+        "RuntimeBindingSupplyResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_RUNTIME_BINDING_ARTIFACT_BOOTSTRAP_NOT_READY",
+            "runtime_binding_receipt_id": None,
+            "output_path": None,
+            "rejection_reasons": ("missing_model_runtime_binding_policy_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_runtime_binding_artifact_supply_bootstrap.run_reddog_model_runtime_binding_artifact_supply_bootstrap",
+        return_value=runtime_binding_supply_result,
+    ) as runtime_binding_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ENFORCED": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(model_selection),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_CATALOG_SNAPSHOT_PATH": str(tmp_path / "catalog.json"),
+                    "REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH": str(tmp_path / "evidence.json"),
+                    "REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH": str(tmp_path / "keys.json"),
+                    "REDDOG_MODEL_BENCHMARK_EVIDENCE_RECEIPTS_PATH": str(tmp_path / "benchmarks.json"),
+                    "REDDOG_MODEL_PROMOTION_EVIDENCE_RECEIPTS_PATH": str(tmp_path / "promotions.json"),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+    runtime_binding_supply.assert_called_once()
+    promote.assert_not_called()
+
+
 def test_main_preflight_authority_source_supply_runs_before_promotion(tmp_path: Path) -> None:
     import main
 


### PR DESCRIPTION
## Summary
- wire explicit REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY=1 into main.py architect FIX promotion preflight
- derive REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH from the resident runtime root when a binding profile is active
- add regressions proving runtime-binding supply runs after model-selection supply and enforced failure blocks promotion before queue mutation

## WSP_97 Evidence
- focused main preflight tests: python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q -> 14 passed
- connected runtime/model tests: python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q -> 121 passed, 1 skipped
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
- git diff --check
- added lines ASCII-clean; legacy touched files contain pre-existing non-ASCII outside this diff

## Truth Boundary
- IMPLEMENTED: explicit startup preflight can materialize a runtime-binding receipt before FIX promotion
- IMPLEMENTED: runtime-binding supply output path is outside-repo/profile-derived
- IMPLEMENTED: enforced runtime-binding supply failure blocks promotion before any queue mutation
- NOT IMPLEMENTED: provider calls, benchmark execution, runtime model default mutation, worker spawn, shell/worktree execution, source mutation, PatternMemory write, or HoloIndex re-indexing

Slice: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
Worker-Lane: resident-runtime-model-binding