### PR TITLE
feat(ai-gateway): feed verified model feedback into autoresearch

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,40 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model Feedback Ledger AutoResearch Signal
+
+**Who:** 0102 Codex
+**Type:** Recursive Learning Signal
+**Slice:** MODEL_FEEDBACK_LEDGER_AUTORESEARCH_SIGNAL_PHASE1
+
+**What:** Extended the champion/challenger AutoResearch planner to accept
+validated model-feedback ledger records as bounded planning signals.
+
+**Why:** RedDog now admits independently verified model-selection outcomes into
+the model-feedback ledger. The AutoResearch planner needs to cite and digest
+those outcomes so verified runtime evidence can influence future benchmark
+campaign priority without promoting models or trusting raw claims.
+
+**Files:**
+- `src/model_champion_challenger_autoresearch.py` - validates same-task,
+  same-catalog feedback records, binds their IDs/digest into the plan receipt,
+  and uses them only to reprioritize known candidates.
+- `tests/test_model_champion_challenger_autoresearch.py` - verifies feedback
+  priority, malformed/mismatched feedback rejection, and no candidate invention.
+
+**Truth Boundary:**
+- IMPLEMENTED: feedback records can raise priority for existing benchmark
+  candidates and are digest-bound into AutoResearch plan receipts.
+- IMPLEMENTED: feedback records must be same task family, same catalog snapshot,
+  have valid source-ratchet digest and verification receipts, and cannot create
+  candidates outside the supplied candidate pool.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  catalog mutation, PatternMemory writes, HoloIndex re-indexing, or runtime model
+  default binding.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-16] - Model Feedback Ledger Admission
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
@@ -93,7 +93,9 @@ class ModelAutoResearchPlanReceipt:
     receipt_id: str
     policy: ModelAutoResearchPolicy
     source_gate_receipt_ids: tuple[str, ...]
+    source_feedback_record_ids: tuple[str, ...]
     candidate_pool_digest: str
+    feedback_ledger_digest: str
     campaign_items: tuple[ModelAutoResearchCampaignItem, ...]
     rejection_reasons: tuple[str, ...] = ()
     schema_version: str = AUTORESEARCH_SCHEMA_VERSION
@@ -104,7 +106,9 @@ class ModelAutoResearchPlanReceipt:
             "receipt_id": self.receipt_id,
             "policy": self.policy.to_dict(),
             "source_gate_receipt_ids": list(self.source_gate_receipt_ids),
+            "source_feedback_record_ids": list(self.source_feedback_record_ids),
             "candidate_pool_digest": self.candidate_pool_digest,
+            "feedback_ledger_digest": self.feedback_ledger_digest,
             "campaign_items": [item.to_dict() for item in self.campaign_items],
             "rejection_reasons": list(self.rejection_reasons),
         }
@@ -115,17 +119,27 @@ def plan_model_champion_challenger_autoresearch(
     promotion_gate_receipts: Sequence[ModelPromotionGateReceipt],
     candidate_pool: Sequence[ModelBenchmarkCandidate],
     policy: ModelAutoResearchPolicy,
+    feedback_records: Sequence[Mapping[str, Any]] = (),
 ) -> ModelAutoResearchPlanReceipt:
     """Plan the next benchmark campaigns from gate receipts and candidates."""
 
     normalized_policy = policy.normalized()
     normalized_candidates = _normalize_candidates(candidate_pool)
     normalized_gates = _normalize_gate_receipts(promotion_gate_receipts, normalized_policy.task_family)
+    normalized_feedback = _normalize_feedback_records(feedback_records, normalized_policy)
+    feedback_model_ids = _feedback_model_ids(normalized_feedback)
     candidate_pool_digest = _digest_prefixed(
         "model_autoresearch_candidate_pool",
         {"candidates": [candidate.to_dict() for candidate in normalized_candidates]},
     )
+    feedback_ledger_digest = _digest_prefixed(
+        "model_autoresearch_feedback_ledger",
+        {"feedback_records": list(normalized_feedback)},
+    )
     source_gate_ids = tuple(sorted(receipt.receipt_id for receipt in normalized_gates))
