### PR TITLE
feat(ai-gateway): supply model autoresearch plan artifacts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,42 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Plan Artifact Supply
+
+**Who:** 0102 Codex
+**Type:** Artifact Supply
+**Slice:** MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_PHASE1
+
+**What:** Added an artifact supplier that materializes a
+`ModelAutoResearchPlanReceipt` from serialized promotion-gate receipts,
+benchmark candidates, policy, and optional model-feedback records.
+
+**Why:** Verified model feedback now reaches the AutoResearch planner, but the
+resident runtime needs an outside-repo artifact seam before future benchmark
+campaign execution can consume it. This supplier validates serialized evidence
+and writes a single plan receipt without running benchmarks or mutating runtime
+defaults.
+
+**Files:**
+- `src/model_autoresearch_plan_artifact_supply.py` - rehydrates promotion-gate
+  receipts, validates candidate topology, consumes optional feedback records,
+  and writes an outside-repo plan JSON atomically.
+- `tests/test_model_autoresearch_plan_artifact_supply.py` - validates accepted
+  supply, inside-repo output rejection, tampered gate/candidate rejection,
+  malformed feedback rejection, and no provider/network/runtime imports.
+
+**Truth Boundary:**
+- IMPLEMENTED: serialized promotion-gate receipts and benchmark candidates can
+  produce a digest-bound AutoResearch plan artifact.
+- IMPLEMENTED: output is denied inside the repository and feedback records
+  remain planner-only signals.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  catalog mutation, PatternMemory writes, HoloIndex re-indexing, runtime model
+  default binding, or resident `main.py` preflight wiring.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model Promotion Gate Receipt Rehydration
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_plan_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_plan_artifact_supply.py
@@ -1,0 +1,293 @@
+"""AutoResearch plan artifact supplier for model intelligence.
+
+This module materializes a ``ModelAutoResearchPlanReceipt`` from already-built
+promotion-gate receipts, benchmark candidates, policy, and optional
+model-feedback ledger records. It does not call providers, run benchmarks,
+promote models, mutate catalogs, write PatternMemory, re-index HoloIndex, or
+bind runtime defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .model_champion_challenger_autoresearch import (
+    ModelAutoResearchPolicy,
+    ModelAutoResearchPlanReceipt,
+    plan_model_champion_challenger_autoresearch,
+)
+from .model_combination_benchmark_harness import (
+    ModelBenchmarkCandidate,
+    ModelBenchmarkRoleAssignment,
+    build_model_benchmark_candidate,
+)
+from .model_promotion_gate import (
+    ModelPromotionGateReceipt,
+    rehydrate_model_promotion_gate_receipt,
+)
+
+
+MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT = "MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT"
+MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT = "MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT"
+
+
+class ModelAutoResearchPlanArtifactSupplyReason:
+    PROMOTION_GATES_MISSING = "model_autoresearch_promotion_gates_missing"
+    PROMOTION_GATES_INVALID = "model_autoresearch_promotion_gates_invalid"
+    CANDIDATE_POOL_MISSING = "model_autoresearch_candidate_pool_missing"
+    CANDIDATE_POOL_INVALID = "model_autoresearch_candidate_pool_invalid"
+    POLICY_INVALID = "model_autoresearch_policy_invalid"
+    FEEDBACK_RECORDS_INVALID = "model_autoresearch_feedback_records_invalid"
+    OUTPUT_PATH_INVALID = "model_autoresearch_output_path_invalid"
+    OUTPUT_WRITE_FAILED = "model_autoresearch_output_write_failed"
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchPlanArtifactSupplyResult:
+    accepted: bool
+    status: str
+    plan_receipt_id: str | None
+    output_path: str | None
+    source_gate_receipt_ids: tuple[str, ...]
+    source_feedback_record_ids: tuple[str, ...]
+    campaign_item_count: int
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_plan_artifact_supply(
+    *,
+    repo_root: Path | str,
+    promotion_gate_receipts: Sequence[Mapping[str, Any] | ModelPromotionGateReceipt],
+    candidate_pool: Sequence[Mapping[str, Any] | ModelBenchmarkCandidate],
+    policy: Mapping[str, Any] | ModelAutoResearchPolicy,
+    output_path: Path | str | None,
+    feedback_records: Sequence[Mapping[str, Any]] = (),
+) -> ModelAutoResearchPlanArtifactSupplyResult:
+    """Verify inputs, plan AutoResearch campaigns, and write one plan receipt."""
+
+    root = Path(repo_root).resolve()
+    reasons: list[str] = []
+    gates: tuple[ModelPromotionGateReceipt, ...] = ()
+    candidates: tuple[ModelBenchmarkCandidate, ...] = ()
+    normalized_policy: ModelAutoResearchPolicy | None = None
+
+    try:
+        gates = _promotion_gate_receipts(promotion_gate_receipts)
+    except Exception:
+        reasons.append(ModelAutoResearchPlanArtifactSupplyReason.PROMOTION_GATES_INVALID)
+    if not promotion_gate_receipts:
+        reasons.append(ModelAutoResearchPlanArtifactSupplyReason.PROMOTION_GATES_MISSING)
+
+    try:
+        candidates = _candidate_pool(candidate_pool)
+    except Exception:
+        reasons.append(ModelAutoResearchPlanArtifactSupplyReason.CANDIDATE_POOL_INVALID)
+    if not candidate_pool:
+        reasons.append(ModelAutoResearchPlanArtifactSupplyReason.CANDIDATE_POOL_MISSING)
+
+    try:
+        normalized_policy = _policy(policy)
+    except Exception:
+        reasons.append(ModelAutoResearchPlanArtifactSupplyReason.POLICY_INVALID)
+
+    resolved_output, output_reasons = _runtime_output_path(
+        output_path,
+        root,
+        ModelAutoResearchPlanArtifactSupplyReason.OUTPUT_PATH_INVALID,
+    )
+    reasons.extend(output_reasons)
+
+    if not reasons:
+        assert normalized_policy is not None
+        try:
+            plan = plan_model_champion_challenger_autoresearch(
+                promotion_gate_receipts=gates,
+                candidate_pool=candidates,
+                policy=normalized_policy,
+                feedback_records=feedback_records,
+            )
+        except Exception:
+            reasons.append(ModelAutoResearchPlanArtifactSupplyReason.FEEDBACK_RECORDS_INVALID)
+            plan = None
+    else:
+        plan = None
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert plan is not None
+    assert resolved_output is not None
+    try:
+        _write_json_atomic(resolved_output, plan.to_dict())
+    except Exception:
+        return _reject((ModelAutoResearchPlanArtifactSupplyReason.OUTPUT_WRITE_FAILED,))
+    return ModelAutoResearchPlanArtifactSupplyResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT,
+        plan_receipt_id=plan.receipt_id,
+        output_path=str(resolved_output),
+        source_gate_receipt_ids=plan.source_gate_receipt_ids,
+        source_feedback_record_ids=plan.source_feedback_record_ids,
+        campaign_item_count=len(plan.campaign_items),
+        rejection_reasons=(),
+    )
+
+
+def _promotion_gate_receipts(
+    values: Sequence[Mapping[str, Any] | ModelPromotionGateReceipt],
+) -> tuple[ModelPromotionGateReceipt, ...]:
+    receipts: list[ModelPromotionGateReceipt] = []
+    for value in values:
+        if isinstance(value, ModelPromotionGateReceipt):
+            receipts.append(value)
+        elif isinstance(value, Mapping):
+            receipts.append(rehydrate_model_promotion_gate_receipt(value))
+        else:
+            raise ValueError("invalid_promotion_gate_receipt")
+    return tuple(receipts)
+
+
+def _candidate_pool(
+    values: Sequence[Mapping[str, Any] | ModelBenchmarkCandidate],
+) -> tuple[ModelBenchmarkCandidate, ...]:
+    candidates: list[ModelBenchmarkCandidate] = []
+    for value in values:
+        if isinstance(value, ModelBenchmarkCandidate):
+            candidates.append(value)
+        elif isinstance(value, Mapping):
+            candidates.append(_candidate(value))
+        else:
+            raise ValueError("invalid_candidate")
+    return tuple(candidates)
+
+
+def _candidate(value: Mapping[str, Any]) -> ModelBenchmarkCandidate:
+    if value.get("schema_version") != "model_benchmark_candidate.v1":
+        raise ValueError("invalid_candidate_schema")
+    role_values = value.get("role_assignments")
+    if not isinstance(role_values, list) or not role_values:
+        raise ValueError("missing_candidate_roles")
+    roles: list[ModelBenchmarkRoleAssignment] = []
+    for item in role_values:
+        if not isinstance(item, Mapping):
+            raise ValueError("invalid_candidate_role")
+        roles.append(
+            ModelBenchmarkRoleAssignment(
+                role=_required(item.get("role"), "role"),
+                model_id=_required(item.get("model_id"), "model_id"),
+                provider=_required(item.get("provider"), "provider"),
+            )
+        )
+    candidate = build_model_benchmark_candidate(roles)
+    if candidate.candidate_id != _required(value.get("candidate_id"), "candidate_id"):
+        raise ValueError("candidate_id_mismatch")
+    if candidate.topology_digest != _required(value.get("topology_digest"), "topology_digest"):
+        raise ValueError("candidate_topology_digest_mismatch")
+    return candidate
+
+
+def _policy(value: Mapping[str, Any] | ModelAutoResearchPolicy) -> ModelAutoResearchPolicy:
+    if isinstance(value, ModelAutoResearchPolicy):
+        return value.normalized()
+    if not isinstance(value, Mapping):
+        raise ValueError("policy_not_mapping")
+    if value.get("schema_version") not in (None, "model_autoresearch_policy.v1"):
+        raise ValueError("invalid_policy_schema")
+    return ModelAutoResearchPolicy(
+        task_family=_required(value.get("task_family"), "task_family"),
+        catalog_snapshot_id=_required(value.get("catalog_snapshot_id"), "catalog_snapshot_id"),
+        max_campaign_items=int(value.get("max_campaign_items") or 3),
+        rebenchmark_challengers=bool(value.get("rebenchmark_challengers", True)),
+        required_verifier_digest=_optional(value.get("required_verifier_digest")),
+        cost_budget_receipt_id=_optional(value.get("cost_budget_receipt_id")),
+    ).normalized()
+
+
+def _runtime_output_path(
+    value: Path | str | None,
+    repo_root: Path,
+    reason: str,
+) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root)
+        return None, [reason]
+    except ValueError:
+        pass
+    return resolved, []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _required(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(name + "_missing")
+    return text
+
+
+def _optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _reject(reasons: Sequence[str]) -> ModelAutoResearchPlanArtifactSupplyResult:
+    return ModelAutoResearchPlanArtifactSupplyResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT,
+        plan_receipt_id=None,
+        output_path=None,
+        source_gate_receipt_ids=(),
+        source_feedback_record_ids=(),
+        campaign_item_count=0,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT",
+    "MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT",
+    "ModelAutoResearchPlanArtifactSupplyReason",
+    "ModelAutoResearchPlanArtifactSupplyResult",
+    "run_reddog_model_autoresearch_plan_artifact_supply",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py
@@ -1,0 +1,265 @@
+"""Tests for model AutoResearch plan artifact supply."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply import (
+    MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT,
+    MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT,
+    ModelAutoResearchPlanArtifactSupplyReason,
+    run_reddog_model_autoresearch_plan_artifact_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+    build_model_benchmark_candidate,
+    run_model_combination_benchmark,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+)
+from modules.ai_intelligence.ai_gateway.src.model_promotion_gate import (
+    ModelPromotionPolicy,
+    evaluate_model_promotion_gate,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_plan_artifact_supply.py"
+)
+
+
+def _candidate(model_id: str):
+    return build_model_benchmark_candidate(
+        (ModelBenchmarkRoleAssignment(role="principal", model_id=model_id, provider="provider"),)
+    )
+
+
+def _tasks():
+    return (
+        ModelBenchmarkTask(
+            task_id="task-001",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-a",
+            expected_output_digest="sha256:expected-a",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+        ModelBenchmarkTask(
+            task_id="task-002",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-b",
+            expected_output_digest="sha256:expected-b",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+    )
+
+
+def _runner(task, candidate):
+    return ModelBenchmarkTaskOutput(
+        output_digest=f"sha256:output:{candidate.candidate_id}:{task.task_id}",
+        runner_receipt_id=f"runner:{candidate.candidate_id}:{task.task_id}",
+        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=5, cost_estimate_usd=0.01),
+    )
+
+
+def _verifier(pass_all: bool):
+    def verifier(task, candidate, output):
+        if pass_all or task.task_id == "task-001":
+            return ModelBenchmarkVerifierResult(
+                decision=VerifierDecision.ACCEPT,
+                verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+                evidence_correct=True,
+            )
+        return ModelBenchmarkVerifierResult(
+            decision=VerifierDecision.REJECT,
+            verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+            evidence_correct=False,
+            rejection_reasons=("bad_claim",),
+        )
+
+    return verifier
+
+
+def _gate(candidate_id: str, *, pass_all: bool):
+    candidate = _candidate(candidate_id)
+    run = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_runner,
+        verifier=_verifier(pass_all),
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    policy = ModelPromotionPolicy(
+        task_family="architecture",
+        candidate_id=candidate_id,
+        min_verifier_pass_rate=0.9,
+        min_sample_count=2,
+        required_task_set_digest=run.task_set_digest,
+        required_held_out_split_digest=run.held_out_split_digest,
+        required_verifier_digest=run.verifier_digest,
+    )
+    return evaluate_model_promotion_gate(
+        benchmark_run_receipt=run,
+        policy=policy,
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+    )
+
+
+def _policy():
+    return {
+        "schema_version": "model_autoresearch_policy.v1",
+        "task_family": "architecture",
+        "catalog_snapshot_id": "model_catalog_snapshot:1",
+        "max_campaign_items": 3,
+        "required_verifier_digest": "sha256:verifier",
+        "cost_budget_receipt_id": "cost_budget:1",
+    }
+
+
+def _feedback_record(model_id: str) -> dict:
+    return {
+        "record_type": "model_selection_outcome_feedback",
+        "schema_version": "model_feedback_ledger_record.v1",
+        "feedback_record_id": "model_feedback_runtime",
+        "outcome_receipt_id": "model_selection_outcome_receipt:runtime",
+        "selection_receipt_id": "model_selection_receipt:runtime",
+        "catalog_snapshot_id": "model_catalog_snapshot:1",
+        "task_family": "architecture",
+        "selected_model_ids": [model_id],
+        "verification_receipt_ids": ["verify:runtime"],
+        "source_ratchet_id": "outcome_ratchet_runtime",
+        "source_ratchet_digest": "sha256:" + "1" * 64,
+    }
+
+
+def test_supplier_writes_plan_from_serialized_inputs_and_feedback(tmp_path: Path):
+    challenger = _gate("provider/challenger", pass_all=False)
+    output = tmp_path / "runtime" / "autoresearch_plan.json"
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts=(challenger.to_dict(),),
+        candidate_pool=(
+            _candidate("provider/challenger").to_dict(),
+            _candidate("provider/new").to_dict(),
+        ),
+        policy=_policy(),
+        feedback_records=(_feedback_record("provider/new"),),
+        output_path=output,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT
+    assert result.plan_receipt_id and result.plan_receipt_id.startswith("model_autoresearch_plan:")
+    assert result.source_gate_receipt_ids == (challenger.receipt_id,)
+    assert result.source_feedback_record_ids == ("model_feedback_runtime",)
+    assert result.no_model_call_performed is True
+    assert result.no_benchmark_run_performed is True
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["receipt_id"] == result.plan_receipt_id
+    assert payload["campaign_items"][0]["candidate_id"] == "provider/new"
+    assert payload["campaign_items"][0]["reason"] == "verified_runtime_feedback_unbenchmarked_candidate"
+
+
+def test_supplier_rejects_inside_repo_output_without_writing():
+    challenger = _gate("provider/challenger", pass_all=False)
+    output = REPO_ROOT / "autoresearch_plan.json"
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts=(challenger.to_dict(),),
+        candidate_pool=(_candidate("provider/challenger").to_dict(),),
+        policy=_policy(),
+        output_path=output,
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT
+    assert ModelAutoResearchPlanArtifactSupplyReason.OUTPUT_PATH_INVALID in result.rejection_reasons
+    assert not output.exists()
+
+
+def test_supplier_rejects_tampered_gate_and_candidate(tmp_path: Path):
+    gate = _gate("provider/challenger", pass_all=False).to_dict()
+    gate["benchmark_run_receipt_id"] = "tampered"
+    candidate = _candidate("provider/challenger").to_dict()
+    tampered_candidate = dict(candidate)
+    tampered_candidate["topology_digest"] = "sha256:tampered"
+
+    bad_gate = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts=(gate,),
+        candidate_pool=(candidate,),
+        policy=_policy(),
+        output_path=tmp_path / "gate.json",
+    )
+    bad_candidate = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts=(_gate("provider/challenger", pass_all=False).to_dict(),),
+        candidate_pool=(tampered_candidate,),
+        policy=_policy(),
+        output_path=tmp_path / "candidate.json",
+    )
+
+    assert ModelAutoResearchPlanArtifactSupplyReason.PROMOTION_GATES_INVALID in bad_gate.rejection_reasons
+    assert ModelAutoResearchPlanArtifactSupplyReason.CANDIDATE_POOL_INVALID in bad_candidate.rejection_reasons
+    assert not (tmp_path / "gate.json").exists()
+    assert not (tmp_path / "candidate.json").exists()
+
+
+def test_supplier_rejects_feedback_record_that_fails_planner_validation(tmp_path: Path):
+    challenger = _gate("provider/challenger", pass_all=False)
+    feedback = _feedback_record("provider/new")
+    feedback["source_ratchet_digest"] = "not-a-digest"
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts=(challenger.to_dict(),),
+        candidate_pool=(_candidate("provider/new").to_dict(),),
+        policy=_policy(),
+        feedback_records=(feedback,),
+        output_path=tmp_path / "plan.json",
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_REJECT
+    assert ModelAutoResearchPlanArtifactSupplyReason.FEEDBACK_RECORDS_INVALID in result.rejection_reasons
+    assert not (tmp_path / "plan.json").exists()
+
+
+def test_supplier_module_has_no_provider_network_command_runtime_or_holoindex_imports():
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Slice
MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_PHASE1

## WSP_97 Truth Boundary
- OBSERVED: model feedback records now influence AutoResearch planning only as bounded priority signals.
- OBSERVED: promotion-gate receipts can now be rehydrated and digest-checked before planning.
- IMPLEMENTED: a bounded artifact supplier materializes one `ModelAutoResearchPlanReceipt` from serialized promotion gates, benchmark candidates, policy, and optional feedback records.
- IMPLEMENTED: output path must be outside the repo and writes atomically.
- IMPLEMENTED: tampered gate receipts, candidate topology mismatches, malformed feedback records, missing inputs, and inside-repo outputs fail closed.
- SPECIFIED_NOT_IMPLEMENTED: no provider calls, benchmark execution, model promotion, catalog mutation, PatternMemory write, HoloIndex re-index, runtime model default binding, or resident `main.py` preflight wiring.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_plan_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py` -> PASS
- `pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py -q` -> 5 passed
- model-intelligence cluster -> 100 passed
- full AI gateway tests -> 109 passed
- `git diff --check` -> PASS before commit
- staged added-line ASCII check -> 0 non-ASCII

## Boundary
This is an artifact-supply bridge only. It makes verified feedback/planning available as JSON without executing benchmarks or changing runtime model selection.