### PR TITLE
feat(reddog): carry runtime binding into authority promotion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1659,6 +1659,9 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         repo_root,
         "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH",
     )
+    model_runtime_binding_receipt_path_supplied = bool(
+        os.getenv("REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH", "").strip()
+    )
     memex_supply_receipt_path = resident_queue_runtime_file_path(
         os.environ,
         repo_root,
@@ -1825,6 +1828,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         )
         if runtime_binding_supply.accepted and runtime_binding_supply.output_path:
             model_runtime_binding_receipt_path = runtime_binding_supply.output_path
+            model_runtime_binding_receipt_path_supplied = True
             os.environ["REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] = model_runtime_binding_receipt_path
         elif runtime_binding_supply_enforced:
             print(
@@ -2039,6 +2043,9 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             work_state_path=work_state_path,
             architect_determination_path=architect_determination_path,
             model_selection_receipt_path=model_selection_receipt_path,
+            model_runtime_binding_receipt_path=(
+                model_runtime_binding_receipt_path if model_runtime_binding_receipt_path_supplied else None
+            ),
             memex_supply_receipt_path=memex_supply_receipt_path,
             authority_profile_source_path=authority_profile_source_path,
             authority_profile_output_path=authority_profile_path,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_AUTHORITY_CARRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Carried optional `RedDogModelRuntimeBindingReceipt` evidence from `main.py`
+  startup preflight into architect-FIX promotion.
+- Promotion now rehydrates and digest-checks supplied runtime-binding receipts,
+  rejects unbound or selection/catalog/task-family mismatches, and records the
+  accepted receipt id/digest on the claim, WRE queue item, promotion record,
+  promotion receipt, and promoted authority profile.
+- Preserved existing flows when no runtime-binding receipt is explicitly
+  supplied or generated; profile-derived default paths no longer accidentally
+  make runtime-binding evidence mandatory.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  signing, worker spawn, shell, worktree, source mutation, PatternMemory write,
+  OpenClaw/Hermes dispatch, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -25,7 +25,11 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import 
     SelectionDecision,
     SelectionPurpose,
 )
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import (
+    ModelRuntimeBindingDecision,
+)
 from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    rehydrate_model_runtime_binding_receipt,
     rehydrate_model_selection_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
@@ -63,6 +67,9 @@ class ArchitectFixPromotionReason:
     MODEL_SELECTION_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_SELECTION_MISSING"
     MODEL_SELECTION_INVALID = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_SELECTION_INVALID"
     MODEL_SELECTION_NOT_PRODUCTION = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_SELECTION_NOT_PRODUCTION"
+    MODEL_RUNTIME_BINDING_INVALID = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_RUNTIME_BINDING_INVALID"
+    MODEL_RUNTIME_BINDING_NOT_BOUND = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_RUNTIME_BINDING_NOT_BOUND"
+    MODEL_RUNTIME_BINDING_MISMATCH = "REJECT_ARCHITECT_FIX_PROMOTION_MODEL_RUNTIME_BINDING_MISMATCH"
     MEMEX_SUPPLY_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_MEMEX_SUPPLY_MISSING"
     MEMEX_SUPPLY_INVALID = "REJECT_ARCHITECT_FIX_PROMOTION_MEMEX_SUPPLY_INVALID"
     AUTHORITY_PROFILE_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_AUTHORITY_PROFILE_MISSING"
@@ -116,6 +123,8 @@ class ArchitectFixPromotionReceipt:
     memex_supply_receipt_id: str
     memex_supply_digest: str
     committed_revision: Optional[str]
+    model_runtime_binding_receipt_id: Optional[str] = None
+    model_runtime_binding_digest: Optional[str] = None
     no_signing_performed: bool = True
     no_worker_spawn_performed: bool = True
     no_worktree_created: bool = True
@@ -177,6 +186,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     authority_profile: Mapping[str, Any],
     model_selection_receipt: Mapping[str, Any],
     memex_supply_receipt: Mapping[str, Any],
+    model_runtime_binding_receipt: Mapping[str, Any] | None = None,
     worker_id: str,
     now_iso: str,
     claim_ttl_seconds: int = 3600,
@@ -217,6 +227,11 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         reasons.append(ArchitectFixPromotionReason.WSP15_ALLOCATION_MISMATCH)
 
     selection_payload = _validate_model_selection(model_selection_receipt, reasons)
+    runtime_binding_payload = _validate_model_runtime_binding(
+        model_runtime_binding_receipt,
+        selection_payload,
+        reasons,
+    )
     memex_payload = _validate_memex_supply(memex_supply_receipt, determination, reasons)
     profile_reasons = _validate_authority_profile(authority_profile)
     reasons.extend(profile_reasons)
@@ -238,6 +253,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     now = _parse_iso(now_iso)
     expires_at = (now + timedelta(seconds=int(claim_ttl_seconds))).isoformat()
     model_selection_digest = _digest(model_selection_receipt)
+    model_runtime_binding_digest = _digest(model_runtime_binding_receipt) if runtime_binding_payload else None
     memex_supply_digest = _digest(memex_supply_receipt)
     allocation_digest = canonical_reddog_wsp15_allocation_digest(allocation)
 
@@ -245,6 +261,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         "selected_slice": selected_slice,
         "determination_receipt_id": determination_id,
         "model_selection_receipt_id": selection_payload["receipt_id"],
+        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
         "memex_supply_receipt_id": memex_payload["receipt_id"],
         "worker_id": worker_id,
         "claimed_at": now_iso,
@@ -259,6 +276,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         "determination_receipt_id": determination_id,
         "wsp15_allocation_receipt_id": allocation["receipt_id"],
         "model_selection_receipt_id": selection_payload["receipt_id"],
+        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
         "memex_supply_receipt_id": memex_payload["receipt_id"],
     }
     queue_item_id = _digest(queue_seed)
