### PR TITLE
feat(ai-gateway): rehydrate model promotion gate receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,38 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model Promotion Gate Receipt Rehydration
+
+**Who:** 0102 Codex
+**Type:** Receipt Integrity
+**Slice:** MODEL_PROMOTION_GATE_RECEIPT_REHYDRATION_PHASE1
+
+**What:** Added rehydration helpers for serialized model-promotion policies,
+promotion evidence receipts, and promotion gate receipts.
+
+**Why:** AutoResearch artifact supply must not trust raw serialized promotion
+gate mappings. Before runtime planning can consume promotion gates from
+outside-repo artifacts, the gate receipt ID and embedded promotion evidence must
+be recomputed and checked.
+
+**Files:**
+- `src/model_promotion_gate.py` - rehydrates and recomputes promotion policy,
+  promotion evidence, and gate receipts, including champion evidence checks.
+- `tests/test_model_promotion_gate.py` - verifies champion/challenger
+  round-trip and tampered/missing/mismatched evidence rejection.
+
+**Truth Boundary:**
+- IMPLEMENTED: serialized promotion gate receipts can be rehydrated with
+  deterministic ID checks and embedded promotion-evidence consistency checks.
+- IMPLEMENTED: champion gate receipts require promotion evidence; tampered
+  receipt bodies and forged evidence reject before downstream planning.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  AutoResearch artifact supply, catalog mutation, PatternMemory writes, or
+  HoloIndex re-indexing.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model Feedback Ledger AutoResearch Signal
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py
@@ -9,6 +9,7 @@ runtime defaults.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -176,6 +177,139 @@ def evaluate_model_promotion_gate(
     )
 
 
