### PR TITLE
feat(reddog): emit model feedback from verified ratchet

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RATCHET_MODEL_FEEDBACK_RECEIPT_BRIDGE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- The queue-authorized verified-outcome ratchet invoke can now emit an optional
+  `ModelSelectionOutcomeReceipt` when the ratchet request includes
+  content-bearing model-selection and runtime-binding receipts.
+- The bridge rehydrates and verifies serialized model receipts before the
+  ratchet store write, so malformed model-feedback evidence fails closed without
+  recording a verified outcome.
+- The resident serial-loop bootstrap now derives model-selection and
+  runtime-binding receipts from the bound work order into the derived ratchet
+  request when outcome-ratchet request binding is enabled.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  model promotion, PatternMemory write, OpenClaw/Hermes dispatch, source
+  mutation, PR publication, reward settlement, or HoloIndex re-indexing was
+  added.
+
 ## 2026-07-17: REDDOG_MODEL_RUNTIME_BINDING_RECURSIVE_RETENTION_CARRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -363,7 +363,10 @@ def run_reddog_main_resident_queue_serial_loop_bootstrap(
             holoindex_evidence=holoindex_evidence,
         )
     if outcome_ratchet_request_binding_enabled and ratchet_request is None:
-        ratchet_request = _derive_outcome_ratchet_request_from_chain(chain_state)
+        ratchet_request = _derive_outcome_ratchet_request_from_chain(
+            chain_state,
+            work_orders=work_orders,
+        )
     if held_out_gate_request_binding_enabled and held_out_gate_request is None:
         held_out_gate_request = _derive_held_out_gate_request_from_chain(chain_state)
     if pattern_memory_admission_request_binding_enabled and admission_request is None:
