### PR TITLE
feat(ai-gateway): admit verified model feedback ledger records

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -100,6 +100,23 @@ receipt to that benchmark evidence. Outcome receipts are feedback-eligible only
 when the independent verifier accepts, task completion is true, evidence is
 verified, and no regression or unauthorized change is detected.
 
+#### Model Feedback Ledger Admission
+
+```python
+rehydrate_model_selection_outcome_receipt(...) -> ModelSelectionOutcomeReceipt
+admit_model_selection_outcome_feedback(...) -> ModelFeedbackLedgerAdmissionResult
+```
+
+The admission layer accepts a serialized or typed
+`ModelSelectionOutcomeReceipt`, recomputes its deterministic receipt ID, requires
+`feedback_eligible == True`, optionally checks the source ratchet verifier and
+runtime-binding fields, and writes a minimal feedback record through an injected
+`ModelFeedbackLedgerStore`.
+
+The default in-memory and JSONL stores are append-only adapters. The API is
+explicit-invoke only and does not call providers, run benchmarks, promote
+models, write PatternMemory, mutate HoloIndex, or bind RedDog runtime defaults.
+
 #### Model Combination Benchmark Harness
 
 ```python

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,45 @@
 # AI Gateway Module Change Log
 
+## [2026-07-16] - Model Feedback Ledger Admission
+
+**Who:** 0102 Codex
+**Type:** Feedback Admission
+**Slice:** REDDOG_MODEL_FEEDBACK_LEDGER_ADMISSION_PHASE1
+
+**What:** Added verified model-selection outcome rehydration and an explicit
+model-feedback ledger admission layer.
+
+**Why:** RedDog verified-outcome ratchet can now emit a
+`ModelSelectionOutcomeReceipt`, but no model-feedback ledger admitted that
+receipt. Recursive model intelligence needs a receipt-checked ledger entry
+before any later benchmark, promotion, or PatternMemory feedback can trust the
+outcome.
+
+**Files:**
+- `src/model_intelligence_outcomes.py` - rehydrates serialized outcome receipts
+  and recomputes deterministic IDs before feedback use.
+- `src/model_feedback_ledger.py` - explicit injected-store admission with
+  source-ratchet consistency checks and secret scanning.
+- `tests/test_model_intelligence_outcomes.py` - serialized receipt rehydration
+  and tamper rejection tests.
+- `tests/test_model_feedback_ledger.py` - ledger admission acceptance,
+  fail-closed, mismatch, secret, and AST boundary tests.
+
+**Truth Boundary:**
+- IMPLEMENTED: explicit ledger admission for feedback-eligible model-selection
+  outcome receipts.
+- IMPLEMENTED: serialized outcome receipts are rehydrated and digest-checked
+  before admission.
+- IMPLEMENTED: optional source-ratchet verifier/runtime-binding consistency is
+  checked before ledger writes.
+- NOT IMPLEMENTED: provider calls, benchmark execution, catalog promotion,
+  runtime default binding, PatternMemory writes, HoloIndex re-indexing, or
+  automatic resident-loop model-feedback admission.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Model Outcome Runtime Binding Feedback Carry
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -47,6 +47,19 @@ before production model selection can trust a champion:
 Catalog scalar fields remain useful for evaluation and ranking, but production
 selection rejects `CHAMPION` unless these evidence receipts are supplied.
 
+## Model Feedback Ledger Admission
+
+`src/model_feedback_ledger.py` admits feedback-eligible
+`ModelSelectionOutcomeReceipt` records into an injected model-feedback ledger.
+It rehydrates serialized outcome receipts, recomputes their deterministic IDs,
+checks optional source-ratchet verifier/runtime-binding consistency, scans the
+feedback record for secret markers, and emits a digest-bound admission receipt.
+
+This layer is the bridge from verified RedDog outcomes back into model
+intelligence feedback. It does not call providers, run benchmarks, promote
+models, write PatternMemory, mutate HoloIndex, or change RedDog runtime model
+defaults.
+
 ## Model Combination Benchmark Harness
 
 `src/model_combination_benchmark_harness.py` runs deterministic held-out

--- a/modules/ai_intelligence/ai_gateway/src/model_feedback_ledger.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_feedback_ledger.py
@@ -1,0 +1,383 @@
+"""Model selection outcome feedback ledger admission.
+
+This module admits independently verified model-selection outcomes into an
+injected feedback ledger. It does not call providers, run benchmarks, promote
+models, execute commands, write PatternMemory, mutate HoloIndex, or change
+RedDog runtime model defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence
+
+from .model_intelligence_outcomes import (
+    ModelSelectionOutcomeReceipt,
+    outcome_feedback_record,
+    rehydrate_model_selection_outcome_receipt,
+)
+
+
+MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT = "MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT"
+MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT = "MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT"
+MODEL_FEEDBACK_LEDGER_RECORD_TYPE = "model_selection_outcome_feedback"
+
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+class ModelFeedbackLedgerAdmissionReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_MODEL_FEEDBACK_LEDGER_ADMISSION_MISSING"
+    STORE_REQUIRED = "REJECT_INJECTED_MODEL_FEEDBACK_LEDGER_STORE_REQUIRED"
+    OUTCOME_RECEIPT_INVALID = "REJECT_MODEL_SELECTION_OUTCOME_RECEIPT_INVALID"
+    OUTCOME_NOT_FEEDBACK_ELIGIBLE = "REJECT_MODEL_SELECTION_OUTCOME_NOT_FEEDBACK_ELIGIBLE"
+    SOURCE_RATCHET_REJECTED = "REJECT_SOURCE_RATCHET_NOT_ACCEPTED"
+    VERIFIER_RECEIPT_MISMATCH = "REJECT_SOURCE_RATCHET_VERIFIER_RECEIPT_MISMATCH"
+    MODEL_RUNTIME_BINDING_MISMATCH = "REJECT_SOURCE_RATCHET_MODEL_RUNTIME_BINDING_MISMATCH"
+    SECRET_IN_RECORD = "REJECT_SECRET_IN_MODEL_FEEDBACK_RECORD"
+    STORE_WRITE_FAILED = "REJECT_MODEL_FEEDBACK_LEDGER_STORE_WRITE_FAILED"
+
+
+class ModelFeedbackLedgerStore(Protocol):
+    def append(self, record: Mapping[str, Any]) -> str:
+        ...
+
+
+class InMemoryModelFeedbackLedgerStore:
+    """Test/local store for model feedback ledger records."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    def append(self, record: Mapping[str, Any]) -> str:
+        payload = dict(record)
+        self.records.append(payload)
+        return f"model-feedback-record-{len(self.records)}"
+
+
+class JsonlModelFeedbackLedgerStore:
+    """Append-only JSONL store for model feedback records."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def append(self, record: Mapping[str, Any]) -> str:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+        with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(line + "\n")
+        return str(record["feedback_record_id"])
+
+
+@dataclass(frozen=True)
+class ModelFeedbackLedgerAdmissionReceipt:
+    admission_id: str
+    outcome_receipt_id: str
+    selection_receipt_id: str
+    catalog_snapshot_id: str
+    task_family: str
+    selected_model_ids: List[str]
+    verification_receipt_ids: List[str]
+    model_runtime_binding_receipt_id: Optional[str]
+    model_runtime_binding_digest: str
+    source_ratchet_id: Optional[str]
+    source_ratchet_digest: str
+    feedback_record_id: Optional[str]
+    feedback_record_digest: str
+    rejection_reasons: List[str]
+    no_provider_call_performed: bool = True
+    no_benchmark_execution_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ModelFeedbackLedgerAdmissionResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    receipt: Optional[ModelFeedbackLedgerAdmissionReceipt] = None
+    explicit_model_feedback_ledger_admission_requested: bool = False
+    feedback_write_performed: bool = False
+    no_provider_call_performed: bool = True
+    no_benchmark_execution_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        return payload
+
+
+def admit_model_selection_outcome_feedback(
+    *,
+    explicit_model_feedback_ledger_admission_requested: bool,
+    model_selection_outcome_receipt: ModelSelectionOutcomeReceipt | Mapping[str, Any],
+    store: Optional[ModelFeedbackLedgerStore],
+    source_ratchet_receipt: Mapping[str, Any] | None = None,
+) -> ModelFeedbackLedgerAdmissionResult:
+    """Admit one verified model-selection outcome into an injected ledger."""
+
+    if explicit_model_feedback_ledger_admission_requested is not True:
+        return _reject(
+            [ModelFeedbackLedgerAdmissionReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+    if store is None:
+        return _reject(
+            [ModelFeedbackLedgerAdmissionReason.STORE_REQUIRED],
+            explicit_requested=True,
+        )
+
+    reasons: List[str] = []
+    try:
+        outcome = _outcome_receipt(model_selection_outcome_receipt)
+    except Exception as exc:
+        return _reject(
+            [
+                ModelFeedbackLedgerAdmissionReason.OUTCOME_RECEIPT_INVALID,
+                f"outcome_error:{type(exc).__name__}",
+            ],
+            explicit_requested=True,
+        )
+
+    try:
+        record = outcome_feedback_record(outcome)
+    except Exception:
+        reasons.append(ModelFeedbackLedgerAdmissionReason.OUTCOME_NOT_FEEDBACK_ELIGIBLE)
+        record = {}
+
+    ratchet = _mapping(source_ratchet_receipt)
+    if ratchet:
+        reasons.extend(_ratchet_binding_rejections(outcome, ratchet))
+
+    if record:
+        record = _feedback_record(outcome=outcome, base_record=record, source_ratchet_receipt=ratchet)
+        if _contains_secret(record):
+            reasons.append(ModelFeedbackLedgerAdmissionReason.SECRET_IN_RECORD)
+
+    if reasons:
+        receipt = _admission_receipt(
+            outcome=outcome,
+            record=record,
+            record_id=None,
+            reasons=reasons,
+            source_ratchet_receipt=ratchet,
+        )
+        return _reject(reasons, explicit_requested=True, receipt=receipt)
+
+    try:
+        record_id = store.append(record)
+    except Exception:
+        receipt = _admission_receipt(
+            outcome=outcome,
+            record=record,
+            record_id=None,
+            reasons=[ModelFeedbackLedgerAdmissionReason.STORE_WRITE_FAILED],
+            source_ratchet_receipt=ratchet,
+        )
+        return _reject(
+            [ModelFeedbackLedgerAdmissionReason.STORE_WRITE_FAILED],
+            explicit_requested=True,
+            receipt=receipt,
+        )
+
+    receipt = _admission_receipt(
+        outcome=outcome,
+        record=record,
+        record_id=str(record_id or ""),
+        reasons=[],
+        source_ratchet_receipt=ratchet,
+    )
+    return ModelFeedbackLedgerAdmissionResult(
+        decision=MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT,
+        rejection_reasons=[],
+        receipt=receipt,
+        explicit_model_feedback_ledger_admission_requested=True,
+        feedback_write_performed=True,
+    )
+
+
+def _outcome_receipt(value: ModelSelectionOutcomeReceipt | Mapping[str, Any]) -> ModelSelectionOutcomeReceipt:
+    if isinstance(value, ModelSelectionOutcomeReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_selection_outcome_receipt(value)
+    raise ValueError("invalid_outcome_receipt")
+
+
+def _feedback_record(
+    *,
+    outcome: ModelSelectionOutcomeReceipt,
+    base_record: Mapping[str, Any],
+    source_ratchet_receipt: Mapping[str, Any],
+) -> Dict[str, Any]:
+    source_ratchet_id, source_ratchet_digest = _source_ratchet_pair(source_ratchet_receipt)
+    record = {
+        "record_type": MODEL_FEEDBACK_LEDGER_RECORD_TYPE,
+        "schema_version": "model_feedback_ledger_record.v1",
+        **dict(base_record),
+        "source_ratchet_id": source_ratchet_id,
+        "source_ratchet_digest": source_ratchet_digest,
+    }
+    record["feedback_record_id"] = "model_feedback_" + _digest(
+        {
+            "outcome_receipt_id": outcome.receipt_id,
+            "source_ratchet_id": source_ratchet_id,
+            "source_ratchet_digest": source_ratchet_digest,
+        }
+    ).removeprefix("sha256:")[:16]
+    return record
+
+
+def _ratchet_binding_rejections(
+    outcome: ModelSelectionOutcomeReceipt,
+    source_ratchet_receipt: Mapping[str, Any],
+) -> List[str]:
+    reasons: List[str] = []
+    if source_ratchet_receipt.get("rejection_reasons"):
+        reasons.append(ModelFeedbackLedgerAdmissionReason.SOURCE_RATCHET_REJECTED)
+    verifier_receipt_id = str(source_ratchet_receipt.get("verifier_receipt_id") or "")
+    if verifier_receipt_id and verifier_receipt_id not in outcome.verification_receipt_ids:
+        reasons.append(ModelFeedbackLedgerAdmissionReason.VERIFIER_RECEIPT_MISMATCH)
+    ratchet_runtime_id = str(source_ratchet_receipt.get("model_runtime_binding_receipt_id") or "")
+    ratchet_runtime_digest = str(source_ratchet_receipt.get("model_runtime_binding_digest") or "")
+    outcome_runtime_id = outcome.model_runtime_binding_receipt_id or ""
+    outcome_runtime_digest = outcome.model_runtime_binding_digest or ""
+    runtime_pairs = [
+        pair
+        for pair in (
+            (ratchet_runtime_id, ratchet_runtime_digest),
+            (outcome_runtime_id, outcome_runtime_digest),
+        )
+        if pair[0] or pair[1]
+    ]
+    if runtime_pairs:
+        for receipt_id, digest in runtime_pairs:
+            if not receipt_id or not _is_digest(digest):
+                reasons.append(ModelFeedbackLedgerAdmissionReason.MODEL_RUNTIME_BINDING_MISMATCH)
+                break
+        else:
+            if any(pair != runtime_pairs[0] for pair in runtime_pairs[1:]):
+                reasons.append(ModelFeedbackLedgerAdmissionReason.MODEL_RUNTIME_BINDING_MISMATCH)
+    return _dedupe(reasons)
+
+
+def _admission_receipt(
+    *,
+    outcome: ModelSelectionOutcomeReceipt,
+    record: Mapping[str, Any],
+    record_id: Optional[str],
+    reasons: Sequence[str],
+    source_ratchet_receipt: Mapping[str, Any],
+) -> ModelFeedbackLedgerAdmissionReceipt:
+    source_ratchet_id, source_ratchet_digest = _source_ratchet_pair(source_ratchet_receipt)
+    deduped = _dedupe(reasons)
+    seed = {
+        "record": record,
+        "record_id": record_id,
+        "rejection_reasons": deduped,
+    }
+    return ModelFeedbackLedgerAdmissionReceipt(
+        admission_id="model_feedback_admission_" + _digest(seed).removeprefix("sha256:")[:16],
+        outcome_receipt_id=outcome.receipt_id,
+        selection_receipt_id=outcome.selection_receipt_id,
+        catalog_snapshot_id=outcome.catalog_snapshot_id,
+        task_family=outcome.task_family,
+        selected_model_ids=list(outcome.selected_model_ids),
+        verification_receipt_ids=list(outcome.verification_receipt_ids),
+        model_runtime_binding_receipt_id=outcome.model_runtime_binding_receipt_id,
+        model_runtime_binding_digest=outcome.model_runtime_binding_digest,
+        source_ratchet_id=source_ratchet_id,
+        source_ratchet_digest=source_ratchet_digest,
+        feedback_record_id=record_id,
+        feedback_record_digest=_digest(record),
+        rejection_reasons=deduped,
+    )
+
+
+def _source_ratchet_pair(source_ratchet_receipt: Mapping[str, Any]) -> tuple[Optional[str], str]:
+    if not source_ratchet_receipt:
+        return None, ""
+    ratchet_id = str(source_ratchet_receipt.get("ratchet_id") or "")
+    return ratchet_id or None, _digest(source_ratchet_receipt)
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    receipt: Optional[ModelFeedbackLedgerAdmissionReceipt] = None,
+) -> ModelFeedbackLedgerAdmissionResult:
+    return ModelFeedbackLedgerAdmissionResult(
+        decision=MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        receipt=receipt,
+        explicit_model_feedback_ledger_admission_requested=explicit_requested,
+        feedback_write_performed=False,
+    )
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value or "").strip()))
+
+
+def _contains_secret(value: Any) -> bool:
+    text = json.dumps(value, sort_keys=True, default=str).lower()
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _is_digest(value: Any) -> bool:
+    text = str(value or "")
+    return (
+        text.startswith("sha256:")
+        and len(text) == 71
+        and all(ch in "0123456789abcdef" for ch in text.removeprefix("sha256:"))
+    )
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "InMemoryModelFeedbackLedgerStore",
+    "JsonlModelFeedbackLedgerStore",
+    "MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT",
+    "MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT",
+    "MODEL_FEEDBACK_LEDGER_RECORD_TYPE",
+    "ModelFeedbackLedgerAdmissionReason",
+    "ModelFeedbackLedgerAdmissionReceipt",
+    "ModelFeedbackLedgerAdmissionResult",
+    "ModelFeedbackLedgerStore",
+    "admit_model_selection_outcome_feedback",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py
@@ -11,6 +11,7 @@ by itself, mutates HoloIndex, or executes commands.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -366,6 +367,87 @@ def outcome_feedback_record(receipt: ModelSelectionOutcomeReceipt) -> dict[str, 
     }
 
 
+def rehydrate_model_selection_outcome_receipt(data: Mapping[str, Any]) -> ModelSelectionOutcomeReceipt:
+    """Rehydrate a serialized outcome receipt and recompute its receipt ID."""
+
+    if not isinstance(data, Mapping):
+        raise ValueError("invalid_outcome_receipt")
+    if data.get("schema_version") != OUTCOME_SCHEMA_VERSION:
+        raise ValueError("invalid_outcome_schema")
+    metrics_data = _mapping_value(data.get("metrics"), "metrics")
+    metrics = ModelOutcomeMetrics(
+        latency_ms=metrics_data.get("latency_ms"),
+        input_tokens=metrics_data.get("input_tokens"),
+        output_tokens=metrics_data.get("output_tokens"),
+        cost_estimate_usd=metrics_data.get("cost_estimate_usd"),
+    ).normalized()
+    selected_model_ids = tuple(str(value) for value in _list_value(data.get("selected_model_ids"), "selected_model_ids"))
+    if not selected_model_ids:
+        raise ValueError("missing_selected_model_ids")
+    verifier = _coerce_verifier_decision(_required("verifier_decision", data.get("verifier_decision")))
+    outcome = OutcomeDecision(_required("outcome_decision", data.get("outcome_decision")))
+    verification_receipts = _normalize_receipts(
+        tuple(str(value) for value in _list_value(data.get("verification_receipt_ids"), "verification_receipt_ids"))
+    )
+    evidence_receipts = _normalize_receipts(
+        tuple(str(value) for value in _list_value(data.get("evidence_receipt_ids", []), "evidence_receipt_ids"))
+    )
+    rejection_reasons = tuple(
+        sorted(
+            _clean_reason(reason)
+            for reason in _list_value(data.get("rejection_reasons", []), "rejection_reasons")
+            if str(reason).strip()
+        )
+    )
+    feedback_eligible = _bool_value(data.get("feedback_eligible"), "feedback_eligible")
+    if feedback_eligible != (not rejection_reasons):
+        raise ValueError("feedback_eligibility_mismatch")
+    expected_outcome = OutcomeDecision.ACCEPTED if feedback_eligible else OutcomeDecision.REJECTED
+    if outcome != expected_outcome:
+        raise ValueError("outcome_decision_mismatch")
+    runtime_binding_id = _optional(data.get("model_runtime_binding_receipt_id"))
+    runtime_binding_digest = _optional(data.get("model_runtime_binding_digest"))
+    if bool(runtime_binding_id) != bool(runtime_binding_digest):
+        raise ValueError("runtime_binding_field_mismatch")
+
+    body = {
+        "schema_version": OUTCOME_SCHEMA_VERSION,
+        "selection_receipt_id": _required("selection_receipt_id", data.get("selection_receipt_id")),
+        "catalog_snapshot_id": _required("catalog_snapshot_id", data.get("catalog_snapshot_id")),
+        "task_family": _required("task_family", data.get("task_family")),
+        "selected_model_ids": list(selected_model_ids),
+        "verifier_decision": verifier.value,
+        "verification_receipt_ids": list(verification_receipts),
+        "outcome_decision": outcome.value,
+        "feedback_eligible": feedback_eligible,
+        "metrics": asdict(metrics),
+        "rejection_reasons": list(rejection_reasons),
+        "evidence_receipt_ids": list(evidence_receipts),
+    }
+    if runtime_binding_id:
+        body["model_runtime_binding_receipt_id"] = runtime_binding_id
+        body["model_runtime_binding_digest"] = runtime_binding_digest
+    receipt_id = _digest_prefixed("model_selection_outcome_receipt", body)
+    if not hmac.compare_digest(receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("outcome_receipt_id_mismatch")
+    return ModelSelectionOutcomeReceipt(
+        receipt_id=receipt_id,
+        selection_receipt_id=body["selection_receipt_id"],
+        model_runtime_binding_receipt_id=runtime_binding_id or None,
+        model_runtime_binding_digest=runtime_binding_digest,
+        catalog_snapshot_id=body["catalog_snapshot_id"],
+        task_family=body["task_family"],
+        selected_model_ids=selected_model_ids,
+        verifier_decision=verifier,
+        verification_receipt_ids=verification_receipts,
+        outcome_decision=outcome,
+        feedback_eligible=feedback_eligible,
+        metrics=metrics,
+        rejection_reasons=rejection_reasons,
+        evidence_receipt_ids=evidence_receipts,
+    )
+
+
 def _runtime_binding_from_receipt(
     value: Mapping[str, Any] | None,
     selection_receipt: ModelSelectionReceipt,
@@ -439,6 +521,28 @@ def _required(name: str, value: Any) -> str:
     if not cleaned:
         raise ValueError(f"missing_{name}")
     return cleaned
+
+
+def _optional(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _mapping_value(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _list_value(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _bool_value(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"invalid_{name}")
+    return value
 
 
 def _positive_int(value: int, name: str) -> int:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_feedback_ledger.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_feedback_ledger.py
@@ -1,0 +1,324 @@
+"""Tests for model feedback ledger admission."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_feedback_ledger import (
+    InMemoryModelFeedbackLedgerStore,
+    MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT,
+    MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT,
+    MODEL_FEEDBACK_LEDGER_RECORD_TYPE,
+    ModelFeedbackLedgerAdmissionReason,
+    admit_model_selection_outcome_feedback,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+    build_model_selection_outcome_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionDecision,
+    select_models_for_task,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_feedback_ledger.py"
+)
+
+
+class FailingModelFeedbackLedgerStore(InMemoryModelFeedbackLedgerStore):
+    def append(self, record):
+        raise RuntimeError("store failed")
+
+
+def _selected_receipt():
+    snapshot = build_model_catalog_snapshot(
+        (
+            ModelCapabilityCard(
+                provider="provider",
+                model_id="provider/model",
+                canonical_model_id="provider/model",
+                source="test",
+                promotion_state=PromotionState.CANDIDATE,
+                task_families=("architecture",),
+            ).normalized(),
+        ),
+        generated_at="2026-07-16T00:00:00+00:00",
+    )
+    receipt = select_models_for_task(snapshot, ModelTaskRequirements(task_family="architecture"))
+    assert receipt.decision == SelectionDecision.SELECTED
+    return receipt
+
+
+def _runtime_binding_receipt(selection):
+    return {
+        "schema_version": "reddog_model_runtime_binding_receipt.v1",
+        "receipt_id": "reddog_model_runtime_binding:test",
+        "decision": "bound",
+        "runtime_surface": "backend_architect",
+        "catalog_snapshot_id": selection.catalog_snapshot_id,
+        "selection_receipt_id": selection.receipt_id,
+        "task_family": selection.requirements.task_family,
+        "principal_model": selection.selected_model_ids[0],
+        "panel_models": [],
+        "role_bindings": [
+            {
+                "role": "principal",
+                "model_id": selection.selected_model_ids[0],
+                "provider": "provider",
+            }
+        ],
+        "benchmark_evidence_receipt_ids": ["model_benchmark_evidence:test"],
+        "promotion_evidence_receipt_ids": ["model_promotion_evidence:test"],
+        "signed_promotion_receipt_ids": ["signature:test"],
+        "policy": {
+            "schema_version": "reddog_model_runtime_binding_policy.v1",
+            "task_family": selection.requirements.task_family,
+            "runtime_surface": "backend_architect",
+            "min_verifier_pass_rate": 0.9,
+            "required_task_set_digest": "sha256:taskset",
+            "required_held_out_split_digest": "sha256:heldout",
+            "required_verifier_digest": "sha256:verifier",
+            "max_panel_models": 4,
+            "required_panel_topology_digest": None,
+            "authority_receipt_id": "authority:test",
+        },
+        "rejection_reasons": [],
+    }
+
+
+def _accepted_outcome(*, verification_receipt_id: str = "verify:1", with_runtime: bool = True):
+    selection = _selected_receipt()
+    return build_model_selection_outcome_receipt(
+        selection,
+        model_runtime_binding_receipt=(
+            _runtime_binding_receipt(selection) if with_runtime else None
+        ),
+        verifier_decision=VerifierDecision.ACCEPT,
+        verification_receipt_ids=(verification_receipt_id,),
+        task_completed=True,
+        evidence_correct=True,
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=200, output_tokens=50),
+    )
+
+
+def _source_ratchet(outcome) -> dict:
+    return {
+        "ratchet_id": "outcome_ratchet_1234",
+        "work_order_id": "wo-model-feedback-1",
+        "verifier_receipt_id": outcome.verification_receipt_ids[0],
+        "model_runtime_binding_receipt_id": outcome.model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": outcome.model_runtime_binding_digest,
+        "rejection_reasons": [],
+    }
+
+
+def test_admits_feedback_eligible_outcome_to_injected_ledger_store():
+    outcome = _accepted_outcome()
+    store = InMemoryModelFeedbackLedgerStore()
+
+    result = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome.to_dict(),
+        source_ratchet_receipt=_source_ratchet(outcome),
+        store=store,
+    )
+
+    assert result.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.feedback_write_performed is True
+    assert result.receipt is not None
+    assert result.receipt.outcome_receipt_id == outcome.receipt_id
+    assert result.receipt.model_runtime_binding_receipt_id == "reddog_model_runtime_binding:test"
+    assert result.receipt.source_ratchet_id == "outcome_ratchet_1234"
+    assert result.receipt.no_provider_call_performed is True
+    assert result.receipt.no_benchmark_execution_performed is True
+    assert result.receipt.no_model_promotion_performed is True
+    assert result.receipt.no_holoindex_reindex_performed is True
+    assert len(store.records) == 1
+    assert store.records[0]["record_type"] == MODEL_FEEDBACK_LEDGER_RECORD_TYPE
+    assert store.records[0]["outcome_receipt_id"] == outcome.receipt_id
+    assert store.records[0]["source_ratchet_id"] == "outcome_ratchet_1234"
+
+
+def test_explicit_request_and_store_are_required():
+    outcome = _accepted_outcome()
+    store = InMemoryModelFeedbackLedgerStore()
+
+    missing_request = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=False,
+        model_selection_outcome_receipt=outcome.to_dict(),
+        store=store,
+    )
+    missing_store = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome.to_dict(),
+        store=None,
+    )
+
+    assert missing_request.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelFeedbackLedgerAdmissionReason.EXPLICIT_INVOKE_MISSING in missing_request.rejection_reasons
+    assert missing_store.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelFeedbackLedgerAdmissionReason.STORE_REQUIRED in missing_store.rejection_reasons
+    assert store.records == []
+
+
+def test_tampered_serialized_outcome_rejects_before_store_write():
+    outcome = _accepted_outcome().to_dict()
+    outcome["selected_model_ids"] = ["provider/other"]
+    store = InMemoryModelFeedbackLedgerStore()
+
+    result = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome,
+        store=store,
+    )
+
+    assert result.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelFeedbackLedgerAdmissionReason.OUTCOME_RECEIPT_INVALID in result.rejection_reasons
+    assert store.records == []
+
+
+def test_rejected_or_incomplete_outcome_never_enters_feedback_ledger():
+    selection = _selected_receipt()
+    outcome = build_model_selection_outcome_receipt(
+        selection,
+        verifier_decision=VerifierDecision.REJECT,
+        verification_receipt_ids=("verify:1",),
+        task_completed=True,
+        evidence_correct=True,
+    )
+    store = InMemoryModelFeedbackLedgerStore()
+
+    result = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome,
+        store=store,
+    )
+
+    assert result.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelFeedbackLedgerAdmissionReason.OUTCOME_NOT_FEEDBACK_ELIGIBLE in result.rejection_reasons
+    assert store.records == []
+
+
+def test_source_ratchet_rejection_verifier_and_runtime_mismatch_fail_closed():
+    outcome = _accepted_outcome()
+
+    cases = [
+        (
+            {"rejection_reasons": ["FAIL_REGRESSION"]},
+            ModelFeedbackLedgerAdmissionReason.SOURCE_RATCHET_REJECTED,
+        ),
+        (
+            {"verifier_receipt_id": "verify:other"},
+            ModelFeedbackLedgerAdmissionReason.VERIFIER_RECEIPT_MISMATCH,
+        ),
+        (
+            {"model_runtime_binding_digest": "sha256:" + "0" * 64},
+            ModelFeedbackLedgerAdmissionReason.MODEL_RUNTIME_BINDING_MISMATCH,
+        ),
+    ]
+
+    for override, expected_reason in cases:
+        source = _source_ratchet(outcome)
+        source.update(override)
+        store = InMemoryModelFeedbackLedgerStore()
+        result = admit_model_selection_outcome_feedback(
+            explicit_model_feedback_ledger_admission_requested=True,
+            model_selection_outcome_receipt=outcome.to_dict(),
+            source_ratchet_receipt=source,
+            store=store,
+        )
+        assert result.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+        assert expected_reason in result.rejection_reasons
+        assert store.records == []
+
+
+def test_secret_marker_in_feedback_record_rejects_before_store_write():
+    outcome = _accepted_outcome(verification_receipt_id="verify:token=leak")
+    store = InMemoryModelFeedbackLedgerStore()
+
+    result = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome.to_dict(),
+        store=store,
+    )
+
+    assert result.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelFeedbackLedgerAdmissionReason.SECRET_IN_RECORD in result.rejection_reasons
+    assert store.records == []
+
+
+def test_store_failure_rejects_with_receipt_and_no_write_claim():
+    outcome = _accepted_outcome()
+
+    result = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome.to_dict(),
+        source_ratchet_receipt=_source_ratchet(outcome),
+        store=FailingModelFeedbackLedgerStore(),
+    )
+
+    assert result.decision == MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelFeedbackLedgerAdmissionReason.STORE_WRITE_FAILED in result.rejection_reasons
+    assert result.feedback_write_performed is False
+    assert result.receipt is not None
+    assert result.receipt.feedback_record_id is None
+
+
+def test_result_is_json_serializable():
+    outcome = _accepted_outcome()
+    result = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=outcome.to_dict(),
+        source_ratchet_receipt=_source_ratchet(outcome),
+        store=InMemoryModelFeedbackLedgerStore(),
+    )
+
+    payload = result.to_dict()
+    assert payload["decision"] == MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT
+    json.dumps(payload, sort_keys=True)
+
+
+def test_model_feedback_ledger_module_has_no_provider_network_command_or_runtime_imports():
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py
@@ -21,6 +21,7 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
     build_model_selection_outcome_receipt,
     outcome_feedback_record,
     production_evidence_for_selection,
+    rehydrate_model_selection_outcome_receipt,
 )
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
     ModelTaskRequirements,
@@ -314,6 +315,54 @@ def test_outcome_feedback_record_carries_runtime_binding_receipt_digest():
     feedback = outcome_feedback_record(receipt)
     assert feedback["model_runtime_binding_receipt_id"] == "reddog_model_runtime_binding:test"
     assert feedback["model_runtime_binding_digest"] == _digest(runtime_binding)
+
+
+def test_rehydrate_outcome_receipt_recomputes_digest_and_preserves_runtime_binding():
+    selection = _selected_receipt()
+    runtime_binding = _runtime_binding_receipt(selection)
+    receipt = build_model_selection_outcome_receipt(
+        selection,
+        model_runtime_binding_receipt=runtime_binding,
+        verifier_decision=VerifierDecision.ACCEPT,
+        verification_receipt_ids=("verify:1",),
+        task_completed=True,
+        evidence_correct=True,
+    )
+
+    rehydrated = rehydrate_model_selection_outcome_receipt(receipt.to_dict())
+
+    assert rehydrated == receipt
+    assert rehydrated.model_runtime_binding_receipt_id == "reddog_model_runtime_binding:test"
+    assert rehydrated.model_runtime_binding_digest == _digest(runtime_binding)
+
+
+def test_rehydrate_outcome_receipt_rejects_tampering_and_inconsistent_feedback_state():
+    selection = _selected_receipt()
+    receipt = build_model_selection_outcome_receipt(
+        selection,
+        verifier_decision=VerifierDecision.ACCEPT,
+        verification_receipt_ids=("verify:1",),
+        task_completed=True,
+        evidence_correct=True,
+    ).to_dict()
+
+    tampered_model = dict(receipt)
+    tampered_model["selected_model_ids"] = ["provider/other"]
+    try:
+        rehydrate_model_selection_outcome_receipt(tampered_model)
+    except ValueError as exc:
+        assert str(exc) == "outcome_receipt_id_mismatch"
+    else:
+        raise AssertionError("expected tampered outcome receipt rejection")
+
+    inconsistent = dict(receipt)
+    inconsistent["feedback_eligible"] = False
+    try:
+        rehydrate_model_selection_outcome_receipt(inconsistent)
+    except ValueError as exc:
+        assert str(exc) == "feedback_eligibility_mismatch"
+    else:
+        raise AssertionError("expected inconsistent feedback state rejection")
 
 
 def test_outcome_receipt_rejects_forged_runtime_binding_receipts():


### PR DESCRIPTION
## Slice
REDDOG_MODEL_FEEDBACK_LEDGER_ADMISSION_PHASE1

## What changed
- Added `rehydrate_model_selection_outcome_receipt()` so serialized model outcome receipts are recomputed before feedback use.
- Added `model_feedback_ledger.py`, an explicit injected-store admission layer for feedback-eligible model selection outcomes.
- Added fail-closed checks for explicit invocation, missing store, tampered outcome receipts, non-feedback-eligible outcomes, source ratchet rejection, verifier mismatch, runtime-binding mismatch, secret markers, and store write failure.
- Updated AI gateway README, INTERFACE, and ModLog.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/src/model_feedback_ledger.py modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py modules/ai_intelligence/ai_gateway/tests/test_model_feedback_ledger.py`
- `pytest modules/ai_intelligence/ai_gateway/tests` -> 99 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 74 passed, 1 skipped
- Combined targeted runtime group -> 173 passed, 1 skipped
- `git diff --cached --check` clean
- staged added-line non-ASCII = 0

## Truth boundary
- No provider calls.
- No benchmark execution.
- No model promotion.
- No RedDog runtime default binding.
- No PatternMemory write.
- No HoloIndex re-index.
- No automatic resident-loop model-feedback admission.