### PR TITLE
feat(reddog): gate queue model feedback ledger admission

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_WRE_QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a queue-authorized explicit invoke guard that consumes an accepted
+  verified-outcome ratchet result and admits its emitted
+  `ModelSelectionOutcomeReceipt` into an injected model-feedback ledger store.
+- The guard fails closed when explicit invocation, the injected store, accepted
+  ratchet payload, ratchet receipt, or model outcome receipt is missing.
+- Reuses the AI gateway model-feedback admission layer, so serialized outcome
+  receipts are rehydrated, source-ratchet verifier/runtime-binding consistency
+  is checked, and secret-bearing feedback records are rejected before store
+  writes.
+- Boundary remains constrained: no model/provider call, benchmark execution,
+  model promotion, PatternMemory write, OpenClaw/Hermes dispatch, source
+  mutation, PR publication, reward settlement, or HoloIndex re-indexing was
+  added.
+
+## 2026-07-17: REDDOG_RATCHET_MODEL_FEEDBACK_RECEIPT_BRIDGE_PHASE1
+
 ## 2026-07-17: REDDOG_RATCHET_MODEL_FEEDBACK_RECEIPT_BRIDGE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py
@@ -1,0 +1,177 @@
+"""RedDog queue-authorized model-feedback ledger admission invoke guard.
+
+Slice: REDDOG_WRE_QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_PHASE1
+
+This module consumes an accepted queue-authorized verified-outcome ratchet
+result that emitted a model-selection outcome receipt, then admits that receipt
+through an injected model-feedback ledger store. It does not call providers, run
+benchmarks, promote models, execute commands, write PatternMemory, mutate
+HoloIndex, publish PRs, merge, or settle rewards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from modules.ai_intelligence.ai_gateway.src.model_feedback_ledger import (
+    MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT,
+    MODEL_FEEDBACK_LEDGER_ADMISSION_REJECT,
+    ModelFeedbackLedgerStore,
+    admit_model_selection_outcome_feedback,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT,
+)
+from modules.infrastructure.wre_core.src.reddog_verified_outcome_ratchet import (
+    OUTCOME_RATCHET_RECORDED,
+)
+
+
+QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_ACCEPT = (
+    "QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_ACCEPT"
+)
+QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT = (
+    "QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT"
+)
+
+
+class QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_MISSING"
+    STORE_REQUIRED = "REJECT_INJECTED_MODEL_FEEDBACK_LEDGER_STORE_REQUIRED"
+    OUTCOME_RATCHET_INVOKE_NOT_ACCEPTED = "REJECT_QUEUE_VERIFIED_OUTCOME_RATCHET_INVOKE_NOT_ACCEPTED"
+    RATCHET_PAYLOAD_MISSING = "REJECT_VERIFIED_OUTCOME_RATCHET_PAYLOAD_MISSING"
+    RATCHET_PAYLOAD_NOT_ACCEPTED = "REJECT_VERIFIED_OUTCOME_RATCHET_PAYLOAD_NOT_ACCEPTED"
+    RATCHET_RECEIPT_MISSING = "REJECT_VERIFIED_OUTCOME_RATCHET_RECEIPT_MISSING"
+    MODEL_OUTCOME_RECEIPT_MISSING = "REJECT_MODEL_SELECTION_OUTCOME_RECEIPT_MISSING"
+    ADMISSION_NOT_ACCEPTED = "REJECT_MODEL_FEEDBACK_LEDGER_ADMISSION_NOT_ACCEPTED"
+
+
+@dataclass(frozen=True)
+class QueueAuthorizedModelFeedbackLedgerAdmissionInvokeResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    model_feedback_admission_result: Optional[Dict[str, Any]] = None
+    explicit_queue_authorized_model_feedback_ledger_admission_requested: bool = False
+    model_feedback_write_performed: bool = False
+    no_provider_call_performed: bool = True
+    no_benchmark_execution_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_pr_publish_performed: bool = True
+    no_merge_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    if hasattr(value, "to_dict"):
+        candidate = value.to_dict()
+        return candidate if isinstance(candidate, Mapping) else {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value or "").strip()))
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    admission_result: Optional[Mapping[str, Any]] = None,
+) -> QueueAuthorizedModelFeedbackLedgerAdmissionInvokeResult:
+    return QueueAuthorizedModelFeedbackLedgerAdmissionInvokeResult(
+        decision=QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        model_feedback_admission_result=dict(admission_result) if admission_result else None,
+        explicit_queue_authorized_model_feedback_ledger_admission_requested=explicit_requested,
+        model_feedback_write_performed=False,
+    )
+
+
+def invoke_reddog_wre_queue_authorized_model_feedback_ledger_admission(
+    *,
+    explicit_queue_authorized_model_feedback_ledger_admission_requested: bool,
+    queue_verified_outcome_ratchet_result: Mapping[str, Any],
+    store: Optional[ModelFeedbackLedgerStore],
+) -> QueueAuthorizedModelFeedbackLedgerAdmissionInvokeResult:
+    """Admit a model-selection outcome receipt after accepted queue ratchet."""
+
+    if explicit_queue_authorized_model_feedback_ledger_admission_requested is not True:
+        return _reject(
+            [QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+    if store is None:
+        return _reject(
+            [QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.STORE_REQUIRED],
+            explicit_requested=True,
+        )
+
+    reasons: List[str] = []
+    queue_ratchet = _mapping(queue_verified_outcome_ratchet_result)
+    if queue_ratchet.get("decision") != QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_ACCEPT:
+        reasons.append(
+            QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.OUTCOME_RATCHET_INVOKE_NOT_ACCEPTED
+        )
+
+    ratchet_payload = _mapping(queue_ratchet.get("ratchet_result"))
+    if not ratchet_payload:
+        reasons.append(QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.RATCHET_PAYLOAD_MISSING)
+    elif (
+        ratchet_payload.get("decision") != OUTCOME_RATCHET_RECORDED
+        or ratchet_payload.get("accepted") is not True
+    ):
+        reasons.append(QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.RATCHET_PAYLOAD_NOT_ACCEPTED)
+
+    ratchet_receipt = _mapping(ratchet_payload.get("receipt"))
+    if not ratchet_receipt:
+        reasons.append(QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.RATCHET_RECEIPT_MISSING)
+
+    model_outcome_receipt = _mapping(queue_ratchet.get("model_selection_outcome_receipt"))
+    if not model_outcome_receipt:
+        reasons.append(QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.MODEL_OUTCOME_RECEIPT_MISSING)
+
+    if reasons:
+        return _reject(reasons, explicit_requested=True)
+
+    admission = admit_model_selection_outcome_feedback(
+        explicit_model_feedback_ledger_admission_requested=True,
+        model_selection_outcome_receipt=model_outcome_receipt,
+        source_ratchet_receipt=ratchet_receipt,
+        store=store,
+    )
+    admission_payload = admission.to_dict()
+    if admission.decision != MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT:
+        return _reject(
+            [
+                QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.ADMISSION_NOT_ACCEPTED,
+                *admission.rejection_reasons,
+            ],
+            explicit_requested=True,
+            admission_result=admission_payload,
+        )
+
+    return QueueAuthorizedModelFeedbackLedgerAdmissionInvokeResult(
+        decision=QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_ACCEPT,
+        rejection_reasons=[],
+        model_feedback_admission_result=admission_payload,
+        explicit_queue_authorized_model_feedback_ledger_admission_requested=True,
+        model_feedback_write_performed=admission.feedback_write_performed,
+    )
+
+
+__all__ = [
+    "QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_ACCEPT",
+    "QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT",
+    "QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason",
+    "QueueAuthorizedModelFeedbackLedgerAdmissionInvokeResult",
+    "invoke_reddog_wre_queue_authorized_model_feedback_ledger_admission",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py
@@ -1,0 +1,183 @@
+"""Tests for REDDOG_WRE_QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_feedback_ledger import (
+    InMemoryModelFeedbackLedgerStore,
+    ModelFeedbackLedgerAdmissionReason,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke import (
+    QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_ACCEPT,
+    QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT,
+    QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason,
+    invoke_reddog_wre_queue_authorized_model_feedback_ledger_admission,
+)
+from modules.communication.moltbot_bridge.src.reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke import (
+    _invoke as _invoke_ratchet,
+    _ratchet_request_with_model_feedback,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py"
+)
+
+
+def _accepted_queue_ratchet() -> dict:
+    return _invoke_ratchet(request=_ratchet_request_with_model_feedback()).to_dict()
+
+
+def _invoke(*, queue_ratchet: dict | None = None, store=None):
+    return invoke_reddog_wre_queue_authorized_model_feedback_ledger_admission(
+        explicit_queue_authorized_model_feedback_ledger_admission_requested=True,
+        queue_verified_outcome_ratchet_result=queue_ratchet or _accepted_queue_ratchet(),
+        store=store or InMemoryModelFeedbackLedgerStore(),
+    )
+
+
+def test_admits_model_feedback_after_accepted_queue_outcome_ratchet() -> None:
+    store = InMemoryModelFeedbackLedgerStore()
+
+    result = _invoke(store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.model_feedback_write_performed is True
+    assert result.model_feedback_admission_result is not None
+    assert (
+        result.model_feedback_admission_result["decision"]
+        == "MODEL_FEEDBACK_LEDGER_ADMISSION_ACCEPT"
+    )
+    assert result.no_provider_call_performed is True
+    assert result.no_benchmark_execution_performed is True
+    assert result.no_model_promotion_performed is True
+    assert result.no_command_execution_performed is True
+    assert result.no_pattern_memory_write_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    assert len(store.records) == 1
+    assert store.records[0]["record_type"] == "model_selection_outcome_feedback"
+    assert store.records[0]["source_ratchet_id"].startswith("outcome_ratchet_")
+
+
+def test_explicit_invoke_and_store_are_required() -> None:
+    store = InMemoryModelFeedbackLedgerStore()
+
+    missing_explicit = invoke_reddog_wre_queue_authorized_model_feedback_ledger_admission(
+        explicit_queue_authorized_model_feedback_ledger_admission_requested=False,
+        queue_verified_outcome_ratchet_result=_accepted_queue_ratchet(),
+        store=store,
+    )
+    missing_store = invoke_reddog_wre_queue_authorized_model_feedback_ledger_admission(
+        explicit_queue_authorized_model_feedback_ledger_admission_requested=True,
+        queue_verified_outcome_ratchet_result=_accepted_queue_ratchet(),
+        store=None,
+    )
+
+    assert missing_explicit.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.EXPLICIT_INVOKE_MISSING
+        in missing_explicit.rejection_reasons
+    )
+    assert missing_store.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.STORE_REQUIRED
+        in missing_store.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_unaccepted_or_missing_ratchet_payload_rejects_before_store() -> None:
+    store = InMemoryModelFeedbackLedgerStore()
+    rejected = _accepted_queue_ratchet()
+    rejected["decision"] = QUEUE_AUTHORIZED_VERIFIED_OUTCOME_RATCHET_INVOKE_REJECT
+    missing_payload = _accepted_queue_ratchet()
+    missing_payload["ratchet_result"] = {}
+
+    first = _invoke(queue_ratchet=rejected, store=store)
+    second = _invoke(queue_ratchet=missing_payload, store=store)
+
+    assert first.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.OUTCOME_RATCHET_INVOKE_NOT_ACCEPTED
+        in first.rejection_reasons
+    )
+    assert second.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.RATCHET_PAYLOAD_MISSING
+        in second.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_missing_model_outcome_receipt_rejects_before_store() -> None:
+    store = InMemoryModelFeedbackLedgerStore()
+    queue_ratchet = _accepted_queue_ratchet()
+    queue_ratchet["model_selection_outcome_receipt"] = None
+
+    result = _invoke(queue_ratchet=queue_ratchet, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.MODEL_OUTCOME_RECEIPT_MISSING
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_admission_rejection_bubbles_up_and_does_not_write() -> None:
+    store = InMemoryModelFeedbackLedgerStore()
+    queue_ratchet = _accepted_queue_ratchet()
+    queue_ratchet["ratchet_result"]["receipt"]["verifier_receipt_id"] = "verify:other"
+
+    result = _invoke(queue_ratchet=queue_ratchet, store=store)
+
+    assert result.decision == QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_REJECT
+    assert (
+        QueueAuthorizedModelFeedbackLedgerAdmissionInvokeReason.ADMISSION_NOT_ACCEPTED
+        in result.rejection_reasons
+    )
+    assert (
+        ModelFeedbackLedgerAdmissionReason.VERIFIER_RECEIPT_MISMATCH
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_module_has_no_provider_network_command_patternmemory_or_holoindex_authority() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__", "open"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Slice
REDDOG_WRE_QUEUE_AUTHORIZED_MODEL_FEEDBACK_LEDGER_ADMISSION_INVOKE_PHASE1

## What changed
- Added queue-authorized explicit invoke guard for model-feedback ledger admission.
- The guard consumes an accepted verified-outcome ratchet result, requires its emitted `ModelSelectionOutcomeReceipt`, and writes through an injected `ModelFeedbackLedgerStore` only after #1209 admission accepts.
- Added rejection-path tests for missing explicit invoke, missing store, rejected/missing ratchet payload, missing model outcome receipt, and admission-level verifier mismatch.
- Updated moltbot_bridge ModLog.

## Validation
- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py`
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py -q` -> 6 passed
- `pytest modules/ai_intelligence/ai_gateway/tests/test_model_feedback_ledger.py modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_outcomes.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_verified_outcome_ratchet_invoke.py modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_model_feedback_ledger_admission_invoke.py -q` -> 40 passed
- `git diff --cached --check` clean
- staged added-line non-ASCII = 0

## Truth boundary
- No provider calls.
- No benchmark execution.
- No model promotion.
- No command execution.
- No PR publish or merge.
- No PatternMemory write.
- No reward settlement.
- No HoloIndex re-index.
- No resident-loop wiring yet.