@@ -275,6 +293,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         "status": "ACTIVE",
         "source_determination_receipt_id": determination_id,
         "model_selection_receipt_id": selection_payload["receipt_id"],
+        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
         "memex_supply_receipt_id": memex_payload["receipt_id"],
     }
     evidence_refs = tuple(
@@ -285,6 +304,11 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
                 f"wsp15_allocation:{allocation['receipt_id']}",
                 f"architect_determination:{determination_id}",
                 f"model_selection:{selection_payload['receipt_id']}",
+                *(
+                    [f"model_runtime_binding:{runtime_binding_payload['receipt_id']}"]
+                    if runtime_binding_payload
+                    else []
+                ),
                 f"memex_supply:{memex_payload['receipt_id']}",
                 *[str(ref) for ref in candidate.get("evidence_refs") or ()],
             ]
@@ -304,6 +328,8 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         "model_catalog_snapshot_id": selection_payload["catalog_snapshot_id"],
         "model_selection_receipt_id": selection_payload["receipt_id"],
         "model_selection_digest": model_selection_digest,
+        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
+        "model_runtime_binding_digest": model_runtime_binding_digest or "",
         "memex_supply_receipt_id": memex_payload["receipt_id"],
         "memex_supply_digest": memex_supply_digest,
         "no_execution_performed": True,
@@ -325,6 +351,9 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         model_selection_receipt=model_selection_receipt,
         model_selection=selection_payload,
         model_selection_digest=model_selection_digest,
+        model_runtime_binding_receipt=model_runtime_binding_receipt,
+        model_runtime_binding=runtime_binding_payload,
+        model_runtime_binding_digest=model_runtime_binding_digest,
         memex_supply=memex_payload,
         memex_supply_digest=memex_supply_digest,
         queue_item_id=queue_item_id,
@@ -342,6 +371,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
             "queue_item_id": queue_item_id,
             "claim_id": claim_id,
             "model_selection_receipt_id": selection_payload["receipt_id"],
+            "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
             "memex_supply_receipt_id": memex_payload["receipt_id"],
             "created_at": now_iso,
         },
@@ -358,6 +388,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         "queue_item_id": queue_item_id,
         "claim_id": claim_id,
         "model_selection_receipt_id": selection_payload["receipt_id"],
+        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
         "memex_supply_receipt_id": memex_payload["receipt_id"],
         "committed_revision": committed_revision,
     }
@@ -377,6 +408,8 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         model_catalog_snapshot_id=selection_payload["catalog_snapshot_id"],
         model_selection_receipt_id=selection_payload["receipt_id"],
         model_selection_digest=model_selection_digest,
+        model_runtime_binding_receipt_id=runtime_binding_payload.get("receipt_id") or None,
+        model_runtime_binding_digest=model_runtime_binding_digest,
         memex_supply_receipt_id=memex_payload["receipt_id"],
         memex_supply_digest=memex_supply_digest,
         committed_revision=committed_revision,
