### PR TITLE
feat(ai-gateway): carry runtime binding into model outcome feedback

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,41 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Model Outcome Runtime Binding Feedback Carry
+
+**Who:** 0102 Codex
+**Type:** Receipt Hardening
+**Slice:** MODEL_SELECTION_OUTCOME_RUNTIME_BINDING_FEEDBACK_PHASE1
+
+**What:** Added optional runtime-binding proof fields to
+`ModelSelectionOutcomeReceipt` and feedback records.
+
+**Why:** Verified RedDog execution now carries model-runtime binding proof
+through verifier, publish, ratchet, held-out, and PatternMemory admission. The
+model-intelligence feedback receipt also needs to cite the model runtime binding
+that actually produced an accepted outcome, so recursive model learning does not
+collapse back to selection-only evidence.
+
+**Files:**
+- `src/model_intelligence_outcomes.py` - validates a supplied
+  `RedDogModelRuntimeBindingReceipt`, recomputes its digest, checks selection,
+  catalog, task-family, decision, and receipt-prefix invariants, and carries the
+  binding into accepted feedback records.
+- `tests/test_model_intelligence_outcomes.py` - runtime-binding carry and
+  forged/mismatched binding rejection tests.
+
+**Truth Boundary:**
+- IMPLEMENTED: optional runtime-binding evidence carry for model selection
+  outcome feedback.
+- IMPLEMENTED: supplied runtime-binding receipts are rehashed and cross-checked
+  before feedback eligibility can cite them.
+- NOT IMPLEMENTED: provider calls, benchmark execution, catalog promotion,
+  PatternMemory writes, HoloIndex re-indexing, or RedDog runtime default
+  mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - RedDog Runtime Binding Artifact Supply
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py
@@ -129,6 +129,8 @@ class ModelSelectionOutcomeReceipt:
 
     receipt_id: str
     selection_receipt_id: str
+    model_runtime_binding_receipt_id: str | None
+    model_runtime_binding_digest: str
     catalog_snapshot_id: str
     task_family: str
     selected_model_ids: tuple[str, ...]
@@ -146,6 +148,8 @@ class ModelSelectionOutcomeReceipt:
             "schema_version": self.schema_version,
             "receipt_id": self.receipt_id,
             "selection_receipt_id": self.selection_receipt_id,
+            "model_runtime_binding_receipt_id": self.model_runtime_binding_receipt_id,
+            "model_runtime_binding_digest": self.model_runtime_binding_digest,
             "catalog_snapshot_id": self.catalog_snapshot_id,
             "task_family": self.task_family,
             "selected_model_ids": list(self.selected_model_ids),
