### PR TITLE
feat(ai-gateway): bootstrap model autoresearch plan supply

### DIFF
--- a/main.py
+++ b/main.py
@@ -1603,12 +1603,19 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=0              Materialize determination/Memex from AgentDB cycle
         REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=0             Materialize model selection receipt from signed evidence
         REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY=0       Materialize runtime binding receipt from signed evidence
+        REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY=0     Materialize model AutoResearch plan from verified receipts
+        REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
         REDDOG_MODEL_BENCHMARK_EVIDENCE_RECEIPTS_PATH        Outside-repo benchmark evidence receipts JSON
         REDDOG_MODEL_PROMOTION_EVIDENCE_RECEIPTS_PATH        Outside-repo promotion evidence receipts JSON
         REDDOG_MODEL_RUNTIME_BINDING_POLICY_PATH             Outside-repo runtime binding policy JSON
+        REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH Outside-repo promotion gate receipts JSON
+        REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH        Outside-repo benchmark candidate pool JSON
+        REDDOG_MODEL_AUTORESEARCH_POLICY_PATH                Outside-repo AutoResearch policy JSON
+        REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH      Optional outside-repo feedback JSON/JSONL
+        REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH          Outside-repo AutoResearch plan output JSON
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY=0 Materialize principal/snapshot from GitHub probe
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY_ENFORCED=0 Block startup if rejected
@@ -1658,6 +1665,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         os.environ,
         repo_root,
         "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH",