+    source_feedback_record_ids = tuple(
+        sorted(str(record["feedback_record_id"]) for record in normalized_feedback)
+    )
     rejection_reasons = _policy_rejections(normalized_policy, normalized_gates)
     campaign_items: list[ModelAutoResearchCampaignItem] = []
     seen_gate_candidate_ids = {receipt.candidate_id for receipt in normalized_gates}
@@ -136,25 +150,39 @@ def plan_model_champion_challenger_autoresearch(
                 receipt.decision == ModelPromotionGateDecision.KEEP_CHALLENGER
                 and normalized_policy.rebenchmark_challengers
             ):
+                has_feedback = receipt.candidate_id in feedback_model_ids
                 campaign_items.append(
                     ModelAutoResearchCampaignItem(
                         candidate_id=receipt.candidate_id,
                         action=ModelAutoResearchAction.REBENCHMARK_CHALLENGER,
-                        priority="P2",
-                        reason="challenger_below_champion_threshold",
+                        priority="P1" if has_feedback else "P2",
+                        reason=(
+                            "verified_runtime_feedback_rebenchmark_challenger"
+                            if has_feedback
+                            else "challenger_below_champion_threshold"
+                        ),
                         source_gate_receipt_id=receipt.receipt_id,
                     )
                 )
         for candidate in normalized_candidates:
             if candidate.candidate_id in seen_gate_candidate_ids:
                 continue
+            has_feedback = candidate.candidate_id in feedback_model_ids
             campaign_items.append(
                 ModelAutoResearchCampaignItem(
                     candidate_id=candidate.candidate_id,
                     action=ModelAutoResearchAction.BENCHMARK_NEW_CANDIDATE,
-                    priority="P1",
-                    reason="candidate_not_yet_benchmarked",
+                    priority="P0" if has_feedback else "P1",
+                    reason=(
+                        "verified_runtime_feedback_unbenchmarked_candidate"
+                        if has_feedback
+                        else "candidate_not_yet_benchmarked"
+                    ),
                 )
+            )
+        if normalized_feedback:
+            campaign_items = list(
+                sorted(campaign_items, key=lambda item: (_priority_rank(item.priority), item.candidate_id))
             )
         campaign_items = campaign_items[: normalized_policy.max_campaign_items]
         if not campaign_items:
@@ -171,7 +199,9 @@ def plan_model_champion_challenger_autoresearch(
         "schema_version": AUTORESEARCH_SCHEMA_VERSION,
         "policy": normalized_policy.to_dict(),
         "source_gate_receipt_ids": list(source_gate_ids),
+        "source_feedback_record_ids": list(source_feedback_record_ids),
         "candidate_pool_digest": candidate_pool_digest,
+        "feedback_ledger_digest": feedback_ledger_digest,
         "campaign_items": [item.to_dict() for item in campaign_items],
         "rejection_reasons": sorted(set(rejection_reasons)),
     }
@@ -179,7 +209,9 @@ def plan_model_champion_challenger_autoresearch(
         receipt_id=_digest_prefixed("model_autoresearch_plan", body),
         policy=normalized_policy,
         source_gate_receipt_ids=source_gate_ids,
+        source_feedback_record_ids=source_feedback_record_ids,
         candidate_pool_digest=candidate_pool_digest,
+        feedback_ledger_digest=feedback_ledger_digest,
         campaign_items=tuple(campaign_items),
         rejection_reasons=tuple(sorted(set(rejection_reasons))),
     )
