### PR TITLE
feat(ai-gateway): rehydrate autoresearch plan receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,39 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Plan Receipt Rehydration
+
+**Who:** 0102 Codex
+**Type:** Receipt Integrity
+**Slice:** MODEL_AUTORESEARCH_PLAN_RECEIPT_REHYDRATION_PHASE1
+
+**What:** Added rehydration helpers for serialized
+`ModelAutoResearchPolicy` and `ModelAutoResearchPlanReceipt`.
+
+**Why:** Future campaign execution must not trust a serialized AutoResearch
+plan list. Before a runner consumes a plan artifact, the policy, source
+receipts, candidate-pool digest, feedback digest, campaign items, and rejection
+reasons must be recomputed against the original deterministic receipt ID.
+
+**Files:**
+- `src/model_champion_challenger_autoresearch.py` - adds policy and plan
+  rehydration, shared canonical digest body, and constant-time receipt ID
+  comparison.
+- `tests/test_model_champion_challenger_autoresearch.py` - verifies valid
+  round-trip rehydration, digest-bound tamper rejection, and malformed campaign
+  shape rejection.
+
+**Truth Boundary:**
+- IMPLEMENTED: serialized AutoResearch plan receipts can be accepted only after
+  schema and digest rehydration.
+- IMPLEMENTED: policy, source-gate IDs, feedback IDs, pool digest, feedback
+  digest, campaign items, verifier flags, and rejection reasons are covered.
+- NOT IMPLEMENTED: benchmark execution, provider calls, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, or resident campaign execution.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Plan Artifact Supply Bootstrap
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
@@ -8,6 +8,7 @@ bind RedDog runtime defaults.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import asdict, dataclass
 from enum import Enum
@@ -195,16 +196,15 @@ def plan_model_champion_challenger_autoresearch(
                     requires_independent_verifier=False,
                 )
             )
