### PR TITLE
feat(reddog): carry runtime binding into worker dispatch

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_WORKER_DISPATCH_CARRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Carried signed model runtime-binding receipt id/digest from issued
+  work-authority into signed worker-dispatch dry-run intents, dispatch runtime
+  receipts, and AgentDB task context.
+- The worker-dispatch runtime and claimed-task executor now fail closed when
+  queue item, dispatch receipt, intent, or task context disagree on runtime
+  model-binding id/digest.
+- Resident work-order materialization now carries the content-bearing
+  `model_runtime_binding_receipt` from the authority profile so readonly 0102
+  audit workers can consume the runtime-selected model topology.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  signing expansion, worker spawn, shell, worktree, source mutation,
+  PatternMemory write, OpenClaw/Hermes dispatch, or HoloIndex re-indexing was
+  added.
+
 ## 2026-07-16: REDDOG_MODEL_RUNTIME_BINDING_SIGNED_AUTHORITY_CHAIN_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -710,6 +710,11 @@ def _materialize_work_orders_from_authority_profile(
         "model_selection_receipt": _nested_mapping(authority_profile, "model_selection_receipt"),
         "model_selection_receipt_id": str(authority_profile.get("model_selection_receipt_id") or ""),
         "model_selection_digest": str(authority_profile.get("model_selection_digest") or ""),
+        "model_runtime_binding_receipt": _nested_mapping(authority_profile, "model_runtime_binding_receipt"),
+        "model_runtime_binding_receipt_id": str(
+            authority_profile.get("model_runtime_binding_receipt_id") or ""
+        ),
+        "model_runtime_binding_digest": str(authority_profile.get("model_runtime_binding_digest") or ""),
     }
     return {work_order_id: work_order}, ()
 

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
@@ -60,6 +60,7 @@ class WorkerDispatchRuntimeReason:
     INTENT_UNSAFE = "REJECT_WORKER_DISPATCH_INTENT_UNSAFE"
     QUEUE_ITEM_MISSING = "REJECT_WORKER_DISPATCH_QUEUE_ITEM_MISSING"
     WSP15_BINDING_MISMATCH = "REJECT_WORKER_DISPATCH_WSP15_BINDING_MISMATCH"
+    MODEL_RUNTIME_BINDING_MISMATCH = "REJECT_WORKER_DISPATCH_MODEL_RUNTIME_BINDING_MISMATCH"
     WRITER_MISSING = "REJECT_WORKER_DISPATCH_WRITER_MISSING"
     WRITER_REJECTED = "REJECT_WORKER_DISPATCH_WRITER_REJECTED"
     IDEMPOTENCY_REPLAY = "REJECT_WORKER_DISPATCH_IDEMPOTENCY_REPLAY"
@@ -98,6 +99,8 @@ class SignedWorkerDispatchRuntimeReceipt:
     requested_operation: str
     wsp15_allocation_receipt_id: str
     wsp15_allocation_digest: str
+    model_runtime_binding_receipt_id: str
+    model_runtime_binding_digest: str
     task_ids: tuple[str, ...]
     intent_ids: tuple[str, ...]
     worker_runtimes: tuple[str, ...]
