### PR TITLE
feat(ai-gateway): rehydrate benchmark run receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,39 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model Benchmark Run Receipt Rehydration
+
+**Who:** 0102 Codex
+**Type:** Receipt Integrity
+**Slice:** MODEL_COMBINATION_BENCHMARK_RUN_RECEIPT_REHYDRATION_PHASE1
+
+**What:** Added rehydration for serialized
+`ModelCombinationBenchmarkRunReceipt` records.
+
+**Why:** AutoResearch campaign execution now emits benchmark run receipts. Any
+later promotion or campaign-execution receipt consumer must be able to verify
+the benchmark run body, embedded evidence receipts, sample counts, accepted
+counts, task-set binding, held-out split, verifier digest, and candidate
+topology before trusting a serialized artifact.
+
+**Files:**
+- `src/model_combination_benchmark_harness.py` - adds benchmark run
+  rehydration, shared canonical digest body, candidate/sample/evidence
+  consistency checks, and constant-time receipt ID comparison.
+- `tests/test_model_combination_benchmark_harness.py` - verifies valid
+  round-trip rehydration, tamper rejection, evidence-count mismatch rejection,
+  and malformed shape rejection.
+
+**Truth Boundary:**
+- IMPLEMENTED: serialized benchmark run receipts can be accepted only after
+  schema, digest, candidate, sample, and evidence consistency checks.
+- NOT IMPLEMENTED: provider calls, benchmark campaign scheduling,
+  AutoResearch promotion, PatternMemory writes, HoloIndex re-indexing, or
+  resident runtime execution.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Campaign Execution
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py
@@ -9,6 +9,7 @@ runtime defaults.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, Mapping, Sequence
@@ -20,6 +21,7 @@ from .model_intelligence_outcomes import (
     build_model_benchmark_evidence_receipt,
 )
 from .model_intelligence_selection import RESERVED_PANEL_ROLES
+from .model_signed_evidence import rehydrate_model_benchmark_evidence_receipt
 
 
 BENCHMARK_RUN_SCHEMA_VERSION = "model_combination_benchmark_run_receipt.v1"
@@ -294,16 +296,15 @@ def run_model_combination_benchmark(
                 metrics=_aggregate_metrics(tuple(sample.metrics for sample in candidate_samples)),
             )
         )