-    body = {
-        "schema_version": AUTORESEARCH_SCHEMA_VERSION,
-        "policy": normalized_policy.to_dict(),
-        "source_gate_receipt_ids": list(source_gate_ids),
-        "source_feedback_record_ids": list(source_feedback_record_ids),
-        "candidate_pool_digest": candidate_pool_digest,
-        "feedback_ledger_digest": feedback_ledger_digest,
-        "campaign_items": [item.to_dict() for item in campaign_items],
-        "rejection_reasons": sorted(set(rejection_reasons)),
-    }
+    body = _plan_digest_body(
+        policy=normalized_policy,
+        source_gate_receipt_ids=source_gate_ids,
+        source_feedback_record_ids=source_feedback_record_ids,
+        candidate_pool_digest=candidate_pool_digest,
+        feedback_ledger_digest=feedback_ledger_digest,
+        campaign_items=tuple(campaign_items),
+        rejection_reasons=tuple(sorted(set(rejection_reasons))),
+    )
     return ModelAutoResearchPlanReceipt(
         receipt_id=_digest_prefixed("model_autoresearch_plan", body),
         policy=normalized_policy,
@@ -214,6 +214,117 @@ def plan_model_champion_challenger_autoresearch(
         feedback_ledger_digest=feedback_ledger_digest,
         campaign_items=tuple(campaign_items),
         rejection_reasons=tuple(sorted(set(rejection_reasons))),
+    )
+
+
+def rehydrate_model_autoresearch_policy(payload: Mapping[str, Any]) -> ModelAutoResearchPolicy:
+    """Rehydrate and normalize a serialized AutoResearch policy."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_autoresearch_policy")
+    if payload.get("schema_version") != AUTORESEARCH_POLICY_SCHEMA_VERSION:
+        raise ValueError("invalid_autoresearch_policy_schema")
+    return ModelAutoResearchPolicy(
+        task_family=_required("task_family", payload.get("task_family")),
+        catalog_snapshot_id=_required("catalog_snapshot_id", payload.get("catalog_snapshot_id")),
+        max_campaign_items=int(payload.get("max_campaign_items") or 3),
+        rebenchmark_challengers=bool(payload.get("rebenchmark_challengers", True)),
+        required_verifier_digest=_optional(payload.get("required_verifier_digest")),
+        cost_budget_receipt_id=_optional(payload.get("cost_budget_receipt_id")),
+    ).normalized()
+
+
+def rehydrate_model_autoresearch_plan_receipt(
+    payload: Mapping[str, Any],
+) -> ModelAutoResearchPlanReceipt:
+    """Rehydrate a serialized AutoResearch plan and verify its receipt digest."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_autoresearch_plan")
+    if payload.get("schema_version") != AUTORESEARCH_SCHEMA_VERSION:
+        raise ValueError("invalid_autoresearch_plan_schema")
+    receipt_id = _required("receipt_id", payload.get("receipt_id"))
+    policy = rehydrate_model_autoresearch_policy(_required_mapping("policy", payload.get("policy")))
+    source_gate_receipt_ids = _string_tuple("source_gate_receipt_ids", payload.get("source_gate_receipt_ids"))
+    source_feedback_record_ids = _string_tuple(
+        "source_feedback_record_ids",
+        payload.get("source_feedback_record_ids"),
+    )
+    candidate_pool_digest = _required("candidate_pool_digest", payload.get("candidate_pool_digest"))
+    feedback_ledger_digest = _required("feedback_ledger_digest", payload.get("feedback_ledger_digest"))
+    campaign_items = tuple(
+        _rehydrate_campaign_item(item)
+        for item in _required_list("campaign_items", payload.get("campaign_items"))
+    )
+    rejection_reasons = tuple(
+        sorted(set(_clean_token(item) for item in _required_list("rejection_reasons", payload.get("rejection_reasons"))))
+    )
+    body = _plan_digest_body(
+        policy=policy,
+        source_gate_receipt_ids=source_gate_receipt_ids,
+        source_feedback_record_ids=source_feedback_record_ids,
+        candidate_pool_digest=candidate_pool_digest,
+        feedback_ledger_digest=feedback_ledger_digest,
+        campaign_items=campaign_items,
+        rejection_reasons=rejection_reasons,
+    )
+    expected = _digest_prefixed("model_autoresearch_plan", body)
+    if not hmac.compare_digest(receipt_id, expected):
+        raise ValueError("model_autoresearch_plan_receipt_id_mismatch")
+    return ModelAutoResearchPlanReceipt(
+        receipt_id=receipt_id,
+        policy=policy,
+        source_gate_receipt_ids=source_gate_receipt_ids,
+        source_feedback_record_ids=source_feedback_record_ids,
+        candidate_pool_digest=candidate_pool_digest,
+        feedback_ledger_digest=feedback_ledger_digest,
+        campaign_items=campaign_items,
+        rejection_reasons=rejection_reasons,
+    )
+
+
+def _plan_digest_body(
+    *,
+    policy: ModelAutoResearchPolicy,
+    source_gate_receipt_ids: Sequence[str],
+    source_feedback_record_ids: Sequence[str],
+    candidate_pool_digest: str,
+    feedback_ledger_digest: str,
+    campaign_items: Sequence[ModelAutoResearchCampaignItem],
+    rejection_reasons: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "schema_version": AUTORESEARCH_SCHEMA_VERSION,
+        "policy": policy.to_dict(),
+        "source_gate_receipt_ids": list(source_gate_receipt_ids),
+        "source_feedback_record_ids": list(source_feedback_record_ids),
+        "candidate_pool_digest": candidate_pool_digest,
+        "feedback_ledger_digest": feedback_ledger_digest,
+        "campaign_items": [item.to_dict() for item in campaign_items],
+        "rejection_reasons": list(rejection_reasons),
+    }
+
+
+def _rehydrate_campaign_item(payload: Any) -> ModelAutoResearchCampaignItem:
+    item = _required_mapping("campaign_item", payload)
+    raw_action = _required("action", item.get("action"))
+    try:
+        action = ModelAutoResearchAction(raw_action)
+    except ValueError as exc:
+        raise ValueError("invalid_autoresearch_campaign_action") from exc
+    priority = _required("priority", item.get("priority"))
+    if priority not in {"P0", "P1", "P2", "P3"}:
+        raise ValueError("invalid_autoresearch_campaign_priority")
+    raw_requires = item.get("requires_independent_verifier")
+    if not isinstance(raw_requires, bool):
+        raise ValueError("invalid_autoresearch_campaign_verifier_flag")
+    return ModelAutoResearchCampaignItem(
+        candidate_id=_required("candidate_id", item.get("candidate_id")),
+        action=action,
+        priority=priority,
+        reason=_clean_token(_required("reason", item.get("reason"))),
+        source_gate_receipt_id=_optional(item.get("source_gate_receipt_id")),
+        requires_independent_verifier=raw_requires,
     )
 
 
@@ -331,6 +442,26 @@ def _required(name: str, value: Any) -> str:
     if not cleaned:
         raise ValueError(f"missing_{name}")
     return cleaned
+
+
+def _required_mapping(name: str, value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _required_list(name: str, value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _string_tuple(name: str, value: Any) -> tuple[str, ...]:
+    raw = _required_list(name, value)
+    records = tuple(_required(name, item) for item in raw)
+    if len(set(records)) != len(records):
+        raise ValueError(f"duplicate_{name}")
+    return records
 
 
 def _optional(value: str | None) -> str | None:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
@@ -9,6 +9,8 @@ from modules.ai_intelligence.ai_gateway.src.model_champion_challenger_autoresear
     ModelAutoResearchAction,
     ModelAutoResearchPolicy,
     plan_model_champion_challenger_autoresearch,
+    rehydrate_model_autoresearch_plan_receipt,
+    rehydrate_model_autoresearch_policy,
 )
 from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
     ModelBenchmarkRoleAssignment,
@@ -181,6 +183,96 @@ def test_autoresearch_uses_feedback_records_as_bounded_priority_signal():
     ]
     assert receipt.campaign_items[0].priority == "P0"
     assert receipt.campaign_items[0].reason == "verified_runtime_feedback_unbenchmarked_candidate"
