### PR TITLE
feat(ai-gateway): rehydrate autoresearch execution receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,39 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Campaign Execution Receipt Rehydration
+
+**Who:** 0102 Codex
+**Type:** Receipt Integrity
+**Slice:** MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_REHYDRATION_PHASE1
+
+**What:** Added rehydration for serialized
+`ModelAutoResearchCampaignExecutionReceipt` artifacts.
+
+**Why:** Campaign execution now emits a benchmark-run-bearing artifact. Future
+promotion, runtime binding, or feedback ratchet consumers must verify the
+campaign receipt and its embedded benchmark run before trusting the execution
+result.
+
+**Files:**
+- `src/model_autoresearch_campaign_execution.py` - adds campaign execution
+  receipt rehydration, shared canonical execution digest body, embedded
+  benchmark-run rehydration, candidate consistency checks, and constant-time
+  receipt ID comparison.
+- `tests/test_model_autoresearch_campaign_execution.py` - verifies round-trip
+  rehydration, digest-bound tamper rejection, embedded benchmark tamper
+  rejection, and malformed shape rejection.
+
+**Truth Boundary:**
+- IMPLEMENTED: serialized campaign execution receipts can be accepted only
+  after schema, digest, embedded benchmark, and candidate consistency checks.
+- NOT IMPLEMENTED: model promotion, runtime binding, PatternMemory writes,
+  HoloIndex re-indexing, provider calls, or automatic resident campaign
+  execution.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model Benchmark Run Receipt Rehydration
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py
@@ -9,6 +9,7 @@ catalogs, write PatternMemory, re-index HoloIndex, or bind runtime defaults.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import os
 import tempfile
@@ -29,6 +30,7 @@ from .model_combination_benchmark_harness import (
     ModelBenchmarkTask,
     ModelCombinationBenchmarkRunReceipt,
     build_model_benchmark_candidate,
+    rehydrate_model_combination_benchmark_run_receipt,
     run_model_combination_benchmark,
 )
 
@@ -187,6 +189,46 @@ def run_reddog_model_autoresearch_campaign_execution(
     )
 
 
