### PR TITLE
feat(reddog): carry model runtime binding into retention receipts

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_RECURSIVE_RETENTION_CARRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Carried optional model-runtime binding id/digest from verifier/ratchet
+  receipts into held-out recursive-improvement regression gate receipts.
+- PatternMemory admission records and receipts now preserve the same
+  runtime-binding proof, so verified recursive learning can attribute outcomes
+  to the runtime-selected model topology.
+- Added fail-closed mismatch guards so admission requests cannot override the
+  gate's runtime-binding evidence.
+- Boundary remains constrained: no model/provider default change, benchmark
+  execution, signing expansion, shell, worktree policy change, source mutation,
+  PatternMemory sink instantiation, OpenClaw/Hermes dispatch, PR publication,
+  reward settlement, or HoloIndex re-indexing was added.
+
 ## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_VERIFIER_OUTCOME_CARRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_pattern_memory_admission_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_pattern_memory_admission_invoke.py
@@ -58,6 +58,7 @@ class QueueAuthorizedPatternMemoryAdmissionInvokeReason:
     PATTERN_MEMORY_NOT_ALLOWED = "REJECT_PATTERN_MEMORY_ADMISSION_NOT_ALLOWED"
     ADMISSION_REQUEST_INVALID = "REJECT_PATTERN_MEMORY_ADMISSION_REQUEST_INVALID"
     WORK_ORDER_ID_MISMATCH = "REJECT_WORK_ORDER_ID_MISMATCH"
+    MODEL_RUNTIME_BINDING_MISMATCH = "REJECT_MODEL_RUNTIME_BINDING_MISMATCH"
     SECRET_IN_RECORD = "REJECT_SECRET_IN_PATTERN_MEMORY_RECORD"
     SINK_WRITE_FAILED = "REJECT_PATTERN_MEMORY_ADMISSION_SINK_WRITE_FAILED"
 
@@ -72,6 +73,8 @@ class QueueAuthorizedPatternMemoryAdmissionReceipt:
     verifier_receipt_id: str
     improvement_job_id: str
     held_out_suite_id: str
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: str
     pattern_memory_record_id: Optional[str]
     record_digest: str
     rejection_reasons: List[str]
@@ -138,6 +141,47 @@ def _same_nonempty(left: Any, right: Any) -> bool:
     return bool(left_text) and left_text == str(right or "")
 
 
