### PR TITLE
feat(reddog): derive runtime-bound artifact requests

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_REQUEST_DERIVATION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Carried content-bearing `model_runtime_binding_receipt` from resident
+  work orders into derived bounded artifact-generation requests.
+- Patched both early bootstrap derivation and the late bounded-worker-pilot
+  handler derivation path, which is the path used by an active serial loop after
+  worktree creation.
+- Added an end-to-end resident bootstrap regression proving the artifact
+  generator receives the runtime-bound model topology before bounded worker
+  materialization.
+- Boundary remains constrained: no model/provider default change, benchmark
+  execution, signing expansion, shell, worktree policy change, source mutation,
+  PatternMemory write, OpenClaw/Hermes dispatch, PR publication, reward
+  settlement, or HoloIndex re-indexing was added.
+
 ## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_WORKER_DISPATCH_CARRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -792,7 +792,7 @@ def _derive_artifact_generation_request_from_chain(
             or ""
         ),
     }
-    return {
+    request = {
         "explicit_artifact_generation_requested": True,
         "work_order_id": work_order_id,
         "slice_name": str(work_order.get("requested_operation") or plan.get("operation") or ""),
@@ -817,6 +817,13 @@ def _derive_artifact_generation_request_from_chain(
         "signed_receipt_chain": dict(signed_receipt_chain),
         "timeout_seconds": 30,
     }
+    model_runtime_binding = _nested_mapping(work_order, "model_runtime_binding_receipt")
+    if model_runtime_binding:
+        request["model_runtime_binding_receipt"] = dict(model_runtime_binding)
+    model_selection = _nested_mapping(work_order, "model_selection_receipt")
+    if model_selection:
+        request["model_selection_receipt"] = dict(model_selection)
+    return request
 
 
 def _derive_outcome_ratchet_request_from_chain(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_bounded_worker_pilot_handler.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_bounded_worker_pilot_handler.py
@@ -293,6 +293,11 @@ def _derive_artifact_generation_request(
         or _mapping(work_order.get("model_selection_receipt"))
         or _mapping(_mapping(work_order.get("operational_context_binding")).get("model_selection_receipt"))
     )
+    model_runtime_binding_receipt = (
+        _mapping(plan.get("model_runtime_binding_receipt"))
+        or _mapping(work_order.get("model_runtime_binding_receipt"))
+        or _mapping(_mapping(work_order.get("operational_context_binding")).get("model_runtime_binding_receipt"))
+    )
     planned_artifacts = _list(plan.get("planned_artifacts"))
     task_summary = str(work_order.get("task_summary") or "")
     if (
@@ -319,7 +324,7 @@ def _derive_artifact_generation_request(
             or ""
         ),
     }
-    return {
+    request = {
         "explicit_artifact_generation_requested": True,
         "work_order_id": str(work_order.get("work_order_id") or ""),
         "slice_name": str(work_order.get("requested_operation") or plan.get("operation") or ""),
@@ -343,6 +348,9 @@ def _derive_artifact_generation_request(
         "model_selection_receipt": dict(model_selection_receipt),
         "timeout_seconds": 30,
     }
+    if model_runtime_binding_receipt:
+        request["model_runtime_binding_receipt"] = dict(model_runtime_binding_receipt)
+    return request
 
 
 __all__ = [

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -65,6 +65,7 @@ from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import 
 )
 from modules.communication.moltbot_bridge.src.reddog_bounded_artifact_generation_runtime import (
     ArtifactGenerationModelResult,
+    RUNTIME_SURFACE_ARTIFACT_GENERATION,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized_bounded_worker_pilot_invoke import (
     _receipt_chain as _pilot_receipt_chain,
@@ -2203,7 +2204,11 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
     repo = _repo(tmp_path)
     principal_public, reddog_public, connector = _ed25519_signing_material()
     pilot_overrides = _pilot_path_overrides()
-    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    runtime_binding = model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_ARTIFACT_GENERATION)
+    snapshot = _snapshot()
+    snapshot["wre_queue_items"][0]["model_runtime_binding_receipt_id"] = runtime_binding["receipt_id"]
+    snapshot["wre_queue_items"][0]["model_runtime_binding_digest"] = _canonical_digest(runtime_binding)
+    state = _write_runtime_json(tmp_path, "work_state.json", snapshot)
     profile = _write_runtime_json(
         tmp_path,
         "profile.json",
@@ -2213,6 +2218,9 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
             requested_operation=PILOT_OPERATION,
             allowed_paths=_pilot_allowed_paths(),
             denied_paths=pilot_overrides["denied_paths"],
+            model_runtime_binding_receipt=runtime_binding,
+            model_runtime_binding_receipt_id=runtime_binding["receipt_id"],
+            model_runtime_binding_digest=_canonical_digest(runtime_binding),
         ),
     )
     snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
@@ -2220,6 +2228,9 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
     work_order = _work_order(
         **pilot_overrides,
         bounded_worker_plan=_pilot_bounded_worker_plan(),
+        model_runtime_binding_receipt=runtime_binding,
+        model_runtime_binding_receipt_id=runtime_binding["receipt_id"],
+        model_runtime_binding_digest=_canonical_digest(runtime_binding),
     )
     work_orders = _write_runtime_json(
         tmp_path,
@@ -2280,6 +2291,9 @@ def test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot(
     assert result.dispatched_stages[-1] == "bounded_worker_pilot"
     assert artifact_generator.calls
     assert artifact_generator.calls[0]["binding"]["work_order_id"] == WORK_ORDER_ID
+    assert artifact_generator.calls[0]["binding"]["model_selection"][
+        "model_runtime_binding_receipt_id"
+    ] == runtime_binding["receipt_id"]
     context = json.loads(str(artifact_generator.calls[0]["context"]))
     assert context["holoindex_evidence"]["retrieval_quality"] == "HIGH"
     stored = json.loads(chain.read_text(encoding="utf-8"))


### PR DESCRIPTION
﻿## Summary

Implements `REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_REQUEST_DERIVATION_PHASE1`.

This completes the next model-runtime binding seam in the resident bounded-worker path:

- derived artifact-generation requests now carry the content-bearing `model_runtime_binding_receipt` from the resident work order
- both early bootstrap derivation and late bounded-worker-pilot handler derivation carry the receipt
- the resident bootstrap regression proves the artifact generator receives the runtime-bound model topology before bounded worker materialization

## Why

The artifact-generation runtime already rejects malformed or wrong-surface runtime-binding receipts and uses valid receipts to derive the model topology. The resident queue derivation path still passed only the older model-selection receipt, so a runtime-bound authority chain could still fall back before producing bounded artifacts.

## Boundaries

No model/provider default change, benchmark execution, signing expansion, shell execution, worktree policy change, source mutation, PatternMemory write, OpenClaw/Hermes dispatch, PR publication, reward settlement, or HoloIndex re-indexing is added.

## Validation

- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/src/reddog_resident_queue_bounded_worker_pilot_handler.py`
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_bootstrap_serial_loop_generates_artifacts_before_bounded_worker_pilot -q` -> 1 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_bounded_artifact_generation_runtime.py -q` -> 16 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 60 passed, 1 skipped
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_bounded_artifact_generation_runtime.py -q` -> 54 passed
- `git diff --check`
- added-line non-ASCII check -> 0
