### PR TITLE
feat(ai-gateway): execute autoresearch campaign plans

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,43 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Campaign Execution
+
+**Who:** 0102 Codex
+**Type:** Bounded Benchmark Execution
+**Slice:** MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_PHASE1
+
+**What:** Added a bounded AutoResearch campaign executor that consumes a
+rehydrated `ModelAutoResearchPlanReceipt`, validates candidate-pool digest and
+verifier requirements, and runs selected candidates through injected benchmark
+runner/verifier seams.
+
+**Why:** The resident model-intelligence lane can now plan benchmark campaigns,
+but future recursive improvement needs a verified execution receipt before any
+promotion or PatternMemory step. This layer produces that receipt without
+direct provider imports or runtime binding.
+
+**Files:**
+- `src/model_autoresearch_campaign_execution.py` - validates plans,
+  candidates, held-out tasks, verifier digests, and outside-repo output before
+  running the existing benchmark harness.
+- `tests/test_model_autoresearch_campaign_execution.py` - verifies successful
+  execution, tampered plan rejection, candidate-pool mismatch rejection,
+  verifier mismatch rejection, STOP/no-op rejection, inside-repo output denial,
+  and no provider/network/runtime imports.
+
+**Truth Boundary:**
+- IMPLEMENTED: verified AutoResearch plans can produce digest-bound campaign
+  execution receipts through injected runner/verifier seams.
+- IMPLEMENTED: serialized plans, candidate topology, candidate-pool digest,
+  task set, verifier digest, and output path are fail-closed before execution.
+- NOT IMPLEMENTED: live provider calls, model promotion, catalog mutation,
+  PatternMemory writes, HoloIndex re-indexing, RedDog runtime binding, or
+  automatic resident campaign execution.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Plan Receipt Rehydration
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py
@@ -1,0 +1,401 @@
+"""Bounded AutoResearch campaign execution for model intelligence.
+
+This module consumes a verified ``ModelAutoResearchPlanReceipt`` and executes
+the selected benchmark candidates through injected runner/verifier seams. It
+does not import provider SDKs, execute commands, promote models, mutate
+catalogs, write PatternMemory, re-index HoloIndex, or bind runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .model_champion_challenger_autoresearch import (
+    ModelAutoResearchAction,
+    ModelAutoResearchPlanReceipt,
+    rehydrate_model_autoresearch_plan_receipt,
+)
+from .model_combination_benchmark_harness import (
+    BenchmarkRunner,
+    BenchmarkVerifier,
+    ModelBenchmarkCandidate,
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    ModelCombinationBenchmarkRunReceipt,
+    build_model_benchmark_candidate,
+    run_model_combination_benchmark,
+)
+
+
+MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT = "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT"
+MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT = "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT"
+MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION = "model_autoresearch_campaign_execution.v1"
+
+
+class ModelAutoResearchCampaignExecutionReason:
+    PLAN_INVALID = "model_autoresearch_execution_plan_invalid"
+    CANDIDATE_POOL_INVALID = "model_autoresearch_execution_candidate_pool_invalid"
+    CANDIDATE_POOL_DIGEST_MISMATCH = "model_autoresearch_execution_candidate_pool_digest_mismatch"
+    TASKS_INVALID = "model_autoresearch_execution_tasks_invalid"
+    VERIFIER_DIGEST_MISMATCH = "model_autoresearch_execution_verifier_digest_mismatch"
+    NO_EXECUTABLE_CAMPAIGN_ITEMS = "model_autoresearch_execution_no_executable_campaign_items"
+    CAMPAIGN_CANDIDATE_MISSING = "model_autoresearch_execution_campaign_candidate_missing"
+    CAMPAIGN_VERIFIER_REQUIRED = "model_autoresearch_execution_campaign_verifier_required"
+    OUTPUT_PATH_INVALID = "model_autoresearch_execution_output_path_invalid"
+    OUTPUT_WRITE_FAILED = "model_autoresearch_execution_output_write_failed"
+    BENCHMARK_RUN_FAILED = "model_autoresearch_execution_benchmark_run_failed"
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCampaignExecutionReceipt:
+    receipt_id: str
+    source_plan_receipt_id: str
+    benchmark_run_receipt: ModelCombinationBenchmarkRunReceipt
+    executed_candidate_ids: tuple[str, ...]
+    skipped_campaign_candidate_ids: tuple[str, ...]
+    schema_version: str = MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "source_plan_receipt_id": self.source_plan_receipt_id,
+            "benchmark_run_receipt": self.benchmark_run_receipt.to_dict(),
+            "executed_candidate_ids": list(self.executed_candidate_ids),
+            "skipped_campaign_candidate_ids": list(self.skipped_campaign_candidate_ids),
+        }
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCampaignExecutionResult:
+    accepted: bool
+    status: str
+    execution_receipt_id: str | None
+    source_plan_receipt_id: str | None
+    benchmark_run_receipt_id: str | None
+    output_path: str | None
+    executed_candidate_ids: tuple[str, ...]
+    task_count: int
+    rejection_reasons: tuple[str, ...]
+    no_direct_provider_call_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_campaign_execution(
+    *,
+    repo_root: Path | str,
+    plan_receipt: Mapping[str, Any] | ModelAutoResearchPlanReceipt,
+    candidate_pool: Sequence[Mapping[str, Any] | ModelBenchmarkCandidate],
+    tasks: Sequence[Mapping[str, Any] | ModelBenchmarkTask],
+    runner: BenchmarkRunner,
+    verifier: BenchmarkVerifier,
+    verifier_digest: str,
+    held_out_split_id: str,
+    output_path: Path | str | None,
+) -> ModelAutoResearchCampaignExecutionResult:
+    """Execute one verified AutoResearch benchmark campaign with injected seams."""
+
+    root = Path(repo_root).resolve()
+    reasons: list[str] = []
+    try:
+        plan = _plan(plan_receipt)
+    except Exception:
+        plan = None
+        reasons.append(ModelAutoResearchCampaignExecutionReason.PLAN_INVALID)
+    try:
+        candidates = _candidate_pool(candidate_pool)
+    except Exception:
+        candidates = ()
+        reasons.append(ModelAutoResearchCampaignExecutionReason.CANDIDATE_POOL_INVALID)
+    try:
+        normalized_tasks = _tasks(tasks)
+    except Exception:
+        normalized_tasks = ()
+        reasons.append(ModelAutoResearchCampaignExecutionReason.TASKS_INVALID)
+    output, output_reasons = _runtime_output_path(
+        output_path,
+        root,
+        ModelAutoResearchCampaignExecutionReason.OUTPUT_PATH_INVALID,
+    )
+    reasons.extend(output_reasons)
+
+    selected_candidates: tuple[ModelBenchmarkCandidate, ...] = ()
+    skipped_candidate_ids: tuple[str, ...] = ()
+    if plan is not None and candidates:
+        candidate_digest = _candidate_pool_digest(candidates)
+        if candidate_digest != plan.candidate_pool_digest:
+            reasons.append(ModelAutoResearchCampaignExecutionReason.CANDIDATE_POOL_DIGEST_MISMATCH)
+        selected_candidates, skipped_candidate_ids, selection_reasons = _select_campaign_candidates(plan, candidates)
+        reasons.extend(selection_reasons)
+    if plan is not None:
+        required_verifier = plan.policy.required_verifier_digest
+        if required_verifier and required_verifier != str(verifier_digest or "").strip():
+            reasons.append(ModelAutoResearchCampaignExecutionReason.VERIFIER_DIGEST_MISMATCH)
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert plan is not None
+    assert output is not None
+    try:
+        benchmark = run_model_combination_benchmark(
+            tasks=normalized_tasks,
+            candidates=selected_candidates,
+            runner=runner,
+            verifier=verifier,
+            verifier_digest=verifier_digest,
+            held_out_split_id=held_out_split_id,
+        )
+    except Exception:
+        return _reject((ModelAutoResearchCampaignExecutionReason.BENCHMARK_RUN_FAILED,))
+    receipt = _execution_receipt(
+        plan=plan,
+        benchmark=benchmark,
+        executed_candidate_ids=tuple(candidate.candidate_id for candidate in selected_candidates),
+        skipped_campaign_candidate_ids=skipped_candidate_ids,
+    )
+    try:
+        _write_json_atomic(output, receipt.to_dict())
+    except Exception:
+        return _reject((ModelAutoResearchCampaignExecutionReason.OUTPUT_WRITE_FAILED,))
+    return ModelAutoResearchCampaignExecutionResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
+        execution_receipt_id=receipt.receipt_id,
+        source_plan_receipt_id=plan.receipt_id,
+        benchmark_run_receipt_id=benchmark.receipt_id,
+        output_path=str(output),
+        executed_candidate_ids=receipt.executed_candidate_ids,
+        task_count=len(normalized_tasks),
+        rejection_reasons=(),
+    )
+
+
+def _plan(value: Mapping[str, Any] | ModelAutoResearchPlanReceipt) -> ModelAutoResearchPlanReceipt:
+    if isinstance(value, ModelAutoResearchPlanReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_autoresearch_plan_receipt(value)
+    raise ValueError("invalid_plan")
+
+
+def _candidate_pool(
+    values: Sequence[Mapping[str, Any] | ModelBenchmarkCandidate],
+) -> tuple[ModelBenchmarkCandidate, ...]:
+    candidates: list[ModelBenchmarkCandidate] = []
+    for value in values:
+        if isinstance(value, ModelBenchmarkCandidate):
+            candidates.append(value)
+        elif isinstance(value, Mapping):
+            candidates.append(_candidate(value))
+        else:
+            raise ValueError("invalid_candidate")
+    if not candidates:
+        raise ValueError("missing_candidate_pool")
+    candidate_ids = [candidate.candidate_id for candidate in candidates]
+    if len(set(candidate_ids)) != len(candidate_ids):
+        raise ValueError("duplicate_candidates")
+    return tuple(sorted(candidates, key=lambda candidate: candidate.candidate_id))
+
+
+def _candidate(value: Mapping[str, Any]) -> ModelBenchmarkCandidate:
+    if value.get("schema_version") != "model_benchmark_candidate.v1":
+        raise ValueError("invalid_candidate_schema")
+    role_values = value.get("role_assignments")
+    if not isinstance(role_values, list) or not role_values:
+        raise ValueError("missing_candidate_roles")
+    roles: list[ModelBenchmarkRoleAssignment] = []
+    for item in role_values:
+        if not isinstance(item, Mapping):
+            raise ValueError("invalid_candidate_role")
+        roles.append(
+            ModelBenchmarkRoleAssignment(
+                role=_required(item.get("role"), "role"),
+                model_id=_required(item.get("model_id"), "model_id"),
+                provider=_required(item.get("provider"), "provider"),
+            )
+        )
+    candidate = build_model_benchmark_candidate(roles)
+    if candidate.candidate_id != _required(value.get("candidate_id"), "candidate_id"):
+        raise ValueError("candidate_id_mismatch")
+    if candidate.topology_digest != _required(value.get("topology_digest"), "topology_digest"):
+        raise ValueError("candidate_topology_digest_mismatch")
+    return candidate
+
+
+def _tasks(values: Sequence[Mapping[str, Any] | ModelBenchmarkTask]) -> tuple[ModelBenchmarkTask, ...]:
+    tasks: list[ModelBenchmarkTask] = []
+    for value in values:
+        if isinstance(value, ModelBenchmarkTask):
+            tasks.append(value.normalized())
+        elif isinstance(value, Mapping):
+            tasks.append(
+                ModelBenchmarkTask(
+                    task_id=_required(value.get("task_id"), "task_id"),
+                    task_family=_required(value.get("task_family"), "task_family"),
+                    prompt_digest=_required(value.get("prompt_digest"), "prompt_digest"),
+                    expected_output_digest=_required(value.get("expected_output_digest"), "expected_output_digest"),
+                    verifier_contract_digest=_required(value.get("verifier_contract_digest"), "verifier_contract_digest"),
+                    metadata=_metadata(value.get("metadata")),
+                ).normalized()
+            )
+        else:
+            raise ValueError("invalid_task")
+    if not tasks:
+        raise ValueError("missing_tasks")
+    return tuple(tasks)
+
+
+def _metadata(value: Any) -> Mapping[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError("invalid_task_metadata")
+    return {str(key): str(item) for key, item in value.items()}
+
+
+def _select_campaign_candidates(
+    plan: ModelAutoResearchPlanReceipt,
+    candidates: tuple[ModelBenchmarkCandidate, ...],
+) -> tuple[tuple[ModelBenchmarkCandidate, ...], tuple[str, ...], tuple[str, ...]]:
+    by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    selected: list[ModelBenchmarkCandidate] = []
+    skipped: list[str] = []
+    reasons: list[str] = []
+    for item in plan.campaign_items:
+        if item.action == ModelAutoResearchAction.STOP:
+            skipped.append(item.candidate_id)
+            continue
+        if not item.requires_independent_verifier:
+            reasons.append(ModelAutoResearchCampaignExecutionReason.CAMPAIGN_VERIFIER_REQUIRED)
+            continue
+        candidate = by_id.get(item.candidate_id)
+        if candidate is None:
+            reasons.append(ModelAutoResearchCampaignExecutionReason.CAMPAIGN_CANDIDATE_MISSING)
+            continue
+        selected.append(candidate)
+    if not selected:
+        reasons.append(ModelAutoResearchCampaignExecutionReason.NO_EXECUTABLE_CAMPAIGN_ITEMS)
+    return tuple(selected), tuple(skipped), _dedupe(reasons)
+
+
+def _candidate_pool_digest(candidates: Sequence[ModelBenchmarkCandidate]) -> str:
+    return _digest_prefixed(
+        "model_autoresearch_candidate_pool",
+        {"candidates": [candidate.to_dict() for candidate in sorted(candidates, key=lambda item: item.candidate_id)]},
+    )
+
+
+def _execution_receipt(
+    *,
+    plan: ModelAutoResearchPlanReceipt,
+    benchmark: ModelCombinationBenchmarkRunReceipt,
+    executed_candidate_ids: tuple[str, ...],
+    skipped_campaign_candidate_ids: tuple[str, ...],
+) -> ModelAutoResearchCampaignExecutionReceipt:
+    body = {
+        "schema_version": MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION,
+        "source_plan_receipt_id": plan.receipt_id,
+        "benchmark_run_receipt_id": benchmark.receipt_id,
+        "executed_candidate_ids": list(executed_candidate_ids),
+        "skipped_campaign_candidate_ids": list(skipped_campaign_candidate_ids),
+        "benchmark_evidence_receipt_ids": [
+            receipt.receipt_id for receipt in benchmark.benchmark_evidence_receipts
+        ],
+    }
+    return ModelAutoResearchCampaignExecutionReceipt(
+        receipt_id=_digest_prefixed("model_autoresearch_campaign_execution", body),
+        source_plan_receipt_id=plan.receipt_id,
+        benchmark_run_receipt=benchmark,
+        executed_candidate_ids=executed_candidate_ids,
+        skipped_campaign_candidate_ids=skipped_campaign_candidate_ids,
+    )
+
+
+def _runtime_output_path(
+    value: Path | str | None,
+    repo_root: Path,
+    reason: str,
+) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [reason]
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root)
+        return None, [reason]
+    except ValueError:
+        pass
+    return resolved, []
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _required(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(name + "_missing")
+    return text
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def _reject(reasons: Sequence[str]) -> ModelAutoResearchCampaignExecutionResult:
+    return ModelAutoResearchCampaignExecutionResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT,
+        execution_receipt_id=None,
+        source_plan_receipt_id=None,
+        benchmark_run_receipt_id=None,
+        output_path=None,
+        executed_candidate_ids=(),
+        task_count=0,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT",
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT",
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION",
+    "ModelAutoResearchCampaignExecutionReason",
+    "ModelAutoResearchCampaignExecutionReceipt",
+    "ModelAutoResearchCampaignExecutionResult",
+    "run_reddog_model_autoresearch_campaign_execution",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py
@@ -1,0 +1,261 @@
+"""Tests for bounded model AutoResearch campaign execution."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
+    MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
+    MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT,
+    ModelAutoResearchCampaignExecutionReason,
+    run_reddog_model_autoresearch_campaign_execution,
+)
+from modules.ai_intelligence.ai_gateway.src.model_champion_challenger_autoresearch import (
+    plan_model_champion_challenger_autoresearch,
+)
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_champion_challenger_autoresearch import (
+    _candidate,
+    _feedback_record,
+    _gate,
+    _policy,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_campaign_execution.py"
+)
+
+
+def _tasks():
+    return (
+        ModelBenchmarkTask(
+            task_id="task-001",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-a",
+            expected_output_digest="sha256:expected-a",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+        ModelBenchmarkTask(
+            task_id="task-002",
+            task_family="architecture",
+            prompt_digest="sha256:prompt-b",
+            expected_output_digest="sha256:expected-b",
+            verifier_contract_digest="sha256:verifier-contract",
+        ),
+    )
+
+
+def _runner(task, candidate):
+    return ModelBenchmarkTaskOutput(
+        output_digest=f"sha256:output:{candidate.candidate_id}:{task.task_id}",
+        runner_receipt_id=f"runner:{candidate.candidate_id}:{task.task_id}",
+        metrics=ModelOutcomeMetrics(
+            latency_ms=100,
+            input_tokens=10,
+            output_tokens=5,
+            cost_estimate_usd=0.01,
+        ),
+    )
+
+
+def _verifier(task, candidate, output):
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.ACCEPT,
+        verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+        evidence_correct=True,
+    )
+
+
+def _plan():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    feedback = _feedback_record("provider/new", suffix="2")
+    return plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger_gate,),
+        candidate_pool=(
+            _candidate("provider/challenger"),
+            _candidate("provider/new"),
+        ),
+        policy=_policy(),
+        feedback_records=(feedback,),
+    )
+
+
+def test_campaign_execution_runs_verified_plan_candidates_and_writes_receipt(tmp_path: Path) -> None:
+    plan = _plan()
+    output = tmp_path / "runtime" / "campaign_execution.json"
+
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=plan.to_dict(),
+        candidate_pool=(
+            _candidate("provider/challenger").to_dict(),
+            _candidate("provider/new").to_dict(),
+        ),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        output_path=output,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT
+    assert result.execution_receipt_id and result.execution_receipt_id.startswith(
+        "model_autoresearch_campaign_execution:"
+    )
+    assert result.source_plan_receipt_id == plan.receipt_id
+    assert result.executed_candidate_ids == ("provider/new", "provider/challenger")
+    assert result.task_count == 2
+    assert result.no_direct_provider_call_performed is True
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["receipt_id"] == result.execution_receipt_id
+    assert payload["source_plan_receipt_id"] == plan.receipt_id
+    assert payload["benchmark_run_receipt"]["task_family"] == "architecture"
+    assert len(payload["benchmark_run_receipt"]["benchmark_evidence_receipts"]) == 2
+
+
+def test_campaign_execution_rejects_tampered_plan_receipt(tmp_path: Path) -> None:
+    plan = _plan().to_dict()
+    plan["campaign_items"][0]["candidate_id"] = "provider/tampered"
+
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=plan,
+        candidate_pool=(_candidate("provider/new").to_dict(),),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        output_path=tmp_path / "execution.json",
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT
+    assert ModelAutoResearchCampaignExecutionReason.PLAN_INVALID in result.rejection_reasons
+
+
+def test_campaign_execution_rejects_candidate_pool_digest_mismatch(tmp_path: Path) -> None:
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=_plan().to_dict(),
+        candidate_pool=(_candidate("provider/challenger").to_dict(),),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        output_path=tmp_path / "execution.json",
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT
+    assert ModelAutoResearchCampaignExecutionReason.CANDIDATE_POOL_DIGEST_MISMATCH in result.rejection_reasons
+    assert ModelAutoResearchCampaignExecutionReason.CAMPAIGN_CANDIDATE_MISSING in result.rejection_reasons
+
+
+def test_campaign_execution_rejects_verifier_digest_mismatch(tmp_path: Path) -> None:
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=_plan().to_dict(),
+        candidate_pool=(
+            _candidate("provider/challenger").to_dict(),
+            _candidate("provider/new").to_dict(),
+        ),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:other",
+        held_out_split_id="heldout-v1",
+        output_path=tmp_path / "execution.json",
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT
+    assert ModelAutoResearchCampaignExecutionReason.VERIFIER_DIGEST_MISMATCH in result.rejection_reasons
+
+
+def test_campaign_execution_rejects_stop_only_plan(tmp_path: Path) -> None:
+    champion_gate = _gate("provider/champion", pass_all=True)
+    plan = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(champion_gate,),
+        candidate_pool=(_candidate("provider/champion"),),
+        policy=_policy(),
+    )
+
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=plan.to_dict(),
+        candidate_pool=(_candidate("provider/champion").to_dict(),),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        output_path=tmp_path / "execution.json",
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT
+    assert ModelAutoResearchCampaignExecutionReason.NO_EXECUTABLE_CAMPAIGN_ITEMS in result.rejection_reasons
+
+
+def test_campaign_execution_rejects_output_inside_repo_without_writing() -> None:
+    output = REPO_ROOT / "model_autoresearch_campaign_execution.json"
+
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=_plan().to_dict(),
+        candidate_pool=(
+            _candidate("provider/challenger").to_dict(),
+            _candidate("provider/new").to_dict(),
+        ),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        output_path=output,
+    )
+
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT
+    assert ModelAutoResearchCampaignExecutionReason.OUTPUT_PATH_INVALID in result.rejection_reasons
+    assert not output.exists()
+
+
+def test_campaign_execution_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
﻿## Summary

Adds `MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_PHASE1`.

This consumes a verified `ModelAutoResearchPlanReceipt`, validates candidate-pool digest and verifier requirements, selects executable campaign candidates, runs the existing benchmark harness through injected runner/verifier seams, and writes one outside-repo campaign execution receipt.

## Truth Boundary

Implemented:
- verified plan consumption through `rehydrate_model_autoresearch_plan_receipt`
- candidate topology and candidate-pool digest checks
- held-out task rehydration
- verifier digest gating
- STOP/no-op plan rejection
- outside-repo execution receipt output

Not implemented:
- live provider calls
- model promotion
- catalog mutation
- PatternMemory writes
- HoloIndex re-indexing
- RedDog runtime binding
- automatic resident campaign execution

## Validation

- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py` -> 7 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 125 passed
- `git diff --check` -> clean (CRLF informational warnings only)

WSP: 15, 22, 50, 97