+    )
+    model_autoresearch_plan_receipt_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH",
     )
     model_runtime_binding_receipt_path_supplied = bool(
         os.getenv("REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH", "").strip()
@@ -1834,6 +1846,62 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print(
                 "[REDDOG-MODEL-RUNTIME-BINDING] Startup blocked by "
                 "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY_ENFORCED=1"
+            )
+            return False
+
+    autoresearch_supply_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY",
+    )
+    autoresearch_supply_enforced = (
+        os.getenv("REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
+    )
+    if autoresearch_supply_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply_bootstrap import (
+                run_reddog_model_autoresearch_plan_artifact_supply_bootstrap,
+            )
+
+            autoresearch_supply = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+                repo_root=repo_root,
+                promotion_gate_receipts_path=os.getenv(
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH",
+                    "",
+                )
+                or None,
+                candidate_pool_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH", "") or None,
+                policy_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_POLICY_PATH", "") or None,
+                feedback_records_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH", "") or None,
+                output_path=model_autoresearch_plan_receipt_path,
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-AUTORESEARCH] Startup artifact supply failed: {exc}")
+            if autoresearch_supply_enforced:
+                print(f"[REDDOG-MODEL-AUTORESEARCH] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-AUTORESEARCH] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        autoresearch_status = "PASS" if autoresearch_supply.accepted else "WARN"
+        autoresearch_reasons = (
+            ",".join(autoresearch_supply.rejection_reasons)
+            if autoresearch_supply.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-AUTORESEARCH] preflight={autoresearch_status} "
+            f"status={autoresearch_supply.status} "
+            f"receipt={autoresearch_supply.plan_receipt_id or '(none)'} "
+            f"campaign_items={autoresearch_supply.campaign_item_count} "
+            f"reasons={autoresearch_reasons}"
+        )
+        if autoresearch_supply.accepted and autoresearch_supply.output_path:
+            model_autoresearch_plan_receipt_path = autoresearch_supply.output_path
+            os.environ["REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH"] = model_autoresearch_plan_receipt_path
+        elif autoresearch_supply_enforced:
+            print(
+                "[REDDOG-MODEL-AUTORESEARCH] Startup blocked by "
+                "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=1"
             )
             return False
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,43 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Plan Artifact Supply Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Artifact Bootstrap
+**Slice:** REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**What:** Added an opt-in main-startup bootstrap for materializing a
+`ModelAutoResearchPlanReceipt` from outside-repo promotion-gate receipts,
+benchmark candidates, AutoResearch policy, and optional model-feedback records.
+
+**Why:** The resident RedDog path can now produce verified model feedback and
+promotion evidence, but future benchmark campaigns need a governed artifact
+handoff before any AutoResearch execution slice runs. This bridges the landed
+planner into preflight while preserving read-only, no-benchmark behavior.
+
+**Files:**
+- `src/model_autoresearch_plan_artifact_supply_bootstrap.py` - reads
+  outside-repo JSON/JSONL inputs, invokes the landed plan supplier, and returns
+  an explicit applied/not-ready bootstrap receipt.
+- `tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py` - verifies
+  JSONL feedback, optional feedback omission, inside-repo rejection, tamper
+  rejection, and no provider/network/runtime imports.
+- `main.py` - adds the opt-in
+  `REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY` preflight hook.
+
+**Truth Boundary:**
+- IMPLEMENTED: configured outside-repo artifacts can materialize a
+  digest-bound AutoResearch plan receipt during startup preflight.
+- IMPLEMENTED: the hook is opt-in, fail-closed when enforced, and propagates
+  only the output receipt path after successful supply.
+- NOT IMPLEMENTED: benchmark execution, model promotion, runtime model binding,
+  PatternMemory writes, HoloIndex re-indexing, provider calls, worker dispatch,
+  or automatic resident campaign execution.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Plan Artifact Supply
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_plan_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_plan_artifact_supply_bootstrap.py
@@ -1,0 +1,261 @@
+"""Main-startup bootstrap for model AutoResearch plan artifact supply.
+
+Slice: REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads outside-repo runtime JSON inputs and materializes a
+``ModelAutoResearchPlanReceipt`` from already verified promotion-gate receipts,
+benchmark candidates, policy, and optional model-feedback records.
+
+It does not call models, run benchmarks, promote models, mutate catalogs, write
+PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers, execute
+commands, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply import (
+    MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT,
+    run_reddog_model_autoresearch_plan_artifact_supply,
+)
+
+
+MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED = (
+    "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED"
+)
+MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY = (
+    "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY"
+)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchPlanArtifactBootstrapResult:
+    accepted: bool
+    status: str
+    plan_receipt_id: Optional[str]
+    output_path: Optional[str]
+    source_gate_receipt_ids: tuple[str, ...]
+    source_feedback_record_ids: tuple[str, ...]
+    campaign_item_count: int
+    rejection_reasons: tuple[str, ...]
+    no_model_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    promotion_gate_receipts_path: Path | str | None,
+    candidate_pool_path: Path | str | None,
+    policy_path: Path | str | None,
+    output_path: Path | str | None,
+    feedback_records_path: Path | str | None = None,
+) -> ModelAutoResearchPlanArtifactBootstrapResult:
+    """Materialize an AutoResearch plan artifact from configured runtime files."""
+
+    root = Path(repo_root).resolve()
+    promotion_payload, promotion_reasons = _read_json_outside_repo(
+        root,
+        promotion_gate_receipts_path,
+        missing_reason="missing_model_autoresearch_promotion_gate_receipts_path",
+        inside_reason="model_autoresearch_promotion_gate_receipts_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_promotion_gate_receipts",
+    )
+    candidate_payload, candidate_reasons = _read_json_outside_repo(
+        root,
+        candidate_pool_path,
+        missing_reason="missing_model_autoresearch_candidate_pool_path",
+        inside_reason="model_autoresearch_candidate_pool_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_candidate_pool",
+    )
+    policy, policy_reasons = _read_json_outside_repo(
+        root,
+        policy_path,
+        missing_reason="missing_model_autoresearch_policy_path",
+        inside_reason="model_autoresearch_policy_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_policy",
+    )
+    feedback_records, feedback_reasons = _read_feedback_records_outside_repo(
+        root,
+        feedback_records_path,
+        inside_reason="model_autoresearch_feedback_records_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_feedback_records",
+    )
+    reasons = [
+        *promotion_reasons,
+        *candidate_reasons,
+        *policy_reasons,
+        *feedback_reasons,
+        *_output_path_reasons(root, output_path),
+    ]
+
+    promotion_gate_receipts = _mapping_list(promotion_payload, "promotion_gate_receipts")
+    candidate_pool = _mapping_list(candidate_payload, "candidate_pool")
+    if promotion_payload is not None and promotion_gate_receipts is None:
+        reasons.append("malformed_model_autoresearch_promotion_gate_receipts")
+    if candidate_payload is not None and candidate_pool is None:
+        reasons.append("malformed_model_autoresearch_candidate_pool")
+    if policy is not None and not isinstance(policy, Mapping):
+        reasons.append("malformed_model_autoresearch_policy")
+    if reasons:
+        return _not_ready(reasons)
+
+    assert promotion_gate_receipts is not None
+    assert candidate_pool is not None
+    assert policy is not None
+    supply = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=root,
+        promotion_gate_receipts=promotion_gate_receipts,
+        candidate_pool=candidate_pool,
+        policy=policy,
+        output_path=output_path,
+        feedback_records=feedback_records,
+    )
+    if not supply.accepted or supply.status != MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT:
+        return _not_ready(supply.rejection_reasons or ("model_autoresearch_plan_artifact_supply_rejected",))
+    return ModelAutoResearchPlanArtifactBootstrapResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED,
+        plan_receipt_id=supply.plan_receipt_id,
+        output_path=supply.output_path,
+        source_gate_receipt_ids=supply.source_gate_receipt_ids,
+        source_feedback_record_ids=supply.source_feedback_record_ids,
+        campaign_item_count=supply.campaign_item_count,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _read_feedback_records_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[tuple[Mapping[str, Any], ...], tuple[str, ...]]:
+    if not value:
+        return (), ()
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return (), (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return (), ("missing_model_autoresearch_feedback_records_path",)
+    try:
+        if resolved.suffix.lower() == ".jsonl":
+            records = []
+            for raw_line in resolved.read_text(encoding="utf-8").splitlines():
+                line = raw_line.strip()
+                if not line:
+                    continue
+                item = json.loads(line)
+                if not isinstance(item, Mapping):
+                    return (), (malformed_reason,)
+                records.append(item)
+            return tuple(records), ()
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return (), (malformed_reason,)
+    records = _mapping_list(payload, "feedback_records")
+    if records is None:
+        return (), (malformed_reason,)
+    return records, ()
+
+
+def _mapping_list(value: Any, key: str) -> tuple[Mapping[str, Any], ...] | None:
+    raw = value
+    if isinstance(value, Mapping):
+        raw = value.get(key)
+    if not isinstance(raw, list):
+        return None
+    records: list[Mapping[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            return None
+        records.append(item)
+    return tuple(records)
+
+
+def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str, ...]:
+    if not value:
+        return ("model_autoresearch_output_path_invalid",)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return ("model_autoresearch_output_path_invalid",)
+    return ()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: tuple[str, ...] | list[str],
+) -> ModelAutoResearchPlanArtifactBootstrapResult:
+    return ModelAutoResearchPlanArtifactBootstrapResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY,
+        plan_receipt_id=None,
+        output_path=None,
+        source_gate_receipt_ids=(),
+        source_feedback_record_ids=(),
+        campaign_item_count=0,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED",
+    "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY",
+    "ModelAutoResearchPlanArtifactBootstrapResult",
+    "run_reddog_model_autoresearch_plan_artifact_supply_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py
@@ -1,0 +1,204 @@
+"""Tests for REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply_bootstrap import (
+    MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED,
+    MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY,
+    run_reddog_model_autoresearch_plan_artifact_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_plan_artifact_supply import (
+    REPO_ROOT,
+    _candidate,
+    _feedback_record,
+    _gate,
+    _policy,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_plan_artifact_supply_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _write_jsonl(root: Path, name: str, records: tuple[dict, ...]) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    return {
+        "gates": _write_json(
+            runtime,
+            "promotion_gates.json",
+            {"promotion_gate_receipts": [_gate("provider/challenger", pass_all=False).to_dict()]},
+        ),
+        "candidates": _write_json(
+            runtime,
+            "candidate_pool.json",
+            {
+                "candidate_pool": [
+                    _candidate("provider/challenger").to_dict(),
+                    _candidate("provider/new").to_dict(),
+                ]
+            },
+        ),
+        "policy": _write_json(runtime, "policy.json", _policy()),
+        "feedback": _write_jsonl(runtime, "feedback.jsonl", (_feedback_record("provider/new"),)),
+        "output": runtime / "autoresearch_plan.json",
+    }
+
+
+def test_bootstrap_materializes_autoresearch_plan_with_jsonl_feedback(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts_path=files["gates"],
+        candidate_pool_path=files["candidates"],
+        policy_path=files["policy"],
+        feedback_records_path=files["feedback"],
+        output_path=files["output"],
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED
+    assert result.plan_receipt_id and result.plan_receipt_id.startswith("model_autoresearch_plan:")
+    assert result.source_feedback_record_ids == ("model_feedback_runtime",)
+    assert result.campaign_item_count == 2
+    assert result.no_model_call_performed is True
+    assert result.no_benchmark_run_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    assert payload["receipt_id"] == result.plan_receipt_id
+    assert any(
+        item["reason"] == "verified_runtime_feedback_unbenchmarked_candidate"
+        for item in payload["campaign_items"]
+    )
+
+
+def test_bootstrap_accepts_missing_optional_feedback_path(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts_path=files["gates"],
+        candidate_pool_path=files["candidates"],
+        policy_path=files["policy"],
+        feedback_records_path=None,
+        output_path=files["output"],
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED
+    assert result.source_feedback_record_ids == ()
+    assert files["output"].exists()
+
+
+def test_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    repo_input = REPO_ROOT / "model_autoresearch_promotion_gates.json"
+    repo_output = REPO_ROOT / "model_autoresearch_plan.json"
+    repo_input.write_text("{}", encoding="utf-8")
+    try:
+        result = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+            repo_root=REPO_ROOT,
+            promotion_gate_receipts_path=repo_input,
+            candidate_pool_path=files["candidates"],
+            policy_path=files["policy"],
+            feedback_records_path=files["feedback"],
+            output_path=repo_output,
+        )
+    finally:
+        repo_input.unlink(missing_ok=True)
+        repo_output.unlink(missing_ok=True)
+
+    assert result.accepted is False
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_promotion_gate_receipts_path_inside_repo" in result.rejection_reasons
+    assert "model_autoresearch_output_path_invalid" in result.rejection_reasons
+
+
+def test_bootstrap_rejects_tampered_gate(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    gate_payload = json.loads(files["gates"].read_text(encoding="utf-8"))
+    gate_payload["promotion_gate_receipts"][0]["receipt_id"] = "tampered"
+    bad_gate_path = _write_json(tmp_path / "runtime", "bad_gates.json", gate_payload)
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts_path=bad_gate_path,
+        candidate_pool_path=files["candidates"],
+        policy_path=files["policy"],
+        feedback_records_path=files["feedback"],
+        output_path=files["output"],
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_promotion_gates_invalid" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_bootstrap_rejects_malformed_feedback_before_planning(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    bad_feedback_path = tmp_path / "runtime" / "bad_feedback.jsonl"
+    bad_feedback_path.write_text('{"ok": true}\nnot-json\n', encoding="utf-8")
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts_path=files["gates"],
+        candidate_pool_path=files["candidates"],
+        policy_path=files["policy"],
+        feedback_records_path=bad_feedback_path,
+        output_path=files["output"],
+    )
+
+    assert result.accepted is False
+    assert result.rejection_reasons == ("malformed_model_autoresearch_feedback_records",)
+    assert not files["output"].exists()
+
+
+def test_bootstrap_module_has_no_execution_network_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -98,6 +98,7 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": "architect_determination.json",
     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": "model_selection_receipt.json",
     "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH": "model_runtime_binding_receipt.json",
+    "REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH": "model_autoresearch_plan_receipt.json",
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": "principal_authority_record.json",
     "REDDOG_PERMISSION_SNAPSHOT_PATH": "permission_snapshot.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -449,6 +449,133 @@ def test_main_preflight_model_runtime_binding_supply_runs_after_model_selection(
     )
 
 
+def test_main_preflight_model_autoresearch_plan_supply_runs_before_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    autoresearch_supply_result = type(
+        "AutoResearchSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED",
+            "plan_receipt_id": "model_autoresearch_plan:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_plan_receipt.json"),
+            "source_gate_receipt_ids": ("model_promotion_gate:1",),
+            "source_feedback_record_ids": ("model_feedback_runtime",),
+            "campaign_item_count": 1,
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply_bootstrap.run_reddog_model_autoresearch_plan_artifact_supply_bootstrap",
+        return_value=autoresearch_supply_result,
+    ) as autoresearch_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH": str(
+                        tmp_path / "promotion_gates.json"
+                    ),
+                    "REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH": str(tmp_path / "candidates.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_POLICY_PATH": str(tmp_path / "autoresearch_policy.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH": str(tmp_path / "feedback.jsonl"),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH"] == str(
+                    runtime_root / "model_autoresearch_plan_receipt.json"
+                )
+
+    autoresearch_supply.assert_called_once()
+    autoresearch_kwargs = autoresearch_supply.call_args.kwargs
+    assert autoresearch_kwargs["promotion_gate_receipts_path"] == str(tmp_path / "promotion_gates.json")
+    assert autoresearch_kwargs["candidate_pool_path"] == str(tmp_path / "candidates.json")
+    assert autoresearch_kwargs["policy_path"] == str(tmp_path / "autoresearch_policy.json")
+    assert autoresearch_kwargs["feedback_records_path"] == str(tmp_path / "feedback.jsonl")
+    assert autoresearch_kwargs["output_path"] == str(runtime_root / "model_autoresearch_plan_receipt.json")
+    promote.assert_called_once()
+
+
+def test_main_preflight_enforced_model_autoresearch_plan_supply_blocks_startup(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    autoresearch_supply_result = type(
+        "AutoResearchSupplyResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_NOT_READY",
+            "plan_receipt_id": None,
+            "output_path": None,
+            "source_gate_receipt_ids": (),
+            "source_feedback_record_ids": (),
+            "campaign_item_count": 0,
+            "rejection_reasons": ("missing_model_autoresearch_policy_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply_bootstrap.run_reddog_model_autoresearch_plan_artifact_supply_bootstrap",
+        return_value=autoresearch_supply_result,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
+                "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+
 def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
﻿## Summary

Adds `REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1`.

This bridges the landed model AutoResearch plan supplier into the RedDog resident startup path as an explicit, opt-in artifact-supply preflight. It reads outside-repo promotion-gate receipts, candidate pool, policy, and optional feedback JSON/JSONL, then materializes one outside-repo `ModelAutoResearchPlanReceipt`.

## Truth Boundary

Implemented:
- outside-repo AutoResearch plan bootstrap module
- optional `main.py` preflight hook behind `REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY`
- profile-derived outside-repo output path for `REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH`
- fail-closed enforced startup behavior
- JSONL model-feedback ledger input support

Not implemented:
- benchmark execution
- model promotion
- runtime model binding
- PatternMemory writes
- HoloIndex re-indexing
- provider/model calls
- worker dispatch
- automatic resident campaign execution

## Validation

- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_plan_artifact_supply_bootstrap.py main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py` -> 11 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 17 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 115 passed
- `git diff --check` -> clean (CRLF informational warnings only)

WSP: 15, 22, 50, 97
