### PR TITLE
feat(ai-gateway): bind autoresearch cycle receipts

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,37 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Receipt
+
+**Who:** 0102 Codex
+**Type:** Receipt Integrity
+**Slice:** MODEL_AUTORESEARCH_CYCLE_RECEIPT_PHASE1
+
+**What:** Added a digest-bound cycle receipt that binds one AutoResearch plan,
+campaign execution, and promotion-gate supply artifact.
+
+**Why:** Recursive model improvement needs a single evidence object proving
+which plan was executed and which promotion-gate receipts resulted before a
+later queue stage or feedback ledger consumes the cycle output.
+
+**Files:**
+- `src/model_autoresearch_cycle_receipt.py` - rehydrates and binds plan,
+  execution, and gate-supply receipts; rejects plan/execution, execution/gate,
+  and candidate coverage mismatches; supports rehydration of the cycle receipt.
+- `tests/test_model_autoresearch_cycle_receipt.py` - verifies successful
+  binding, each mismatch rejection, receipt tamper rejection, and AST
+  import/call denylist controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: receipt-bound proof for plan -> execution -> promotion-gate
+  supply continuity.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn,
+  shell execution, file output, or main.py preflight wiring.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Campaign Promotion Gate Supply Bootstrap
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt.py
@@ -1,0 +1,217 @@
+"""Digest-bound model AutoResearch cycle receipt.
+
+Slice: MODEL_AUTORESEARCH_CYCLE_RECEIPT_PHASE1
+
+This module binds one AutoResearch cycle:
+
+plan receipt -> campaign execution receipt -> promotion-gate supply receipt
+
+It does not call providers, run benchmarks, promote models, mutate catalogs,
+write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers,
+execute commands, or write files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from .model_autoresearch_campaign_execution import (
+    ModelAutoResearchCampaignExecutionReceipt,
+    rehydrate_model_autoresearch_campaign_execution_receipt,
+)
+from .model_autoresearch_campaign_promotion_gate_supply import (
+    ModelAutoResearchCampaignPromotionGateSupplyReceipt,
+    rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt,
+)
+from .model_champion_challenger_autoresearch import (
+    ModelAutoResearchPlanReceipt,
+    rehydrate_model_autoresearch_plan_receipt,
+)
+
+
+MODEL_AUTORESEARCH_CYCLE_SCHEMA_VERSION = "model_autoresearch_cycle_receipt.v1"
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCycleReceipt:
+    receipt_id: str
+    source_plan_receipt_id: str
+    campaign_execution_receipt_id: str
+    promotion_gate_supply_receipt_id: str
+    executed_candidate_ids: tuple[str, ...]
+    promotion_gate_receipt_ids: tuple[str, ...]
+    schema_version: str = MODEL_AUTORESEARCH_CYCLE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "source_plan_receipt_id": self.source_plan_receipt_id,
+            "campaign_execution_receipt_id": self.campaign_execution_receipt_id,
+            "promotion_gate_supply_receipt_id": self.promotion_gate_supply_receipt_id,
+            "executed_candidate_ids": list(self.executed_candidate_ids),
+            "promotion_gate_receipt_ids": list(self.promotion_gate_receipt_ids),
+        }
+
+
+def build_model_autoresearch_cycle_receipt(
+    *,
+    plan_receipt: Mapping[str, Any] | ModelAutoResearchPlanReceipt,
+    campaign_execution_receipt: Mapping[str, Any] | ModelAutoResearchCampaignExecutionReceipt,
+    promotion_gate_supply_receipt: Mapping[str, Any] | ModelAutoResearchCampaignPromotionGateSupplyReceipt,
+) -> ModelAutoResearchCycleReceipt:
+    """Build a receipt that binds one complete AutoResearch evidence cycle."""
+
+    plan = _plan(plan_receipt)
+    execution = _execution(campaign_execution_receipt)
+    gate_supply = _gate_supply(promotion_gate_supply_receipt)
+    if execution.source_plan_receipt_id != plan.receipt_id:
+        raise ValueError("autoresearch_cycle_plan_execution_mismatch")
+    if gate_supply.source_execution_receipt_id != execution.receipt_id:
+        raise ValueError("autoresearch_cycle_execution_gate_mismatch")
+    gate_candidate_ids = tuple(sorted(gate.candidate_id for gate in gate_supply.promotion_gate_receipts))
+    executed_candidate_ids = tuple(sorted(execution.executed_candidate_ids))
+    if gate_candidate_ids != executed_candidate_ids:
+        raise ValueError("autoresearch_cycle_candidate_mismatch")
+    promotion_gate_receipt_ids = tuple(gate.receipt_id for gate in gate_supply.promotion_gate_receipts)
+    body = _cycle_digest_body(
+        source_plan_receipt_id=plan.receipt_id,
+        campaign_execution_receipt_id=execution.receipt_id,
+        promotion_gate_supply_receipt_id=gate_supply.receipt_id,
+        executed_candidate_ids=executed_candidate_ids,
+        promotion_gate_receipt_ids=promotion_gate_receipt_ids,
+    )
+    return ModelAutoResearchCycleReceipt(
+        receipt_id=_digest_prefixed("model_autoresearch_cycle", body),
+        source_plan_receipt_id=plan.receipt_id,
+        campaign_execution_receipt_id=execution.receipt_id,
+        promotion_gate_supply_receipt_id=gate_supply.receipt_id,
+        executed_candidate_ids=executed_candidate_ids,
+        promotion_gate_receipt_ids=promotion_gate_receipt_ids,
+    )
+
+
+def rehydrate_model_autoresearch_cycle_receipt(
+    payload: Mapping[str, Any],
+) -> ModelAutoResearchCycleReceipt:
+    """Rehydrate a serialized cycle receipt and verify its digest."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_autoresearch_cycle_receipt")
+    if payload.get("schema_version") != MODEL_AUTORESEARCH_CYCLE_SCHEMA_VERSION:
+        raise ValueError("invalid_autoresearch_cycle_schema")
+    source_plan_receipt_id = _required(payload.get("source_plan_receipt_id"), "source_plan_receipt_id")
+    campaign_execution_receipt_id = _required(
+        payload.get("campaign_execution_receipt_id"),
+        "campaign_execution_receipt_id",
+    )
+    promotion_gate_supply_receipt_id = _required(
+        payload.get("promotion_gate_supply_receipt_id"),
+        "promotion_gate_supply_receipt_id",
+    )
+    executed_candidate_ids = _string_tuple(payload.get("executed_candidate_ids"), "executed_candidate_ids")
+    promotion_gate_receipt_ids = _string_tuple(
+        payload.get("promotion_gate_receipt_ids"),
+        "promotion_gate_receipt_ids",
+    )
+    body = _cycle_digest_body(
+        source_plan_receipt_id=source_plan_receipt_id,
+        campaign_execution_receipt_id=campaign_execution_receipt_id,
+        promotion_gate_supply_receipt_id=promotion_gate_supply_receipt_id,
+        executed_candidate_ids=executed_candidate_ids,
+        promotion_gate_receipt_ids=promotion_gate_receipt_ids,
+    )
+    receipt_id = _digest_prefixed("model_autoresearch_cycle", body)
+    if not hmac.compare_digest(receipt_id, _required(payload.get("receipt_id"), "receipt_id")):
+        raise ValueError("autoresearch_cycle_receipt_id_mismatch")
+    return ModelAutoResearchCycleReceipt(
+        receipt_id=receipt_id,
+        source_plan_receipt_id=source_plan_receipt_id,
+        campaign_execution_receipt_id=campaign_execution_receipt_id,
+        promotion_gate_supply_receipt_id=promotion_gate_supply_receipt_id,
+        executed_candidate_ids=executed_candidate_ids,
+        promotion_gate_receipt_ids=promotion_gate_receipt_ids,
+    )
+
+
+def _plan(value: Mapping[str, Any] | ModelAutoResearchPlanReceipt) -> ModelAutoResearchPlanReceipt:
+    if isinstance(value, ModelAutoResearchPlanReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_autoresearch_plan_receipt(value)
+    raise ValueError("invalid_autoresearch_plan")
+
+
+def _execution(
+    value: Mapping[str, Any] | ModelAutoResearchCampaignExecutionReceipt,
+) -> ModelAutoResearchCampaignExecutionReceipt:
+    if isinstance(value, ModelAutoResearchCampaignExecutionReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_autoresearch_campaign_execution_receipt(value)
+    raise ValueError("invalid_autoresearch_execution")
+
+
+def _gate_supply(
+    value: Mapping[str, Any] | ModelAutoResearchCampaignPromotionGateSupplyReceipt,
+) -> ModelAutoResearchCampaignPromotionGateSupplyReceipt:
+    if isinstance(value, ModelAutoResearchCampaignPromotionGateSupplyReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt(value)
+    raise ValueError("invalid_autoresearch_gate_supply")
+
+
+def _cycle_digest_body(
+    *,
+    source_plan_receipt_id: str,
+    campaign_execution_receipt_id: str,
+    promotion_gate_supply_receipt_id: str,
+    executed_candidate_ids: tuple[str, ...],
+    promotion_gate_receipt_ids: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "schema_version": MODEL_AUTORESEARCH_CYCLE_SCHEMA_VERSION,
+        "source_plan_receipt_id": source_plan_receipt_id,
+        "campaign_execution_receipt_id": campaign_execution_receipt_id,
+        "promotion_gate_supply_receipt_id": promotion_gate_supply_receipt_id,
+        "executed_candidate_ids": list(executed_candidate_ids),
+        "promotion_gate_receipt_ids": list(promotion_gate_receipt_ids),
+    }
+
+
+def _required(value: Any, name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(name + "_missing")
+    return text
+
+
+def _required_list(value: Any, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(name + "_invalid")
+    return value
+
+
+def _string_tuple(value: Any, name: str) -> tuple[str, ...]:
+    records = tuple(_required(item, name) for item in _required_list(value, name))
+    if len(set(records)) != len(records):
+        raise ValueError(name + "_duplicate")
+    return records
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CYCLE_SCHEMA_VERSION",
+    "ModelAutoResearchCycleReceipt",
+    "build_model_autoresearch_cycle_receipt",
+    "rehydrate_model_autoresearch_cycle_receipt",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt.py
@@ -1,0 +1,164 @@
+"""Tests for MODEL_AUTORESEARCH_CYCLE_RECEIPT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
+    rehydrate_model_autoresearch_campaign_execution_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply import (
+    rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt,
+    run_reddog_model_autoresearch_campaign_promotion_gate_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import (
+    build_model_autoresearch_cycle_receipt,
+    rehydrate_model_autoresearch_cycle_receipt,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
+    REPO_ROOT,
+    _execution_payload,
+    _plan,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_promotion_gate_supply import (
+    _policies,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_cycle_receipt.py"
+)
+
+
+def _cycle_sources(tmp_path: Path):
+    plan = _plan()
+    execution_payload = _execution_payload(tmp_path)
+    execution = rehydrate_model_autoresearch_campaign_execution_receipt(execution_payload)
+    gate_output = tmp_path / "runtime" / "promotion_gates.json"
+    gate_result = run_reddog_model_autoresearch_campaign_promotion_gate_supply(
+        repo_root=REPO_ROOT,
+        campaign_execution_receipt=execution_payload,
+        promotion_policies=_policies(execution_payload),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+        output_path=gate_output,
+    )
+    assert gate_result.accepted is True
+    gate_supply = rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt(
+        json.loads(gate_output.read_text(encoding="utf-8"))
+    )
+    return plan, execution, gate_supply
+
+
+def test_cycle_receipt_binds_plan_execution_and_gate_supply(tmp_path: Path) -> None:
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+
+    receipt = build_model_autoresearch_cycle_receipt(
+        plan_receipt=plan,
+        campaign_execution_receipt=execution,
+        promotion_gate_supply_receipt=gate_supply,
+    )
+
+    assert receipt.receipt_id.startswith("model_autoresearch_cycle:")
+    assert receipt.source_plan_receipt_id == plan.receipt_id
+    assert receipt.campaign_execution_receipt_id == execution.receipt_id
+    assert receipt.promotion_gate_supply_receipt_id == gate_supply.receipt_id
+    assert receipt.executed_candidate_ids == ("provider/challenger", "provider/new")
+    assert rehydrate_model_autoresearch_cycle_receipt(receipt.to_dict()) == receipt
+
+
+def test_cycle_receipt_rejects_plan_execution_mismatch(tmp_path: Path) -> None:
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    mismatched_execution = replace(execution, source_plan_receipt_id="model_autoresearch_plan:other")
+
+    try:
+        build_model_autoresearch_cycle_receipt(
+            plan_receipt=plan,
+            campaign_execution_receipt=mismatched_execution,
+            promotion_gate_supply_receipt=gate_supply,
+        )
+    except ValueError as exc:
+        assert str(exc) == "autoresearch_cycle_plan_execution_mismatch"
+    else:
+        raise AssertionError("mismatched plan/execution was accepted")
+
+
+def test_cycle_receipt_rejects_execution_gate_mismatch(tmp_path: Path) -> None:
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    mismatched_gate = replace(gate_supply, source_execution_receipt_id="model_autoresearch_campaign_execution:other")
+
+    try:
+        build_model_autoresearch_cycle_receipt(
+            plan_receipt=plan,
+            campaign_execution_receipt=execution,
+            promotion_gate_supply_receipt=mismatched_gate,
+        )
+    except ValueError as exc:
+        assert str(exc) == "autoresearch_cycle_execution_gate_mismatch"
+    else:
+        raise AssertionError("mismatched execution/gate was accepted")
+
+
+def test_cycle_receipt_rejects_candidate_coverage_mismatch(tmp_path: Path) -> None:
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    missing_gate = replace(gate_supply, promotion_gate_receipts=gate_supply.promotion_gate_receipts[:1])
+
+    try:
+        build_model_autoresearch_cycle_receipt(
+            plan_receipt=plan,
+            campaign_execution_receipt=execution,
+            promotion_gate_supply_receipt=missing_gate,
+        )
+    except ValueError as exc:
+        assert str(exc) == "autoresearch_cycle_candidate_mismatch"
+    else:
+        raise AssertionError("mismatched candidate coverage was accepted")
+
+
+def test_cycle_receipt_rehydration_rejects_tamper(tmp_path: Path) -> None:
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    receipt = build_model_autoresearch_cycle_receipt(
+        plan_receipt=plan,
+        campaign_execution_receipt=execution,
+        promotion_gate_supply_receipt=gate_supply,
+    ).to_dict()
+    receipt["executed_candidate_ids"] = ["provider/new"]
+
+    try:
+        rehydrate_model_autoresearch_cycle_receipt(receipt)
+    except ValueError as exc:
+        assert str(exc) == "autoresearch_cycle_receipt_id_mismatch"
+    else:
+        raise AssertionError("tampered cycle receipt was accepted")
+
+
+def test_cycle_receipt_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
﻿## Slice
MODEL_AUTORESEARCH_CYCLE_RECEIPT_PHASE1

## WSP_97 truth boundary
- IMPLEMENTED: digest-bound cycle receipt that binds one AutoResearch plan receipt, campaign execution receipt, and campaign promotion-gate supply receipt.
- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn, shell execution, file output, or main.py preflight wiring.

## Scope
- `modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt.py`
- `modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt.py`
- `modules/ai_intelligence/ai_gateway/ModLog.md`

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt.py` -> 6 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests` -> 157 passed
- `git diff --check` -> clean (CRLF warnings only)