+def rehydrate_model_promotion_policy(data: Mapping[str, Any]) -> ModelPromotionPolicy:
+    """Rehydrate a serialized promotion policy and normalize its fields."""
+
+    if not isinstance(data, Mapping):
+        raise ValueError("invalid_promotion_policy")
+    if data.get("schema_version") != PROMOTION_POLICY_SCHEMA_VERSION:
+        raise ValueError("invalid_promotion_policy_schema")
+    return ModelPromotionPolicy(
+        task_family=_required("task_family", data.get("task_family")),
+        candidate_id=_required("candidate_id", data.get("candidate_id")),
+        min_verifier_pass_rate=float(data.get("min_verifier_pass_rate")),
+        min_sample_count=int(data.get("min_sample_count")),
+        required_task_set_digest=_required("required_task_set_digest", data.get("required_task_set_digest")),
+        required_held_out_split_digest=_required(
+            "required_held_out_split_digest",
+            data.get("required_held_out_split_digest"),
+        ),
+        required_verifier_digest=_required("required_verifier_digest", data.get("required_verifier_digest")),
+        max_latency_ms=_optional_int(data.get("max_latency_ms")),
+        max_cost_estimate_usd=_optional_float(data.get("max_cost_estimate_usd")),
+    ).normalized()
+
+
+def rehydrate_model_promotion_evidence_receipt(
+    data: Mapping[str, Any],
+) -> ModelPromotionEvidenceReceipt:
+    """Rehydrate promotion evidence and recompute its deterministic ID."""
+
+    if not isinstance(data, Mapping):
+        raise ValueError("invalid_promotion_evidence")
+    if data.get("schema_version") != "model_promotion_evidence_receipt.v1":
+        raise ValueError("invalid_promotion_evidence_schema")
+    promotion_state = PromotionState(_required("promotion_state", data.get("promotion_state")))
+    threshold = _threshold(float(data.get("min_verifier_pass_rate")))
+    body = {
+        "schema_version": "model_promotion_evidence_receipt.v1",
+        "model_id": _required("model_id", data.get("model_id")),
+        "task_family": _clean_token(_required("task_family", data.get("task_family"))),
+        "benchmark_evidence_receipt_id": _required(
+            "benchmark_evidence_receipt_id",
+            data.get("benchmark_evidence_receipt_id"),
+        ),
+        "promotion_state": promotion_state.value,
+        "promotion_authority_receipt_id": _required(
+            "promotion_authority_receipt_id",
+            data.get("promotion_authority_receipt_id"),
+        ),
+        "signed_promotion_receipt_id": _required(
+            "signed_promotion_receipt_id",
+            data.get("signed_promotion_receipt_id"),
+        ),
+        "min_verifier_pass_rate": threshold,
+    }
+    receipt_id = _digest_prefixed("model_promotion_evidence", body)
+    if not hmac.compare_digest(receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("promotion_evidence_receipt_id_mismatch")
+    return ModelPromotionEvidenceReceipt(
+        receipt_id=receipt_id,
+        model_id=body["model_id"],
+        task_family=body["task_family"],
+        benchmark_evidence_receipt_id=body["benchmark_evidence_receipt_id"],
+        promotion_state=promotion_state,
+        promotion_authority_receipt_id=body["promotion_authority_receipt_id"],
+        signed_promotion_receipt_id=body["signed_promotion_receipt_id"],
+        min_verifier_pass_rate=threshold,
+    )
+
+
+def rehydrate_model_promotion_gate_receipt(data: Mapping[str, Any]) -> ModelPromotionGateReceipt:
+    """Rehydrate a serialized promotion gate receipt and recompute its ID."""
+
+    if not isinstance(data, Mapping):
+        raise ValueError("invalid_promotion_gate_receipt")
+    if data.get("schema_version") != PROMOTION_GATE_SCHEMA_VERSION:
+        raise ValueError("invalid_promotion_gate_schema")
+    policy = rehydrate_model_promotion_policy(_mapping(data.get("policy"), "policy"))
+    decision = ModelPromotionGateDecision(_required("decision", data.get("decision")))
+    candidate_id = _required("candidate_id", data.get("candidate_id"))
+    task_family = _clean_token(_required("task_family", data.get("task_family")))
+    benchmark_run_receipt_id = _required(
+        "benchmark_run_receipt_id",
+        data.get("benchmark_run_receipt_id"),
+    )
+    benchmark_evidence_receipt_id = _optional(data.get("benchmark_evidence_receipt_id"))
+    promotion_evidence = None
+    promotion_raw = data.get("promotion_evidence_receipt")
+    if promotion_raw is not None:
+        promotion_evidence = rehydrate_model_promotion_evidence_receipt(
+            _mapping(promotion_raw, "promotion_evidence_receipt")
+        )
+    if decision == ModelPromotionGateDecision.PROMOTE_CHAMPION and promotion_evidence is None:
+        raise ValueError("promotion_evidence_missing")
+    if promotion_evidence is not None:
+        if promotion_evidence.model_id != candidate_id:
+            raise ValueError("promotion_evidence_candidate_mismatch")
+        if promotion_evidence.task_family != task_family:
+            raise ValueError("promotion_evidence_task_family_mismatch")
+        if promotion_evidence.benchmark_evidence_receipt_id != benchmark_evidence_receipt_id:
+            raise ValueError("promotion_evidence_benchmark_mismatch")
+    rejection_reasons = tuple(
+        sorted(
+            _clean_token(reason)
+            for reason in _list(data.get("rejection_reasons", []))
+            if str(reason).strip()
+        )
+    )
+    body = {
+        "schema_version": PROMOTION_GATE_SCHEMA_VERSION,
+        "decision": decision.value,
+        "candidate_id": candidate_id,
+        "task_family": task_family,
+        "benchmark_run_receipt_id": benchmark_run_receipt_id,
+        "benchmark_evidence_receipt_id": benchmark_evidence_receipt_id,
+        "policy": policy.to_dict(),
+        "promotion_evidence_receipt_id": promotion_evidence.receipt_id if promotion_evidence else None,
+        "rejection_reasons": sorted(set(rejection_reasons)),
+    }
+    receipt_id = _digest_prefixed("model_promotion_gate", body)
+    if not hmac.compare_digest(receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("promotion_gate_receipt_id_mismatch")
+    return ModelPromotionGateReceipt(
+        receipt_id=receipt_id,
+        decision=decision,
+        candidate_id=candidate_id,
+        task_family=task_family,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
+        benchmark_evidence_receipt_id=benchmark_evidence_receipt_id,
+        policy=policy,
+        promotion_evidence_receipt=promotion_evidence,
+        rejection_reasons=rejection_reasons,
+    )
+
+
 def _find_candidate_evidence(
     benchmark_run_receipt: ModelCombinationBenchmarkRunReceipt,
     candidate_id: str,
@@ -237,11 +371,44 @@ def _benchmark_run_projection(receipt: ModelCombinationBenchmarkRunReceipt) -> d
     }
 
 
+def _mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name}_missing")
+    return value
+
+
+def _list(value: Any) -> tuple[Any, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return (value,)
+
+
 def _required(name: str, value: Any) -> str:
     cleaned = str(value).strip()
     if not cleaned:
         raise ValueError(f"missing_{name}")
     return cleaned
+
+
+def _optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    return int(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    return float(value)
 
 
 def _threshold(value: float) -> float:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_promotion_gate.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_promotion_gate.py
@@ -22,6 +22,7 @@ from modules.ai_intelligence.ai_gateway.src.model_promotion_gate import (
     ModelPromotionGateDecision,
     ModelPromotionPolicy,
     evaluate_model_promotion_gate,
+    rehydrate_model_promotion_gate_receipt,
 )
 
 
@@ -254,6 +255,59 @@ def test_gate_digest_is_stable_and_binds_signed_receipt():
 
     assert first.receipt_id == second.receipt_id
     assert first.receipt_id != changed.receipt_id
+
+
+def test_rehydrate_promotion_gate_receipt_round_trips_champion_and_challenger():
+    champion = evaluate_model_promotion_gate(
+        benchmark_run_receipt=_benchmark(),
+        policy=_policy(_benchmark()),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+    challenger_run = _benchmark(verifier=_rejecting_verifier)
+    challenger = evaluate_model_promotion_gate(
+        benchmark_run_receipt=challenger_run,
+        policy=_policy(challenger_run),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+    hydrated_champion = rehydrate_model_promotion_gate_receipt(champion.to_dict())
+    hydrated_challenger = rehydrate_model_promotion_gate_receipt(challenger.to_dict())
+
+    assert hydrated_champion.receipt_id == champion.receipt_id
+    assert hydrated_champion.promotion_evidence_receipt is not None
+    assert hydrated_challenger.receipt_id == challenger.receipt_id
+    assert hydrated_challenger.decision == ModelPromotionGateDecision.KEEP_CHALLENGER
+
+
+def test_rehydrate_promotion_gate_rejects_tampering_and_inconsistent_evidence():
+    receipt = evaluate_model_promotion_gate(
+        benchmark_run_receipt=_benchmark(),
+        policy=_policy(_benchmark()),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    ).to_dict()
+
+    tampered_id = dict(receipt)
+    tampered_id["benchmark_run_receipt_id"] = "model_combination_benchmark_run_projection:tampered"
+    missing_evidence = dict(receipt)
+    missing_evidence["promotion_evidence_receipt"] = None
+    mismatched_evidence = dict(receipt)
+    mismatched_evidence["promotion_evidence_receipt"] = dict(receipt["promotion_evidence_receipt"])
+    mismatched_evidence["promotion_evidence_receipt"]["model_id"] = "provider/other"
+
+    for payload, expected in (
+        (tampered_id, "promotion_gate_receipt_id_mismatch"),
+        (missing_evidence, "promotion_evidence_missing"),
+        (mismatched_evidence, "promotion_evidence_receipt_id_mismatch"),
+    ):
+        try:
+            rehydrate_model_promotion_gate_receipt(payload)
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError("tampered promotion gate receipt was accepted")
 
 
 def test_promotion_gate_module_has_no_network_command_or_runtime_binding_imports():


### PR DESCRIPTION
## Slice
MODEL_PROMOTION_GATE_RECEIPT_REHYDRATION_PHASE1

## WSP_97 Truth Boundary
- OBSERVED: AutoResearch artifact/runtime supply would need to consume serialized promotion-gate receipts.
- IMPLEMENTED: serialized promotion policies, promotion evidence receipts, and promotion gate receipts can now be rehydrated with deterministic ID recomputation.
- IMPLEMENTED: champion gate receipts require embedded promotion evidence; tampered bodies, missing evidence, and mismatched evidence reject before planning.
- SPECIFIED_NOT_IMPLEMENTED: no artifact supply, provider call, benchmark execution, model promotion, catalog mutation, PatternMemory write, HoloIndex re-index, or runtime default binding.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_promotion_gate.py modules/ai_intelligence/ai_gateway/tests/test_model_promotion_gate.py ...` -> PASS
- `pytest modules/ai_intelligence/ai_gateway/tests/test_model_promotion_gate.py -q` -> 11 passed
- model-intelligence cluster -> 95 passed
- full AI gateway tests -> 104 passed
- `git diff --check` -> PASS before commit
- staged added-line ASCII check -> 0 non-ASCII

## Boundary
This is a receipt-integrity prerequisite for later AutoResearch artifact supply. It does not run or select models.