### PR TITLE
feat(ai-gateway): supply autoresearch promotion gates at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1607,6 +1607,8 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY=0 Execute deterministic campaign fixture
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY=0 Materialize campaign promotion-gate receipts
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
@@ -1624,6 +1626,9 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID Held-out split ID for benchmark receipt
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE       deterministic_fixture only
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture only
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH Outside-repo promotion policies JSON
+        REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID Optional promotion authority receipt ID
+        REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID Optional signed promotion receipt ID
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY=0 Materialize principal/snapshot from GitHub probe
         REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY_ENFORCED=0 Block startup if rejected
@@ -1679,10 +1684,20 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         repo_root,
         "REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH",
     )
+    model_autoresearch_promotion_gate_receipts_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH",
+    )
     model_autoresearch_campaign_execution_receipt_path = resident_queue_runtime_file_path(
         os.environ,
         repo_root,
         "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH",
+    )
+    model_autoresearch_campaign_promotion_policies_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH",
     )
     model_runtime_binding_receipt_path_supplied = bool(
         os.getenv("REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH", "").strip()
@@ -1877,11 +1892,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
 
             autoresearch_supply = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
                 repo_root=repo_root,
-                promotion_gate_receipts_path=os.getenv(
-                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH",
-                    "",
-                )
-                or None,
+                promotion_gate_receipts_path=model_autoresearch_promotion_gate_receipts_path or None,
                 candidate_pool_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH", "") or None,
                 policy_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_POLICY_PATH", "") or None,
                 feedback_records_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH", "") or None,
@@ -1980,6 +1991,70 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print(
                 "[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] Startup blocked by "
                 "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=1"
+            )
+            return False
+
+    autoresearch_campaign_gate_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY",
+    )
+    autoresearch_campaign_gate_enforced = (
+        os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED", "0") != "0"
+    )
+    if autoresearch_campaign_gate_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply_bootstrap import (
+                run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap,
+            )
+
+            autoresearch_campaign_gate = (
+                run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap(
+                    repo_root=repo_root,
+                    campaign_execution_receipt_path=model_autoresearch_campaign_execution_receipt_path,
+                    promotion_policies_path=model_autoresearch_campaign_promotion_policies_path or None,
+                    output_path=model_autoresearch_promotion_gate_receipts_path,
+                    promotion_authority_receipt_id=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID",
+                        "",
+                    )
+                    or None,
+                    signed_promotion_receipt_id=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID",
+                        "",
+                    )
+                    or None,
+                )
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-AUTORESEARCH-GATE] Startup artifact supply failed: {exc}")
+            if autoresearch_campaign_gate_enforced:
+                print(f"[REDDOG-MODEL-AUTORESEARCH-GATE] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-AUTORESEARCH-GATE] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        gate_status = "PASS" if autoresearch_campaign_gate.accepted else "WARN"
+        gate_reasons = (
+            ",".join(autoresearch_campaign_gate.rejection_reasons)
+            if autoresearch_campaign_gate.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-AUTORESEARCH-GATE] preflight={gate_status} "
+            f"status={autoresearch_campaign_gate.status} "
+            f"receipt={autoresearch_campaign_gate.supply_receipt_id or '(none)'} "
+            f"gates={len(autoresearch_campaign_gate.promotion_gate_receipt_ids)} "
+            f"reasons={gate_reasons}"
+        )
+        if autoresearch_campaign_gate.accepted and autoresearch_campaign_gate.output_path:
+            model_autoresearch_promotion_gate_receipts_path = autoresearch_campaign_gate.output_path
+            os.environ["REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH"] = (
+                model_autoresearch_promotion_gate_receipts_path
+            )
+        elif autoresearch_campaign_gate_enforced:
+            print(
+                "[REDDOG-MODEL-AUTORESEARCH-GATE] Startup blocked by "
+                "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=1"
             )
             return False
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,39 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Campaign Promotion Gate Supply Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Preflight Adapter
+**Slice:** REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**What:** Added a disabled-by-default bootstrap for materializing promotion-gate
+receipts from outside-repo AutoResearch campaign execution and promotion-policy
+artifacts.
+
+**Why:** The campaign execution bridge can now produce promotion-gate receipts,
+but resident startup needs an explicit, outside-repo artifact pathway to persist
+those receipts for the next planning cycle.
+
+**Files:**
+- `src/model_autoresearch_campaign_promotion_gate_supply_bootstrap.py` - reads
+  outside-repo campaign execution and promotion policy JSON, invokes the
+  promotion-gate supply bridge, and writes an outside-repo gate supply receipt.
+- `tests/test_model_autoresearch_campaign_promotion_gate_supply_bootstrap.py`
+  - verifies successful materialization, inside-repo path rejection, malformed
+  policy rejection, candidate mismatch rejection, and AST import/call denylist
+  controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: opt-in campaign promotion-gate artifact supply from outside-repo
+  receipts and policies.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn,
+  shell execution, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Campaign Promotion Gate Supply
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_promotion_gate_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_promotion_gate_supply_bootstrap.py
@@ -1,0 +1,200 @@
+"""Main-startup bootstrap for model AutoResearch promotion-gate supply.
+
+Slice: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads an outside-repo campaign execution receipt plus explicit
+promotion policies, then materializes promotion-gate receipts for the next
+AutoResearch planning cycle.
+
+It does not call providers, run benchmarks, promote models, mutate catalogs,
+write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers,
+execute commands, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply import (
+    MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ACCEPT,
+    run_reddog_model_autoresearch_campaign_promotion_gate_supply,
+)
+
+
+MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED = (
+    "MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED"
+)
+MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY = (
+    "MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY"
+)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCampaignPromotionGateBootstrapResult:
+    accepted: bool
+    status: str
+    supply_receipt_id: Optional[str]
+    source_execution_receipt_id: Optional[str]
+    output_path: Optional[str]
+    promotion_gate_receipt_ids: tuple[str, ...]
+    rejection_reasons: tuple[str, ...]
+    no_direct_provider_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    campaign_execution_receipt_path: Path | str | None,
+    promotion_policies_path: Path | str | None,
+    output_path: Path | str | None,
+    promotion_authority_receipt_id: str | None = None,
+    signed_promotion_receipt_id: str | None = None,
+) -> ModelAutoResearchCampaignPromotionGateBootstrapResult:
+    """Materialize promotion-gate receipts from outside-repo runtime files."""
+
+    root = Path(repo_root).resolve()
+    execution_payload, execution_reasons = _read_json_outside_repo(
+        root,
+        campaign_execution_receipt_path,
+        missing_reason="missing_model_autoresearch_campaign_execution_receipt_path",
+        inside_reason="model_autoresearch_campaign_execution_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_campaign_execution_receipt",
+    )
+    policy_payload, policy_reasons = _read_json_outside_repo(
+        root,
+        promotion_policies_path,
+        missing_reason="missing_model_autoresearch_campaign_promotion_policies_path",
+        inside_reason="model_autoresearch_campaign_promotion_policies_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_campaign_promotion_policies",
+    )
+    reasons = [
+        *execution_reasons,
+        *policy_reasons,
+        *_output_path_reasons(root, output_path),
+    ]
+    promotion_policies = _mapping_list(policy_payload, "promotion_policies")
+    if execution_payload is not None and not isinstance(execution_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_campaign_execution_receipt")
+    if policy_payload is not None and promotion_policies is None:
+        reasons.append("malformed_model_autoresearch_campaign_promotion_policies")
+    if reasons:
+        return _not_ready(reasons)
+
+    assert isinstance(execution_payload, Mapping)
+    assert promotion_policies is not None
+    supply = run_reddog_model_autoresearch_campaign_promotion_gate_supply(
+        repo_root=root,
+        campaign_execution_receipt=execution_payload,
+        promotion_policies=promotion_policies,
+        output_path=output_path,
+        promotion_authority_receipt_id=promotion_authority_receipt_id,
+        signed_promotion_receipt_id=signed_promotion_receipt_id,
+    )
+    if not supply.accepted or supply.status != MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ACCEPT:
+        return _not_ready(supply.rejection_reasons or ("model_autoresearch_campaign_promotion_gate_rejected",))
+    return ModelAutoResearchCampaignPromotionGateBootstrapResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED,
+        supply_receipt_id=supply.supply_receipt_id,
+        source_execution_receipt_id=supply.source_execution_receipt_id,
+        output_path=supply.output_path,
+        promotion_gate_receipt_ids=supply.promotion_gate_receipt_ids,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _mapping_list(value: Any, key: str) -> tuple[Mapping[str, Any], ...] | None:
+    raw = value
+    if isinstance(value, Mapping):
+        raw = value.get(key)
+    if not isinstance(raw, list):
+        return None
+    records: list[Mapping[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, Mapping):
+            return None
+        records.append(item)
+    return tuple(records)
+
+
+def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str, ...]:
+    if not value:
+        return ("model_autoresearch_campaign_promotion_gate_output_path_invalid",)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return ("model_autoresearch_campaign_promotion_gate_output_path_invalid",)
+    return ()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: tuple[str, ...] | list[str],
+) -> ModelAutoResearchCampaignPromotionGateBootstrapResult:
+    return ModelAutoResearchCampaignPromotionGateBootstrapResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY,
+        supply_receipt_id=None,
+        source_execution_receipt_id=None,
+        output_path=None,
+        promotion_gate_receipt_ids=(),
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED",
+    "MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY",
+    "ModelAutoResearchCampaignPromotionGateBootstrapResult",
+    "run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_promotion_gate_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_promotion_gate_supply_bootstrap.py
@@ -1,0 +1,152 @@
+"""Tests for REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply import (
+    rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply_bootstrap import (
+    MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED,
+    MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY,
+    run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
+    REPO_ROOT,
+    _execution_payload,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_promotion_gate_supply import (
+    _policies,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_campaign_promotion_gate_supply_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    execution = _execution_payload(tmp_path)
+    return {
+        "execution": _write_json(runtime, "campaign_execution.json", execution),
+        "policies": _write_json(runtime, "promotion_policies.json", {"promotion_policies": list(_policies(execution))}),
+        "output": runtime / "promotion_gates.json",
+    }
+
+
+def test_campaign_promotion_gate_bootstrap_materializes_gate_supply(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        campaign_execution_receipt_path=files["execution"],
+        promotion_policies_path=files["policies"],
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+        output_path=files["output"],
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED
+    assert result.supply_receipt_id
+    assert len(result.promotion_gate_receipt_ids) == 2
+    assert result.no_model_promotion_performed is True
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    receipt = rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt(payload)
+    assert receipt.receipt_id == result.supply_receipt_id
+
+
+def test_campaign_promotion_gate_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    repo_execution = REPO_ROOT / "model_autoresearch_campaign_execution_receipt.json"
+    repo_output = REPO_ROOT / "model_autoresearch_campaign_promotion_gates.json"
+    repo_execution.write_text("{}", encoding="utf-8")
+    try:
+        result = run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap(
+            repo_root=REPO_ROOT,
+            campaign_execution_receipt_path=repo_execution,
+            promotion_policies_path=files["policies"],
+            output_path=repo_output,
+        )
+    finally:
+        repo_execution.unlink(missing_ok=True)
+        repo_output.unlink(missing_ok=True)
+
+    assert result.accepted is False
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_campaign_execution_receipt_path_inside_repo" in result.rejection_reasons
+    assert "model_autoresearch_campaign_promotion_gate_output_path_invalid" in result.rejection_reasons
+
+
+def test_campaign_promotion_gate_bootstrap_rejects_malformed_policy_payload(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    bad_policy = _write_json(tmp_path / "runtime", "bad_policies.json", {"promotion_policies": [{}]})
+
+    result = run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        campaign_execution_receipt_path=files["execution"],
+        promotion_policies_path=bad_policy,
+        output_path=files["output"],
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_campaign_gate_policies_invalid" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_campaign_promotion_gate_bootstrap_rejects_policy_candidate_mismatch(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    payload = json.loads(files["policies"].read_text(encoding="utf-8"))
+    payload["promotion_policies"] = payload["promotion_policies"][:1]
+    short_policy = _write_json(tmp_path / "runtime", "short_policies.json", payload)
+
+    result = run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        campaign_execution_receipt_path=files["execution"],
+        promotion_policies_path=short_policy,
+        output_path=files["output"],
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_campaign_gate_policy_candidate_mismatch" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_campaign_promotion_gate_bootstrap_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added profile-derived runtime paths for
+  `REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH` and
+  `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH`.
+- Wired `main.py` to optionally run campaign promotion-gate artifact supply
+  after campaign execution supply and before FIX promotion.
+- Successful supply updates `REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH`
+  so a later AutoResearch planning cycle can consume the fresh gate receipts.
+- The hook is disabled by default and only consumes outside-repo execution and
+  policy artifacts.
+- Boundary remains constrained: no provider call, benchmark execution,
+  HoloIndex re-index, PatternMemory write, model promotion, runtime binding,
+  worker spawn, source mutation, PR publication, reward settlement, or merge
+  authority was added.
+
 ## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -98,9 +98,15 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": "architect_determination.json",
     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": "model_selection_receipt.json",
     "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH": "model_runtime_binding_receipt.json",
+    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH": (
+        "model_autoresearch_promotion_gate_receipts.json"
+    ),
     "REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH": "model_autoresearch_plan_receipt.json",
     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH": (
         "model_autoresearch_campaign_execution_receipt.json"
+    ),
+    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH": (
+        "model_autoresearch_campaign_promotion_policies.json"
     ),
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": "principal_authority_record.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -705,6 +705,133 @@ def test_main_preflight_enforced_model_autoresearch_campaign_execution_blocks_st
             assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
 
 
+def test_main_preflight_model_autoresearch_campaign_gate_supply_runs_before_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    gate_result = type(
+        "AutoResearchCampaignGateResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_APPLIED",
+            "supply_receipt_id": "model_autoresearch_campaign_promotion_gate_supply:runtime",
+            "source_execution_receipt_id": "model_autoresearch_campaign_execution:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_promotion_gate_receipts.json"),
+            "promotion_gate_receipt_ids": ("model_promotion_gate:1",),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply_bootstrap.run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap",
+        return_value=gate_result,
+    ) as gate_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID": "authority:1",
+                    "REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID": "signed:1",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH"] == str(
+                    runtime_root / "model_autoresearch_promotion_gate_receipts.json"
+                )
+
+    gate_supply.assert_called_once()
+    gate_kwargs = gate_supply.call_args.kwargs
+    assert gate_kwargs["campaign_execution_receipt_path"] == str(
+        runtime_root / "model_autoresearch_campaign_execution_receipt.json"
+    )
+    assert gate_kwargs["promotion_policies_path"] == str(
+        runtime_root / "model_autoresearch_campaign_promotion_policies.json"
+    )
+    assert gate_kwargs["output_path"] == str(runtime_root / "model_autoresearch_promotion_gate_receipts.json")
+    assert gate_kwargs["promotion_authority_receipt_id"] == "authority:1"
+    assert gate_kwargs["signed_promotion_receipt_id"] == "signed:1"
+    promote.assert_called_once()
+
+
+def test_main_preflight_enforced_model_autoresearch_campaign_gate_supply_blocks_startup(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    gate_result = type(
+        "AutoResearchCampaignGateResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_BOOTSTRAP_NOT_READY",
+            "supply_receipt_id": None,
+            "source_execution_receipt_id": None,
+            "output_path": None,
+            "promotion_gate_receipt_ids": (),
+            "rejection_reasons": ("missing_model_autoresearch_campaign_promotion_policies_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply_bootstrap.run_reddog_model_autoresearch_campaign_promotion_gate_supply_bootstrap",
+        return_value=gate_result,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY": "1",
+                "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+
 def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
﻿## Slice
REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_MAIN_PREFLIGHT_PHASE1

## WSP_97 truth boundary
- IMPLEMENTED: disabled-by-default `main.py` preflight hook and AI gateway bootstrap that materializes campaign promotion-gate receipts from outside-repo campaign execution and promotion-policy artifacts.
- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn, shell execution, extension mutation, PR publication, reward settlement, or merge authority.

## Scope
- `main.py`
- `modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_promotion_gate_supply_bootstrap.py`
- `modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_promotion_gate_supply_bootstrap.py`
- `modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py`
- `modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py`
- ModLogs

## Validation
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_promotion_gate_supply_bootstrap.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_promotion_gate_supply_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_promotion_gate_supply_bootstrap.py` -> 5 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py` -> 21 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 151 passed
- `git diff --check` -> clean (CRLF warnings only)
