### PR TITLE
feat(ai-gateway): supply autoresearch campaign execution artifacts

### DIFF
--- a/main.py
+++ b/main.py
@@ -1605,6 +1605,8 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY=0       Materialize runtime binding receipt from signed evidence
         REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY=0     Materialize model AutoResearch plan from verified receipts
         REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY=0 Execute deterministic campaign fixture
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
@@ -1616,6 +1618,12 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_POLICY_PATH                Outside-repo AutoResearch policy JSON
         REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH      Optional outside-repo feedback JSON/JSONL
         REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH          Outside-repo AutoResearch plan output JSON
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH        Outside-repo held-out campaign tasks JSON
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH Outside-repo campaign execution output JSON
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST   Verifier digest required by plan policy
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID Held-out split ID for benchmark receipt
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE       deterministic_fixture only
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture only
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY=0 Materialize principal/snapshot from GitHub probe
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY_ENFORCED=0 Block startup if rejected
@@ -1670,6 +1678,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         os.environ,
         repo_root,
         "REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH",
+    )
+    model_autoresearch_campaign_execution_receipt_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH",
     )
     model_runtime_binding_receipt_path_supplied = bool(
         os.getenv("REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH", "").strip()
@@ -1902,6 +1915,71 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print(
                 "[REDDOG-MODEL-AUTORESEARCH] Startup blocked by "
                 "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=1"
+            )
+            return False
+
+    autoresearch_campaign_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY",
+    )
+    autoresearch_campaign_enforced = (
+        os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED", "0") != "0"
+    )
+    if autoresearch_campaign_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution_artifact_supply_bootstrap import (
+                run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap,
+            )
+
+            autoresearch_campaign = (
+                run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+                    repo_root=repo_root,
+                    plan_receipt_path=model_autoresearch_plan_receipt_path,
+                    candidate_pool_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH", "") or None,
+                    tasks_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH", "") or None,
+                    output_path=model_autoresearch_campaign_execution_receipt_path,
+                    verifier_digest=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST", ""),
+                    held_out_split_id=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID", ""),
+                    runner_mode=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE",
+                        "deterministic_fixture",
+                    ),
+                    verifier_mode=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE",
+                        "deterministic_fixture",
+                    ),
+                )
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] Startup artifact supply failed: {exc}")
+            if autoresearch_campaign_enforced:
+                print(f"[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        campaign_status = "PASS" if autoresearch_campaign.accepted else "WARN"
+        campaign_reasons = (
+            ",".join(autoresearch_campaign.rejection_reasons)
+            if autoresearch_campaign.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] preflight={campaign_status} "
+            f"status={autoresearch_campaign.status} "
+            f"receipt={autoresearch_campaign.execution_receipt_id or '(none)'} "
+            f"tasks={autoresearch_campaign.task_count} "
+            f"reasons={campaign_reasons}"
+        )
+        if autoresearch_campaign.accepted and autoresearch_campaign.output_path:
+            model_autoresearch_campaign_execution_receipt_path = autoresearch_campaign.output_path
+            os.environ["REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH"] = (
+                model_autoresearch_campaign_execution_receipt_path
+            )
+        elif autoresearch_campaign_enforced:
+            print(
+                "[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] Startup blocked by "
+                "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=1"
             )
             return False
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,40 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Campaign Execution Artifact Supply Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Preflight Adapter
+**Slice:** REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**What:** Added a disabled-by-default bootstrap for materializing
+`ModelAutoResearchCampaignExecutionReceipt` artifacts from outside-repo runtime
+inputs.
+
+**Why:** The model AutoResearch lane needs a governed way to advance from a
+verified campaign plan to a receipt-bearing benchmark execution artifact before
+any promotion, runtime model binding, or PatternMemory feedback can trust it.
+
+**Files:**
+- `src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` -
+  reads outside-repo plan, candidate pool, and held-out task JSON; runs the
+  bounded campaign executor with deterministic fixture seams; writes only an
+  outside-repo execution receipt.
+- `tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py`
+  - verifies successful receipt materialization, rehydration, fail-closed path
+  handling, verifier mismatch rejection, unsupported mode rejection, and AST
+  import/call denylist controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: opt-in campaign execution artifact supply using deterministic
+  fixture runner/verifier seams and outside-repo receipt output.
+- NOT IMPLEMENTED: provider calls, network research, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime model binding, worker
+  spawn, shell execution, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Campaign Execution Receipt Rehydration
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -1,0 +1,320 @@
+"""Main-startup bootstrap for model AutoResearch campaign execution artifacts.
+
+Slice: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads outside-repo runtime JSON inputs and materializes a
+``ModelAutoResearchCampaignExecutionReceipt`` using the bounded campaign
+executor and deterministic fixture seams.
+
+It does not call provider SDKs, execute commands, promote models, mutate
+catalogs, write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn
+workers, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
+    MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
+    run_reddog_model_autoresearch_campaign_execution,
+)
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkCandidate,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    VerifierDecision,
+)
+
+
+MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED = (
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED"
+)
+MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY = (
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY"
+)
+MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER = "deterministic_fixture"
+MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER = "deterministic_fixture"
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCampaignExecutionBootstrapResult:
+    accepted: bool
+    status: str
+    execution_receipt_id: Optional[str]
+    source_plan_receipt_id: Optional[str]
+    benchmark_run_receipt_id: Optional[str]
+    output_path: Optional[str]
+    executed_candidate_ids: tuple[str, ...]
+    task_count: int
+    rejection_reasons: tuple[str, ...]
+    no_direct_provider_call_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    plan_receipt_path: Path | str | None,
+    candidate_pool_path: Path | str | None,
+    tasks_path: Path | str | None,
+    output_path: Path | str | None,
+    verifier_digest: str,
+    held_out_split_id: str,
+    runner_mode: str = MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER,
+    verifier_mode: str = MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER,
+) -> ModelAutoResearchCampaignExecutionBootstrapResult:
+    """Materialize an AutoResearch campaign execution artifact from runtime files."""
+
+    root = Path(repo_root).resolve()
+    plan_payload, plan_reasons = _read_json_outside_repo(
+        root,
+        plan_receipt_path,
+        missing_reason="missing_model_autoresearch_plan_receipt_path",
+        inside_reason="model_autoresearch_plan_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_plan_receipt",
+    )
+    candidate_payload, candidate_reasons = _read_json_outside_repo(
+        root,
+        candidate_pool_path,
+        missing_reason="missing_model_autoresearch_campaign_candidate_pool_path",
+        inside_reason="model_autoresearch_campaign_candidate_pool_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_campaign_candidate_pool",
+    )
+    task_payload, task_reasons = _read_json_outside_repo(
+        root,
+        tasks_path,
+        missing_reason="missing_model_autoresearch_campaign_tasks_path",
+        inside_reason="model_autoresearch_campaign_tasks_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_campaign_tasks",
+    )
+    reasons = [
+        *plan_reasons,
+        *candidate_reasons,
+        *task_reasons,
+        *_output_path_reasons(root, output_path),
+        *_mode_reasons(runner_mode, verifier_mode),
+    ]
+    verifier_text = str(verifier_digest or "").strip()
+    held_out_text = str(held_out_split_id or "").strip()
+    if not verifier_text:
+        reasons.append("missing_model_autoresearch_campaign_verifier_digest")
+    if not held_out_text:
+        reasons.append("missing_model_autoresearch_campaign_held_out_split_id")
+
+    candidate_pool = _mapping_list(candidate_payload, "candidate_pool")
+    tasks = _mapping_list(task_payload, "tasks")
+    if plan_payload is not None and not isinstance(plan_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_plan_receipt")
+    if candidate_payload is not None and candidate_pool is None:
+        reasons.append("malformed_model_autoresearch_campaign_candidate_pool")
+    if task_payload is not None and tasks is None:
+        reasons.append("malformed_model_autoresearch_campaign_tasks")
+    if reasons:
+        return _not_ready(reasons)
+
+    assert isinstance(plan_payload, Mapping)
+    assert candidate_pool is not None
+    assert tasks is not None
+    execution = run_reddog_model_autoresearch_campaign_execution(
+        repo_root=root,
+        plan_receipt=plan_payload,
+        candidate_pool=candidate_pool,
+        tasks=tasks,
+        runner=_fixture_runner,
+        verifier=_fixture_verifier,
+        verifier_digest=verifier_text,
+        held_out_split_id=held_out_text,
+        output_path=output_path,
+    )
+    if not execution.accepted or execution.status != MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT:
+        return _not_ready(
+            execution.rejection_reasons or ("model_autoresearch_campaign_execution_rejected",)
+        )
+    return ModelAutoResearchCampaignExecutionBootstrapResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED,
+        execution_receipt_id=execution.execution_receipt_id,
+        source_plan_receipt_id=execution.source_plan_receipt_id,
+        benchmark_run_receipt_id=execution.benchmark_run_receipt_id,
+        output_path=execution.output_path,
+        executed_candidate_ids=execution.executed_candidate_ids,
+        task_count=execution.task_count,
+        rejection_reasons=(),
+    )
+
+
+def _fixture_runner(
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+) -> ModelBenchmarkTaskOutput:
+    output_digest = _digest(
+        "model_autoresearch_fixture_output",
+        {
+            "candidate_id": candidate.candidate_id,
+            "task_id": task.task_id,
+            "prompt_digest": task.prompt_digest,
+            "expected_output_digest": task.expected_output_digest,
+        },
+    )
+    return ModelBenchmarkTaskOutput(
+        output_digest=output_digest,
+        runner_receipt_id=_digest(
+            "model_autoresearch_fixture_runner",
+            {"candidate_id": candidate.candidate_id, "task_id": task.task_id},
+        ),
+        metrics=ModelOutcomeMetrics(
+            latency_ms=0,
+            input_tokens=0,
+            output_tokens=0,
+            cost_estimate_usd=0.0,
+        ),
+    )
+
+
+def _fixture_verifier(
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+    output: ModelBenchmarkTaskOutput,
+) -> ModelBenchmarkVerifierResult:
+    expected = _digest(
+        "model_autoresearch_fixture_output",
+        {
+            "candidate_id": candidate.candidate_id,
+            "task_id": task.task_id,
+            "prompt_digest": task.prompt_digest,
+            "expected_output_digest": task.expected_output_digest,
+        },
+    )
+    accepted = output.output_digest == expected
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.ACCEPT if accepted else VerifierDecision.REJECT,
+        verifier_receipt_id=_digest(
+            "model_autoresearch_fixture_verifier",
+            {
+                "candidate_id": candidate.candidate_id,
+                "task_id": task.task_id,
+                "output_digest": output.output_digest,
+                "accepted": accepted,
+            },
+        ),
+        evidence_correct=accepted,
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _mapping_list(value: Any, key: str) -> tuple[Mapping[str, Any], ...] | None:
+    raw = value
+    if isinstance(value, Mapping):
+        raw = value.get(key)
+    if not isinstance(raw, list):
+        return None
+    records: list[Mapping[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            return None
+        records.append(item)
+    return tuple(records)
+
+
+def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str, ...]:
+    if not value:
+        return ("model_autoresearch_campaign_execution_output_path_invalid",)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return ("model_autoresearch_campaign_execution_output_path_invalid",)
+    return ()
+
+
+def _mode_reasons(runner_mode: str, verifier_mode: str) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if str(runner_mode or "").strip() != MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER:
+        reasons.append("unsupported_model_autoresearch_campaign_runner_mode")
+    if str(verifier_mode or "").strip() != MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER:
+        reasons.append("unsupported_model_autoresearch_campaign_verifier_mode")
+    return tuple(reasons)
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _digest(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _not_ready(
+    reasons: tuple[str, ...] | list[str],
+) -> ModelAutoResearchCampaignExecutionBootstrapResult:
+    return ModelAutoResearchCampaignExecutionBootstrapResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY,
+        execution_receipt_id=None,
+        source_plan_receipt_id=None,
+        benchmark_run_receipt_id=None,
+        output_path=None,
+        executed_candidate_ids=(),
+        task_count=0,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED",
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY",
+    "MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER",
+    "MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER",
+    "ModelAutoResearchCampaignExecutionBootstrapResult",
+    "run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -1,0 +1,193 @@
+"""Tests for REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
+    rehydrate_model_autoresearch_campaign_execution_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution_artifact_supply_bootstrap import (
+    MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED,
+    MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY,
+    run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
+    REPO_ROOT,
+    _plan,
+    _tasks,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_champion_challenger_autoresearch import (
+    _candidate,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_campaign_execution_artifact_supply_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    return {
+        "plan": _write_json(runtime, "autoresearch_plan.json", _plan().to_dict()),
+        "candidates": _write_json(
+            runtime,
+            "candidate_pool.json",
+            {
+                "candidate_pool": [
+                    _candidate("provider/challenger").to_dict(),
+                    _candidate("provider/new").to_dict(),
+                ]
+            },
+        ),
+        "tasks": _write_json(runtime, "tasks.json", {"tasks": [task.to_dict() for task in _tasks()]}),
+        "output": runtime / "campaign_execution.json",
+    }
+
+
+def test_campaign_execution_bootstrap_materializes_rehydratable_receipt(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED
+    assert result.execution_receipt_id
+    assert result.execution_receipt_id.startswith("model_autoresearch_campaign_execution:")
+    assert result.executed_candidate_ids == ("provider/new", "provider/challenger")
+    assert result.task_count == 2
+    assert result.no_direct_provider_call_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
+    assert receipt.receipt_id == result.execution_receipt_id
+
+
+def test_campaign_execution_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    repo_plan = REPO_ROOT / "model_autoresearch_plan_receipt.json"
+    repo_output = REPO_ROOT / "model_autoresearch_campaign_execution.json"
+    repo_plan.write_text("{}", encoding="utf-8")
+    try:
+        result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+            repo_root=REPO_ROOT,
+            plan_receipt_path=repo_plan,
+            candidate_pool_path=files["candidates"],
+            tasks_path=files["tasks"],
+            output_path=repo_output,
+            verifier_digest="sha256:verifier",
+            held_out_split_id="heldout-v1",
+        )
+    finally:
+        repo_plan.unlink(missing_ok=True)
+        repo_output.unlink(missing_ok=True)
+
+    assert result.accepted is False
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_plan_receipt_path_inside_repo" in result.rejection_reasons
+    assert "model_autoresearch_campaign_execution_output_path_invalid" in result.rejection_reasons
+
+
+def test_campaign_execution_bootstrap_rejects_malformed_tasks_before_execution(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    bad_tasks = _write_json(tmp_path / "runtime", "bad_tasks.json", {"tasks": [{"task_id": "missing"}]})
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=bad_tasks,
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_execution_tasks_invalid" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_campaign_execution_bootstrap_rejects_verifier_mismatch(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        output_path=files["output"],
+        verifier_digest="sha256:wrong",
+        held_out_split_id="heldout-v1",
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_execution_verifier_digest_mismatch" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_campaign_execution_bootstrap_rejects_non_fixture_modes(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode="provider",
+        verifier_mode="remote",
+    )
+
+    assert result.accepted is False
+    assert "unsupported_model_autoresearch_campaign_runner_mode" in result.rejection_reasons
+    assert "unsupported_model_autoresearch_campaign_verifier_mode" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_campaign_execution_bootstrap_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH` as a
+  profile-derived resident runtime path.
+- Wired `main.py` to optionally run the model AutoResearch campaign execution
+  artifact-supply bootstrap after plan artifact supply and before FIX
+  promotion.
+- The hook is disabled by default and uses only the deterministic fixture
+  runner/verifier mode exposed by the AI gateway bootstrap.
+- Enforced mode can block startup when the campaign execution artifact cannot
+  be materialized.
+- Boundary remains constrained: no RedDog extension runtime, provider call,
+  shell execution, HoloIndex re-index, PatternMemory write, model promotion,
+  worker spawn, source mutation, PR publication, reward settlement, or merge
+  authority was added.
+
 ## 2026-07-17: REDDOG_RESIDENT_MODEL_FEEDBACK_LEDGER_PROFILE_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -99,6 +99,9 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": "model_selection_receipt.json",
     "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH": "model_runtime_binding_receipt.json",
     "REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH": "model_autoresearch_plan_receipt.json",
+    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH": (
+        "model_autoresearch_campaign_execution_receipt.json"
+    ),
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": "principal_authority_record.json",
     "REDDOG_PERMISSION_SNAPSHOT_PATH": "permission_snapshot.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -576,6 +576,135 @@ def test_main_preflight_enforced_model_autoresearch_plan_supply_blocks_startup(
             assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
 
 
+def test_main_preflight_model_autoresearch_campaign_execution_supply_runs_before_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    campaign_result = type(
+        "AutoResearchCampaignResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED",
+            "execution_receipt_id": "model_autoresearch_campaign_execution:runtime",
+            "source_plan_receipt_id": "model_autoresearch_plan:runtime",
+            "benchmark_run_receipt_id": "model_benchmark_run:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_campaign_execution_receipt.json"),
+            "executed_candidate_ids": ("provider/new",),
+            "task_count": 2,
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution_artifact_supply_bootstrap.run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap",
+        return_value=campaign_result,
+    ) as campaign_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH": str(tmp_path / "candidates.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH": str(tmp_path / "tasks.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST": "sha256:verifier",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID": "heldout-v1",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ[
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH"
+                ] == str(runtime_root / "model_autoresearch_campaign_execution_receipt.json")
+
+    campaign_supply.assert_called_once()
+    campaign_kwargs = campaign_supply.call_args.kwargs
+    assert campaign_kwargs["plan_receipt_path"] == str(runtime_root / "model_autoresearch_plan_receipt.json")
+    assert campaign_kwargs["candidate_pool_path"] == str(tmp_path / "candidates.json")
+    assert campaign_kwargs["tasks_path"] == str(tmp_path / "tasks.json")
+    assert campaign_kwargs["output_path"] == str(runtime_root / "model_autoresearch_campaign_execution_receipt.json")
+    assert campaign_kwargs["verifier_digest"] == "sha256:verifier"
+    assert campaign_kwargs["held_out_split_id"] == "heldout-v1"
+    promote.assert_called_once()
+
+
+def test_main_preflight_enforced_model_autoresearch_campaign_execution_blocks_startup(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    campaign_result = type(
+        "AutoResearchCampaignResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY",
+            "execution_receipt_id": None,
+            "source_plan_receipt_id": None,
+            "benchmark_run_receipt_id": None,
+            "output_path": None,
+            "executed_candidate_ids": (),
+            "task_count": 0,
+            "rejection_reasons": ("missing_model_autoresearch_campaign_tasks_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution_artifact_supply_bootstrap.run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap",
+        return_value=campaign_result,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "1",
+                "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+
 def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
﻿## Slice
REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1

## WSP_97 truth boundary
- IMPLEMENTED: disabled-by-default `main.py` preflight hook and AI gateway bootstrap that materializes a `ModelAutoResearchCampaignExecutionReceipt` from outside-repo plan/candidate/task artifacts using deterministic fixture runner/verifier seams.
- NOT IMPLEMENTED: provider calls, network research, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell execution, extension mutation, PR publication, reward settlement, or merge authority.

## Scope
- `main.py`
- `modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py`
- `modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py`
- `modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py`
- `modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py`
- ModLogs

## Validation
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` -> 6 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py` -> 19 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 139 passed
- `git diff --check` -> clean (CRLF warnings only)

## Note
A guessed profile-specific test path did not exist, so coverage is through the resident preflight test file that exercises the profile-derived runtime path.