+def rehydrate_model_autoresearch_campaign_execution_receipt(
+    payload: Mapping[str, Any],
+) -> ModelAutoResearchCampaignExecutionReceipt:
+    """Rehydrate a serialized campaign execution receipt and verify its digest."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_autoresearch_campaign_execution_receipt")
+    if payload.get("schema_version") != MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION:
+        raise ValueError("invalid_autoresearch_campaign_execution_schema")
+    receipt_id = _required(payload.get("receipt_id"), "receipt_id")
+    source_plan_receipt_id = _required(payload.get("source_plan_receipt_id"), "source_plan_receipt_id")
+    benchmark_run_receipt = rehydrate_model_combination_benchmark_run_receipt(
+        _required_mapping(payload.get("benchmark_run_receipt"), "benchmark_run_receipt")
+    )
+    executed_candidate_ids = _string_tuple(payload.get("executed_candidate_ids"), "executed_candidate_ids")
+    skipped_candidate_ids = _string_tuple(
+        payload.get("skipped_campaign_candidate_ids"),
+        "skipped_campaign_candidate_ids",
+    )
+    benchmark_candidate_ids = tuple(candidate.candidate_id for candidate in benchmark_run_receipt.candidates)
+    if tuple(sorted(executed_candidate_ids)) != tuple(sorted(benchmark_candidate_ids)):
+        raise ValueError("autoresearch_execution_candidate_mismatch")
+    body = _execution_digest_body(
+        source_plan_receipt_id=source_plan_receipt_id,
+        benchmark_run_receipt=benchmark_run_receipt,
+        executed_candidate_ids=executed_candidate_ids,
+        skipped_campaign_candidate_ids=skipped_candidate_ids,
+    )
+    expected = _digest_prefixed("model_autoresearch_campaign_execution", body)
+    if not hmac.compare_digest(receipt_id, expected):
+        raise ValueError("model_autoresearch_campaign_execution_receipt_id_mismatch")
+    return ModelAutoResearchCampaignExecutionReceipt(
+        receipt_id=receipt_id,
+        source_plan_receipt_id=source_plan_receipt_id,
+        benchmark_run_receipt=benchmark_run_receipt,
+        executed_candidate_ids=executed_candidate_ids,
+        skipped_campaign_candidate_ids=skipped_candidate_ids,
+    )
+
+
 def _plan(value: Mapping[str, Any] | ModelAutoResearchPlanReceipt) -> ModelAutoResearchPlanReceipt:
     if isinstance(value, ModelAutoResearchPlanReceipt):
         return value
@@ -309,16 +351,12 @@ def _execution_receipt(
     executed_candidate_ids: tuple[str, ...],
     skipped_campaign_candidate_ids: tuple[str, ...],
 ) -> ModelAutoResearchCampaignExecutionReceipt:
-    body = {
-        "schema_version": MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION,
-        "source_plan_receipt_id": plan.receipt_id,
-        "benchmark_run_receipt_id": benchmark.receipt_id,
-        "executed_candidate_ids": list(executed_candidate_ids),
-        "skipped_campaign_candidate_ids": list(skipped_campaign_candidate_ids),
-        "benchmark_evidence_receipt_ids": [
-            receipt.receipt_id for receipt in benchmark.benchmark_evidence_receipts
-        ],
-    }
+    body = _execution_digest_body(
+        source_plan_receipt_id=plan.receipt_id,
+        benchmark_run_receipt=benchmark,
+        executed_candidate_ids=executed_candidate_ids,
+        skipped_campaign_candidate_ids=skipped_campaign_candidate_ids,
+    )
     return ModelAutoResearchCampaignExecutionReceipt(
         receipt_id=_digest_prefixed("model_autoresearch_campaign_execution", body),
         source_plan_receipt_id=plan.receipt_id,
@@ -326,6 +364,25 @@ def _execution_receipt(
         executed_candidate_ids=executed_candidate_ids,
         skipped_campaign_candidate_ids=skipped_campaign_candidate_ids,
     )
+
+
+def _execution_digest_body(
+    *,
+    source_plan_receipt_id: str,
+    benchmark_run_receipt: ModelCombinationBenchmarkRunReceipt,
+    executed_candidate_ids: tuple[str, ...],
+    skipped_campaign_candidate_ids: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "schema_version": MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_SCHEMA_VERSION,
+        "source_plan_receipt_id": source_plan_receipt_id,
+        "benchmark_run_receipt_id": benchmark_run_receipt.receipt_id,
+        "executed_candidate_ids": list(executed_candidate_ids),
+        "skipped_campaign_candidate_ids": list(skipped_campaign_candidate_ids),
+        "benchmark_evidence_receipt_ids": [
+            receipt.receipt_id for receipt in benchmark_run_receipt.benchmark_evidence_receipts
+        ],
+    }
 
 
 def _runtime_output_path(
@@ -367,6 +424,25 @@ def _required(value: Any, name: str) -> str:
     return text
 
 
+def _required_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(name + "_invalid")
+    return value
+
+
+def _required_list(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(name + "_invalid")
+    return value
+
+
+def _string_tuple(value: Any, name: str) -> tuple[str, ...]:
+    records = tuple(_required(item, name) for item in _required_list(value, name))
+    if len(set(records)) != len(records):
+        raise ValueError(name + "_duplicate")
+    return records
+
+
 def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
@@ -397,5 +473,6 @@ __all__ = [
     "ModelAutoResearchCampaignExecutionReason",
     "ModelAutoResearchCampaignExecutionReceipt",
     "ModelAutoResearchCampaignExecutionResult",
+    "rehydrate_model_autoresearch_campaign_execution_receipt",
     "run_reddog_model_autoresearch_campaign_execution",
 ]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py
@@ -10,6 +10,7 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_executio
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_REJECT,
     ModelAutoResearchCampaignExecutionReason,
+    rehydrate_model_autoresearch_campaign_execution_receipt,
     run_reddog_model_autoresearch_campaign_execution,
 )
 from modules.ai_intelligence.ai_gateway.src.model_champion_challenger_autoresearch import (
@@ -97,6 +98,26 @@ def _plan():
     )
 
 
+def _execution_payload(tmp_path: Path) -> dict:
+    output = tmp_path / "runtime" / "campaign_execution.json"
+    result = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=REPO_ROOT,
+        plan_receipt=_plan().to_dict(),
+        candidate_pool=(
+            _candidate("provider/challenger").to_dict(),
+            _candidate("provider/new").to_dict(),
+        ),
+        tasks=[task.to_dict() for task in _tasks()],
+        runner=_runner,
+        verifier=_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        output_path=output,
+    )
+    assert result.accepted is True
+    return json.loads(output.read_text(encoding="utf-8"))
+
+
 def test_campaign_execution_runs_verified_plan_candidates_and_writes_receipt(tmp_path: Path) -> None:
     plan = _plan()
     output = tmp_path / "runtime" / "campaign_execution.json"
@@ -130,6 +151,72 @@ def test_campaign_execution_runs_verified_plan_candidates_and_writes_receipt(tmp
     assert payload["source_plan_receipt_id"] == plan.receipt_id
     assert payload["benchmark_run_receipt"]["task_family"] == "architecture"
     assert len(payload["benchmark_run_receipt"]["benchmark_evidence_receipts"]) == 2
+
+
+def test_campaign_execution_receipt_rehydrates_with_benchmark_consistency(tmp_path: Path) -> None:
+    payload = _execution_payload(tmp_path)
+
+    receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
+
+    assert receipt.to_dict() == payload
+    assert receipt.source_plan_receipt_id == payload["source_plan_receipt_id"]
+    assert receipt.executed_candidate_ids == ("provider/new", "provider/challenger")
+
+
+def test_campaign_execution_receipt_rejects_tampered_digest_bound_fields(tmp_path: Path) -> None:
+    payload = _execution_payload(tmp_path)
+    mutations = []
+
+    source_tamper = dict(payload)
+    source_tamper["source_plan_receipt_id"] = "model_autoresearch_plan:tampered"
+    mutations.append(source_tamper)
+
+    executed_tamper = dict(payload)
+    executed_tamper["executed_candidate_ids"] = ["provider/new"]
+    mutations.append(executed_tamper)
+
+    skipped_tamper = dict(payload)
+    skipped_tamper["skipped_campaign_candidate_ids"] = ["none"]
+    mutations.append(skipped_tamper)
+
+    for item in mutations:
+        try:
+            rehydrate_model_autoresearch_campaign_execution_receipt(item)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("tampered campaign execution receipt was accepted")
+
+
+def test_campaign_execution_receipt_rejects_embedded_benchmark_tamper(tmp_path: Path) -> None:
+    payload = _execution_payload(tmp_path)
+    payload["benchmark_run_receipt"]["samples"][0]["accepted"] = False
+
+    try:
+        rehydrate_model_autoresearch_campaign_execution_receipt(payload)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("tampered embedded benchmark run was accepted")
+
+
+def test_campaign_execution_receipt_rejects_malformed_shape_before_digest_check(tmp_path: Path) -> None:
+    payload = _execution_payload(tmp_path)
+    bad_schema = dict(payload)
+    bad_schema["schema_version"] = "other"
+    bad_ids = dict(payload)
+    bad_ids["executed_candidate_ids"] = "provider/new"
+
+    for item, expected in (
+        (bad_schema, "invalid_autoresearch_campaign_execution_schema"),
+        (bad_ids, "executed_candidate_ids_invalid"),
+    ):
+        try:
+            rehydrate_model_autoresearch_campaign_execution_receipt(item)
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError(f"expected {expected}")
 
 
 def test_campaign_execution_rejects_tampered_plan_receipt(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Slice
MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_REHYDRATION_PHASE1

## WSP_97 truth boundary
- IMPLEMENTED: serialized `ModelAutoResearchCampaignExecutionReceipt` rehydration with schema validation, canonical receipt digest recomputation, embedded benchmark run rehydration, candidate consistency checks, duplicate ID rejection, and constant-time receipt ID comparison.
- NOT IMPLEMENTED: model promotion, runtime binding, PatternMemory writes, HoloIndex re-indexing, provider calls, or automatic resident campaign execution.

## Scope
- `modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py`
- `modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py`
- `modules/ai_intelligence/ai_gateway/ModLog.md`

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py` -> 11 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 133 passed
- `git diff --check` -> clean (CRLF warnings only)