@@ -264,6 +267,8 @@ def publish_reddog_signed_worker_dispatch_runtime(
         reasons.append(WorkerDispatchRuntimeReason.WRITER_MISSING)
     if not _wsp15_matches_queue_item(receipt, queue_item):
         reasons.append(WorkerDispatchRuntimeReason.WSP15_BINDING_MISMATCH)
+    if not _model_runtime_binding_matches_queue_item(receipt, queue_item):
+        reasons.append(WorkerDispatchRuntimeReason.MODEL_RUNTIME_BINDING_MISMATCH)
 
     if seen_intent_ids is not None:
         for intent in intents:
@@ -360,6 +365,8 @@ def _receipt(
         requested_operation=str(receipt.get("requested_operation") or ""),
         wsp15_allocation_receipt_id=str(receipt.get("wsp15_allocation_receipt_id") or ""),
         wsp15_allocation_digest=str(receipt.get("wsp15_allocation_digest") or ""),
+        model_runtime_binding_receipt_id=str(receipt.get("model_runtime_binding_receipt_id") or ""),
+        model_runtime_binding_digest=str(receipt.get("model_runtime_binding_digest") or ""),
         task_ids=tuple(task.task_id for task in tasks),
         intent_ids=intent_ids,
         worker_runtimes=tuple(sorted({str(_mapping(intent).get("worker_runtime") or "") for intent in _list(receipt.get("dispatch_intents"))})),
@@ -396,6 +403,8 @@ def _build_task(
         "signed_authority_worker_dispatch_receipt": dict(dryrun_receipt),
         "worker_dispatch_intent": dict(intent),
         "wsp15_allocation_receipt": dict(_mapping(queue_item.get("wsp15_allocation_receipt"))),
+        "model_runtime_binding_receipt_id": str(dryrun_receipt.get("model_runtime_binding_receipt_id") or ""),
+        "model_runtime_binding_digest": str(dryrun_receipt.get("model_runtime_binding_digest") or ""),
         "execution_allowed_by_dispatch_runtime": False,
         "requires_downstream_stages": [
             "work_order_invocation",
@@ -455,6 +464,9 @@ def _intent_safe(intent: Mapping[str, Any], receipt: Mapping[str, Any]) -> bool:
     ):
         if str(intent.get(key) or "") != str(receipt.get(key) or ""):
             return False
+    for key in ("model_runtime_binding_receipt_id", "model_runtime_binding_digest"):
+        if str(intent.get(key) or "") != str(receipt.get(key) or ""):
+            return False
     return True
 
 
@@ -467,6 +479,25 @@ def _wsp15_matches_queue_item(receipt: Mapping[str, Any], queue_item: Mapping[st
     return (
         str(receipt.get("wsp15_allocation_receipt_id") or "") == str(allocation.get("receipt_id") or "")
         and str(receipt.get("wsp15_allocation_digest") or "") == _digest(allocation)
+    )
+
+
+def _model_runtime_binding_matches_queue_item(receipt: Mapping[str, Any], queue_item: Mapping[str, Any]) -> bool:
+    receipt_id = str(receipt.get("model_runtime_binding_receipt_id") or "")
+    receipt_digest = str(receipt.get("model_runtime_binding_digest") or "")
+    queue_id = str(queue_item.get("model_runtime_binding_receipt_id") or "")
+    queue_digest = str(queue_item.get("model_runtime_binding_digest") or "")
+    if bool(receipt_id) != bool(receipt_digest):
+        return False
+    if bool(queue_id) != bool(queue_digest):
+        return False
+    if not receipt_id and not queue_id:
+        return True
+    return (
+        receipt_id == queue_id
+        and receipt_digest == queue_digest
+        and receipt_id.startswith("reddog_model_runtime_binding:")
+        and receipt_digest.startswith("sha256:")
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py
@@ -48,6 +48,7 @@ class SignedAuthorityWorkerDispatchDryRunReason:
     WSP15_PRIORITY_MISMATCH = "REJECT_WSP15_PRIORITY_MISMATCH"
     WSP15_MPS_TOTAL_MISMATCH = "REJECT_WSP15_MPS_TOTAL_MISMATCH"
     WSP15_REASONING_TIER_MISMATCH = "REJECT_WSP15_REASONING_TIER_MISMATCH"
+    MODEL_RUNTIME_BINDING_MISMATCH = "REJECT_MODEL_RUNTIME_BINDING_MISMATCH"
     QUEUE_MUTATION_NOT_ALLOWED = "REJECT_QUEUE_MUTATION_NOT_ALLOWED"
     HERMES_EXECUTION_NOT_ALLOWED = "REJECT_HERMES_EXECUTION_NOT_ALLOWED"
     WORKER_PLAN_EMPTY = "REJECT_WORKER_PLAN_EMPTY"
@@ -66,6 +67,8 @@ class WorkerDispatchIntent:
     requested_operation: str
     wsp15_allocation_receipt_id: str
     wsp15_allocation_digest: str
+    model_runtime_binding_receipt_id: str = ""
+    model_runtime_binding_digest: str = ""
     dry_run_only: bool = True
     no_worker_spawn_performed: bool = True
     no_openclaw_enqueue_performed: bool = True
@@ -86,6 +89,8 @@ class SignedAuthorityWorkerDispatchDryRunReceipt:
     wsp15_priority: str
     wsp15_mps_total: int
     wsp15_reasoning_tier: str
+    model_runtime_binding_receipt_id: str
+    model_runtime_binding_digest: str
     dispatch_intent_count: int
     dispatch_intents: Tuple[WorkerDispatchIntent, ...]
     no_worker_spawn_performed: bool = True
@@ -206,6 +211,8 @@ def _build_intents(
         "requested_operation": str(work_authority["requested_operation"]),
         "wsp15_allocation_receipt_id": str(allocation["receipt_id"]),
         "wsp15_allocation_digest": _digest(allocation),
+        "model_runtime_binding_receipt_id": str(work_authority.get("model_runtime_binding_receipt_id") or ""),
+        "model_runtime_binding_digest": str(work_authority.get("model_runtime_binding_digest") or ""),
     }
 
     roles: List[tuple[str, str, str]] = []
@@ -300,6 +307,15 @@ def plan_reddog_signed_authority_worker_dispatch_dry_run(
         reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_MPS_TOTAL_MISMATCH)
     if str(work_authority.get("wsp15_reasoning_tier") or "") != str(allocation["reasoning_tier"]):
         reasons.append(SignedAuthorityWorkerDispatchDryRunReason.WSP15_REASONING_TIER_MISMATCH)
+    runtime_binding_id = str(work_authority.get("model_runtime_binding_receipt_id") or "")
+    runtime_binding_digest = str(work_authority.get("model_runtime_binding_digest") or "")
+    if bool(runtime_binding_id) != bool(runtime_binding_digest):
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.MODEL_RUNTIME_BINDING_MISMATCH)
+    if runtime_binding_id and (
+        not runtime_binding_id.startswith("reddog_model_runtime_binding:")
+        or not runtime_binding_digest.startswith("sha256:")
+    ):
+        reasons.append(SignedAuthorityWorkerDispatchDryRunReason.MODEL_RUNTIME_BINDING_MISMATCH)
     if reasons:
         return _reject(reasons, explicit_requested=True)
 
@@ -314,6 +330,8 @@ def plan_reddog_signed_authority_worker_dispatch_dry_run(
         "work_order_id": work_authority["work_order_id"],
         "wsp15_allocation_receipt_id": allocation_receipt_id,
         "wsp15_allocation_digest": allocation_digest,
+        "model_runtime_binding_receipt_id": runtime_binding_id,
+        "model_runtime_binding_digest": runtime_binding_digest,
         "dispatch_intent_ids": [intent.intent_id for intent in intents],
     }
     receipt = SignedAuthorityWorkerDispatchDryRunReceipt(
@@ -326,6 +344,8 @@ def plan_reddog_signed_authority_worker_dispatch_dry_run(
         wsp15_priority=str(allocation["priority"]),
         wsp15_mps_total=int(allocation["mps_total"]),
         wsp15_reasoning_tier=str(allocation["reasoning_tier"]),
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
         dispatch_intent_count=len(intents),
         dispatch_intents=intents,
     )

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py
@@ -175,6 +175,19 @@ def build_readonly_0102_context_from_signed_worker(
     work_order_id = str(signed_authority_receipt.get("work_order_id") or worker_dispatch_intent.get("work_order_id") or "")
     foundup_id = str(signed_authority_receipt.get("foundup_id") or worker_dispatch_intent.get("foundup_id") or "")
     principal_id = str(signed_authority_receipt.get("principal_id") or worker_dispatch_intent.get("principal_id") or "")
+    model_runtime_binding_receipt = _mapping(task_context.get("model_runtime_binding_receipt"))
+    model_runtime_binding_receipt_id = str(
+        task_context.get("model_runtime_binding_receipt_id")
+        or worker_dispatch_intent.get("model_runtime_binding_receipt_id")
+        or signed_authority_receipt.get("model_runtime_binding_receipt_id")
+        or ""
+    )
+    model_runtime_binding_digest = str(
+        task_context.get("model_runtime_binding_digest")
+        or worker_dispatch_intent.get("model_runtime_binding_digest")
+        or signed_authority_receipt.get("model_runtime_binding_digest")
+        or ""
+    )
     assignment = {
         "assignment_id": "signed-0102-review-" + _digest(
             {
@@ -196,7 +209,11 @@ def build_readonly_0102_context_from_signed_worker(
         "signed_worker_capability": str(task_context.get("capability") or ""),
         "wsp15_allocation_receipt_id": str(allocation.get("receipt_id") or ""),
         "wsp15_allocation_digest": allocation_digest,
+        "model_runtime_binding_receipt_id": model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": model_runtime_binding_digest,
     }
+    if model_runtime_binding_receipt:
+        assignment["model_runtime_binding_receipt"] = dict(model_runtime_binding_receipt)
     return {
         "source": READONLY_AUDIT_TASK_SOURCE,
         "worker_mode": MODEL_WORKER_MODE,
@@ -206,6 +223,13 @@ def build_readonly_0102_context_from_signed_worker(
         "wsp15_allocation_receipt": dict(allocation),
         "wsp15_allocation_receipt_id": str(allocation.get("receipt_id") or ""),
         "wsp15_allocation_digest": allocation_digest,
+        "model_runtime_binding_receipt_id": model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": model_runtime_binding_digest,
+        **(
+            {"model_runtime_binding_receipt": dict(model_runtime_binding_receipt)}
+            if model_runtime_binding_receipt
+            else {}
+        ),
         "swarm_receipt": {
             "swarm_id": "signed-worker-dispatch",
             "signed_worker_task_id": str(task_id),
@@ -230,6 +254,8 @@ def build_readonly_0102_context_from_signed_worker(
             "capability": str(task_context.get("capability") or ""),
             "intent_id": str(worker_dispatch_intent.get("intent_id") or ""),
             "signed_authority_receipt_id": str(signed_authority_receipt.get("receipt_id") or ""),
+            "model_runtime_binding_receipt_id": model_runtime_binding_receipt_id,
+            "model_runtime_binding_digest": model_runtime_binding_digest,
         },
     }
 

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py
@@ -36,6 +36,7 @@ class SignedWorkerDispatchTaskExecutorReason:
     INTENT_NOT_IN_RECEIPT = "REJECT_SIGNED_WORKER_INTENT_NOT_IN_RECEIPT"
     CONTEXT_INTENT_MISMATCH = "REJECT_SIGNED_WORKER_CONTEXT_INTENT_MISMATCH"
     WSP15_MISMATCH = "REJECT_SIGNED_WORKER_WSP15_MISMATCH"
+    MODEL_RUNTIME_BINDING_MISMATCH = "REJECT_SIGNED_WORKER_MODEL_RUNTIME_BINDING_MISMATCH"
     REPORT_CONTRACT_MISMATCH = "REJECT_SIGNED_WORKER_REPORT_CONTRACT_MISMATCH"
     EXECUTION_FLAG_MISMATCH = "REJECT_SIGNED_WORKER_EXECUTION_FLAG_MISMATCH"
     RUNNER_MISSING = "REJECT_SIGNED_WORKER_RUNNER_MISSING"
@@ -134,6 +135,9 @@ def execute_reddog_signed_worker_dispatch_task(
             reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
         if str(intent.get("wsp15_allocation_digest") or "") != _digest(allocation):
             reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
+
+    model_binding_reasons = _model_runtime_binding_reasons(context=context, intent=intent, receipt=receipt)
+    reasons.extend(model_binding_reasons)
 
     if context.get("execution_allowed_by_dispatch_runtime") is not False:
         reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
@@ -265,6 +269,37 @@ def _receipt_contains_intent(receipt: Mapping[str, Any], intent: Mapping[str, An
         str(_mapping(value).get("intent_id") or "")
         for value in _list(receipt.get("dispatch_intents"))
     }
+
+
+def _model_runtime_binding_reasons(
+    *,
+    context: Mapping[str, Any],
+    intent: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> list[str]:
+    context_id = str(context.get("model_runtime_binding_receipt_id") or "")
+    context_digest = str(context.get("model_runtime_binding_digest") or "")
+    intent_id = str(intent.get("model_runtime_binding_receipt_id") or "")
+    intent_digest = str(intent.get("model_runtime_binding_digest") or "")
+    receipt_id = str(receipt.get("model_runtime_binding_receipt_id") or "")
+    receipt_digest = str(receipt.get("model_runtime_binding_digest") or "")
+    pairs = ((context_id, context_digest), (intent_id, intent_digest), (receipt_id, receipt_digest))
+    if any(bool(item_id) != bool(item_digest) for item_id, item_digest in pairs):
+        return [SignedWorkerDispatchTaskExecutorReason.MODEL_RUNTIME_BINDING_MISMATCH]
+    if not context_id and not intent_id and not receipt_id:
+        return []
+    if not (
+        context_id
+        == intent_id
+        == receipt_id
+        and context_digest
+        == intent_digest
+        == receipt_digest
+        and receipt_id.startswith("reddog_model_runtime_binding:")
+        and receipt_digest.startswith("sha256:")
+    ):
+        return [SignedWorkerDispatchTaskExecutorReason.MODEL_RUNTIME_BINDING_MISMATCH]
+    return []
 
 
 __all__ = [

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -17,8 +17,13 @@ import pytest
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_loop_bootstrap import (
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
+    _canonical_digest,
+    _materialize_work_orders_from_authority_profile,
     _operational_context_binding,
     run_reddog_main_resident_queue_serial_loop_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    RUNTIME_SURFACE_READONLY_AUDIT,
 )
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_runtime_dependency_bundle import (
     REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
@@ -70,6 +75,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
     FakeDraftPrRunner,
+)
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
 )
 from modules.infrastructure.wre_core.src import reddog_verified_outcome_ratchet as ratchet
 from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
@@ -270,6 +278,33 @@ def _work_order(**overrides: object) -> dict[str, object]:
     }
     payload.update(overrides)
     return payload
+
+
+def test_authority_profile_materializer_carries_model_runtime_binding_receipt() -> None:
+    runtime_binding = model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT)
+    snapshot = _snapshot()
+    queue_item = snapshot["wre_queue_items"][0]
+    queue_item["model_runtime_binding_receipt_id"] = runtime_binding["receipt_id"]
+    queue_item["model_runtime_binding_digest"] = _canonical_digest(runtime_binding)
+    profile = _profile(
+        model_runtime_binding_receipt=runtime_binding,
+        model_runtime_binding_receipt_id=runtime_binding["receipt_id"],
+        model_runtime_binding_digest=_canonical_digest(runtime_binding),
+    )
+
+    work_orders, reasons = _materialize_work_orders_from_authority_profile(
+        snapshot=snapshot,
+        authority_profile=profile,
+        requested_queue_item_id="queue-1",
+        now_iso=NOW,
+    )
+
+    assert reasons == ()
+    assert work_orders is not None
+    work_order = work_orders[WORK_ORDER_ID]
+    assert work_order["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert work_order["model_runtime_binding_digest"] == _canonical_digest(runtime_binding)
+    assert work_order["model_runtime_binding_receipt"]["receipt_id"] == runtime_binding["receipt_id"]
 
 
 def _work_orders(**overrides: object) -> dict[str, object]:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py
@@ -142,18 +142,25 @@ def _dryrun_result(allocation=None, intents=None, **overrides):
     return payload
 
 
-def _snapshot(allocation=None):
+def _runtime_binding_refs():
+    return {
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:abc123",
+        "model_runtime_binding_digest": "sha256:model-runtime-binding",
+    }
+
+
+def _snapshot(allocation=None, **queue_overrides):
     allocation = allocation or _allocation()
+    queue_item = {
+        "queue_item_id": "queue-1",
+        "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+        "status": "QUEUED",
+        "wsp15_allocation_receipt": allocation,
+    }
+    queue_item.update(queue_overrides)
     return {
         "schema_version": "reddog_authoritative_work_state.v1",
-        "wre_queue_items": [
-            {
-                "queue_item_id": "queue-1",
-                "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
-                "status": "QUEUED",
-                "wsp15_allocation_receipt": allocation,
-            }
-        ],
+        "wre_queue_items": [queue_item],
     }
 
 
@@ -179,6 +186,71 @@ def test_publishes_signed_worker_dispatch_intents_as_pending_tasks() -> None:
     assert {task.context["worker_runtime"] for task in result.tasks} == {"0102", "openclaw"}
     assert all(task.context["execution_allowed_by_dispatch_runtime"] is False for task in result.tasks)
     assert all(runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL in task.required_skills for task in result.tasks)
+
+
+def test_carries_signed_model_runtime_binding_into_agentdb_task_context() -> None:
+    allocation = _allocation()
+    refs = _runtime_binding_refs()
+    intents = (
+        _intent("coding_worker_1", "0102", "bounded_code_change", allocation, **refs),
+    )
+    dryrun = _dryrun_result(
+        allocation=allocation,
+        intents=intents,
+        receipt={
+            **_dryrun_result(allocation=allocation, intents=intents)["receipt"],
+            **refs,
+        },
+    )
+    writer = _FakeWriter()
+
+    result = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=dryrun,
+        work_state_snapshot=_snapshot(allocation, **refs),
+        queue_item_id="queue-1",
+        writer=writer,
+    )
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.model_runtime_binding_receipt_id == refs["model_runtime_binding_receipt_id"]
+    assert result.receipt.model_runtime_binding_digest == refs["model_runtime_binding_digest"]
+    assert result.tasks[0].context["model_runtime_binding_receipt_id"] == refs[
+        "model_runtime_binding_receipt_id"
+    ]
+    assert result.tasks[0].context["model_runtime_binding_digest"] == refs[
+        "model_runtime_binding_digest"
+    ]
+
+
+def test_rejects_model_runtime_binding_conflict_between_signed_receipt_and_queue() -> None:
+    allocation = _allocation()
+    refs = _runtime_binding_refs()
+    intents = (
+        _intent("coding_worker_1", "0102", "bounded_code_change", allocation, **refs),
+    )
+    dryrun = _dryrun_result(
+        allocation=allocation,
+        intents=intents,
+        receipt={
+            **_dryrun_result(allocation=allocation, intents=intents)["receipt"],
+            **refs,
+        },
+    )
+
+    result = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=dryrun,
+        work_state_snapshot=_snapshot(
+            allocation,
+            model_runtime_binding_receipt_id="reddog_model_runtime_binding:other",
+            model_runtime_binding_digest=refs["model_runtime_binding_digest"],
+        ),
+        queue_item_id="queue-1",
+        writer=_FakeWriter(),
+    )
+
+    assert result.accepted is False
+    assert runtime.WorkerDispatchRuntimeReason.MODEL_RUNTIME_BINDING_MISMATCH in result.rejection_reasons
 
 
 def test_agentdb_writer_publishes_tasks_atomically() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py
@@ -151,6 +151,61 @@ def test_accepts_verified_signed_authority_and_emits_wsp15_worker_intents() -> N
     assert result.receipt.no_hermes_dispatch_performed is True
 
 
+def test_carries_model_runtime_binding_from_signed_authority() -> None:
+    allocation = _allocation()
+    runtime = _runtime_result(
+        allocation,
+        authority_result={
+            "accepted": True,
+            "receipt": {"status": AUTHORITY_ISSUED, "receipt_id": "auth-1"},
+            "work_authority": _work_authority(
+                allocation,
+                model_runtime_binding_receipt_id="reddog_model_runtime_binding:abc123",
+                model_runtime_binding_digest="sha256:model-runtime-binding",
+            ),
+        },
+    )
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=runtime)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.model_runtime_binding_receipt_id == "reddog_model_runtime_binding:abc123"
+    assert result.receipt.model_runtime_binding_digest == "sha256:model-runtime-binding"
+    assert {
+        intent.model_runtime_binding_receipt_id
+        for intent in result.receipt.dispatch_intents
+    } == {"reddog_model_runtime_binding:abc123"}
+    assert {
+        intent.model_runtime_binding_digest
+        for intent in result.receipt.dispatch_intents
+    } == {"sha256:model-runtime-binding"}
+
+
+def test_rejects_one_sided_model_runtime_binding_in_signed_authority() -> None:
+    allocation = _allocation()
+    runtime = _runtime_result(
+        allocation,
+        authority_result={
+            "accepted": True,
+            "receipt": {"status": AUTHORITY_ISSUED, "receipt_id": "auth-1"},
+            "work_authority": _work_authority(
+                allocation,
+                model_runtime_binding_receipt_id="reddog_model_runtime_binding:abc123",
+                model_runtime_binding_digest="",
+            ),
+        },
+    )
+
+    result = _plan(allocation=allocation, queue_authority_runtime_result=runtime)
+
+    assert result.accepted is False
+    assert (
+        dispatch.SignedAuthorityWorkerDispatchDryRunReason.MODEL_RUNTIME_BINDING_MISMATCH
+        in result.rejection_reasons
+    )
+
+
 def test_preserves_legacy_openclaw_candidate_for_non_code_worker_plan() -> None:
     allocation = _allocation()
     allocation["worker_plan"] = dict(allocation["worker_plan"], coding_worker_count=0)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -41,6 +41,7 @@ from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly
     Signed0102ReadOnlyReviewRunner,
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    RUNTIME_SURFACE_READONLY_AUDIT,
     RepoAuditModelResult,
 )
 from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
@@ -74,6 +75,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     _work_order,
     _write_runtime_json,
     run_reddog_main_resident_queue_serial_loop_bootstrap,
+)
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
 )
 from modules.infrastructure.wre_core.src.wre_autonomous_slice_verifier_runtime import (
     AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
@@ -316,6 +320,8 @@ def _dryrun_result(allocation=None, intent=None):
         "wsp15_priority": allocation["priority"],
         "wsp15_mps_total": allocation["mps_total"],
         "wsp15_reasoning_tier": allocation["reasoning_tier"],
+        "model_runtime_binding_receipt_id": str(intent.get("model_runtime_binding_receipt_id") or ""),
+        "model_runtime_binding_digest": str(intent.get("model_runtime_binding_digest") or ""),
         "dispatch_intent_count": 1,
         "dispatch_intents": [intent],
         "no_worker_spawn_performed": True,
@@ -335,18 +341,18 @@ def _dryrun_result(allocation=None, intent=None):
     }
 
 
-def _snapshot(allocation=None):
+def _snapshot(allocation=None, **queue_overrides):
     allocation = allocation or _allocation()
+    queue_item = {
+        "queue_item_id": "queue-1",
+        "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+        "status": "QUEUED",
+        "wsp15_allocation_receipt": allocation,
+    }
+    queue_item.update(queue_overrides)
     return {
         "schema_version": "reddog_authoritative_work_state.v1",
-        "wre_queue_items": [
-            {
-                "queue_item_id": "queue-1",
-                "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
-                "status": "QUEUED",
-                "wsp15_allocation_receipt": allocation,
-            }
-        ],
+        "wre_queue_items": [queue_item],
     }
 
 
@@ -360,6 +366,28 @@ def _task_context():
     assert result.accepted is True
     task = result.tasks[0]
     return dict(task.context)
+
+
+def _task_context_with_model_runtime_binding(runtime_binding=None):
+    runtime_binding = runtime_binding or model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT
+    )
+    allocation = _allocation()
+    binding_refs = {
+        "model_runtime_binding_receipt_id": runtime_binding["receipt_id"],
+        "model_runtime_binding_digest": _digest(runtime_binding),
+    }
+    intent = _intent(allocation, **binding_refs)
+    result = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(allocation=allocation, intent=intent),
+        work_state_snapshot=_snapshot(allocation, **binding_refs),
+        queue_item_id="queue-1",
+        writer=_CollectingWriter(),
+    )
+    assert result.accepted is True
+    context = dict(result.tasks[0].context)
+    context["model_runtime_binding_receipt"] = runtime_binding
+    return context, runtime_binding
 
 
 def _publish_agentdb_task(**intent_overrides) -> str:
@@ -439,6 +467,51 @@ def test_signed_worker_executor_accepts_valid_task_with_injected_runner(tmp_path
     assert runner.calls[0]["worker_dispatch_intent"]["intent_id"] == "worker_dispatch_intent_openclaw_candidate"
 
 
+def test_signed_worker_executor_preserves_signed_model_runtime_binding_metadata(
+    tmp_path: Path,
+) -> None:
+    context, runtime_binding = _task_context_with_model_runtime_binding()
+    runner = _FakeRunner()
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-1",
+        repo_root=tmp_path,
+        runner=runner,
+    )
+
+    assert result.accepted is True
+    task_context = runner.calls[0]["task_context"]
+    assert task_context["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert task_context["model_runtime_binding_digest"] == _digest(runtime_binding)
+    assert task_context["worker_dispatch_intent"]["model_runtime_binding_receipt_id"] == (
+        runtime_binding["receipt_id"]
+    )
+    assert task_context["signed_authority_worker_dispatch_receipt"][
+        "model_runtime_binding_receipt_id"
+    ] == runtime_binding["receipt_id"]
+
+
+def test_signed_worker_executor_rejects_tampered_model_runtime_binding_context(
+    tmp_path: Path,
+) -> None:
+    context, _ = _task_context_with_model_runtime_binding()
+    context["model_runtime_binding_digest"] = "sha256:tampered"
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-1",
+        repo_root=tmp_path,
+        runner=_FakeRunner(),
+    )
+
+    assert result.accepted is False
+    assert (
+        SignedWorkerDispatchTaskExecutorReason.MODEL_RUNTIME_BINDING_MISMATCH
+        in result.rejection_reasons
+    )
+
+
 def test_signed_0102_readonly_runner_executes_architect_review_with_bound_targets(
     tmp_path: Path,
 ) -> None:
@@ -483,6 +556,52 @@ def test_signed_0102_readonly_runner_executes_architect_review_with_bound_target
     assert model_runner.calls[0]["binding"]["wsp15_allocation_receipt_id"] == allocation["receipt_id"]
     assert result.no_source_repo_mutation_performed is True
     assert result.no_shell_command_executed is True
+
+
+def test_signed_0102_readonly_runner_receives_model_runtime_binding_receipt(
+    tmp_path: Path,
+) -> None:
+    repo = _repo_with_readonly_target(tmp_path)
+    allocation = _valid_readonly_allocation()
+    runtime_binding = model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT)
+    binding_refs = {
+        "model_runtime_binding_receipt_id": runtime_binding["receipt_id"],
+        "model_runtime_binding_digest": _digest(runtime_binding),
+    }
+    intent = _intent(
+        allocation,
+        intent_id="worker_dispatch_intent_fusion_lead",
+        role="fusion_lead",
+        worker_runtime="0102",
+        capability="architect_review",
+        **binding_refs,
+    )
+    context = runtime.publish_reddog_signed_worker_dispatch_runtime(
+        worker_dispatch_dryrun_result=_dryrun_result(allocation=allocation, intent=intent),
+        work_state_snapshot=_snapshot(allocation, **binding_refs),
+        queue_item_id="queue-1",
+        writer=_CollectingWriter(),
+    ).tasks[0].context
+    context = dict(context)
+    context["model_runtime_binding_receipt"] = runtime_binding
+    model_runner = _EchoEvidenceModelRunner()
+
+    result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-0102-runtime-binding",
+        repo_root=repo,
+        runner=Signed0102ReadOnlyReviewRunner(
+            model_runner=model_runner,
+            holoindex_adapter=_FakeQueryAdapter(),
+            codeindex_adapter=_FakeQueryAdapter(),
+        ),
+    )
+
+    assert result.accepted is True
+    binding = model_runner.calls[0]["binding"]["model_selection"]
+    assert binding["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    worker_receipt = result.runner_result["readonly_result"]["report"]["worker_receipt"]
+    assert worker_receipt["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
 
 
 def test_signed_0102_readonly_runner_rejects_bounded_code_change(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Summary

Implements `REDDOG_MODEL_RUNTIME_BINDING_WORKER_DISPATCH_CARRY_PHASE1`.

This carries signed model runtime-binding metadata through the worker-dispatch chain after the signed authority step:

- signed work-authority -> worker-dispatch dry-run intents and receipt
- worker-dispatch runtime -> AgentDB task context and runtime receipt
- claimed-task executor -> fail-closed consistency check across context, intent, and signed dispatch receipt
- signed 0102 readonly binding -> readonly audit task context and assignment
- resident work-order materializer -> content-bearing `model_runtime_binding_receipt` from authority profile

## Why

#1202 bound the runtime model receipt into signed authority, but the next WSP_15 seam was whether the signed worker task and resident worker assignment inherited that evidence. Without this carry, a downstream readonly worker could fall back to stale/static model selection even though the authority chain was signed with a runtime binding.

## Boundaries

No model/provider call, benchmark execution, signing expansion, worker spawn, shell execution, worktree creation, source mutation, PatternMemory write, OpenClaw/Hermes dispatch, PR publication, reward settlement, or HoloIndex re-indexing is added.

## Validation

- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/src/reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py`
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_authority_worker_dispatch_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 68 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_authority_profile_materializer_carries_model_runtime_binding_receipt -q` -> 1 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 60 passed, 1 skipped
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py -q` -> 43 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_request_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authority_runtime_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py -q` -> 39 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 38 passed
- `git diff --check`
- added-line non-ASCII check -> 0
