### PR TITLE
feat(reddog): bind runtime model receipt into signed authority

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_SIGNED_AUTHORITY_CHAIN_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Carried optional model runtime-binding receipt id/digest from validated WRE
+  queue items through the queue-authority dry-run planner into
+  `DelegatedAuthorityRuntimeRequest`.
+- The signer runtime now validates optional runtime-binding fields and includes
+  them in the signed work-authority payload and issued-authority store record.
+- The work-order verifier rejects malformed one-sided runtime-binding fields
+  and signature verification rejects any post-signing runtime-binding tamper.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  worker spawn, shell, worktree, OpenClaw/Hermes dispatch, source mutation,
+  PatternMemory write, or HoloIndex re-indexing was added.
+
 ## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_AUTHORITY_CARRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py
@@ -297,6 +297,8 @@ class DelegatedAuthorityRuntimeRequest:
     key_epoch: str
     consensus_receipt_digest: Optional[str] = None
     sovereign_authorization_digest: Optional[str] = None
+    model_runtime_binding_receipt_id: Optional[str] = None
+    model_runtime_binding_digest: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -473,6 +475,13 @@ def _commit_issued_authority(
         "wsp15_allocation_digest": request.wsp15_allocation_digest,
         "status": AUTHORITY_ISSUED,
     }
+    if request.model_runtime_binding_receipt_id or request.model_runtime_binding_digest:
+        issued_next[request.work_order_id]["model_runtime_binding_receipt_id"] = str(
+            request.model_runtime_binding_receipt_id or ""
+        )
+        issued_next[request.work_order_id]["model_runtime_binding_digest"] = str(
+            request.model_runtime_binding_digest or ""
+        )
     next_state["issued_authorities"] = issued_next
     return store.commit(next_state, expected_revision=expected_revision)
 
@@ -537,6 +546,12 @@ def issue_delegated_authority_runtime(
         or request.wsp15_priority not in {"P0", "P1", "P2", "P3", "P4"}
         or type(request.wsp15_mps_total) is not int
         or request.wsp15_reasoning_tier not in {"REGULAR", "HIGH", "ULTRA"}
+    ):
+        return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.MALFORMED_REQUEST])
+    has_runtime_binding = bool(request.model_runtime_binding_receipt_id or request.model_runtime_binding_digest)
+    if has_runtime_binding and not (
+        str(request.model_runtime_binding_receipt_id or "").startswith("reddog_model_runtime_binding:")
+        and str(request.model_runtime_binding_digest or "").startswith("sha256:")
     ):
         return _rejection_result(now=now, request=request, reasons=[RuntimeRejectCode.MALFORMED_REQUEST])
 
@@ -646,6 +661,9 @@ def issue_delegated_authority_runtime(
         "sovereign_authorization_digest": request.sovereign_authorization_digest,
         "receipt_chain": [],
     }