+def _is_digest(value: Any) -> bool:
+    text = str(value or "")
+    return (
+        text.startswith("sha256:")
+        and len(text) == 71
+        and all(ch in "0123456789abcdef" for ch in text.removeprefix("sha256:"))
+    )
+
+
+def _runtime_binding_pair(value: Mapping[str, Any]) -> tuple[str, str]:
+    receipt_id = str(
+        value.get("model_runtime_binding_receipt_id")
+        or value.get("runtime_binding_receipt_id")
+        or ""
+    )
+    digest = str(value.get("model_runtime_binding_digest") or "")
+    return receipt_id, digest
+
+
+def _runtime_binding_ok(
+    gate_receipt: Mapping[str, Any],
+    admission_request: Mapping[str, Any],
+) -> bool:
+    pairs = [
+        pair
+        for pair in (
+            _runtime_binding_pair(gate_receipt),
+            _runtime_binding_pair(admission_request),
+        )
+        if pair[0] or pair[1]
+    ]
+    if not pairs:
+        return True
+    for receipt_id, digest in pairs:
+        if not receipt_id or not digest:
+            return False
+        if not receipt_id.startswith("reddog_model_runtime_binding:") or not _is_digest(digest):
+            return False
+    return all(pair == pairs[0] for pair in pairs[1:])
+
+
 def _record_from_gate(
     *,
     gate_result: Mapping[str, Any],
@@ -154,6 +198,10 @@ def _record_from_gate(
         "improvement_job_id": str(gate_receipt.get("improvement_job_id") or ""),
         "held_out_suite_id": str(gate_receipt.get("held_out_suite_id") or ""),
         "held_out_suite_digest": str(gate_receipt.get("held_out_suite_digest") or ""),
+        "model_runtime_binding_receipt_id": str(
+            gate_receipt.get("model_runtime_binding_receipt_id") or ""
+        ),
+        "model_runtime_binding_digest": str(gate_receipt.get("model_runtime_binding_digest") or ""),
         "candidate_head_sha": str(gate_receipt.get("candidate_head_sha") or ""),
         "regression_test_count": int(gate_receipt.get("regression_test_count") or 0),
         "pattern_memory_admission_allowed": True,
@@ -183,6 +231,11 @@ def _build_receipt(
         verifier_receipt_id=str(record.get("verifier_receipt_id") or ""),
         improvement_job_id=str(record.get("improvement_job_id") or ""),
         held_out_suite_id=str(record.get("held_out_suite_id") or ""),
+        model_runtime_binding_receipt_id=str(
+            record.get("model_runtime_binding_receipt_id") or ""
+        )
+        or None,
+        model_runtime_binding_digest=str(record.get("model_runtime_binding_digest") or ""),
         pattern_memory_record_id=record_id,
         record_digest=_digest(record),
         rejection_reasons=deduped,
@@ -252,6 +305,10 @@ def invoke_reddog_wre_queue_authorized_pattern_memory_admission(
         gate_receipt.get("work_order_id"),
     ):
         reasons.append(QueueAuthorizedPatternMemoryAdmissionInvokeReason.WORK_ORDER_ID_MISMATCH)
+    elif gate_receipt and request and not _runtime_binding_ok(gate_receipt, request):
+        reasons.append(
+            QueueAuthorizedPatternMemoryAdmissionInvokeReason.MODEL_RUNTIME_BINDING_MISMATCH
+        )
 
     record = (
         _record_from_gate(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_held_out_regression_gate_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_held_out_regression_gate_invoke.py
@@ -73,6 +73,14 @@ def _queue_ratchet_result(*, accepted: bool = True, decision: str | None = None)
     }
 
 
+def _queue_ratchet_result_with_runtime_binding() -> dict:
+    result = _queue_ratchet_result()
+    receipt = result["ratchet_result"]["receipt"]
+    receipt["model_runtime_binding_receipt_id"] = "reddog_model_runtime_binding:test"
+    receipt["model_runtime_binding_digest"] = _digest("5")
+    return result
+
+
 def _gate_request() -> dict:
     return {
         "work_order_id": WORK_ORDER_ID,
@@ -127,6 +135,14 @@ def _gate_request() -> dict:
     }
 
 
+def _gate_request_with_runtime_binding() -> dict:
+    request = _gate_request()
+    receipt = request["verification_result"]["receipt"]
+    receipt["model_runtime_binding_receipt_id"] = "reddog_model_runtime_binding:test"
+    receipt["model_runtime_binding_digest"] = _digest("5")
+    return request
+
+
 def _invoke(*, queue_ratchet: dict | None = None, request: dict | None = None):
     return invoke_reddog_wre_queue_authorized_held_out_regression_gate(
         explicit_queue_authorized_held_out_regression_gate_requested=True,
@@ -152,6 +168,21 @@ def test_accepts_held_out_gate_after_queue_outcome_ratchet() -> None:
     assert result.no_merge_performed is True
     assert result.no_reward_settlement_performed is True
     assert result.no_holoindex_reindex_performed is True
+
+
+def test_carries_model_runtime_binding_from_queue_ratchet_to_gate() -> None:
+    result = _invoke(
+        queue_ratchet=_queue_ratchet_result_with_runtime_binding(),
+        request=_gate_request_with_runtime_binding(),
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_HELD_OUT_REGRESSION_GATE_INVOKE_ACCEPT
+    assert result.gate_result is not None
+    assert (
+        result.gate_result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.gate_result.receipt.model_runtime_binding_digest == _digest("5")
 
 
 def test_explicit_invoke_missing_rejects() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_pattern_memory_admission_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_pattern_memory_admission_invoke.py
@@ -89,6 +89,14 @@ def _queue_gate_result(*, accepted: bool = True, decision: str | None = None) ->
     }
 
 
+def _queue_gate_result_with_runtime_binding() -> dict:
+    result = _queue_gate_result()
+    receipt = result["gate_result"]["receipt"]
+    receipt["model_runtime_binding_receipt_id"] = "reddog_model_runtime_binding:test"
+    receipt["model_runtime_binding_digest"] = _digest("5")
+    return result
+
+
 def _admission_request() -> dict:
     return {
         "work_order_id": WORK_ORDER_ID,
@@ -125,6 +133,8 @@ def test_admits_verified_held_out_outcome_to_injected_sink() -> None:
     assert result.receipt.pattern_memory_record_id == "pattern-memory-record-1"
     assert result.receipt.gate_id == GATE_ID
     assert result.receipt.ratchet_id == RATCHET_ID
+    assert result.receipt.model_runtime_binding_receipt_id is None
+    assert result.receipt.model_runtime_binding_digest == ""
     assert result.receipt.no_command_execution_performed is True
     assert result.receipt.no_pr_publish_performed is True
     assert result.receipt.no_merge_performed is True
@@ -133,6 +143,45 @@ def test_admits_verified_held_out_outcome_to_injected_sink() -> None:
     assert len(sink.records) == 1
     assert sink.records[0]["record_type"] == "reddog_verified_recursive_improvement_outcome"
     assert sink.records[0]["work_order_id"] == WORK_ORDER_ID
+
+
+def test_admission_record_carries_model_runtime_binding_from_gate() -> None:
+    sink = FakePatternMemorySink()
+
+    result = _invoke(queue_gate=_queue_gate_result_with_runtime_binding(), sink=sink)
+
+    assert result.decision == QUEUE_AUTHORIZED_PATTERN_MEMORY_ADMISSION_INVOKE_ACCEPT
+    assert result.receipt is not None
+    assert (
+        result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.receipt.model_runtime_binding_digest == _digest("5")
+    assert (
+        sink.records[0]["model_runtime_binding_receipt_id"]
+        == "reddog_model_runtime_binding:test"
+    )
+    assert sink.records[0]["model_runtime_binding_digest"] == _digest("5")
+
+
+def test_admission_request_cannot_override_model_runtime_binding() -> None:
+    request = _admission_request()
+    request["model_runtime_binding_receipt_id"] = "reddog_model_runtime_binding:test"
+    request["model_runtime_binding_digest"] = _digest("6")
+    sink = FakePatternMemorySink()
+
+    result = _invoke(
+        queue_gate=_queue_gate_result_with_runtime_binding(),
+        request=request,
+        sink=sink,
+    )
+
+    assert result.decision == QUEUE_AUTHORIZED_PATTERN_MEMORY_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedPatternMemoryAdmissionInvokeReason.MODEL_RUNTIME_BINDING_MISMATCH
+        in result.rejection_reasons
+    )
+    assert sink.records == []
 
 
 def test_explicit_invoke_missing_rejects_before_sink() -> None:

--- a/modules/infrastructure/wre_core/src/reddog_held_out_recursive_improvement_regression_gate.py
+++ b/modules/infrastructure/wre_core/src/reddog_held_out_recursive_improvement_regression_gate.py
@@ -39,6 +39,7 @@ FAIL_AUTHOR_GENERATED_SUITE = "FAIL_AUTHOR_GENERATED_SUITE"
 FAIL_REGRESSION_FAILED = "FAIL_REGRESSION_FAILED"
 FAIL_DIGEST_BINDING = "FAIL_DIGEST_BINDING"
 FAIL_HOLOINDEX_EVIDENCE = "FAIL_HOLOINDEX_EVIDENCE"
+FAIL_MODEL_RUNTIME_BINDING = "FAIL_MODEL_RUNTIME_BINDING"
 FAIL_PATTERN_MEMORY_ALREADY_WRITTEN = "FAIL_PATTERN_MEMORY_ALREADY_WRITTEN"
 FAIL_SECRET_IN_EVIDENCE = "FAIL_SECRET_IN_EVIDENCE"
 
@@ -69,6 +70,8 @@ class HeldOutRecursiveImprovementRegressionReceipt:
     candidate_digest: str
     candidate_head_sha: str
     holoindex_freshness_receipt_digest: str
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: str
     regression_test_count: int
     pattern_memory_admission_requested: bool
     pattern_memory_admission_allowed: bool
@@ -189,6 +192,45 @@ def _holoindex_ok(holoindex_evidence: Mapping[str, Any]) -> bool:
     return _is_digest(holoindex_evidence.get("holoindex_freshness_receipt_digest"))
 
 
+def _runtime_binding_pair(value: Mapping[str, Any]) -> tuple[str, str]:
+    receipt_id = str(
+        value.get("model_runtime_binding_receipt_id")
+        or value.get("runtime_binding_receipt_id")
+        or ""
+    )
+    digest = str(value.get("model_runtime_binding_digest") or "")
+    return receipt_id, digest
+
+
+def _runtime_binding_ok(request: Mapping[str, Any]) -> tuple[bool, Optional[str], str]:
+    verification_result = _mapping(request.get("verification_result"))
+    verification_receipt = _mapping(verification_result.get("receipt"))
+    ratchet_result = _mapping(request.get("ratchet_result"))
+    ratchet_receipt = _mapping(ratchet_result.get("receipt"))
+    pairs = [
+        pair
+        for pair in (
+            _runtime_binding_pair(request),
+            _runtime_binding_pair(verification_receipt),
+            _runtime_binding_pair(ratchet_receipt),
+        )
+        if pair[0] or pair[1]
+    ]
+    if not pairs:
+        return True, None, ""
+    normalized: List[tuple[str, str]] = []
+    for receipt_id, digest in pairs:
+        if not receipt_id or not digest:
+            return False, receipt_id or None, digest
+        if not receipt_id.startswith("reddog_model_runtime_binding:") or not _is_digest(digest):
+            return False, receipt_id, digest
+        normalized.append((receipt_id, digest))
+    first = normalized[0]
+    if any(pair != first for pair in normalized[1:]):
+        return False, first[0], first[1]
+    return True, first[0], first[1]
+
+
 def _job_is_pending_dry_run(improvement_job: Mapping[str, Any]) -> bool:
     return (
         str(improvement_job.get("job_id") or "").strip() != ""
@@ -278,6 +320,7 @@ def evaluate_held_out_recursive_improvement_regression_gate(
     ratchet_id = str(ratchet_receipt.get("ratchet_id") or "")
     improvement_job_id = str(improvement_job.get("job_id") or "")
     pattern_requested = req.get("enable_pattern_memory_admission") is True
+    runtime_binding_ok, runtime_binding_id, runtime_binding_digest = _runtime_binding_ok(req)
 
     reasons: List[str] = []
     if not all([work_order_id, slice_name, improvement_job_id]):
@@ -302,6 +345,8 @@ def evaluate_held_out_recursive_improvement_regression_gate(
 
     if not _holoindex_ok(holoindex_evidence):
         reasons.append(FAIL_HOLOINDEX_EVIDENCE)
+    if not runtime_binding_ok:
+        reasons.append(FAIL_MODEL_RUNTIME_BINDING)
     if _contains_secret(
         {
             "improvement_job": improvement_job,
@@ -328,6 +373,8 @@ def evaluate_held_out_recursive_improvement_regression_gate(
         "holoindex_freshness_receipt_digest": str(
             holoindex_evidence.get("holoindex_freshness_receipt_digest") or ""
         ),
+        "model_runtime_binding_receipt_id": runtime_binding_id or "",
+        "model_runtime_binding_digest": runtime_binding_digest,
         "pattern_memory_admission_requested": pattern_requested,
         "pattern_memory_admission_allowed": pattern_allowed,
         "rejection_reasons": deduped,
@@ -347,6 +394,8 @@ def evaluate_held_out_recursive_improvement_regression_gate(
         holoindex_freshness_receipt_digest=str(
             holoindex_evidence.get("holoindex_freshness_receipt_digest") or ""
         ),
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
         regression_test_count=_int(held_out_suite.get("test_count")),
         pattern_memory_admission_requested=pattern_requested,
         pattern_memory_admission_allowed=pattern_allowed,
@@ -371,6 +420,7 @@ __all__ = [
     "FAIL_HELD_OUT_SUITE",
     "FAIL_HOLOINDEX_EVIDENCE",
     "FAIL_IMPROVEMENT_JOB_NOT_DRY_RUN_PENDING",
+    "FAIL_MODEL_RUNTIME_BINDING",
     "FAIL_PATTERN_MEMORY_ALREADY_WRITTEN",
     "FAIL_RATCHET_RECEIPT",
     "FAIL_REGRESSION_FAILED",

--- a/modules/infrastructure/wre_core/tests/test_reddog_held_out_recursive_improvement_regression_gate.py
+++ b/modules/infrastructure/wre_core/tests/test_reddog_held_out_recursive_improvement_regression_gate.py
@@ -106,8 +106,45 @@ def test_accepts_independent_held_out_regression_after_verifier_and_ratchet() ->
     assert result.receipt.pattern_memory_admission_allowed is True
     assert result.receipt.pattern_memory_admission_requested is True
     assert result.receipt.regression_test_count == 12
+    assert result.receipt.model_runtime_binding_receipt_id is None
+    assert result.receipt.model_runtime_binding_digest == ""
     assert result.receipt.no_pattern_memory_write_performed is True
     assert result.receipt.no_test_execution_performed is True
+
+
+def test_carries_model_runtime_binding_from_verifier_and_ratchet_receipts() -> None:
+    req = valid_request()
+    req["verification_result"]["receipt"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["verification_result"]["receipt"]["model_runtime_binding_digest"] = _digest("5")
+    req["ratchet_result"]["receipt"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["ratchet_result"]["receipt"]["model_runtime_binding_digest"] = _digest("5")
+
+    result = gate.evaluate_held_out_recursive_improvement_regression_gate(req)
+
+    assert result.accepted is True
+    assert (
+        result.receipt.model_runtime_binding_receipt_id
+        == "reddog_model_runtime_binding:test"
+    )
+    assert result.receipt.model_runtime_binding_digest == _digest("5")
+
+
+def test_rejects_model_runtime_binding_mismatch() -> None:
+    req = valid_request()
+    req["verification_result"]["receipt"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["verification_result"]["receipt"]["model_runtime_binding_digest"] = _digest("5")
+    req["ratchet_result"]["receipt"]["model_runtime_binding_receipt_id"] = (
+        "reddog_model_runtime_binding:test"
+    )
+    req["ratchet_result"]["receipt"]["model_runtime_binding_digest"] = _digest("6")
+
+    assert_reject(req, gate.FAIL_MODEL_RUNTIME_BINDING)
 
 
 def test_pattern_memory_admission_not_allowed_unless_requested() -> None:


### PR DESCRIPTION
## Slice
REDDOG_MODEL_RUNTIME_BINDING_RECURSIVE_RETENTION_CARRY_PHASE1

## WSP_97 Evidence
- Carries optional model runtime-binding id/digest from verifier and outcome-ratchet receipts into held-out recursive-improvement gate receipts.
- Carries the same proof into PatternMemory admission records and admission receipts.
- Rejects admission request overrides that conflict with gate runtime-binding evidence.
- Legacy no-binding packets remain accepted.

## Validation
- python -m py_compile changed runtime modules
- pytest retention/admission focused suites: 39 passed
- pytest full downstream chain from verifier through PatternMemory admission: 116 passed
- git diff --check clean
- added-line non-ASCII check: 0

## Boundary
No model/provider default change, benchmark execution, signing expansion, shell execution, worktree policy change, source mutation outside receipts/tests, PatternMemory sink instantiation, OpenClaw/Hermes dispatch, PR publication at runtime, reward settlement, or HoloIndex re-indexing.