### PR TITLE
feat(reddog): carry model runtime binding into verifier outcomes

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_VERIFIER_OUTCOME_CARRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Carried optional model-runtime binding id/digest from signed authority and
+  bounded artifact-generation receipts into independent verifier receipts.
+- Draft-PR publish and verified-outcome ratchet receipts now preserve the same
+  runtime-binding proof and fail closed if a downstream request tries to
+  override it.
+- The queue-authorized verifier wrapper now enriches verifier requests from the
+  bounded artifact-generation receipt so model runtime evidence is not lost
+  between artifact synthesis and independent verification.
+- Boundary remains constrained: no model/provider default change, benchmark
+  execution, signing expansion, shell, worktree policy change, source mutation,
+  PatternMemory write, OpenClaw/Hermes dispatch, PR publication, reward
+  settlement, or HoloIndex re-indexing was added.
+
 ## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_REQUEST_DERIVATION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_slice_verifier_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_slice_verifier_invoke.py
@@ -129,6 +129,7 @@ def _pilot_flags_ok(queue_pilot: Mapping[str, Any], pilot_payload: Mapping[str, 
 def _enrich_verifier_request(
     verifier_request: Mapping[str, Any],
     pilot_receipt: Mapping[str, Any],
+    artifact_generation_receipt: Mapping[str, Any],
 ) -> Dict[str, Any]:
     enriched = dict(verifier_request)
     enriched["worktree_receipt"] = {
@@ -139,6 +140,8 @@ def _enrich_verifier_request(
         "accepted": True,
         **dict(pilot_receipt),
     }
+    if artifact_generation_receipt:
+        enriched["artifact_generation_receipt"] = dict(artifact_generation_receipt)
     return enriched
 
 
@@ -170,6 +173,9 @@ def invoke_reddog_wre_queue_authorized_slice_verifier(
     pilot_receipt = _mapping(pilot_payload.get("receipt"))
     if not pilot_receipt:
         reasons.append(QueueAuthorizedSliceVerifierInvokeReason.PILOT_RECEIPT_MISSING)
+    artifact_generation_receipt = _mapping(
+        _mapping(queue_pilot.get("artifact_generation_result")).get("receipt")
+    )
 
     if pilot_payload and not _pilot_flags_ok(queue_pilot, pilot_payload):
         reasons.append(QueueAuthorizedSliceVerifierInvokeReason.PILOT_SIDE_EFFECT_FLAGS_INVALID)
@@ -187,7 +193,13 @@ def invoke_reddog_wre_queue_authorized_slice_verifier(
     if reasons:
         return _reject(reasons, explicit_requested=True)
 
-    verifier = verify_autonomous_slice_runtime(_enrich_verifier_request(verifier_payload, pilot_receipt))
+    verifier = verify_autonomous_slice_runtime(
+        _enrich_verifier_request(
+            verifier_payload,
+            pilot_receipt,
+            artifact_generation_receipt,
+        )
+    )
     if verifier.decision != AUTONOMOUS_SLICE_VERIFIER_ACCEPT:
         return _reject(
             [

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_slice_verifier_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_slice_verifier_invoke.py
@@ -162,6 +162,28 @@ def test_invokes_autonomous_verifier_from_accepted_bounded_pilot() -> None:
     assert result.no_holoindex_reindex_performed is True
 
 
+def test_carries_artifact_generation_model_runtime_binding_into_verifier() -> None:
+    queue_pilot = _queue_pilot_result()
+    queue_pilot["artifact_generation_result"] = {
+        "accepted": True,
+        "receipt": {
+            "receipt_id": "bounded_artifacts_1234",
+            "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:test",
+            "model_runtime_binding_digest": _digest("c"),
+        },
+    }
+
+    result = _invoke(queue_pilot=queue_pilot)
+
+    assert result.decision == QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_ACCEPT
+    assert result.verifier_result is not None
+    assert (
+        result.verifier_result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.verifier_result.receipt.model_runtime_binding_digest == _digest("c")
+
+
 def test_explicit_invoke_missing_rejects_before_verifier() -> None:
     result = invoke_reddog_wre_queue_authorized_slice_verifier(
         explicit_queue_authorized_slice_verifier_requested=False,

--- a/modules/infrastructure/wre_core/src/reddog_verified_draft_pr_publish.py
+++ b/modules/infrastructure/wre_core/src/reddog_verified_draft_pr_publish.py
@@ -30,6 +30,7 @@ FAIL_BRANCH_POLICY = "FAIL_BRANCH_POLICY"
 FAIL_DRAFT_ONLY = "FAIL_DRAFT_ONLY"
 FAIL_PR_METADATA = "FAIL_PR_METADATA"
 FAIL_SECRET_IN_PR_METADATA = "FAIL_SECRET_IN_PR_METADATA"
+FAIL_MODEL_RUNTIME_BINDING = "FAIL_MODEL_RUNTIME_BINDING"
 FAIL_PUSH_BRANCH = "FAIL_PUSH_BRANCH"
 FAIL_CREATE_DRAFT_PR = "FAIL_CREATE_DRAFT_PR"
 FAIL_PR_URL = "FAIL_PR_URL"
@@ -74,6 +75,8 @@ class VerifiedDraftPrPublishReceipt:
     verified_head_sha: str
     draft_pr_url: str
     changed_paths: List[str]
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: str
     rejection_reasons: List[str]
     accepted: bool
     no_ready_performed: bool = True
@@ -149,6 +152,52 @@ def _draft_url_ok(url: str) -> bool:
     return url.startswith("https://github.com/") and "/pull/" in url
 
 
+def _is_digest(value: Any) -> bool:
+    text = str(value or "")
+    return (
+        text.startswith("sha256:")
+        and len(text) == 71
+        and all(ch in "0123456789abcdef" for ch in text.removeprefix("sha256:"))
+    )
+
+
+def _runtime_binding_pair(value: Mapping[str, Any]) -> tuple[str, str]:
+    receipt_id = str(
+        value.get("model_runtime_binding_receipt_id")
+        or value.get("runtime_binding_receipt_id")
+        or ""
+    )
+    digest = str(value.get("model_runtime_binding_digest") or "")
+    return receipt_id, digest
+
+
+def _runtime_binding_ok(
+    verifier_receipt: Mapping[str, Any],
+    request: Mapping[str, Any],
+) -> tuple[bool, Optional[str], str]:
+    pairs = [
+        pair
+        for pair in (
+            _runtime_binding_pair(verifier_receipt),
+            _runtime_binding_pair(request),
+        )
+        if pair[0] or pair[1]
+    ]
+    if not pairs:
+        return True, None, ""
+    normalized: List[tuple[str, str]] = []
+    for receipt_id, digest in pairs:
+        if not receipt_id or not digest:
+            return False, receipt_id or None, digest
+        if not receipt_id.startswith("reddog_model_runtime_binding:") or not _is_digest(digest):
+            return False, receipt_id, digest
+        normalized.append((receipt_id, digest))
+    first = normalized[0]
+    if any(pair != first for pair in normalized[1:]):
+        return False, first[0], first[1]
+    return True, first[0], first[1]
+
+
 def _receipt_seed(
     *,
     work_order_id: str,
@@ -159,6 +208,8 @@ def _receipt_seed(
     verified_head_sha: str,
     draft_pr_url: str,
     changed_paths: List[str],
+    model_runtime_binding_receipt_id: str,
+    model_runtime_binding_digest: str,
     rejection_reasons: List[str],
 ) -> Dict[str, Any]:
     return {
@@ -170,6 +221,8 @@ def _receipt_seed(
         "verified_head_sha": verified_head_sha,
         "draft_pr_url": draft_pr_url,
         "changed_paths": changed_paths,
+        "model_runtime_binding_receipt_id": model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": model_runtime_binding_digest,
         "rejection_reasons": rejection_reasons,
     }
 
@@ -186,6 +239,8 @@ def _result(
     verified_head_sha: str,
     draft_pr_url: str,
     changed_paths: List[str],
+    model_runtime_binding_receipt_id: Optional[str] = None,
+    model_runtime_binding_digest: str = "",
     push_result: Mapping[str, Any] | None = None,
 ) -> VerifiedDraftPrPublishResult:
     deduped = _dedupe(reasons)
@@ -198,6 +253,8 @@ def _result(
         verified_head_sha=verified_head_sha,
         draft_pr_url=draft_pr_url,
         changed_paths=changed_paths,
+        model_runtime_binding_receipt_id=model_runtime_binding_receipt_id or "",
+        model_runtime_binding_digest=model_runtime_binding_digest,
         rejection_reasons=deduped,
     )
     receipt = VerifiedDraftPrPublishReceipt(
@@ -210,6 +267,8 @@ def _result(
         verified_head_sha=verified_head_sha,
         draft_pr_url=draft_pr_url,
         changed_paths=changed_paths,
+        model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
+        model_runtime_binding_digest=model_runtime_binding_digest,
         rejection_reasons=deduped,
         accepted=accepted,
     )
@@ -251,6 +310,10 @@ def publish_verified_draft_pr(
     body = str(req.get("pr_body") or "")
     worktree_path = Path(str(req.get("worktree_path") or ""))
     reasons: List[str] = []
+    runtime_binding_ok, runtime_binding_id, runtime_binding_digest = _runtime_binding_ok(
+        verifier_receipt,
+        req,
+    )
 
     if (
         verifier_result.get("accepted") is not True
@@ -272,6 +335,8 @@ def publish_verified_draft_pr(
         reasons.append(FAIL_PR_METADATA)
     if _contains_secret({"title": title, "body": body}):
         reasons.append(FAIL_SECRET_IN_PR_METADATA)
+    if not runtime_binding_ok:
+        reasons.append(FAIL_MODEL_RUNTIME_BINDING)
 
     if reasons:
         return _result(
@@ -285,6 +350,8 @@ def publish_verified_draft_pr(
             verified_head_sha=verified_head_sha,
             draft_pr_url="",
             changed_paths=changed_paths,
+            model_runtime_binding_receipt_id=runtime_binding_id,
+            model_runtime_binding_digest=runtime_binding_digest,
         )
 
     push_result = dict(runner.push_branch(worktree_path=worktree_path, branch_name=branch_name))
@@ -300,6 +367,8 @@ def publish_verified_draft_pr(
             verified_head_sha=verified_head_sha,
             draft_pr_url="",
             changed_paths=changed_paths,
+            model_runtime_binding_receipt_id=runtime_binding_id,
+            model_runtime_binding_digest=runtime_binding_digest,
             push_result=push_result,
         )
 
@@ -322,6 +391,8 @@ def publish_verified_draft_pr(
             verified_head_sha=verified_head_sha,
             draft_pr_url="",
             changed_paths=changed_paths,
+            model_runtime_binding_receipt_id=runtime_binding_id,
+            model_runtime_binding_digest=runtime_binding_digest,
             push_result=push_result,
         )
 
@@ -337,6 +408,8 @@ def publish_verified_draft_pr(
             verified_head_sha=verified_head_sha,
             draft_pr_url=str(draft_pr_url or ""),
             changed_paths=changed_paths,
+            model_runtime_binding_receipt_id=runtime_binding_id,
+            model_runtime_binding_digest=runtime_binding_digest,
             push_result=push_result,
         )
 
@@ -351,6 +424,8 @@ def publish_verified_draft_pr(
         verified_head_sha=verified_head_sha,
         draft_pr_url=str(draft_pr_url),
         changed_paths=changed_paths,
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
         push_result=push_result,
     )
 
@@ -360,6 +435,7 @@ __all__ = [
     "FAIL_CREATE_DRAFT_PR",
     "FAIL_DRAFT_ONLY",
     "FAIL_HEAD_MISMATCH",
+    "FAIL_MODEL_RUNTIME_BINDING",
     "FAIL_PR_METADATA",
     "FAIL_PR_URL",
     "FAIL_PUSH_BRANCH",

--- a/modules/infrastructure/wre_core/src/reddog_verified_outcome_ratchet.py
+++ b/modules/infrastructure/wre_core/src/reddog_verified_outcome_ratchet.py
@@ -33,6 +33,7 @@ FAIL_PUBLISH_RECEIPT = "FAIL_PUBLISH_RECEIPT"
 FAIL_RECEIPT_SET = "FAIL_RECEIPT_SET"
 FAIL_COST_LATENCY = "FAIL_COST_LATENCY"
 FAIL_HOLOINDEX_EVIDENCE = "FAIL_HOLOINDEX_EVIDENCE"
+FAIL_MODEL_RUNTIME_BINDING = "FAIL_MODEL_RUNTIME_BINDING"
 FAIL_SECRET_IN_RECEIPT = "FAIL_SECRET_IN_RECEIPT"
 FAIL_PATTERN_MEMORY_UNVERIFIED = "FAIL_PATTERN_MEMORY_UNVERIFIED"
 FAIL_STORE_WRITE = "FAIL_STORE_WRITE"
@@ -103,6 +104,8 @@ class VerifiedOutcomeRatchetReceipt:
     acceptance_receipt_digest: str
     failure_receipt_digest: Optional[str]
     holoindex_freshness_receipt_digest: str
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: str
     pattern_memory_eligible: bool
     pattern_memory_write_performed: bool
     pattern_memory_record_id: Optional[str]
@@ -205,6 +208,54 @@ def _holoindex_ok(holoindex_evidence: Mapping[str, Any]) -> bool:
     return bool(str(holoindex_evidence.get("holoindex_freshness_receipt_digest") or ""))
 
 
+def _is_digest(value: Any) -> bool:
+    text = str(value or "")
+    return (
+        text.startswith("sha256:")
+        and len(text) == 71
+        and all(ch in "0123456789abcdef" for ch in text.removeprefix("sha256:"))
+    )
+
+
+def _runtime_binding_pair(value: Mapping[str, Any]) -> tuple[str, str]:
+    receipt_id = str(
+        value.get("model_runtime_binding_receipt_id")
+        or value.get("runtime_binding_receipt_id")
+        or ""
+    )
+    digest = str(value.get("model_runtime_binding_digest") or "")
+    return receipt_id, digest
+
+
+def _runtime_binding_ok(request: Mapping[str, Any]) -> tuple[bool, Optional[str], str]:
+    verification_result = _mapping(request.get("verification_result"))
+    verification_receipt = _mapping(verification_result.get("receipt"))
+    publish_result = _mapping(request.get("publish_result"))
+    publish_receipt = _mapping(publish_result.get("receipt"))
+    pairs = [
+        pair
+        for pair in (
+            _runtime_binding_pair(request),
+            _runtime_binding_pair(verification_receipt),
+            _runtime_binding_pair(publish_receipt),
+        )
+        if pair[0] or pair[1]
+    ]
+    if not pairs:
+        return True, None, ""
+    normalized: List[tuple[str, str]] = []
+    for receipt_id, digest in pairs:
+        if not receipt_id or not digest:
+            return False, receipt_id or None, digest
+        if not receipt_id.startswith("reddog_model_runtime_binding:") or not _is_digest(digest):
+            return False, receipt_id, digest
+        normalized.append((receipt_id, digest))
+    first = normalized[0]
+    if any(pair != first for pair in normalized[1:]):
+        return False, first[0], first[1]
+    return True, first[0], first[1]
+
+
 def _cost_latency_ok(cost: Mapping[str, Any], latency: Mapping[str, Any]) -> bool:
     for key in ("total_tokens", "estimated_cost_usd"):
         if key not in cost:
@@ -237,6 +288,7 @@ def _build_receipt(
     failure = _mapping(request.get("failure_receipt"))
     holoindex = _mapping(request.get("holoindex_evidence"))
     execution_receipts = _list(request.get("execution_receipts"))
+    _, runtime_binding_id, runtime_binding_digest = _runtime_binding_ok(request)
     work_order_id = str(
         request.get("work_order_id") or verification_receipt.get("work_order_id") or ""
     )
@@ -255,6 +307,8 @@ def _build_receipt(
         "verification_digest": _receipt_digest(verification_result),
         "acceptance_receipt_digest": _receipt_digest(acceptance),
         "failure_receipt_digest": _receipt_digest(failure) if failure else None,
+        "model_runtime_binding_receipt_id": runtime_binding_id or "",
+        "model_runtime_binding_digest": runtime_binding_digest,
         "rejection_reasons": reasons,
     }
     return VerifiedOutcomeRatchetReceipt(
@@ -274,6 +328,8 @@ def _build_receipt(
         holoindex_freshness_receipt_digest=str(
             holoindex.get("holoindex_freshness_receipt_digest") or ""
         ),
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
         pattern_memory_eligible=pattern_memory_eligible,
         pattern_memory_write_performed=pattern_memory_write_performed,
         pattern_memory_record_id=pattern_memory_record_id,
@@ -298,6 +354,7 @@ def ratchet_verified_outcome(
     failure = _mapping(req.get("failure_receipt"))
     holoindex = _mapping(req.get("holoindex_evidence"))
     outcome_status = str(req.get("outcome_status") or "")
+    runtime_binding_ok, _, _ = _runtime_binding_ok(req)
     reasons: List[str] = []
 
     if (
@@ -319,6 +376,8 @@ def ratchet_verified_outcome(
         reasons.append(FAIL_COST_LATENCY)
     if not _holoindex_ok(holoindex):
         reasons.append(FAIL_HOLOINDEX_EVIDENCE)
+    if not runtime_binding_ok:
+        reasons.append(FAIL_MODEL_RUNTIME_BINDING)
     if _contains_secret(
         {
             "request": req.get("request_receipt"),
@@ -410,6 +469,7 @@ def ratchet_verified_outcome(
 __all__ = [
     "FAIL_COST_LATENCY",
     "FAIL_HOLOINDEX_EVIDENCE",
+    "FAIL_MODEL_RUNTIME_BINDING",
     "FAIL_PATTERN_MEMORY_UNVERIFIED",
     "FAIL_PATTERN_MEMORY_WRITE",
     "FAIL_PUBLISH_RECEIPT",

--- a/modules/infrastructure/wre_core/src/wre_autonomous_slice_verifier_runtime.py
+++ b/modules/infrastructure/wre_core/src/wre_autonomous_slice_verifier_runtime.py
@@ -32,6 +32,7 @@ FAIL_SIGNED_AUTHORITY = "FAIL_SIGNED_AUTHORITY"
 FAIL_RECEIPT_CHAIN = "FAIL_RECEIPT_CHAIN"
 FAIL_WORKTREE_RECEIPT = "FAIL_WORKTREE_RECEIPT"
 FAIL_HOLOINDEX_EVIDENCE = "FAIL_HOLOINDEX_EVIDENCE"
+FAIL_MODEL_RUNTIME_BINDING = "FAIL_MODEL_RUNTIME_BINDING"
 FAIL_PATTERN_MEMORY_WRITE = "FAIL_PATTERN_MEMORY_WRITE"
 FAIL_PR_OR_MERGE_ALREADY_PERFORMED = "FAIL_PR_OR_MERGE_ALREADY_PERFORMED"
 
@@ -86,6 +87,8 @@ class AutonomousSliceVerifierReceipt:
     receipt_chain_terminal_hash: str
     worktree_receipt_digest: str
     holoindex_freshness_receipt_digest: str
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: str
     rejection_reasons: List[str]
     accepted: bool
     no_command_execution_performed: bool = True
@@ -287,6 +290,55 @@ def _holoindex_evidence_ok(holoindex_evidence: Mapping[str, Any]) -> bool:
     return _is_digest(holoindex_evidence.get("holoindex_freshness_receipt_digest"))
 
 
+def _runtime_binding_pair(value: Mapping[str, Any]) -> tuple[str, str]:
+    receipt_id = str(
+        value.get("model_runtime_binding_receipt_id")
+        or value.get("runtime_binding_receipt_id")
+        or ""
+    )
+    digest = str(value.get("model_runtime_binding_digest") or "")
+    return receipt_id, digest
+
+
+def _runtime_binding_sources(req: Mapping[str, Any]) -> List[tuple[str, str]]:
+    sources: List[tuple[str, str]] = []
+    signed_authority = _mapping(req.get("signed_authority"))
+    candidates = [
+        req,
+        signed_authority,
+        _mapping(signed_authority.get("work_authority")),
+        _mapping(signed_authority.get("authority")),
+        _mapping(signed_authority.get("payload")),
+        _mapping(req.get("artifact_generation_receipt")),
+        _mapping(_mapping(req.get("artifact_generation_result")).get("receipt")),
+        _mapping(req.get("bounded_worker_pilot_receipt")),
+    ]
+    for candidate in candidates:
+        pair = _runtime_binding_pair(candidate)
+        if pair[0] or pair[1]:
+            sources.append(pair)
+    return sources
+
+
+def _runtime_binding_ok(req: Mapping[str, Any]) -> tuple[bool, Optional[str], str]:
+    pairs = _runtime_binding_sources(req)
+    if not pairs:
+        return True, None, ""
+
+    normalized: List[tuple[str, str]] = []
+    for receipt_id, digest in pairs:
+        if not receipt_id or not digest:
+            return False, receipt_id or None, digest
+        if not receipt_id.startswith("reddog_model_runtime_binding:") or not _is_digest(digest):
+            return False, receipt_id, digest
+        normalized.append((receipt_id, digest))
+
+    first = normalized[0]
+    if any(pair != first for pair in normalized[1:]):
+        return False, first[0], first[1]
+    return True, first[0], first[1]
+
+
 def _all_paths_in_scope(paths: Sequence[str], req: Mapping[str, Any]) -> bool:
     allowed_patterns = [str(item) for item in _list(req.get("allowed_path_patterns"))]
     forbidden_patterns = [str(item) for item in _list(req.get("forbidden_path_patterns"))]
@@ -319,6 +371,7 @@ def verify_autonomous_slice_runtime(request: Mapping[str, Any]) -> AutonomousSli
     worktree_receipt = _mapping(req.get("worktree_receipt"))
     pilot_receipt = _mapping(req.get("bounded_worker_pilot_receipt"))
     holoindex_evidence = _mapping(req.get("holoindex_evidence"))
+    runtime_binding_ok, runtime_binding_id, runtime_binding_digest = _runtime_binding_ok(req)
 
     work_order_id = str(req.get("work_order_id") or "")
     slice_name = str(req.get("slice_name") or "")
@@ -365,6 +418,8 @@ def verify_autonomous_slice_runtime(request: Mapping[str, Any]) -> AutonomousSli
         reasons.append(FAIL_WORKTREE_RECEIPT)
     if not _holoindex_evidence_ok(holoindex_evidence):
         reasons.append(FAIL_HOLOINDEX_EVIDENCE)
+    if not runtime_binding_ok:
+        reasons.append(FAIL_MODEL_RUNTIME_BINDING)
     if req.get("pattern_memory_write_performed") is True:
         reasons.append(FAIL_PATTERN_MEMORY_WRITE)
     if req.get("draft_pr_published") is True or req.get("merge_performed") is True:
@@ -402,6 +457,8 @@ def verify_autonomous_slice_runtime(request: Mapping[str, Any]) -> AutonomousSli
         "holoindex_freshness_receipt_digest": str(
             holoindex_evidence.get("holoindex_freshness_receipt_digest") or ""
         ),
+        "model_runtime_binding_receipt_id": runtime_binding_id or "",
+        "model_runtime_binding_digest": runtime_binding_digest,
         "rejection_reasons": deduped,
     }
     receipt = AutonomousSliceVerifierReceipt(
@@ -421,6 +478,8 @@ def verify_autonomous_slice_runtime(request: Mapping[str, Any]) -> AutonomousSli
         holoindex_freshness_receipt_digest=str(
             holoindex_evidence.get("holoindex_freshness_receipt_digest") or ""
         ),
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
         rejection_reasons=deduped,
         accepted=accepted,
     )
@@ -444,6 +503,7 @@ __all__ = [
     "FAIL_DIFF_EVIDENCE",
     "FAIL_HEAD_SHA",
     "FAIL_HOLOINDEX_EVIDENCE",
+    "FAIL_MODEL_RUNTIME_BINDING",
     "FAIL_PATTERN_MEMORY_WRITE",
     "FAIL_PR_OR_MERGE_ALREADY_PERFORMED",
     "FAIL_PROTECTED_SURFACE",

--- a/modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py
+++ b/modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py
@@ -50,6 +50,13 @@ def _verifier_result(*, accepted: bool = True) -> dict:
     }
 
 
+def _verifier_result_with_runtime_binding() -> dict:
+    result = _verifier_result()
+    result["receipt"]["model_runtime_binding_receipt_id"] = "reddog_model_runtime_binding:test"
+    result["receipt"]["model_runtime_binding_digest"] = "sha256:" + ("1" * 64)
+    return result
+
+
 def valid_request() -> dict:
     return {
         "verifier_result": _verifier_result(),
@@ -88,10 +95,40 @@ def test_publishes_draft_pr_only_after_accepted_verifier_result() -> None:
     assert result.receipt.draft_pr_url.endswith("/pull/1000")
     assert result.receipt.verified_head_sha == HEAD_SHA
     assert result.receipt.changed_paths == [PATH]
+    assert result.receipt.model_runtime_binding_receipt_id is None
+    assert result.receipt.model_runtime_binding_digest == ""
     assert result.receipt.no_ready_performed is True
     assert result.receipt.no_merge_performed is True
     assert result.receipt.no_pattern_memory_write_performed is True
     assert [call[0] for call in runner.calls] == ["push_branch", "create_draft_pr"]
+
+
+def test_publish_receipt_carries_verifier_model_runtime_binding() -> None:
+    req = valid_request()
+    req["verifier_result"] = _verifier_result_with_runtime_binding()
+
+    result = publish.publish_verified_draft_pr(req, runner=FakeRunner())
+
+    assert result.accepted is True
+    assert (
+        result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.receipt.model_runtime_binding_digest == "sha256:" + ("1" * 64)
+
+
+def test_rejects_publish_runtime_binding_override() -> None:
+    req = valid_request()
+    req["verifier_result"] = _verifier_result_with_runtime_binding()
+    req["model_runtime_binding_receipt_id"] = "reddog_model_runtime_binding:test"
+    req["model_runtime_binding_digest"] = "sha256:" + ("2" * 64)
+    runner = FakeRunner()
+
+    result = publish.publish_verified_draft_pr(req, runner=runner)
+
+    assert result.accepted is False
+    assert publish.FAIL_MODEL_RUNTIME_BINDING in result.rejection_reasons
+    assert runner.calls == []
 
 
 def test_rejects_unaccepted_or_malformed_verifier_result_before_runner() -> None:

--- a/modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py
+++ b/modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py
@@ -89,6 +89,19 @@ def valid_request() -> dict:
     }
 
 
+def request_with_runtime_binding() -> dict:
+    req = valid_request()
+    req["verification_result"]["receipt"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["verification_result"]["receipt"]["model_runtime_binding_digest"] = _digest("3")
+    req["publish_result"]["receipt"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["publish_result"]["receipt"]["model_runtime_binding_digest"] = _digest("3")
+    return req
+
+
 def assert_reject(req: dict, code: str) -> ratchet.VerifiedOutcomeRatchetResult:
     store = ratchet.InMemoryOutcomeRatchetStore()
     result = ratchet.ratchet_verified_outcome(req, store=store)
@@ -112,9 +125,35 @@ def test_records_verified_outcome_without_pattern_memory_by_default() -> None:
     assert result.receipt.pattern_memory_eligible is True
     assert result.receipt.pattern_memory_write_performed is False
     assert result.receipt.pattern_memory_record_id is None
+    assert result.receipt.model_runtime_binding_receipt_id is None
+    assert result.receipt.model_runtime_binding_digest == ""
     assert result.store_record_id == result.receipt.ratchet_id
     assert len(store.records) == 1
     assert store.records[0]["ratchet_receipt"]["ratchet_id"] == result.receipt.ratchet_id
+
+
+def test_ratchet_receipt_carries_model_runtime_binding_from_verification_chain() -> None:
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = ratchet.ratchet_verified_outcome(request_with_runtime_binding(), store=store)
+
+    assert result.accepted is True
+    assert (
+        result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.receipt.model_runtime_binding_digest == _digest("3")
+    assert (
+        store.records[0]["ratchet_receipt"]["model_runtime_binding_receipt_id"]
+        == "reddog_model_runtime_binding:test"
+    )
+
+
+def test_ratchet_rejects_model_runtime_binding_mismatch() -> None:
+    req = request_with_runtime_binding()
+    req["publish_result"]["receipt"]["model_runtime_binding_digest"] = _digest("4")
+
+    assert_reject(req, ratchet.FAIL_MODEL_RUNTIME_BINDING)
 
 
 def test_pattern_memory_sink_receives_only_verified_accepted_outcome() -> None:

--- a/modules/infrastructure/wre_core/tests/test_wre_autonomous_slice_verifier_runtime.py
+++ b/modules/infrastructure/wre_core/tests/test_wre_autonomous_slice_verifier_runtime.py
@@ -110,9 +110,47 @@ def test_accepts_complete_machine_derived_slice_packet() -> None:
     assert result.receipt.receipt_chain_terminal_hash == _digest("4")
     assert result.receipt.worktree_receipt_digest == _digest("5")
     assert result.receipt.holoindex_freshness_receipt_digest == _digest("6")
+    assert result.receipt.model_runtime_binding_receipt_id is None
+    assert result.receipt.model_runtime_binding_digest == ""
     assert result.receipt.no_command_execution_performed is True
     assert result.receipt.no_pr_publish_performed is True
     assert result.receipt.no_pattern_memory_write_performed is True
+
+
+def test_carries_model_runtime_binding_from_signed_authority() -> None:
+    req = valid_request()
+    req["signed_authority"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["signed_authority"]["model_runtime_binding_digest"] = _digest("7")
+
+    result = verifier.verify_autonomous_slice_runtime(req)
+
+    assert result.accepted is True
+    assert (
+        result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.receipt.model_runtime_binding_digest == _digest("7")
+
+
+def test_rejects_conflicting_or_one_sided_model_runtime_binding() -> None:
+    req = valid_request()
+    req["signed_authority"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    assert_reject(req, verifier.FAIL_MODEL_RUNTIME_BINDING)
+
+    req = valid_request()
+    req["signed_authority"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["signed_authority"]["model_runtime_binding_digest"] = _digest("7")
+    req["artifact_generation_receipt"] = {
+        "model_runtime_binding_receipt_id": "reddog_model_runtime_binding:test",
+        "model_runtime_binding_digest": _digest("8"),
+    }
+    assert_reject(req, verifier.FAIL_MODEL_RUNTIME_BINDING)
 
 
 def test_rejects_missing_identity_and_self_verification() -> None:


### PR DESCRIPTION
## Slice
REDDOG_MODEL_RUNTIME_BINDING_VERIFIER_OUTCOME_CARRY_PHASE1

## WSP_97 Evidence
- Carries optional model runtime-binding id/digest into independent verifier receipts.
- Enriches verifier requests from bounded artifact-generation receipts so runtime model evidence is not lost before independent verification.
- Carries the same proof through verified draft-PR publish receipts and verified outcome ratchet receipts.
- Fails closed on one-sided, malformed, or conflicting runtime-binding id/digest pairs.
- Legacy no-binding packets remain accepted.

## Validation
- python -m py_compile changed runtime modules
- pytest verifier/publish/ratchet/queue verifier suites: 56 passed
- pytest downstream queue wrapper + artifact generation + resident pilot suites: 51 passed
- pytest held-out + PatternMemory admission consumers: 34 passed
- git diff --check clean
- added-line non-ASCII check: 0

## Boundary
No model/provider default change, benchmark execution, signing expansion, shell execution, worktree policy change, source mutation outside receipts/tests, PatternMemory write, OpenClaw/Hermes dispatch, PR publication at runtime, reward settlement, or HoloIndex re-indexing.