-    body = {
-        "schema_version": BENCHMARK_RUN_SCHEMA_VERSION,
-        "task_family": task_family,
-        "task_set_digest": task_set_digest,
-        "held_out_split_digest": held_out_split_digest,
-        "verifier_digest": verifier_digest_value,
-        "candidates": [candidate.to_dict() for candidate in normalized_candidates],
-        "samples": [sample.to_dict() for sample in samples],
-        "benchmark_evidence_receipt_ids": [receipt.receipt_id for receipt in benchmark_receipts],
-    }
+    body = _benchmark_run_digest_body(
+        task_family=task_family,
+        task_set_digest=task_set_digest,
+        held_out_split_digest=held_out_split_digest,
+        verifier_digest=verifier_digest_value,
+        candidates=normalized_candidates,
+        samples=tuple(samples),
+        benchmark_evidence_receipts=tuple(benchmark_receipts),
+    )
     return ModelCombinationBenchmarkRunReceipt(
         receipt_id=_digest_prefixed("model_combination_benchmark_run", body),
         task_family=task_family,
@@ -314,6 +315,194 @@ def run_model_combination_benchmark(
         samples=tuple(samples),
         benchmark_evidence_receipts=tuple(benchmark_receipts),
     )
+
+
+def rehydrate_model_combination_benchmark_run_receipt(
+    payload: Mapping[str, Any],
+) -> ModelCombinationBenchmarkRunReceipt:
+    """Rehydrate a serialized benchmark run and verify its digest and evidence."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_benchmark_run_receipt")
+    if payload.get("schema_version") != BENCHMARK_RUN_SCHEMA_VERSION:
+        raise ValueError("invalid_benchmark_run_schema")
+    receipt_id = _required("receipt_id", payload.get("receipt_id"))
+    task_family = _clean_token(_required("task_family", payload.get("task_family")))
+    task_set_digest = _required("task_set_digest", payload.get("task_set_digest"))
+    held_out_split_digest = _required("held_out_split_digest", payload.get("held_out_split_digest"))
+    verifier_digest = _required("verifier_digest", payload.get("verifier_digest"))
+    candidates = _rehydrate_candidates(payload.get("candidates"))
+    samples = _rehydrate_samples(payload.get("samples"))
+    benchmark_receipts = _rehydrate_benchmark_evidence_receipts(
+        payload.get("benchmark_evidence_receipts")
+    )
+    _validate_benchmark_run_consistency(
+        task_family=task_family,
+        task_set_digest=task_set_digest,
+        held_out_split_digest=held_out_split_digest,
+        verifier_digest=verifier_digest,
+        candidates=candidates,
+        samples=samples,
+        benchmark_evidence_receipts=benchmark_receipts,
+    )
+    body = _benchmark_run_digest_body(
+        task_family=task_family,
+        task_set_digest=task_set_digest,
+        held_out_split_digest=held_out_split_digest,
+        verifier_digest=verifier_digest,
+        candidates=candidates,
+        samples=samples,
+        benchmark_evidence_receipts=benchmark_receipts,
+    )
+    expected = _digest_prefixed("model_combination_benchmark_run", body)
+    if not hmac.compare_digest(receipt_id, expected):
+        raise ValueError("model_combination_benchmark_run_receipt_id_mismatch")
+    return ModelCombinationBenchmarkRunReceipt(
+        receipt_id=receipt_id,
+        task_family=task_family,
+        task_set_digest=task_set_digest,
+        held_out_split_digest=held_out_split_digest,
+        verifier_digest=verifier_digest,
+        candidates=candidates,
+        samples=samples,
+        benchmark_evidence_receipts=benchmark_receipts,
+    )
+
+
+def _benchmark_run_digest_body(
+    *,
+    task_family: str,
+    task_set_digest: str,
+    held_out_split_digest: str,
+    verifier_digest: str,
+    candidates: Sequence[ModelBenchmarkCandidate],
+    samples: Sequence[ModelBenchmarkSampleReceipt],
+    benchmark_evidence_receipts: Sequence[ModelBenchmarkEvidenceReceipt],
+) -> dict[str, Any]:
+    return {
+        "schema_version": BENCHMARK_RUN_SCHEMA_VERSION,
+        "task_family": task_family,
+        "task_set_digest": task_set_digest,
+        "held_out_split_digest": held_out_split_digest,
+        "verifier_digest": verifier_digest,
+        "candidates": [candidate.to_dict() for candidate in candidates],
+        "samples": [sample.to_dict() for sample in samples],
+        "benchmark_evidence_receipt_ids": [
+            receipt.receipt_id for receipt in benchmark_evidence_receipts
+        ],
+    }
+
+
+def _rehydrate_candidates(value: Any) -> tuple[ModelBenchmarkCandidate, ...]:
+    raw = _required_list("candidates", value)
+    candidates: list[ModelBenchmarkCandidate] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise ValueError("invalid_benchmark_candidate")
+        if item.get("schema_version") != CANDIDATE_SCHEMA_VERSION:
+            raise ValueError("invalid_benchmark_candidate_schema")
+        role_values = _required_list("candidate_role_assignments", item.get("role_assignments"))
+        roles: list[ModelBenchmarkRoleAssignment] = []
+        for role_item in role_values:
+            if not isinstance(role_item, Mapping):
+                raise ValueError("invalid_benchmark_candidate_role")
+            roles.append(
+                ModelBenchmarkRoleAssignment(
+                    role=_required("role", role_item.get("role")),
+                    model_id=_required("model_id", role_item.get("model_id")),
+                    provider=_required("provider", role_item.get("provider")),
+                )
+            )
+        candidate = build_model_benchmark_candidate(roles)
+        if candidate.candidate_id != _required("candidate_id", item.get("candidate_id")):
+            raise ValueError("benchmark_candidate_id_mismatch")
+        if candidate.topology_digest != _required("topology_digest", item.get("topology_digest")):
+            raise ValueError("benchmark_candidate_topology_digest_mismatch")
+        candidates.append(candidate)
+    return _normalize_candidates(candidates)
+
+
+def _rehydrate_samples(value: Any) -> tuple[ModelBenchmarkSampleReceipt, ...]:
+    raw = _required_list("samples", value)
+    samples: list[ModelBenchmarkSampleReceipt] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            raise ValueError("invalid_benchmark_sample")
+        samples.append(
+            ModelBenchmarkSampleReceipt(
+                task_id=_required("task_id", item.get("task_id")),
+                candidate_id=_required("candidate_id", item.get("candidate_id")),
+                decision=_coerce_verifier_decision(_required("decision", item.get("decision"))),
+                accepted=_required_bool("accepted", item.get("accepted")),
+                output_digest=_optional(item.get("output_digest")),
+                runner_receipt_id=_optional(item.get("runner_receipt_id")),
+                verifier_receipt_id=_optional(item.get("verifier_receipt_id")),
+                metrics=_rehydrate_metrics(item.get("metrics")),
+                rejection_reasons=tuple(
+                    sorted(_clean_token(reason) for reason in _required_list("rejection_reasons", item.get("rejection_reasons")))
+                ),
+            )
+        )
+    return tuple(sorted(samples, key=lambda sample: (sample.candidate_id, sample.task_id)))
+
+
+def _rehydrate_metrics(value: Any) -> ModelOutcomeMetrics:
+    if not isinstance(value, Mapping):
+        raise ValueError("invalid_benchmark_sample_metrics")
+    return ModelOutcomeMetrics(
+        latency_ms=_optional_int(value.get("latency_ms")),
+        input_tokens=_optional_int(value.get("input_tokens")),
+        output_tokens=_optional_int(value.get("output_tokens")),
+        cost_estimate_usd=_optional_float(value.get("cost_estimate_usd")),
+    ).normalized()
+
+
+def _rehydrate_benchmark_evidence_receipts(value: Any) -> tuple[ModelBenchmarkEvidenceReceipt, ...]:
+    raw = _required_list("benchmark_evidence_receipts", value)
+    receipts = tuple(
+        rehydrate_model_benchmark_evidence_receipt(item)
+        for item in raw
+        if isinstance(item, Mapping)
+    )
+    if len(receipts) != len(raw):
+        raise ValueError("invalid_benchmark_evidence_receipt")
+    receipt_ids = [receipt.receipt_id for receipt in receipts]
+    if len(set(receipt_ids)) != len(receipt_ids):
+        raise ValueError("duplicate_benchmark_evidence_receipts")
+    return tuple(sorted(receipts, key=lambda receipt: receipt.receipt_id))
+
+
+def _validate_benchmark_run_consistency(
+    *,
+    task_family: str,
+    task_set_digest: str,
+    held_out_split_digest: str,
+    verifier_digest: str,
+    candidates: tuple[ModelBenchmarkCandidate, ...],
+    samples: tuple[ModelBenchmarkSampleReceipt, ...],
+    benchmark_evidence_receipts: tuple[ModelBenchmarkEvidenceReceipt, ...],
+) -> None:
+    candidate_ids = {candidate.candidate_id for candidate in candidates}
+    sample_candidate_ids = {sample.candidate_id for sample in samples}
+    evidence_model_ids = {receipt.model_id for receipt in benchmark_evidence_receipts}
+    if not sample_candidate_ids.issubset(candidate_ids):
+        raise ValueError("benchmark_sample_candidate_mismatch")
+    if evidence_model_ids != candidate_ids:
+        raise ValueError("benchmark_evidence_candidate_mismatch")
+    for receipt in benchmark_evidence_receipts:
+        if receipt.task_family != task_family:
+            raise ValueError("benchmark_evidence_task_family_mismatch")
+        if receipt.task_set_digest != task_set_digest:
+            raise ValueError("benchmark_evidence_task_set_digest_mismatch")
+        if receipt.held_out_split_digest != held_out_split_digest:
+            raise ValueError("benchmark_evidence_held_out_split_digest_mismatch")
+        if receipt.verifier_digest != verifier_digest:
+            raise ValueError("benchmark_evidence_verifier_digest_mismatch")
+        candidate_samples = [sample for sample in samples if sample.candidate_id == receipt.model_id]
+        if receipt.sample_count != len(candidate_samples):
+            raise ValueError("benchmark_evidence_sample_count_mismatch")
+        if receipt.accepted_count != sum(1 for sample in candidate_samples if sample.accepted):
+            raise ValueError("benchmark_evidence_accepted_count_mismatch")
 
 
 def _run_one_sample(
@@ -435,6 +624,37 @@ def _required(name: str, value: Any) -> str:
     if not cleaned:
         raise ValueError(f"missing_{name}")
     return cleaned
+
+
+def _required_list(name: str, value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _required_bool(name: str, value: Any) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)
 
 
 def _clean_token(value: Any) -> str:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py
@@ -11,6 +11,7 @@ from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness 
     ModelBenchmarkTaskOutput,
     ModelBenchmarkVerifierResult,
     build_model_benchmark_candidate,
+    rehydrate_model_combination_benchmark_run_receipt,
     run_model_combination_benchmark,
 )
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
@@ -86,6 +87,104 @@ def test_single_model_benchmark_produces_evidence_receipt_bound_to_held_out_task
     assert evidence.prompt_topology_digest == candidate.topology_digest
     assert evidence.metrics.input_tokens == 20
     assert evidence.metrics.output_tokens == 10
+
+
+def test_benchmark_run_receipt_rehydrates_with_digest_and_evidence_consistency():
+    candidate = _single_candidate()
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    assert rehydrate_model_combination_benchmark_run_receipt(receipt.to_dict()) == receipt
+
+
+def test_benchmark_run_receipt_rejects_tampered_digest_bound_fields():
+    candidate = _single_candidate()
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    mutations = []
+
+    task_family_tamper = receipt.to_dict()
+    task_family_tamper["task_family"] = "security"
+    mutations.append(task_family_tamper)
+
+    candidate_tamper = receipt.to_dict()
+    candidate_tamper["candidates"][0]["candidate_id"] = "provider/tampered"
+    mutations.append(candidate_tamper)
+
+    sample_tamper = receipt.to_dict()
+    sample_tamper["samples"][0]["accepted"] = False
+    mutations.append(sample_tamper)
+
+    for payload in mutations:
+        try:
+            rehydrate_model_combination_benchmark_run_receipt(payload)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("tampered benchmark run receipt was accepted")
+
+
+def test_benchmark_run_receipt_rejects_self_consistent_evidence_mismatch():
+    candidate = _single_candidate()
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    payload = receipt.to_dict()
+    payload["benchmark_evidence_receipts"][0]["accepted_count"] = 1
+
+    try:
+        rehydrate_model_combination_benchmark_run_receipt(payload)
+    except ValueError as exc:
+        assert str(exc) in {
+            "benchmark_receipt_id_mismatch",
+            "benchmark_evidence_accepted_count_mismatch",
+        }
+    else:
+        raise AssertionError("tampered benchmark evidence was accepted")
+
+
+def test_benchmark_run_receipt_rejects_malformed_shape_before_digest_check():
+    candidate = _single_candidate()
+    receipt = run_model_combination_benchmark(
+        tasks=_tasks(),
+        candidates=(candidate,),
+        runner=_accepting_runner,
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+    bad_schema = receipt.to_dict()
+    bad_schema["schema_version"] = "other"
+    bad_bool = receipt.to_dict()
+    bad_bool["samples"][0]["accepted"] = "true"
+
+    for payload, expected in (
+        (bad_schema, "invalid_benchmark_run_schema"),
+        (bad_bool, "invalid_accepted"),
+    ):
+        try:
+            rehydrate_model_combination_benchmark_run_receipt(payload)
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError(f"expected {expected}")
 
 
 def test_panel_candidate_binds_role_topology_and_is_not_direct_model_id():


### PR DESCRIPTION
﻿## Summary

Adds `MODEL_COMBINATION_BENCHMARK_RUN_RECEIPT_REHYDRATION_PHASE1`.

This lets downstream AutoResearch and promotion consumers verify serialized benchmark run artifacts before trusting them. The rehydrator checks schema, candidate topology, samples, embedded benchmark evidence receipts, task family, task-set digest, held-out split, verifier digest, sample counts, accepted counts, and recomputes the benchmark run receipt ID with constant-time comparison.

## Truth Boundary

Implemented:
- `rehydrate_model_combination_benchmark_run_receipt`
- shared canonical benchmark run digest body
- candidate/sample/evidence consistency checks
- tests for round-trip, tamper rejection, evidence mismatch rejection, and malformed shape rejection

Not implemented:
- provider calls
- benchmark campaign scheduling
- AutoResearch promotion
- PatternMemory writes
- HoloIndex re-indexing
- resident runtime execution

## Validation

- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_combination_benchmark_harness.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py` -> 13 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 129 passed
- `git diff --check` -> clean (CRLF informational warnings only)

WSP: 15, 22, 50, 97