+    if has_runtime_binding:
+        work_authority["model_runtime_binding_receipt_id"] = str(request.model_runtime_binding_receipt_id)
+        work_authority["model_runtime_binding_digest"] = str(request.model_runtime_binding_digest)
     workauth_input = canonical_signing_input(work_authority, PREFIX_WORKAUTH)
     workauth_sign = signer_client.sign(
         SigningRequest(

--- a/modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
+++ b/modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
@@ -346,6 +346,13 @@ def verify_delegated_work_authority(
         or str(work_authority.get("wsp15_reasoning_tier") or "") not in {"REGULAR", "HIGH", "ULTRA"}
     ):
         return reject(ReasonCode.MALFORMED_PAYLOAD)
+    runtime_binding_id = str(work_authority.get("model_runtime_binding_receipt_id") or "")
+    runtime_binding_digest = str(work_authority.get("model_runtime_binding_digest") or "")
+    if (runtime_binding_id or runtime_binding_digest) and not (
+        runtime_binding_id.startswith("reddog_model_runtime_binding:")
+        and runtime_binding_digest.startswith("sha256:")
+    ):
+        return reject(ReasonCode.MALFORMED_PAYLOAD)
 
     principal_id = str(identity["principal_id"])
     reddog_id = str(identity["reddog_id"])

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py
@@ -39,6 +39,7 @@ FAIL_DENIED_PATH_SCOPE = "FAIL_DENIED_PATH_SCOPE"
 FAIL_HIGH_AUTHORITY_COSIGN = "FAIL_HIGH_AUTHORITY_COSIGN"
 FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY = "FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY"
 FAIL_WSP15_ALLOCATION_BINDING = "FAIL_WSP15_ALLOCATION_BINDING"
+FAIL_MODEL_RUNTIME_BINDING = "FAIL_MODEL_RUNTIME_BINDING"
 
 _REQUIRED_PROFILE_FIELDS = (
     "principal_id",
@@ -77,6 +78,8 @@ class QueueAuthorityRequestDryRunReceipt:
     wsp15_priority: str
     wsp15_mps_total: int
     reasoning_tier: str
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: Optional[str]
     delegated_authority_request_digest: str
     signer_invoked: bool = False
     signature_verified: bool = False
@@ -198,6 +201,38 @@ def _valid_queue_wsp15_binding(queue_receipt: Mapping[str, Any], profile: Mappin
     return True
 
 
+def _profile_runtime_binding(profile: Mapping[str, Any]) -> tuple[str, str]:
+    binding = _mapping(profile.get("operational_context_binding"))
+    receipt_id = str(
+        profile.get("model_runtime_binding_receipt_id")
+        or binding.get("model_runtime_binding_receipt_id")
+        or ""
+    )
+    digest = str(
+        profile.get("model_runtime_binding_digest")
+        or binding.get("model_runtime_binding_digest")
+        or ""
+    )
+    return receipt_id, digest
+
+
+def _valid_model_runtime_binding(queue_receipt: Mapping[str, Any], profile: Mapping[str, Any]) -> bool:
+    queue_receipt_id = str(queue_receipt.get("model_runtime_binding_receipt_id") or "")
+    queue_digest = str(queue_receipt.get("model_runtime_binding_digest") or "")
+    profile_receipt_id, profile_digest = _profile_runtime_binding(profile)
+    any_binding = any((queue_receipt_id, queue_digest, profile_receipt_id, profile_digest))
+    if not any_binding:
+        return True
+    if not (
+        queue_receipt_id.startswith("reddog_model_runtime_binding:")
+        and queue_digest.startswith("sha256:")
+        and profile_receipt_id == queue_receipt_id
+        and profile_digest == queue_digest
+    ):
+        return False
+    return True
+
+
 def _path_within_foundup(path: str, foundup_id: str) -> bool:
     if not path or "\\" in path or ":" in path or path.startswith("/") or "\x00" in path:
         return False
@@ -252,6 +287,8 @@ def plan_reddog_wre_queue_authority_request_dry_run(
 
     if queue_receipt and profile and not _valid_queue_wsp15_binding(queue_receipt, profile):
         reasons.append(FAIL_WSP15_ALLOCATION_BINDING)
+    if queue_receipt and profile and not _valid_model_runtime_binding(queue_receipt, profile):
+        reasons.append(FAIL_MODEL_RUNTIME_BINDING)
 
     missing = [field for field in _REQUIRED_PROFILE_FIELDS if field not in profile or profile.get(field) in (None, "", ())]
     if missing:
@@ -278,6 +315,8 @@ def plan_reddog_wre_queue_authority_request_dry_run(
         return _reject(deduped)
 
     queue_item_id = str(queue_receipt.get("queue_item_id") or queue.get("selected_queue_item_id") or "")
+    model_runtime_binding_receipt_id = str(queue_receipt.get("model_runtime_binding_receipt_id") or "")
+    model_runtime_binding_digest = str(queue_receipt.get("model_runtime_binding_digest") or "")
     request = DelegatedAuthorityRuntimeRequest(
         work_order_id=str(profile.get("work_order_id") or _work_order_id(queue_item_id)),
         principal_id=str(profile["principal_id"]),
@@ -296,6 +335,8 @@ def plan_reddog_wre_queue_authority_request_dry_run(
         wsp15_priority=str(queue_receipt.get("wsp15_priority") or ""),
         wsp15_mps_total=int(queue_receipt.get("wsp15_mps_total")),
         wsp15_reasoning_tier=str(queue_receipt.get("reasoning_tier") or ""),
+        model_runtime_binding_receipt_id=model_runtime_binding_receipt_id or None,
+        model_runtime_binding_digest=model_runtime_binding_digest or None,
         identity_nonce=str(profile["identity_nonce"]),
         work_authority_nonce=str(profile["work_authority_nonce"]),
         issued_at=int(profile["issued_at"]),
@@ -332,6 +373,8 @@ def plan_reddog_wre_queue_authority_request_dry_run(
         wsp15_priority=str(queue_receipt.get("wsp15_priority") or ""),
         wsp15_mps_total=int(queue_receipt.get("wsp15_mps_total")),
         reasoning_tier=str(queue_receipt.get("reasoning_tier") or ""),
+        model_runtime_binding_receipt_id=model_runtime_binding_receipt_id or None,
+        model_runtime_binding_digest=model_runtime_binding_digest or None,
         delegated_authority_request_digest=request_digest,
     )
     return QueueAuthorityRequestDryRunResult(
@@ -352,6 +395,7 @@ __all__ = [
     "FAIL_PROFILE_NON_ASCII",
     "FAIL_QUEUE_CONSUMER_NOT_READY",
     "FAIL_REQUIRED_FIELD",
+    "FAIL_MODEL_RUNTIME_BINDING",
     "FAIL_UNSUPPORTED_REPO_WIDE_AUTHORITY",
     "FAIL_WSP15_ALLOCATION_BINDING",
     "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT",

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_runtime_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_runtime_invoke.py
@@ -109,6 +109,16 @@ def _request_from_payload(payload: Mapping[str, Any]) -> DelegatedAuthorityRunti
         wsp15_priority=str(payload["wsp15_priority"]),
         wsp15_mps_total=int(payload["wsp15_mps_total"]),
         wsp15_reasoning_tier=str(payload["wsp15_reasoning_tier"]),
+        model_runtime_binding_receipt_id=(
+            str(payload["model_runtime_binding_receipt_id"])
+            if payload.get("model_runtime_binding_receipt_id")
+            else None
+        ),
+        model_runtime_binding_digest=(
+            str(payload["model_runtime_binding_digest"])
+            if payload.get("model_runtime_binding_digest")
+            else None
+        ),
         identity_nonce=str(payload["identity_nonce"]),
         work_authority_nonce=str(payload["work_authority_nonce"]),
         issued_at=int(payload["issued_at"]),

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py
@@ -55,6 +55,8 @@ class WREQueueConsumerDryRunReceipt:
     wsp15_mps_total: int
     reasoning_tier: str
     next_required_gate: str
+    model_runtime_binding_receipt_id: Optional[str] = None
+    model_runtime_binding_digest: Optional[str] = None
     execution_ready: bool = False
     no_queue_mutation_performed: bool = True
     no_worker_spawn_performed: bool = True
@@ -284,6 +286,8 @@ def plan_reddog_wre_queue_consumer_dry_run(
         "wsp15_priority": allocation_priority,
         "wsp15_mps_total": allocation_total,
         "reasoning_tier": allocation_tier,
+        "model_runtime_binding_receipt_id": str(selected.get("model_runtime_binding_receipt_id") or ""),
+        "model_runtime_binding_digest": str(selected.get("model_runtime_binding_digest") or ""),
         "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
     }
     receipt = WREQueueConsumerDryRunReceipt(
@@ -298,6 +302,8 @@ def plan_reddog_wre_queue_consumer_dry_run(
         wsp15_priority=allocation_priority,
         wsp15_mps_total=allocation_total,
         reasoning_tier=allocation_tier,
+        model_runtime_binding_receipt_id=str(selected.get("model_runtime_binding_receipt_id") or "") or None,
+        model_runtime_binding_digest=str(selected.get("model_runtime_binding_digest") or "") or None,
         next_required_gate=NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
     )
     return WREQueueConsumerDryRunResult(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
@@ -156,6 +156,8 @@ def _request(**overrides) -> DelegatedAuthorityRuntimeRequest:
         "wsp15_priority": "P0",
         "wsp15_mps_total": 20,
         "wsp15_reasoning_tier": "ULTRA",
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+        "model_runtime_binding_digest": "sha256:model-runtime-binding",
         "identity_nonce": "identity-nonce-0001",
         "work_authority_nonce": "workauth-nonce-0001",
         "issued_at": _NOW - 5,
@@ -209,6 +211,8 @@ def test_runtime_issues_records_accepted_by_existing_verifier() -> None:
     assert signer.requests[1].signer_role == "reddog"
     assert result.work_authority["wsp15_allocation_receipt_id"] == "sha256:wsp15-allocation"
     assert result.work_authority["wsp15_allocation_digest"] == "sha256:wsp15-allocation-digest"
+    assert result.work_authority["model_runtime_binding_receipt_id"] == "reddog_model_runtime_binding:abc123"
+    assert result.work_authority["model_runtime_binding_digest"] == "sha256:model-runtime-binding"
 
     verified = verify_delegated_work_authority(
         work_authority=result.work_authority,
@@ -245,6 +249,36 @@ def test_changed_signed_wsp15_allocation_digest_rejects() -> None:
 
     assert verified.accepted is False
     assert ReasonCode.WORKAUTH_SIGNATURE_INVALID in verified.reason_codes
+
+
+def test_changed_signed_runtime_binding_digest_rejects() -> None:
+    result, signer, _, snapshot_resolver = _issue()
+
+    assert result.accepted is True
+    assert result.identity and result.work_authority
+    result.work_authority["model_runtime_binding_digest"] = "sha256:changed-after-signing"
+
+    verified = verify_delegated_work_authority(
+        work_authority=result.work_authority,
+        identity=result.identity,
+        signature_verifier=signer,
+        principal_key_resolver=_PrincipalKeyResolver(),
+        nonce_store=InMemoryNonceStore(),
+        snapshot_resolver=snapshot_resolver,
+        revocation_oracle=_NoRevocation(),
+        now=_NOW,
+        required_valve_state=_VALVE,
+    )
+
+    assert verified.accepted is False
+    assert ReasonCode.WORKAUTH_SIGNATURE_INVALID in verified.reason_codes
+
+
+def test_malformed_runtime_binding_field_rejects_before_signing() -> None:
+    result, _, _, _ = _issue(model_runtime_binding_receipt_id="not-a-runtime-binding")
+
+    assert result.accepted is False
+    assert RuntimeRejectCode.MALFORMED_REQUEST in result.receipt.rejection_reasons
 
 
 def test_default_signer_fails_closed() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py
@@ -41,6 +41,8 @@ def _queue_result(**overrides):
         "wsp15_priority": "P0",
         "wsp15_mps_total": 18,
         "reasoning_tier": "ULTRA",
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+        "model_runtime_binding_digest": "sha256:model-runtime-binding",
         "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
         "execution_ready": False,
         "no_queue_mutation_performed": True,
@@ -88,6 +90,8 @@ def _profile(**overrides):
             "reasoning_tier": "ULTRA",
             "worker_plan": {"fusion_required": True},
         },
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+        "model_runtime_binding_digest": "sha256:model-runtime-binding",
     }
     profile.update(overrides)
     return profile
@@ -127,11 +131,15 @@ def test_builds_delegated_authority_runtime_request_without_signing() -> None:
     assert request["wsp15_priority"] == "P0"
     assert request["wsp15_mps_total"] == 18
     assert request["wsp15_reasoning_tier"] == "ULTRA"
+    assert request["model_runtime_binding_receipt_id"] == "reddog_model_runtime_binding:abc123"
+    assert request["model_runtime_binding_digest"] == "sha256:model-runtime-binding"
     assert result.receipt.wsp15_allocation_receipt_id == "sha256:wsp15-allocation"
     assert result.receipt.wsp15_allocation_digest == "sha256:wsp15-allocation-digest"
     assert result.receipt.wsp15_priority == "P0"
     assert result.receipt.wsp15_mps_total == 18
     assert result.receipt.reasoning_tier == "ULTRA"
+    assert result.receipt.model_runtime_binding_receipt_id == "reddog_model_runtime_binding:abc123"
+    assert result.receipt.model_runtime_binding_digest == "sha256:model-runtime-binding"
     assert result.receipt.delegated_authority_request_digest.startswith("sha256:")
 
 
@@ -184,6 +192,35 @@ def test_rejects_profile_wsp15_binding_that_conflicts_with_queue() -> None:
 
     assert result.accepted is False
     assert planner.FAIL_WSP15_ALLOCATION_BINDING in result.rejection_reasons
+
+
+def test_rejects_model_runtime_binding_that_conflicts_with_queue() -> None:
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=_queue_result(),
+        authority_profile=_profile(model_runtime_binding_digest="sha256:other"),
+    )
+
+    assert result.accepted is False
+    assert planner.FAIL_MODEL_RUNTIME_BINDING in result.rejection_reasons
+
+
+def test_allows_legacy_queue_without_model_runtime_binding() -> None:
+    queue = _queue_result()
+    queue["receipt"].pop("model_runtime_binding_receipt_id")
+    queue["receipt"].pop("model_runtime_binding_digest")
+    profile = _profile()
+    profile.pop("model_runtime_binding_receipt_id")
+    profile.pop("model_runtime_binding_digest")
+
+    result = planner.plan_reddog_wre_queue_authority_request_dry_run(
+        queue_consumer_result=queue,
+        authority_profile=profile,
+    )
+
+    assert result.accepted is True
+    assert result.delegated_authority_request is not None
+    assert result.delegated_authority_request["model_runtime_binding_receipt_id"] is None
+    assert result.delegated_authority_request["model_runtime_binding_digest"] is None
 
 
 def test_rejects_missing_required_profile_field() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py
@@ -124,6 +124,8 @@ def _queue_result():
         "wsp15_priority": "P0",
         "wsp15_mps_total": 20,
         "reasoning_tier": "ULTRA",
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+        "model_runtime_binding_digest": "sha256:model-runtime-binding",
         "next_required_gate": NEXT_GATE_SIGNED_AUTHORITY_REQUIRED,
         "execution_ready": False,
         "no_queue_mutation_performed": True,
@@ -162,6 +164,8 @@ def _profile(**overrides):
         "key_epoch": "epoch-1",
         "consensus_receipt_digest": "sha256:consensus",
         "sovereign_authorization_digest": "sha256:012-token",
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+        "model_runtime_binding_digest": "sha256:model-runtime-binding",
     }
     profile.update(overrides)
     return profile
@@ -272,6 +276,10 @@ def test_invokes_injected_signer_and_issues_authority_without_execution() -> Non
     assert result.authority_result.receipt.no_execution_performed is True
     assert result.authority_result.receipt.no_worker_spawn_performed is True
     assert result.authority_result.receipt.no_openclaw_enqueue_performed is True
+    assert result.authority_result.work_authority is not None
+    assert result.authority_result.work_authority["model_runtime_binding_receipt_id"] == (
+        "reddog_model_runtime_binding:abc123"
+    )
     assert len(signer.requests) == 2
     state = store.load()
     assert state["issued_authorities"]
@@ -308,6 +316,8 @@ def test_payload_round_trips_into_runtime_request_type() -> None:
         wsp15_priority=str(request["wsp15_priority"]),
         wsp15_mps_total=int(request["wsp15_mps_total"]),
         wsp15_reasoning_tier=str(request["wsp15_reasoning_tier"]),
+        model_runtime_binding_receipt_id=str(request["model_runtime_binding_receipt_id"]),
+        model_runtime_binding_digest=str(request["model_runtime_binding_digest"]),
         identity_nonce=str(request["identity_nonce"]),
         work_authority_nonce=str(request["work_authority_nonce"]),
         issued_at=int(request["issued_at"]),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
@@ -89,6 +89,8 @@ def _snapshot(**overrides):
                     f"wsp15_allocation:{allocation['receipt_id']}",
                 ],
                 "wsp15_allocation_receipt": allocation,
+                "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+                "model_runtime_binding_digest": "sha256:model-runtime-binding",
                 "no_execution_performed": True,
             }
         ],
@@ -115,6 +117,8 @@ def test_accepts_one_fresh_queued_item_without_execution() -> None:
     assert result.receipt.wsp15_priority == "P0"
     assert result.receipt.wsp15_mps_total == 18
     assert result.receipt.reasoning_tier == "ULTRA"
+    assert result.receipt.model_runtime_binding_receipt_id == "reddog_model_runtime_binding:abc123"
+    assert result.receipt.model_runtime_binding_digest == "sha256:model-runtime-binding"
     assert result.receipt.no_queue_mutation_performed is True
     assert result.receipt.no_worker_spawn_performed is True
     assert result.receipt.no_worktree_created is True


### PR DESCRIPTION
## Summary
- carry optional model runtime-binding receipt id/digest from WRE queue consumer receipts into queue-authority requests
- validate queue/profile runtime-binding consistency before authority request generation
- include optional runtime-binding fields in delegated authority requests, signed work-authority payloads, issued-authority store records, and runtime invoke reconstruction
- reject malformed one-sided runtime-binding fields and prove post-signing tamper fails verification

## WSP_97 truth boundary
- OBSERVED: #1201 binds runtime model receipt evidence into promotion/queue/profile artifacts
- IMPLEMENTED: signed authority chain now includes and signs the runtime-binding receipt id/digest when present
- PRESERVED: legacy queues without runtime-binding fields remain accepted
- NOT IMPLEMENTED: provider calls, benchmark execution, worker spawn, worktree creation, shell execution, OpenClaw/Hermes dispatch, PR publication, PatternMemory writes, or HoloIndex re-indexing

## Verification
- python -m py_compile modules/communication/moltbot_bridge/src/reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py modules/communication/moltbot_bridge/src/reddog_wre_queue_authority_runtime_invoke.py modules/communication/moltbot_bridge/src/reddog_work_order_signature_verifier.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py -q  # 32 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py -q  # 24 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding_artifact_supply_bootstrap.py -q  # 171 passed
- git diff --check
- added-line ASCII check: 0 non-ASCII
