### PR TITLE
feat(reddog): bind model feedback ledger profile path

### DIFF
--- a/main.py
+++ b/main.py
@@ -2337,6 +2337,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_draft_pr_runner_mode,
             resident_queue_evidence_command_runner_mode,
             resident_queue_materializer_mode,
+            resident_queue_model_feedback_ledger_store_path,
             resident_queue_outcome_ratchet_store_path,
             resident_queue_pattern_memory_admission_db_path,
             resident_queue_runtime_file_path,
@@ -2515,6 +2516,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             publish_request_path=os.getenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", "") or None,
             ratchet_request_path=os.getenv("REDDOG_OUTCOME_RATCHET_REQUEST_PATH", "") or None,
             outcome_ratchet_store_path=resident_queue_outcome_ratchet_store_path(
+                os.environ,
+                repo_root,
+            )
+            or None,
+            model_feedback_ledger_store_path=resident_queue_model_feedback_ledger_store_path(
                 os.environ,
                 repo_root,
             )

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RESIDENT_MODEL_FEEDBACK_LEDGER_PROFILE_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_MODEL_FEEDBACK_LEDGER_STORE_PATH` as the resident runtime path
+  for queue-stage model-feedback ledger admission.
+- Draft-PR-and-higher resident profiles now derive an outside-repo JSONL path
+  under `.reddog/model_feedback/<repo>/model_feedback.jsonl`.
+- `main.py` and the signed OpenClaw queue-loop runner now pass that path into
+  the resident serial-loop bootstrap so the `model_feedback_admission` stage can
+  admit verified model-selection outcomes without manual injection.
+- Boundary remains constrained: no provider call, benchmark execution, model
+  promotion, command execution, PatternMemory write, OpenClaw/Hermes dispatch,
+  source mutation, PR publication, reward settlement, or HoloIndex re-indexing
+  was added.
+
 ## 2026-07-17: REDDOG_RESIDENT_QUEUE_MODEL_FEEDBACK_LEDGER_ADMISSION_STAGE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -254,6 +254,27 @@ def resident_queue_outcome_ratchet_store_path(
     )
 
 
+def resident_queue_model_feedback_ledger_store_path(
+    env: Mapping[str, str],
+    repo_root: Path | str,
+) -> str:
+    """Return explicit/default model-feedback ledger store path."""
+
+    raw = str(env.get("REDDOG_MODEL_FEEDBACK_LEDGER_STORE_PATH") or "").strip()
+    if raw:
+        return raw
+    if resident_queue_binding_profile(env) not in _DRAFT_PR_OR_HIGHER_PROFILES:
+        return ""
+    root = Path(repo_root).resolve()
+    return str(
+        root.parent
+        / ".reddog"
+        / "model_feedback"
+        / _repo_slug(root)
+        / "model_feedback.jsonl"
+    )
+
+
 def resident_queue_pattern_memory_admission_db_path(
     env: Mapping[str, str],
     repo_root: Path | str,
@@ -312,6 +333,7 @@ __all__ = [
     "resident_queue_draft_pr_runner_mode",
     "resident_queue_evidence_command_runner_mode",
     "resident_queue_materializer_mode",
+    "resident_queue_model_feedback_ledger_store_path",
     "resident_queue_outcome_ratchet_store_path",
     "resident_queue_pattern_memory_admission_db_path",
     "resident_queue_runtime_file_path",

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py
@@ -29,6 +29,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     resident_queue_draft_pr_runner_mode,
     resident_queue_evidence_command_runner_mode,
     resident_queue_materializer_mode,
+    resident_queue_model_feedback_ledger_store_path,
     resident_queue_outcome_ratchet_store_path,
     resident_queue_pattern_memory_admission_db_path,
     resident_queue_runtime_file_path,
@@ -253,6 +254,10 @@ def _bootstrap_kwargs(env: Mapping[str, str], *, repo_root: Path | str) -> dict[
         env,
         repo_root,
     )
+    model_feedback_ledger_store_path = resident_queue_model_feedback_ledger_store_path(
+        env,
+        repo_root,
+    )
     pairs = {
         "work_orders_path": "REDDOG_WORK_ORDERS_PATH",
         "valve_environment_path": "REDDOG_EXECUTION_VALVE_ENV_PATH",
@@ -292,6 +297,8 @@ def _bootstrap_kwargs(env: Mapping[str, str], *, repo_root: Path | str) -> dict[
         payload["evidence_command_runner_mode"] = evidence_command_runner_mode
     if outcome_ratchet_store_path:
         payload["outcome_ratchet_store_path"] = outcome_ratchet_store_path
+    if model_feedback_ledger_store_path:
+        payload["model_feedback_ledger_store_path"] = model_feedback_ledger_store_path
     for key, env_name in (
         ("pilot_dryrun_binding_enabled", "REDDOG_PILOT_DRYRUN_BINDING"),
         (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -4099,6 +4099,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
                 "REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH": str(tmp_path / "publish_request.json"),
                 "REDDOG_OUTCOME_RATCHET_REQUEST_PATH": str(tmp_path / "ratchet_request.json"),
                 "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(tmp_path / "ratchet.jsonl"),
+                "REDDOG_MODEL_FEEDBACK_LEDGER_STORE_PATH": str(
+                    tmp_path / "model_feedback.jsonl"
+                ),
                 "REDDOG_HELD_OUT_GATE_REQUEST_PATH": str(tmp_path / "held_out_gate_request.json"),
                 "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_PATH": str(
                     tmp_path / "pattern_memory_admission_request.json"
@@ -4165,6 +4168,9 @@ def test_main_serial_loop_preflight_passes_when_bootstrap_applies(tmp_path: Path
     )
     assert mocked.call_args.kwargs["outcome_ratchet_store_path"] == str(
         tmp_path / "ratchet.jsonl"
+    )
+    assert mocked.call_args.kwargs["model_feedback_ledger_store_path"] == str(
+        tmp_path / "model_feedback.jsonl"
     )
     assert mocked.call_args.kwargs["outcome_ratchet_request_binding_enabled"] is True
     assert mocked.call_args.kwargs["held_out_gate_request_path"] == str(
@@ -4381,6 +4387,13 @@ def test_main_serial_loop_preflight_draft_pr_profile_derives_draft_runner(
         / REPO_ROOT.resolve().name
         / "verified_outcomes.jsonl"
     )
+    assert mocked.call_args.kwargs["model_feedback_ledger_store_path"] == str(
+        REPO_ROOT.resolve().parent
+        / ".reddog"
+        / "model_feedback"
+        / REPO_ROOT.resolve().name
+        / "model_feedback.jsonl"
+    )
     assert mocked.call_args.kwargs["pattern_memory_admission_sink"] is None
     assert mocked.call_args.kwargs["draft_pr_runner"].__class__.__name__ == "RealWorktreeRunner"
     assert mocked.call_args.kwargs["draft_pr_runner"].timeout_s == 91
@@ -4435,6 +4448,13 @@ def test_main_serial_loop_preflight_pattern_memory_profile_derives_sink(
         / "outcome_ratchet"
         / REPO_ROOT.resolve().name
         / "verified_outcomes.jsonl"
+    )
+    assert mocked.call_args.kwargs["model_feedback_ledger_store_path"] == str(
+        REPO_ROOT.resolve().parent
+        / ".reddog"
+        / "model_feedback"
+        / REPO_ROOT.resolve().name
+        / "model_feedback.jsonl"
     )
     sink = mocked.call_args.kwargs["pattern_memory_admission_sink"]
     assert sink is not None

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -647,6 +647,13 @@ def test_runtime_binding_draft_pr_profile_supplies_verified_draft_runner(
         / tmp_path.resolve().name
         / "verified_outcomes.jsonl"
     )
+    assert bootstrap.calls[0]["model_feedback_ledger_store_path"] == str(
+        tmp_path.resolve().parent
+        / ".reddog"
+        / "model_feedback"
+        / tmp_path.resolve().name
+        / "model_feedback.jsonl"
+    )
     assert "pattern_memory_admission_sink" not in bootstrap.calls[0]
     draft_runner = bootstrap.calls[0]["draft_pr_runner"]
     assert draft_runner.__class__.__name__ == "_FakeDraftPrRunner"
@@ -698,6 +705,13 @@ def test_runtime_binding_pattern_memory_profile_derives_outside_repo_sink(
         / "outcome_ratchet"
         / tmp_path.resolve().name
         / "verified_outcomes.jsonl"
+    )
+    assert bootstrap.calls[0]["model_feedback_ledger_store_path"] == str(
+        tmp_path.resolve().parent
+        / ".reddog"
+        / "model_feedback"
+        / tmp_path.resolve().name
+        / "model_feedback.jsonl"
     )
     sink = bootstrap.calls[0]["pattern_memory_admission_sink"]
     assert sink.__class__.__name__ == "RedDogVerifiedPatternMemorySink"


### PR DESCRIPTION
## Slice
REDDOG_RESIDENT_MODEL_FEEDBACK_LEDGER_PROFILE_BINDING_PHASE1

## WSP_97 Truth Boundary
- OBSERVED: #1211 added the resident `model_feedback_admission` stage and handler.
- OBSERVED: this PR only binds `REDDOG_MODEL_FEEDBACK_LEDGER_STORE_PATH` through resident profile derivation, `main.py`, and the signed OpenClaw queue-loop runtime binding.
- OBSERVED: draft-PR-and-higher resident profiles derive an outside-repo `.reddog/model_feedback/<repo>/model_feedback.jsonl` path when no explicit env path is supplied.
- SPECIFIED_NOT_IMPLEMENTED: no provider call, benchmark execution, model promotion, command execution, PatternMemory write, HoloIndex re-index, PR publication, source mutation, reward settlement, or OpenClaw/Hermes dispatch is introduced here.

## Validation
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/communication/moltbot_bridge/src/reddog_signed_worker_openclaw_queue_loop_runtime_binding.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py` -> PASS
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 99 passed, 1 skipped
- resident queue cluster -> 343 passed, 1 skipped
- `git diff --cached --check` -> PASS before commit
- staged added-line ASCII check -> 0 non-ASCII

## Boundary
This is a profile-binding/runtime-configuration slice only. It makes the #1211 model feedback ledger stage usable in resident profiles without manual bootstrap injection.