@@ -275,6 +279,7 @@ def production_evidence_for_selection(
 def build_model_selection_outcome_receipt(
     selection_receipt: ModelSelectionReceipt,
     *,
+    model_runtime_binding_receipt: Mapping[str, Any] | None = None,
     verifier_decision: VerifierDecision | str,
     verification_receipt_ids: tuple[str, ...] = (),
     task_completed: bool = False,
@@ -290,6 +295,10 @@ def build_model_selection_outcome_receipt(
     verifier = _coerce_verifier_decision(verifier_decision)
     normalized_verification_receipts = _normalize_receipts(verification_receipt_ids)
     normalized_evidence_receipts = _normalize_receipts(evidence_receipt_ids)
+    runtime_binding_id, runtime_binding_digest = _runtime_binding_from_receipt(
+        model_runtime_binding_receipt,
+        selection_receipt,
+    )
     normalized_rejections = tuple(sorted(_clean_reason(reason) for reason in rejection_reasons if str(reason).strip()))
     metrics_value = (metrics or ModelOutcomeMetrics()).normalized()
     automatic_rejections = _automatic_rejection_reasons(
@@ -318,9 +327,14 @@ def build_model_selection_outcome_receipt(
         "rejection_reasons": list(all_rejections),
         "evidence_receipt_ids": list(normalized_evidence_receipts),
     }
+    if runtime_binding_id:
+        body["model_runtime_binding_receipt_id"] = runtime_binding_id
+        body["model_runtime_binding_digest"] = runtime_binding_digest
     return ModelSelectionOutcomeReceipt(
         receipt_id=_digest_prefixed("model_selection_outcome_receipt", body),
         selection_receipt_id=selection_receipt.receipt_id,
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
         catalog_snapshot_id=selection_receipt.catalog_snapshot_id,
         task_family=selection_receipt.requirements.task_family,
         selected_model_ids=selection_receipt.selected_model_ids,
@@ -342,12 +356,36 @@ def outcome_feedback_record(receipt: ModelSelectionOutcomeReceipt) -> dict[str, 
     return {
         "outcome_receipt_id": receipt.receipt_id,
         "selection_receipt_id": receipt.selection_receipt_id,
+        "model_runtime_binding_receipt_id": receipt.model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": receipt.model_runtime_binding_digest,
         "catalog_snapshot_id": receipt.catalog_snapshot_id,
         "task_family": receipt.task_family,
         "selected_model_ids": list(receipt.selected_model_ids),
         "verification_receipt_ids": list(receipt.verification_receipt_ids),
         "metrics": asdict(receipt.metrics.normalized()),
     }
+
+
+def _runtime_binding_from_receipt(
+    value: Mapping[str, Any] | None,
+    selection_receipt: ModelSelectionReceipt,
+) -> tuple[str | None, str]:
+    if value is None:
+        return None, ""
+    if not isinstance(value, Mapping):
+        raise ValueError("invalid_model_runtime_binding_receipt")
+    receipt_id = _required("model_runtime_binding_receipt_id", value.get("receipt_id"))
+    if not receipt_id.startswith("reddog_model_runtime_binding:"):
+        raise ValueError("invalid_model_runtime_binding_receipt_id")
+    if str(value.get("decision") or "").strip().lower() != "bound":
+        raise ValueError("model_runtime_binding_not_bound")
+    if str(value.get("selection_receipt_id") or "").strip() != selection_receipt.receipt_id:
+        raise ValueError("model_runtime_binding_selection_mismatch")
+    if str(value.get("catalog_snapshot_id") or "").strip() != selection_receipt.catalog_snapshot_id:
+        raise ValueError("model_runtime_binding_catalog_mismatch")
+    if str(value.get("task_family") or "").strip() != selection_receipt.requirements.task_family:
+        raise ValueError("model_runtime_binding_task_family_mismatch")
+    return receipt_id, _sha256_digest(value)
 
 
 def _automatic_rejection_reasons(
@@ -448,6 +486,11 @@ def _non_negative_float_or_none(value: float | None) -> float | None:
     if parsed < 0:
         raise ValueError("negative_metric")
     return parsed
+
+
+def _sha256_digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
 def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+import hashlib
+import json
 from pathlib import Path
 
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
@@ -46,6 +48,49 @@ def _selected_receipt():
     receipt = select_models_for_task(snapshot, ModelTaskRequirements(task_family="architecture"))
     assert receipt.decision == SelectionDecision.SELECTED
     return receipt
+
+
+def _digest(value) -> str:
+    return "sha256:" + hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    ).hexdigest()
+
+
+def _runtime_binding_receipt(selection):
+    return {
+        "schema_version": "reddog_model_runtime_binding_receipt.v1",
+        "receipt_id": "reddog_model_runtime_binding:test",
+        "decision": "bound",
+        "runtime_surface": "backend_architect",
+        "catalog_snapshot_id": selection.catalog_snapshot_id,
+        "selection_receipt_id": selection.receipt_id,
+        "task_family": selection.requirements.task_family,
+        "principal_model": selection.selected_model_ids[0],
+        "panel_models": [],
+        "role_bindings": [
+            {
+                "role": "principal",
+                "model_id": selection.selected_model_ids[0],
+                "provider": "provider",
+            }
+        ],
+        "benchmark_evidence_receipt_ids": ["model_benchmark_evidence:test"],
+        "promotion_evidence_receipt_ids": ["model_promotion_evidence:test"],
+        "signed_promotion_receipt_ids": ["signature:test"],
+        "policy": {
+            "schema_version": "reddog_model_runtime_binding_policy.v1",
+            "task_family": selection.requirements.task_family,
+            "runtime_surface": "backend_architect",
+            "min_verifier_pass_rate": 0.9,
+            "required_task_set_digest": "sha256:taskset",
+            "required_held_out_split_digest": "sha256:heldout",
+            "required_verifier_digest": "sha256:verifier",
+            "max_panel_models": 4,
+            "required_panel_topology_digest": None,
+            "authority_receipt_id": "authority:test",
+        },
+        "rejection_reasons": [],
+    }
 
 
 def test_benchmark_evidence_binds_held_out_task_set_verifier_topology_and_metrics():
@@ -245,7 +290,59 @@ def test_outcome_receipt_accepts_only_verified_complete_results():
 
     assert receipt.outcome_decision == OutcomeDecision.ACCEPTED
     assert receipt.feedback_eligible is True
-    assert outcome_feedback_record(receipt)["outcome_receipt_id"] == receipt.receipt_id
+    feedback = outcome_feedback_record(receipt)
+    assert feedback["outcome_receipt_id"] == receipt.receipt_id
+    assert feedback["model_runtime_binding_receipt_id"] is None
+    assert feedback["model_runtime_binding_digest"] == ""
+
+
+def test_outcome_feedback_record_carries_runtime_binding_receipt_digest():
+    selection = _selected_receipt()
+    runtime_binding = _runtime_binding_receipt(selection)
+    receipt = build_model_selection_outcome_receipt(
+        selection,
+        model_runtime_binding_receipt=runtime_binding,
+        verifier_decision=VerifierDecision.ACCEPT,
+        verification_receipt_ids=("verify:1",),
+        task_completed=True,
+        evidence_correct=True,
+    )
+
+    assert receipt.feedback_eligible is True
+    assert receipt.model_runtime_binding_receipt_id == "reddog_model_runtime_binding:test"
+    assert receipt.model_runtime_binding_digest == _digest(runtime_binding)
+    feedback = outcome_feedback_record(receipt)
+    assert feedback["model_runtime_binding_receipt_id"] == "reddog_model_runtime_binding:test"
+    assert feedback["model_runtime_binding_digest"] == _digest(runtime_binding)
+
+
+def test_outcome_receipt_rejects_forged_runtime_binding_receipts():
+    selection = _selected_receipt()
+    valid = _runtime_binding_receipt(selection)
+    cases = [
+        ("selection_receipt_id", "other", "model_runtime_binding_selection_mismatch"),
+        ("catalog_snapshot_id", "other", "model_runtime_binding_catalog_mismatch"),
+        ("task_family", "other", "model_runtime_binding_task_family_mismatch"),
+        ("decision", "rejected", "model_runtime_binding_not_bound"),
+        ("receipt_id", "model_runtime_binding:test", "invalid_model_runtime_binding_receipt_id"),
+    ]
+
+    for key, value, reason in cases:
+        forged = dict(valid)
+        forged[key] = value
+        try:
+            build_model_selection_outcome_receipt(
+                selection,
+                model_runtime_binding_receipt=forged,
+                verifier_decision=VerifierDecision.ACCEPT,
+                verification_receipt_ids=("verify:1",),
+                task_completed=True,
+                evidence_correct=True,
+            )
+        except ValueError as exc:
+            assert str(exc) == reason
+        else:
+            raise AssertionError(f"expected {reason}")
 
 
 def test_outcome_receipt_rejects_unverified_or_regressed_results():


### PR DESCRIPTION
## Summary
- add optional model runtime-binding fields to model selection outcome receipts and feedback records
- rehash supplied RedDog runtime-binding receipts and reject unbound, mismatched, or forged evidence before feedback can cite them
- keep legacy/evaluation outcome receipt IDs stable when no runtime-binding receipt is supplied

## Validation
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
- pytest modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_selection.py modules/infrastructure/wre_core/tests/test_wre_autonomous_slice_verifier_runtime.py modules/infrastructure/wre_core/tests/test_reddog_verified_draft_pr_publish.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py modules/infrastructure/wre_core/tests/test_reddog_held_out_recursive_improvement_regression_gate.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_pattern_memory_admission_invoke.py (119 passed)
- git diff --check
- added_line_non_ascii=0

Truth Boundary: no provider calls, benchmark execution, catalog promotion, PatternMemory writes, HoloIndex re-indexing, or RedDog runtime default mutation.