@@ -482,6 +515,40 @@ def _validate_model_selection(selection: Mapping[str, Any], reasons: list[str]) 
     }
 
 
+def _validate_model_runtime_binding(
+    binding: Mapping[str, Any] | None,
+    model_selection: Mapping[str, Any],
+    reasons: list[str],
+) -> Mapping[str, Any]:
+    if not binding:
+        return {}
+    try:
+        receipt = rehydrate_model_runtime_binding_receipt(binding)
+    except Exception:
+        reasons.append(ArchitectFixPromotionReason.MODEL_RUNTIME_BINDING_INVALID)
+        return {}
+    if receipt.decision != ModelRuntimeBindingDecision.BOUND:
+        reasons.append(ArchitectFixPromotionReason.MODEL_RUNTIME_BINDING_NOT_BOUND)
+    if not model_selection:
+        reasons.append(ArchitectFixPromotionReason.MODEL_RUNTIME_BINDING_MISMATCH)
+    elif (
+        receipt.selection_receipt_id != str(model_selection.get("receipt_id") or "")
+        or receipt.catalog_snapshot_id != str(model_selection.get("catalog_snapshot_id") or "")
+        or receipt.task_family != str(model_selection.get("task_family") or "")
+    ):
+        reasons.append(ArchitectFixPromotionReason.MODEL_RUNTIME_BINDING_MISMATCH)
+    return {
+        "receipt_id": receipt.receipt_id,
+        "selection_receipt_id": receipt.selection_receipt_id,
+        "catalog_snapshot_id": receipt.catalog_snapshot_id,
+        "task_family": receipt.task_family,
+        "runtime_surface": receipt.runtime_surface,
+        "principal_model": receipt.principal_model or "",
+        "panel_models": tuple(receipt.panel_models),
+        "role_bindings": tuple(binding.to_dict() for binding in receipt.role_bindings),
+    }
+
+
 def _validate_memex_supply(
     memex_supply: Mapping[str, Any],
     determination: Mapping[str, Any],
@@ -540,6 +607,9 @@ def _promoted_authority_profile(
     model_selection_receipt: Mapping[str, Any],
     model_selection: Mapping[str, Any],
     model_selection_digest: str,
+    model_runtime_binding_receipt: Mapping[str, Any] | None,
+    model_runtime_binding: Mapping[str, Any],
+    model_runtime_binding_digest: str | None,
     memex_supply: Mapping[str, Any],
     memex_supply_digest: str,
     queue_item_id: str,
@@ -562,10 +632,22 @@ def _promoted_authority_profile(
         "model_selection_receipt_id": model_selection["receipt_id"],
         "model_selection_digest": model_selection_digest,
         "model_selection_receipt": dict(model_selection_receipt),
+        "model_runtime_binding_receipt_id": model_runtime_binding.get("receipt_id", ""),
+        "model_runtime_binding_digest": model_runtime_binding_digest or "",
         "memex_supply_receipt_id": memex_supply["receipt_id"],
         "memex_supply_digest": memex_supply_digest,
         "holoindex_evidence": dict(holoindex_evidence),
     }
+    if model_runtime_binding:
+        binding.update(
+            {
+                "model_runtime_binding_receipt": dict(model_runtime_binding_receipt or {}),
+                "model_runtime_binding_runtime_surface": model_runtime_binding["runtime_surface"],
+                "model_runtime_binding_principal_model": model_runtime_binding["principal_model"],
+                "model_runtime_binding_panel_models": list(model_runtime_binding["panel_models"]),
+                "model_runtime_binding_role_bindings": list(model_runtime_binding["role_bindings"]),
+            }
+        )
     profile.update(
         {
             "work_order_id": str(profile.get("work_order_id") or _work_order_id(queue_item_id)),
@@ -583,12 +665,20 @@ def _promoted_authority_profile(
             "model_selection_receipt_id": model_selection["receipt_id"],
             "model_selection_digest": model_selection_digest,
             "model_selection_receipt": dict(model_selection_receipt),
+            "model_runtime_binding_receipt_id": model_runtime_binding.get("receipt_id", ""),
+            "model_runtime_binding_digest": model_runtime_binding_digest or "",
             "memex_supply_receipt_id": memex_supply["receipt_id"],
             "memex_supply_digest": memex_supply_digest,
             "operational_context_binding": binding,
             "holoindex_evidence": dict(holoindex_evidence),
         }
     )
+    if model_runtime_binding:
+        profile["model_runtime_binding_receipt"] = dict(model_runtime_binding_receipt or {})
+        profile["model_runtime_binding_runtime_surface"] = model_runtime_binding["runtime_surface"]
+        profile["model_runtime_binding_principal_model"] = model_runtime_binding["principal_model"]
+        profile["model_runtime_binding_panel_models"] = list(model_runtime_binding["panel_models"])
+        profile["model_runtime_binding_role_bindings"] = list(model_runtime_binding["role_bindings"])
     return profile
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
@@ -77,6 +77,7 @@ def run_reddog_main_architect_fix_promotion_bootstrap(
     memex_supply_receipt_path: Path | str | None,
     authority_profile_source_path: Path | str | None,
     authority_profile_output_path: Path | str | None,
+    model_runtime_binding_receipt_path: Path | str | None = None,
     worker_id: str = "reddog-main-architect-fix-promotion",
     now_iso: str | None = None,
 ) -> RedDogMainArchitectFixPromotionBootstrapResult:
@@ -108,6 +109,13 @@ def run_reddog_main_architect_fix_promotion_bootstrap(
         unreadable_reason="malformed_model_selection_receipt",
     )
     reasons.extend(model_reasons)
+    model_runtime_binding, runtime_binding_reasons = _read_optional_json_outside_repo(
+        root,
+        model_runtime_binding_receipt_path,
+        inside_reason="model_runtime_binding_receipt_path_inside_repo",
+        unreadable_reason="malformed_model_runtime_binding_receipt",
+    )
+    reasons.extend(runtime_binding_reasons)
     memex_supply, memex_reasons = _read_json_outside_repo(
         root,
         memex_supply_receipt_path,
@@ -152,6 +160,7 @@ def run_reddog_main_architect_fix_promotion_bootstrap(
         work_state_store=store,
         authority_profile=authority_profile,
         model_selection_receipt=model_selection,
+        model_runtime_binding_receipt=model_runtime_binding,
         memex_supply_receipt=memex_supply,
         worker_id=worker_id,
         now_iso=now_iso or datetime.now(timezone.utc).isoformat(),
@@ -191,6 +200,33 @@ def _read_json_outside_repo(
         repo_root,
         value,
         missing_reason=missing_reason,
+        inside_reason=inside_reason,
+    )
+    if reasons:
+        return None, reasons
+    assert path is not None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, [unreadable_reason]
+    if not isinstance(payload, Mapping):
+        return None, [unreadable_reason]
+    return payload, []
+
+
+def _read_optional_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    inside_reason: str,
+    unreadable_reason: str,
+) -> tuple[Optional[Mapping[str, Any]], list[str]]:
+    if not value:
+        return None, []
+    path, reasons = _resolve_existing_file_outside_repo(
+        repo_root,
+        value,
+        missing_reason=unreadable_reason,
         inside_reason=inside_reason,
     )
     if reasons:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -24,6 +24,11 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import 
     SelectionPurpose,
     select_models_for_task,
 )
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import (
+    ModelRuntimeBindingPolicy,
+    RUNTIME_BINDING_SCHEMA_VERSION,
+    _digest_prefixed,
+)
 from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
     ModelEvidenceSignerRole,
     ModelEvidenceSubjectType,
@@ -306,6 +311,50 @@ def _model_selection(*, purpose: SelectionPurpose = SelectionPurpose.PRODUCTION)
     return json.loads(json.dumps(receipt.to_dict(), sort_keys=True))
 
 
+def _runtime_binding(
+    model_selection: Mapping[str, Any] | None = None,
+    **overrides: Any,
+) -> dict[str, Any]:
+    selection = dict(model_selection or _model_selection())
+    requirements = dict(selection["requirements"])
+    selected_models = tuple(str(model_id) for model_id in selection["selected_model_ids"])
+    principal_model = selected_models[0]
+    policy = ModelRuntimeBindingPolicy(
+        task_family=str(requirements["task_family"]),
+        runtime_surface="reddog_fusion",
+        min_verifier_pass_rate=0.8,
+        required_task_set_digest="sha256:task-set",
+        required_held_out_split_digest="sha256:held-out",
+        required_verifier_digest="sha256:verifier",
+        authority_receipt_id="runtime-authority:architect-fix",
+    ).to_dict()
+    body = {
+        "schema_version": RUNTIME_BINDING_SCHEMA_VERSION,
+        "decision": "bound",
+        "runtime_surface": policy["runtime_surface"],
+        "catalog_snapshot_id": str(selection["catalog_snapshot_id"]),
+        "selection_receipt_id": str(selection["receipt_id"]),
+        "task_family": str(requirements["task_family"]),
+        "principal_model": principal_model,
+        "panel_models": [],
+        "role_bindings": [
+            {
+                "role": "principal",
+                "model_id": principal_model,
+                "provider": principal_model.split("/", 1)[0],
+            }
+        ],
+        "benchmark_evidence_receipt_ids": ["model_benchmark_evidence:architect-fix"],
+        "promotion_evidence_receipt_ids": ["model_promotion_evidence:architect-fix"],
+        "signed_promotion_receipt_ids": ["signature:promotion"],
+        "policy": policy,
+        "rejection_reasons": [],
+    }
+    body.update(overrides)
+    body["receipt_id"] = _digest_prefixed("reddog_model_runtime_binding", body)
+    return json.loads(json.dumps(body, sort_keys=True))
+
+
 def _promote(**overrides: Any):
     store = overrides.pop("store", InMemoryAuthoritativeWorkStateStore(_work_state()))
     args = {
@@ -354,6 +403,82 @@ def test_promotes_fix_determination_to_queue_item_and_authority_profile() -> Non
     assert queue_result.accepted is True
     assert queue_result.status == WRE_QUEUE_CONSUMER_DRYRUN_READY
     assert queue_result.selected_slice == "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+
+
+def test_promotes_runtime_binding_into_queue_claim_and_authority_profile() -> None:
+    model_selection = _model_selection()
+    runtime_binding = _runtime_binding(model_selection)
+
+    result, store = _promote(
+        model_selection_receipt=model_selection,
+        model_runtime_binding_receipt=runtime_binding,
+    )
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.model_runtime_binding_receipt_id == runtime_binding["receipt_id"]
+    assert result.receipt.model_runtime_binding_digest == promotion._digest(runtime_binding)
+    assert result.authority_profile is not None
+    assert result.authority_profile["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert result.authority_profile["model_runtime_binding_receipt"]["receipt_id"] == runtime_binding["receipt_id"]
+    assert result.authority_profile["model_runtime_binding_principal_model"] == runtime_binding["principal_model"]
+    assert result.authority_profile["operational_context_binding"]["model_runtime_binding_receipt_id"] == (
+        runtime_binding["receipt_id"]
+    )
+    assert result.authority_profile["operational_context_binding"]["model_runtime_binding_receipt"][
+        "receipt_id"
+    ] == runtime_binding["receipt_id"]
+
+    snapshot = store.load()
+    claim = snapshot["worker_claims"][0]
+    queue_item = snapshot["wre_queue_items"][0]
+    promotion_record = snapshot["architect_fix_promotions"][0]
+    assert claim["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert queue_item["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert queue_item["model_runtime_binding_digest"] == promotion._digest(runtime_binding)
+    assert f"model_runtime_binding:{runtime_binding['receipt_id']}" in queue_item["evidence_refs"]
+    assert promotion_record["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+
+
+def test_rejects_runtime_binding_for_different_model_selection_without_store_mutation() -> None:
+    model_selection = _model_selection()
+    runtime_binding = _runtime_binding(
+        model_selection,
+        selection_receipt_id="model_selection_receipt:different",
+    )
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        model_selection_receipt=model_selection,
+        model_runtime_binding_receipt=runtime_binding,
+    )
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.MODEL_RUNTIME_BINDING_MISMATCH in result.rejection_reasons
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_unbound_runtime_binding_without_store_mutation() -> None:
+    model_selection = _model_selection()
+    runtime_binding = _runtime_binding(
+        model_selection,
+        decision="rejected",
+        principal_model=None,
+        role_bindings=[],
+        rejection_reasons=["missing_verified_production_evidence"],
+    )
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        model_selection_receipt=model_selection,
+        model_runtime_binding_receipt=runtime_binding,
+    )
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.MODEL_RUNTIME_BINDING_NOT_BOUND in result.rejection_reasons
+    assert store.load()["wre_queue_items"] == []
 
 
 def test_rejects_non_fix_determination_without_store_mutation() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -17,6 +17,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed
     _determination,
     _memex_supply,
     _model_selection,
+    _runtime_binding,
     _work_state,
 )
 
@@ -47,10 +48,16 @@ def _write_json(tmp_path: Path, name: str, payload: object) -> Path:
 
 
 def _runtime_files(tmp_path: Path) -> dict[str, Path]:
+    model_selection = _model_selection()
     return {
         "work_state": _write_json(tmp_path, "authoritative_work_state.json", _work_state()),
         "determination": _write_json(tmp_path, "architect_determination.json", _determination()),
-        "model_selection": _write_json(tmp_path, "model_selection.json", _model_selection()),
+        "model_selection": _write_json(tmp_path, "model_selection.json", model_selection),
+        "model_runtime_binding": _write_json(
+            tmp_path,
+            "model_runtime_binding.json",
+            _runtime_binding(model_selection),
+        ),
         "memex_supply": _write_json(tmp_path, "memex_supply.json", _memex_supply()),
         "authority_profile_source": _write_json(
             tmp_path,
@@ -95,6 +102,32 @@ def test_bootstrap_promotes_fix_and_writes_authority_profile(tmp_path: Path) -> 
     assert work_state["wre_queue_items"][0]["queue_item_id"] == result.queue_item_id
     assert work_state["worker_claims"][0]["claim_id"] == result.claim_id
     assert not (repo / ".reddog").exists()
+
+
+def test_bootstrap_forwards_runtime_binding_receipt_into_promotion(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+
+    result = run_reddog_main_architect_fix_promotion_bootstrap(
+        repo_root=repo,
+        work_state_path=files["work_state"],
+        architect_determination_path=files["determination"],
+        model_selection_receipt_path=files["model_selection"],
+        model_runtime_binding_receipt_path=files["model_runtime_binding"],
+        memex_supply_receipt_path=files["memex_supply"],
+        authority_profile_source_path=files["authority_profile_source"],
+        authority_profile_output_path=files["authority_profile_output"],
+        worker_id="reddog-main-test",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    promoted_profile = json.loads(files["authority_profile_output"].read_text(encoding="utf-8"))
+    runtime_binding = json.loads(files["model_runtime_binding"].read_text(encoding="utf-8"))
+    assert promoted_profile["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert promoted_profile["operational_context_binding"]["model_runtime_binding_receipt_id"] == (
+        runtime_binding["receipt_id"]
+    )
 
 
 def test_bootstrap_rejects_authority_profile_output_inside_repo(tmp_path: Path) -> None:
@@ -305,6 +338,7 @@ def test_main_preflight_model_selection_supply_runs_before_promotion(tmp_path: P
     promote.assert_called_once()
     promote_kwargs = promote.call_args.kwargs
     assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
+    assert promote_kwargs["model_runtime_binding_receipt_path"] is None
 
 
 def test_main_preflight_model_runtime_binding_supply_runs_after_model_selection(
@@ -410,6 +444,9 @@ def test_main_preflight_model_runtime_binding_supply_runs_after_model_selection(
     promote.assert_called_once()
     promote_kwargs = promote.call_args.kwargs
     assert promote_kwargs["model_selection_receipt_path"] == str(runtime_root / "model_selection_receipt.json")
+    assert promote_kwargs["model_runtime_binding_receipt_path"] == str(
+        runtime_root / "model_runtime_binding_receipt.json"
+    )
 
 
 def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(


### PR DESCRIPTION
## Summary
- carry optional RedDogModelRuntimeBindingReceipt evidence from main startup preflight into architect-FIX promotion
- rehydrate/digest-check supplied runtime-binding receipts and reject unbound or selection/catalog/task-family mismatches before queue mutation
- record accepted runtime-binding receipt id/digest on worker claim, WRE queue item, promotion record, promotion receipt, and promoted authority profile
- preserve existing flows when no runtime-binding receipt is explicitly supplied or generated

## WSP_97 truth boundary
- OBSERVED: runtime-binding receipt supply exists upstream and writes outside-repo artifacts only
- OBSERVED: promotion previously carried model-selection and Memex receipts but not model-runtime-binding evidence
- IMPLEMENTED: optional runtime-binding validation/carry in promotion and main bootstrap
- NOT IMPLEMENTED: provider calls, benchmarks, signing, worker spawn, OpenClaw/Hermes dispatch, worktree creation, PR creation, PatternMemory writes, or HoloIndex re-indexing

## Verification
- python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py -q
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q
- pytest modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply_bootstrap.py -q  # 174 passed, 1 skipped
- git diff --check
- added-line ASCII check: 0 non-ASCII