@@ -224,6 +256,76 @@ def _policy_rejections(
     return tuple(sorted(set(reasons)))
 
 
+def _normalize_feedback_records(
+    feedback_records: Sequence[Mapping[str, Any]],
+    policy: ModelAutoResearchPolicy,
+) -> tuple[dict[str, Any], ...]:
+    normalized: list[dict[str, Any]] = []
+    record_ids: list[str] = []
+    for record in feedback_records:
+        if not isinstance(record, Mapping):
+            raise ValueError("invalid_feedback_record")
+        candidate = dict(record)
+        if candidate.get("record_type") != "model_selection_outcome_feedback":
+            raise ValueError("invalid_feedback_record_type")
+        if candidate.get("schema_version") != "model_feedback_ledger_record.v1":
+            raise ValueError("invalid_feedback_record_schema")
+        record_id = _required("feedback_record_id", candidate.get("feedback_record_id"))
+        if not record_id.startswith("model_feedback_"):
+            raise ValueError("invalid_feedback_record_id")
+        for field in (
+            "outcome_receipt_id",
+            "selection_receipt_id",
+            "catalog_snapshot_id",
+            "task_family",
+            "source_ratchet_id",
+            "source_ratchet_digest",
+        ):
+            _required(field, candidate.get(field))
+        if candidate["task_family"] != policy.task_family:
+            raise ValueError("feedback_task_family_mismatch")
+        if candidate["catalog_snapshot_id"] != policy.catalog_snapshot_id:
+            raise ValueError("feedback_catalog_snapshot_mismatch")
+        selected_model_ids = tuple(str(value).strip() for value in candidate.get("selected_model_ids") or ())
+        if not selected_model_ids or any(not value for value in selected_model_ids):
+            raise ValueError("feedback_selected_model_ids_missing")
+        verification_receipt_ids = tuple(
+            str(value).strip() for value in candidate.get("verification_receipt_ids") or ()
+        )
+        if not verification_receipt_ids or any(not value for value in verification_receipt_ids):
+            raise ValueError("feedback_verification_receipts_missing")
+        if not _is_digest(candidate.get("source_ratchet_digest")):
+            raise ValueError("feedback_source_ratchet_digest_invalid")
+        normalized.append(
+            {
+                "feedback_record_id": record_id,
+                "outcome_receipt_id": str(candidate["outcome_receipt_id"]),
+                "selection_receipt_id": str(candidate["selection_receipt_id"]),
+                "catalog_snapshot_id": str(candidate["catalog_snapshot_id"]),
+                "task_family": str(candidate["task_family"]),
+                "selected_model_ids": list(selected_model_ids),
+                "verification_receipt_ids": list(verification_receipt_ids),
+                "source_ratchet_id": str(candidate["source_ratchet_id"]),
+                "source_ratchet_digest": str(candidate["source_ratchet_digest"]),
+            }
+        )
+        record_ids.append(record_id)
+    if len(set(record_ids)) != len(record_ids):
+        raise ValueError("duplicate_feedback_record_ids")
+    return tuple(sorted(normalized, key=lambda item: item["feedback_record_id"]))
+
+
+def _feedback_model_ids(feedback_records: tuple[dict[str, Any], ...]) -> set[str]:
+    model_ids: set[str] = set()
+    for record in feedback_records:
+        model_ids.update(str(value) for value in record["selected_model_ids"])
+    return model_ids
+
+
+def _priority_rank(priority: str) -> int:
+    return {"P0": 0, "P1": 1, "P2": 2, "P3": 3}.get(priority, 9)
+
+
 def _required(name: str, value: Any) -> str:
     cleaned = str(value).strip()
     if not cleaned:
@@ -240,6 +342,15 @@ def _optional(value: str | None) -> str | None:
 
 def _clean_token(value: Any) -> str:
     return str(value).strip().lower().replace(" ", "_")
+
+
+def _is_digest(value: Any) -> bool:
+    text = str(value or "")
+    return (
+        text.startswith("sha256:")
+        and len(text) == 71
+        and all(ch in "0123456789abcdef" for ch in text.removeprefix("sha256:"))
+    )
 
 
 def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
@@ -117,6 +117,22 @@ def _policy():
     )
 
 
+def _feedback_record(model_id: str, *, suffix: str = "1") -> dict:
+    return {
+        "record_type": "model_selection_outcome_feedback",
+        "schema_version": "model_feedback_ledger_record.v1",
+        "feedback_record_id": f"model_feedback_{suffix}",
+        "outcome_receipt_id": f"model_selection_outcome_receipt:{suffix}",
+        "selection_receipt_id": f"model_selection_receipt:{suffix}",
+        "catalog_snapshot_id": "model_catalog_snapshot:1",
+        "task_family": "architecture",
+        "selected_model_ids": [model_id],
+        "verification_receipt_ids": [f"verify:{suffix}"],
+        "source_ratchet_id": f"outcome_ratchet_{suffix}",
+        "source_ratchet_digest": "sha256:" + suffix[0].rjust(64, "0"),
+    }
+
+
 def test_autoresearch_plans_new_candidate_and_rebenchmark_challenger():
     champion_gate = _gate("provider/champion", pass_all=True)
     challenger_gate = _gate("provider/challenger", pass_all=False)