+
+
+def test_autoresearch_plan_receipt_rehydrates_with_digest_verification():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    feedback = _feedback_record("provider/new", suffix="2")
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger_gate,),
+        candidate_pool=(
+            _candidate("provider/challenger"),
+            _candidate("provider/new"),
+        ),
+        policy=_policy(),
+        feedback_records=(feedback,),
+    )
+
+    rehydrated = rehydrate_model_autoresearch_plan_receipt(receipt.to_dict())
+
+    assert rehydrated == receipt
+    assert rehydrate_model_autoresearch_policy(receipt.policy.to_dict()) == receipt.policy
+
+
+def test_autoresearch_plan_receipt_rejects_tampered_security_fields():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger_gate,),
+        candidate_pool=(
+            _candidate("provider/challenger"),
+            _candidate("provider/new"),
+        ),
+        policy=_policy(),
+    )
+    mutations = []
+
+    policy_tamper = receipt.to_dict()
+    policy_tamper["policy"]["catalog_snapshot_id"] = "model_catalog_snapshot:tampered"
+    mutations.append(policy_tamper)
+
+    source_gate_tamper = receipt.to_dict()
+    source_gate_tamper["source_gate_receipt_ids"] = ["model_promotion_gate:tampered"]
+    mutations.append(source_gate_tamper)
+
+    pool_tamper = receipt.to_dict()
+    pool_tamper["candidate_pool_digest"] = "model_autoresearch_candidate_pool:tampered"
+    mutations.append(pool_tamper)
+
+    feedback_tamper = receipt.to_dict()
+    feedback_tamper["feedback_ledger_digest"] = "model_autoresearch_feedback_ledger:tampered"
+    mutations.append(feedback_tamper)
+
+    campaign_tamper = receipt.to_dict()
+    campaign_tamper["campaign_items"][0]["candidate_id"] = "provider/tampered"
+    mutations.append(campaign_tamper)
+
+    rejection_tamper = receipt.to_dict()
+    rejection_tamper["rejection_reasons"] = ["invented_reason"]
+    mutations.append(rejection_tamper)
+
+    for payload in mutations:
+        try:
+            rehydrate_model_autoresearch_plan_receipt(payload)
+        except ValueError as exc:
+            assert str(exc) == "model_autoresearch_plan_receipt_id_mismatch"
+        else:
+            raise AssertionError("tampered AutoResearch plan receipt was accepted")
+
+
+def test_autoresearch_plan_receipt_rejects_malformed_shape_before_digest_check():
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(_gate("provider/challenger", pass_all=False),),
+        candidate_pool=(_candidate("provider/challenger"),),
+        policy=_policy(),
+    )
+    bad_schema = receipt.to_dict()
+    bad_schema["schema_version"] = "other"
+    bad_action = receipt.to_dict()
+    bad_action["campaign_items"][0]["action"] = "run_provider_live"
+    bad_verifier_flag = receipt.to_dict()
+    bad_verifier_flag["campaign_items"][0]["requires_independent_verifier"] = "true"
+
+    for payload, expected in (
+        (bad_schema, "invalid_autoresearch_plan_schema"),
+        (bad_action, "invalid_autoresearch_campaign_action"),
+        (bad_verifier_flag, "invalid_autoresearch_campaign_verifier_flag"),
+    ):
+        try:
+            rehydrate_model_autoresearch_plan_receipt(payload)
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError(f"expected {expected}")
 
 
 def test_autoresearch_rejects_malformed_or_mismatched_feedback_records():


### PR DESCRIPTION
﻿## Summary

Adds `MODEL_AUTORESEARCH_PLAN_RECEIPT_REHYDRATION_PHASE1`.

This gives future AutoResearch campaign execution a verified way to consume serialized `ModelAutoResearchPlanReceipt` artifacts. The rehydrator checks schema, policy, source gate IDs, feedback IDs, candidate-pool digest, feedback digest, campaign items, verifier flags, rejection reasons, and recomputes the deterministic receipt ID with constant-time comparison.

## Truth Boundary

Implemented:
- `rehydrate_model_autoresearch_policy`
- `rehydrate_model_autoresearch_plan_receipt`
- shared canonical plan digest body between planner and rehydrator
- tests for round-trip, digest-bound tamper rejection, and malformed campaign shape rejection

Not implemented:
- benchmark execution
- provider/model calls
- model promotion
- PatternMemory writes
- HoloIndex re-indexing
- resident campaign execution

## Validation

- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py` -> 13 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 118 passed
- `git diff --check` -> clean (CRLF informational warnings only)

WSP: 15, 22, 50, 97