@@ -828,6 +831,7 @@ def _derive_artifact_generation_request_from_chain(
 
 def _derive_outcome_ratchet_request_from_chain(
     chain_state: Mapping[str, Any],
+    work_orders: Mapping[str, Any] | None = None,
 ) -> Mapping[str, Any] | None:
     stages = _chain_stage_results(chain_state)
     verifier_stage = _nested_mapping(stages, "slice_verifier")
@@ -841,7 +845,7 @@ def _derive_outcome_ratchet_request_from_chain(
     slice_name = str(verification_receipt.get("slice_name") or "")
     if not work_order_id or not slice_name:
         return None
-    return {
+    request: dict[str, Any] = {
         "work_order_id": work_order_id,
         "slice_name": slice_name,
         "outcome_status": "accepted",
@@ -875,6 +879,14 @@ def _derive_outcome_ratchet_request_from_chain(
         "holoindex_evidence": _derived_holoindex_evidence(stages),
         "enable_pattern_memory_write": False,
     }
+    work_order = _work_order_from_runtime_mapping(work_orders, work_order_id)
+    model_selection = _nested_mapping(work_order, "model_selection_receipt")
+    if model_selection:
+        request["model_selection_receipt"] = dict(model_selection)
+    model_runtime_binding = _nested_mapping(work_order, "model_runtime_binding_receipt")
+    if model_runtime_binding:
+        request["model_runtime_binding_receipt"] = dict(model_runtime_binding)
+    return request
 
 
 def _derive_held_out_gate_request_from_chain(
@@ -1042,6 +1054,18 @@ def _queue_item(*, snapshot: Mapping[str, Any], queue_item_id: str) -> Mapping[s
         if isinstance(item, Mapping) and str(item.get("queue_item_id") or "") == queue_item_id:
             return item
     return {}
+
+
+def _work_order_from_runtime_mapping(
+    work_orders: Mapping[str, Any] | None,
+    work_order_id: str,
+) -> Mapping[str, Any]:
+    if not work_orders or not work_order_id:
+        return {}
+    orders = _nested_mapping(work_orders, "work_orders")
+    if orders:
+        return _nested_mapping(orders, work_order_id)
+    return _nested_mapping(work_orders, work_order_id)
 
 
 def _slug(value: str) -> str:

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
@@ -17,6 +17,15 @@ from typing import Any, Dict, List, Mapping, Optional, Sequence
 from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_draft_pr_publish_invoke import (
     QUEUE_AUTHORIZED_VERIFIED_DRAFT_PR_PUBLISH_INVOKE_ACCEPT,
 )
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+    build_model_selection_outcome_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    rehydrate_model_runtime_binding_receipt,
+    rehydrate_model_selection_receipt,
+)
 from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
     VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
 )
@@ -49,6 +58,7 @@ class QueueAuthorizedVerifiedOutcomeRatchetInvokeReason:
     WORK_ORDER_ID_MISMATCH = "REJECT_WORK_ORDER_ID_MISMATCH"
     PATTERN_MEMORY_EXPLICIT_MISSING = "REJECT_PATTERN_MEMORY_EXPLICIT_MISSING"
     PATTERN_MEMORY_SINK_REQUIRED = "REJECT_PATTERN_MEMORY_SINK_REQUIRED"
+    MODEL_FEEDBACK_RECEIPT_INVALID = "REJECT_MODEL_FEEDBACK_RECEIPT_INVALID"
     RATCHET_NOT_ACCEPTED = "REJECT_VERIFIED_OUTCOME_RATCHET_NOT_ACCEPTED"
 
 
@@ -57,6 +67,7 @@ class QueueAuthorizedVerifiedOutcomeRatchetInvokeResult:
     decision: str
     rejection_reasons: List[str] = field(default_factory=list)
     ratchet_result: Optional[VerifiedOutcomeRatchetResult] = None
+    model_selection_outcome_receipt: Optional[Dict[str, Any]] = None
     explicit_queue_authorized_verified_outcome_ratchet_requested: bool = False
     explicit_pattern_memory_write_requested: bool = False
     no_command_execution_performed: bool = True
@@ -104,6 +115,43 @@ def _reject(
 def _same_nonempty(left: Any, right: Any) -> bool:
     left_text = str(left or "")
     return bool(left_text) and left_text == str(right or "")
+
+
+def _model_feedback_receipt(request: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    selection_raw = _mapping(request.get("model_selection_receipt"))
+    runtime_raw = _mapping(request.get("model_runtime_binding_receipt"))
+    if not selection_raw and not runtime_raw:
+        return None
+    selection = rehydrate_model_selection_receipt(selection_raw)
+    runtime_binding = None
+    if runtime_raw:
+        runtime_binding = rehydrate_model_runtime_binding_receipt(runtime_raw).to_dict()
+    verifier_result = _mapping(request.get("verification_result"))
+    verifier_receipt = _mapping(verifier_result.get("receipt"))
+    publish_result = _mapping(request.get("publish_result"))
+    publish_receipt = _mapping(publish_result.get("receipt"))
+    latency = _mapping(request.get("latency_receipt"))
+    cost = _mapping(request.get("cost_receipt"))
+    receipt = build_model_selection_outcome_receipt(
+        selection,
+        model_runtime_binding_receipt=runtime_binding,
+        verifier_decision=VerifierDecision.ACCEPT,
+        verification_receipt_ids=(str(verifier_receipt.get("receipt_id") or ""),),
+        task_completed=True,
+        evidence_correct=True,
+        unauthorized_changes_detected=False,
+        regression_detected=False,
+        metrics=ModelOutcomeMetrics(
+            latency_ms=int(latency.get("wall_time_ms") or 0),
+            input_tokens=int(cost.get("total_tokens") or 0),
+            cost_estimate_usd=float(cost.get("estimated_cost_usd") or 0),
+        ),
+        evidence_receipt_ids=(
+            str(verifier_receipt.get("receipt_id") or ""),
+            str(publish_receipt.get("receipt_id") or ""),
+        ),
+    )
+    return receipt.to_dict()
 
 
 def _enrich_ratchet_request(
@@ -202,12 +250,26 @@ def invoke_reddog_wre_queue_authorized_verified_outcome_ratchet(
             explicit_pattern_requested=explicit_pattern_memory_write_requested,
         )
 
+    enriched_request = _enrich_ratchet_request(
+        request,
+        publish_payload,
+        enable_pattern_memory_write=pattern_requested_by_request,
+    )
+    model_feedback_receipt: Optional[Dict[str, Any]] = None
+    try:
+        model_feedback_receipt = _model_feedback_receipt(enriched_request)
+    except Exception as exc:
+        return _reject(
+            [
+                QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.MODEL_FEEDBACK_RECEIPT_INVALID,
+                f"model_feedback_error:{type(exc).__name__}",
+            ],
+            explicit_requested=True,
+            explicit_pattern_requested=explicit_pattern_memory_write_requested,
+        )
+
     ratcheted = ratchet_verified_outcome(
-        _enrich_ratchet_request(
-            request,
-            publish_payload,
-            enable_pattern_memory_write=pattern_requested_by_request,
-        ),
+        enriched_request,
         store=store,
         pattern_memory_sink=pattern_memory_sink,
     )
@@ -226,6 +288,7 @@ def invoke_reddog_wre_queue_authorized_verified_outcome_ratchet(
         decision=QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
         rejection_reasons=[],
         ratchet_result=ratcheted,
+        model_selection_outcome_receipt=model_feedback_receipt,
         explicit_queue_authorized_verified_outcome_ratchet_requested=True,
         explicit_pattern_memory_write_requested=explicit_pattern_memory_write_requested,
     )

--- a/modules/communication/moltbot_bridge/tests/model_runtime_binding_receipt_test_helpers.py
+++ b/modules/communication/moltbot_bridge/tests/model_runtime_binding_receipt_test_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
@@ -33,13 +34,13 @@ from modules.ai_intelligence.ai_gateway.tests.model_signed_evidence_test_helpers
 )
 
 
-def model_runtime_binding_receipt(
+def model_selection_and_runtime_binding_receipts(
     *,
     runtime_surface: str,
     model_id: str = "openai/gpt-5.6-code",
     task_family: str = "reddog_runtime_model_call",
-) -> dict[str, Any]:
-    """Build a valid single-model runtime binding receipt for runtime tests."""
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build matching model-selection and runtime-binding receipts for tests."""
 
     task_set_digest = "sha256:task-set"
     held_out_digest = "sha256:held-out"
@@ -122,4 +123,24 @@ def model_runtime_binding_receipt(
     )
     assert selection.decision == SelectionDecision.SELECTED
     assert receipt.decision == ModelRuntimeBindingDecision.BOUND
-    return receipt.to_dict()
+    return _json_normalized(selection.to_dict()), _json_normalized(receipt.to_dict())
+
+
+def model_runtime_binding_receipt(
+    *,
+    runtime_surface: str,
+    model_id: str = "openai/gpt-5.6-code",
+    task_family: str = "reddog_runtime_model_call",
+) -> dict[str, Any]:
+    """Build a valid single-model runtime binding receipt for runtime tests."""
+
+    _, receipt = model_selection_and_runtime_binding_receipts(
+        runtime_surface=runtime_surface,
+        model_id=model_id,
+        task_family=task_family,
+    )
+    return receipt
+
+
+def _json_normalized(value: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(value, sort_keys=True, default=str))

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -18,6 +18,7 @@ from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_serial_
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_APPLIED,
     REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_BOOTSTRAP_NOT_READY,
     _canonical_digest,
+    _derive_outcome_ratchet_request_from_chain,
     _materialize_work_orders_from_authority_profile,
     _operational_context_binding,
     run_reddog_main_resident_queue_serial_loop_bootstrap,
@@ -78,6 +79,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized
     FakeDraftPrRunner,
 )
 from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_selection_and_runtime_binding_receipts,
     model_runtime_binding_receipt,
 )
 from modules.infrastructure.wre_core.src import reddog_verified_outcome_ratchet as ratchet
@@ -311,6 +313,55 @@ def test_authority_profile_materializer_carries_model_runtime_binding_receipt() 
 def _work_orders(**overrides: object) -> dict[str, object]:
     order = _work_order(**overrides)
     return {"work_orders": {WORK_ORDER_ID: order}}
+
+
+def test_derived_outcome_ratchet_request_carries_model_feedback_receipts() -> None:
+    selection, runtime_binding = model_selection_and_runtime_binding_receipts(
+        runtime_surface=RUNTIME_SURFACE_ARTIFACT_GENERATION,
+    )
+    chain_state = {
+        "schema_version": "reddog_resident_queue_chain_results.v1",
+        "stage_results": {
+            "slice_verifier": {
+                "verifier_result": {
+                    "accepted": True,
+                    "decision": AUTONOMOUS_SLICE_VERIFIER_ACCEPT,
+                    "receipt": {
+                        "receipt_id": "wre_slice_verify_1234",
+                        "work_order_id": WORK_ORDER_ID,
+                        "slice_name": "REDDOG_TEST_SLICE_PHASE1",
+                        "worker_id": "worker:author",
+                    },
+                }
+            },
+            "verified_draft_pr_publish": {
+                "publish_result": {
+                    "accepted": True,
+                    "decision": "VERIFIED_DRAFT_PR_PUBLISH_ACCEPT",
+                    "receipt": {
+                        "receipt_id": "verified_draft_pr_1234",
+                        "work_order_id": WORK_ORDER_ID,
+                    },
+                }
+            },
+        },
+    }
+    work_orders = _work_orders(
+        model_selection_receipt=selection,
+        model_runtime_binding_receipt=runtime_binding,
+    )
+
+    request = _derive_outcome_ratchet_request_from_chain(
+        chain_state,
+        work_orders=work_orders,
+    )
+
+    assert request is not None
+    assert request["model_selection_receipt"]["receipt_id"] == selection["receipt_id"]
+    assert (
+        request["model_runtime_binding_receipt"]["receipt_id"]
+        == runtime_binding["receipt_id"]
+    )
 
 
 def _valve_environment(**overrides: object) -> dict[str, object]:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py
@@ -16,6 +16,9 @@ from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verifi
     QueueAuthorizedVerifiedOutcomeRatchetInvokeReason,
     invoke_reddog_wre_queue_authorized_verified_outcome_ratchet,
 )
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_selection_and_runtime_binding_receipts,
+)
 from modules.infrastructure.wre_core.src import reddog_verified_outcome_ratchet as ratchet
 from modules.infrastructure.wre_core.src.reddog_verified_draft_pr_publish import (
     VERIFIED_DRAFT_PR_PUBLISH_ACCEPT,
@@ -140,6 +143,17 @@ def _ratchet_request() -> dict:
     }
 
 
+def _ratchet_request_with_model_feedback() -> dict:
+    selection, runtime_binding = model_selection_and_runtime_binding_receipts(
+        runtime_surface="backend_architect",
+        task_family="reddog_runtime_model_call",
+    )
+    request = _ratchet_request()
+    request["model_selection_receipt"] = selection
+    request["model_runtime_binding_receipt"] = runtime_binding
+    return request
+
+
 def _invoke(
     *,
     queue_publish: dict | None = None,
@@ -178,6 +192,39 @@ def test_records_outcome_from_accepted_queue_publish_result() -> None:
     assert result.no_merge_performed is True
     assert result.no_reward_settlement_performed is True
     assert result.no_holoindex_reindex_performed is True
+
+
+def test_emits_model_selection_outcome_feedback_when_model_receipts_are_bound() -> None:
+    result = _invoke(request=_ratchet_request_with_model_feedback())
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT
+    assert result.model_selection_outcome_receipt is not None
+    feedback = result.model_selection_outcome_receipt
+    assert feedback["feedback_eligible"] is True
+    assert feedback["selection_receipt_id"] == _ratchet_request_with_model_feedback()[
+        "model_selection_receipt"
+    ]["receipt_id"]
+    assert feedback["model_runtime_binding_receipt_id"] == _ratchet_request_with_model_feedback()[
+        "model_runtime_binding_receipt"
+    ]["receipt_id"]
+    assert feedback["verification_receipt_ids"] == [VERIFIER_RECEIPT_ID]
+    assert feedback["evidence_receipt_ids"] == [PUBLISH_RECEIPT_ID, VERIFIER_RECEIPT_ID]
+
+
+def test_invalid_model_feedback_receipt_rejects_before_ratchet_store_write() -> None:
+    request = _ratchet_request_with_model_feedback()
+    request["model_runtime_binding_receipt"] = dict(request["model_runtime_binding_receipt"])
+    request["model_runtime_binding_receipt"]["selection_receipt_id"] = "model_selection_receipt:other"
+    store = ratchet.InMemoryOutcomeRatchetStore()
+
+    result = _invoke(request=request, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    assert (
+        QueueAuthorizedVerifiedOutcomeRatchetInvokeReason.MODEL_FEEDBACK_RECEIPT_INVALID
+        in result.rejection_reasons
+    )
+    assert store.records == []
 
 
 def test_explicit_invoke_missing_rejects_before_store() -> None:


### PR DESCRIPTION
## Summary
- emit an optional ModelSelectionOutcomeReceipt from the queue-authorized verified outcome ratchet when model-selection/runtime-binding receipts are present
- rehydrate and verify serialized model receipts before any ratchet store write, so malformed model feedback evidence fails closed
- derive model-selection and runtime-binding receipts from bound resident work orders into derived ratchet requests

## Validation
- python -m py_compile modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/model_runtime_binding_receipt_test_helpers.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_derived_outcome_ratchet_request_carries_model_feedback_receipts modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py (24 passed)
- pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_outcome_ratchet_handler.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py (82 passed, 1 skipped)
- pytest modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_pattern_memory_admission_invoke.py modules/infrastructure/wre_core/tests/test_reddog_verified_outcome_ratchet.py modules/infrastructure/wre_core/tests/test_reddog_held_out_recursive_improvement_regression_gate.py (62 passed)
- git diff --check
- added_line_non_ascii=0

Truth Boundary: no model/provider call, benchmark execution, model promotion, PatternMemory write, OpenClaw/Hermes dispatch, source mutation, PR publication, reward settlement, or HoloIndex re-indexing.