@@ -140,6 +156,69 @@ def test_autoresearch_plans_new_candidate_and_rebenchmark_challenger():
         "provider/new",
     ]
     assert all(item.requires_independent_verifier for item in receipt.campaign_items)
+
+
+def test_autoresearch_uses_feedback_records_as_bounded_priority_signal():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    feedback = _feedback_record("provider/new", suffix="2")
+
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger_gate,),
+        candidate_pool=(
+            _candidate("provider/challenger"),
+            _candidate("provider/new"),
+        ),
+        policy=_policy(),
+        feedback_records=(feedback,),
+    )
+
+    assert receipt.rejection_reasons == ()
+    assert receipt.source_feedback_record_ids == ("model_feedback_2",)
+    assert receipt.feedback_ledger_digest.startswith("model_autoresearch_feedback_ledger:")
+    assert [item.candidate_id for item in receipt.campaign_items] == [
+        "provider/new",
+        "provider/challenger",
+    ]
+    assert receipt.campaign_items[0].priority == "P0"
+    assert receipt.campaign_items[0].reason == "verified_runtime_feedback_unbenchmarked_candidate"
+
+
+def test_autoresearch_rejects_malformed_or_mismatched_feedback_records():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    malformed = _feedback_record("provider/new")
+    malformed["source_ratchet_digest"] = "not-a-digest"
+    mismatched = _feedback_record("provider/new")
+    mismatched["task_family"] = "security"
+
+    for record, expected in (
+        (malformed, "feedback_source_ratchet_digest_invalid"),
+        (mismatched, "feedback_task_family_mismatch"),
+    ):
+        try:
+            plan_model_champion_challenger_autoresearch(
+                promotion_gate_receipts=(challenger_gate,),
+                candidate_pool=(_candidate("provider/new"),),
+                policy=_policy(),
+                feedback_records=(record,),
+            )
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError("feedback record was accepted")
+
+
+def test_autoresearch_feedback_cannot_invent_candidate():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger_gate,),
+        candidate_pool=(_candidate("provider/challenger"),),
+        policy=_policy(),
+        feedback_records=(_feedback_record("provider/unlisted"),),
+    )
+
+    assert [item.candidate_id for item in receipt.campaign_items] == ["provider/challenger"]
+    assert all(item.candidate_id != "provider/unlisted" for item in receipt.campaign_items)
 
 
 def test_autoresearch_stops_when_no_candidates_need_work():


### PR DESCRIPTION
## Slice
MODEL_FEEDBACK_LEDGER_AUTORESEARCH_SIGNAL_PHASE1

## WSP_97 Truth Boundary
- OBSERVED: model feedback ledger admission now persists verified model-selection outcomes.
- OBSERVED: AutoResearch previously planned only from promotion-gate receipts and candidate pool.
- IMPLEMENTED: AutoResearch can now consume validated feedback ledger records as bounded priority signals for known candidates.
- IMPLEMENTED: plan receipts bind `source_feedback_record_ids` and `feedback_ledger_digest`.
- IMPLEMENTED: malformed, wrong-task, wrong-catalog, missing-verification, bad source-ratchet digest, and duplicate feedback records fail closed.
- IMPLEMENTED: feedback cannot invent benchmark candidates outside the supplied candidate pool.
- SPECIFIED_NOT_IMPLEMENTED: no provider calls, benchmark execution, model promotion, catalog mutation, PatternMemory write, HoloIndex re-index, or runtime model default binding.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py` -> PASS
- `pytest modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py -q` -> 10 passed
- model-intelligence cluster -> 93 passed
- full AI gateway tests -> 102 passed
- `git diff --check` -> PASS before commit
- staged added-line ASCII check -> 0 non-ASCII

## Boundary
This is a planner signal slice only. It makes verified runtime feedback visible to benchmark campaign planning without running benchmarks or promoting a model.