### PR TITLE
feat(ai-gateway): supply autoresearch cycle receipts at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1609,6 +1609,8 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY=0 Materialize campaign promotion-gate receipts
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=0 Block startup if rejected
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY=0 Materialize campaign cycle receipt
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
@@ -1627,6 +1629,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE       deterministic_fixture only
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture only
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH Outside-repo promotion policies JSON
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH         Outside-repo AutoResearch cycle receipt JSON
         REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID Optional promotion authority receipt ID
         REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID Optional signed promotion receipt ID
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
@@ -1698,6 +1701,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         os.environ,
         repo_root,
         "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH",
+    )
+    model_autoresearch_cycle_receipt_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH",
     )
     model_runtime_binding_receipt_path_supplied = bool(
         os.getenv("REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH", "").strip()
@@ -2055,6 +2063,59 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print(
                 "[REDDOG-MODEL-AUTORESEARCH-GATE] Startup blocked by "
                 "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=1"
+            )
+            return False
+
+    autoresearch_cycle_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY",
+    )
+    autoresearch_cycle_enforced = (
+        os.getenv("REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_ENFORCED", "0") != "0"
+    )
+    if autoresearch_cycle_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt_supply_bootstrap import (
+                run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap,
+            )
+
+            autoresearch_cycle = run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+                repo_root=repo_root,
+                plan_receipt_path=model_autoresearch_plan_receipt_path,
+                campaign_execution_receipt_path=model_autoresearch_campaign_execution_receipt_path,
+                promotion_gate_supply_receipt_path=model_autoresearch_promotion_gate_receipts_path,
+                output_path=model_autoresearch_cycle_receipt_path,
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-AUTORESEARCH-CYCLE] Startup artifact supply failed: {exc}")
+            if autoresearch_cycle_enforced:
+                print(f"[REDDOG-MODEL-AUTORESEARCH-CYCLE] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-AUTORESEARCH-CYCLE] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        cycle_status = "PASS" if autoresearch_cycle.accepted else "WARN"
+        cycle_reasons = (
+            ",".join(autoresearch_cycle.rejection_reasons)
+            if autoresearch_cycle.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-AUTORESEARCH-CYCLE] preflight={cycle_status} "
+            f"status={autoresearch_cycle.status} "
+            f"receipt={autoresearch_cycle.cycle_receipt_id or '(none)'} "
+            f"plan={autoresearch_cycle.source_plan_receipt_id or '(none)'} "
+            f"execution={autoresearch_cycle.campaign_execution_receipt_id or '(none)'} "
+            f"gate={autoresearch_cycle.promotion_gate_supply_receipt_id or '(none)'} "
+            f"reasons={cycle_reasons}"
+        )
+        if autoresearch_cycle.accepted and autoresearch_cycle.output_path:
+            model_autoresearch_cycle_receipt_path = autoresearch_cycle.output_path
+            os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH"] = model_autoresearch_cycle_receipt_path
+        elif autoresearch_cycle_enforced:
+            print(
+                "[REDDOG-MODEL-AUTORESEARCH-CYCLE] Startup blocked by "
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_ENFORCED=1"
             )
             return False
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,38 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Receipt Supply Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Preflight Adapter
+**Slice:** REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**What:** Added a disabled-by-default bootstrap for materializing a model
+AutoResearch cycle receipt from outside-repo plan, campaign execution, and
+promotion-gate supply artifacts.
+
+**Why:** The resident startup loop can now carry one digest-bound evidence
+object proving that the plan, execution, and gate supply belong to the same
+AutoResearch cycle before later feedback or planning stages consume it.
+
+**Files:**
+- `src/model_autoresearch_cycle_receipt_supply_bootstrap.py` - reads
+  outside-repo artifacts, invokes the cycle receipt builder, and writes the
+  cycle receipt outside the repository.
+- `tests/test_model_autoresearch_cycle_receipt_supply_bootstrap.py` - verifies
+  successful materialization, inside-repo path rejection, tamper rejection,
+  malformed execution rejection, and AST import/call denylist controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: opt-in AutoResearch cycle receipt artifact supply from
+  outside-repo receipts.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn,
+  shell execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Receipt
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt_supply_bootstrap.py
@@ -1,0 +1,222 @@
+"""Main-startup bootstrap for model AutoResearch cycle receipt supply.
+
+Slice: REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads outside-repo plan, campaign execution, and promotion-gate
+supply artifacts, then materializes a digest-bound AutoResearch cycle receipt.
+
+It does not call providers, run benchmarks, promote models, mutate catalogs,
+write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers,
+execute commands, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import (
+    build_model_autoresearch_cycle_receipt,
+)
+
+
+MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED = (
+    "MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED"
+)
+MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY = (
+    "MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY"
+)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCycleReceiptBootstrapResult:
+    accepted: bool
+    status: str
+    cycle_receipt_id: Optional[str]
+    output_path: Optional[str]
+    source_plan_receipt_id: Optional[str]
+    campaign_execution_receipt_id: Optional[str]
+    promotion_gate_supply_receipt_id: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_direct_provider_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+    *,
+    repo_root: Path | str,
+    plan_receipt_path: Path | str | None,
+    campaign_execution_receipt_path: Path | str | None,
+    promotion_gate_supply_receipt_path: Path | str | None,
+    output_path: Path | str | None,
+) -> ModelAutoResearchCycleReceiptBootstrapResult:
+    """Materialize an AutoResearch cycle receipt from configured runtime files."""
+
+    root = Path(repo_root).resolve()
+    plan_payload, plan_reasons = _read_json_outside_repo(
+        root,
+        plan_receipt_path,
+        missing_reason="missing_model_autoresearch_cycle_plan_receipt_path",
+        inside_reason="model_autoresearch_cycle_plan_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_cycle_plan_receipt",
+    )
+    execution_payload, execution_reasons = _read_json_outside_repo(
+        root,
+        campaign_execution_receipt_path,
+        missing_reason="missing_model_autoresearch_cycle_execution_receipt_path",
+        inside_reason="model_autoresearch_cycle_execution_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_cycle_execution_receipt",
+    )
+    gate_payload, gate_reasons = _read_json_outside_repo(
+        root,
+        promotion_gate_supply_receipt_path,
+        missing_reason="missing_model_autoresearch_cycle_gate_supply_receipt_path",
+        inside_reason="model_autoresearch_cycle_gate_supply_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_cycle_gate_supply_receipt",
+    )
+    reasons = [
+        *plan_reasons,
+        *execution_reasons,
+        *gate_reasons,
+        *_output_path_reasons(root, output_path),
+    ]
+    if plan_payload is not None and not isinstance(plan_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_cycle_plan_receipt")
+    if execution_payload is not None and not isinstance(execution_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_cycle_execution_receipt")
+    if gate_payload is not None and not isinstance(gate_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_cycle_gate_supply_receipt")
+    if reasons:
+        return _not_ready(reasons)
+
+    assert isinstance(plan_payload, Mapping)
+    assert isinstance(execution_payload, Mapping)
+    assert isinstance(gate_payload, Mapping)
+    try:
+        receipt = build_model_autoresearch_cycle_receipt(
+            plan_receipt=plan_payload,
+            campaign_execution_receipt=execution_payload,
+            promotion_gate_supply_receipt=gate_payload,
+        )
+    except Exception as exc:
+        return _not_ready(("model_autoresearch_cycle_receipt_invalid", f"cycle_error:{type(exc).__name__}"))
+
+    output = _resolve_output_path(root, output_path)
+    assert output is not None
+    try:
+        _write_json_atomic(output, receipt.to_dict())
+    except Exception:
+        return _not_ready(("model_autoresearch_cycle_receipt_output_write_failed",))
+    return ModelAutoResearchCycleReceiptBootstrapResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED,
+        cycle_receipt_id=receipt.receipt_id,
+        output_path=str(output),
+        source_plan_receipt_id=receipt.source_plan_receipt_id,
+        campaign_execution_receipt_id=receipt.campaign_execution_receipt_id,
+        promotion_gate_supply_receipt_id=receipt.promotion_gate_supply_receipt_id,
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str, ...]:
+    if not value:
+        return ("model_autoresearch_cycle_receipt_output_path_invalid",)
+    resolved = _resolve_output_path(repo_root, value)
+    if resolved is None or _is_inside(resolved, repo_root):
+        return ("model_autoresearch_cycle_receipt_output_path_invalid",)
+    return ()
+
+
+def _resolve_output_path(repo_root: Path, value: Path | str | None) -> Path | None:
+    if not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    return path.resolve()
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: tuple[str, ...] | list[str],
+) -> ModelAutoResearchCycleReceiptBootstrapResult:
+    return ModelAutoResearchCycleReceiptBootstrapResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY,
+        cycle_receipt_id=None,
+        output_path=None,
+        source_plan_receipt_id=None,
+        campaign_execution_receipt_id=None,
+        promotion_gate_supply_receipt_id=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED",
+    "MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY",
+    "ModelAutoResearchCycleReceiptBootstrapResult",
+    "run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt_supply_bootstrap.py
@@ -1,0 +1,177 @@
+"""Tests for REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply import (
+    run_reddog_model_autoresearch_campaign_promotion_gate_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import (
+    rehydrate_model_autoresearch_cycle_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt_supply_bootstrap import (
+    MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED,
+    MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY,
+    run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
+    REPO_ROOT,
+    _execution_payload,
+    _plan,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_promotion_gate_supply import (
+    _policies,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_cycle_receipt_supply_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _inputs(tmp_path: Path) -> dict[str, Path]:
+    runtime = tmp_path / "runtime"
+    plan = _plan()
+    execution = _execution_payload(tmp_path)
+    plan_path = _write_json(runtime, "plan.json", plan.to_dict())
+    execution_path = _write_json(runtime, "campaign_execution.json", execution)
+    gate_output = runtime / "promotion_gates.json"
+    gate_result = run_reddog_model_autoresearch_campaign_promotion_gate_supply(
+        repo_root=REPO_ROOT,
+        campaign_execution_receipt=execution,
+        promotion_policies=_policies(execution),
+        promotion_authority_receipt_id="authority:1",
+        signed_promotion_receipt_id="signed:1",
+        output_path=gate_output,
+    )
+    assert gate_result.accepted is True
+    return {
+        "plan": plan_path,
+        "execution": execution_path,
+        "gate": gate_output,
+        "output": runtime / "cycle_receipt.json",
+    }
+
+
+def test_cycle_receipt_bootstrap_materializes_rehydratable_cycle_receipt(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=files["execution"],
+        promotion_gate_supply_receipt_path=files["gate"],
+        output_path=files["output"],
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED
+    assert result.cycle_receipt_id
+    assert (result.source_plan_receipt_id or "").startswith("model_autoresearch_plan:")
+    assert result.campaign_execution_receipt_id
+    assert result.promotion_gate_supply_receipt_id
+    assert result.no_model_promotion_performed is True
+    assert result.no_runtime_binding_performed is True
+    assert result.no_repo_mutation_performed is True
+
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    receipt = rehydrate_model_autoresearch_cycle_receipt(payload)
+    assert receipt.receipt_id == result.cycle_receipt_id
+
+
+def test_cycle_receipt_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    repo_plan = REPO_ROOT / "model_autoresearch_plan_receipt.json"
+    repo_output = REPO_ROOT / "model_autoresearch_cycle_receipt.json"
+    repo_plan.write_text("{}", encoding="utf-8")
+    try:
+        result = run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+            repo_root=REPO_ROOT,
+            plan_receipt_path=repo_plan,
+            campaign_execution_receipt_path=files["execution"],
+            promotion_gate_supply_receipt_path=files["gate"],
+            output_path=repo_output,
+        )
+    finally:
+        repo_plan.unlink(missing_ok=True)
+        repo_output.unlink(missing_ok=True)
+
+    assert result.accepted is False
+    assert result.status == MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_cycle_plan_receipt_path_inside_repo" in result.rejection_reasons
+    assert "model_autoresearch_cycle_receipt_output_path_invalid" in result.rejection_reasons
+
+
+def test_cycle_receipt_bootstrap_rejects_tampered_gate_supply(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    gate_payload = json.loads(files["gate"].read_text(encoding="utf-8"))
+    gate_payload["source_execution_receipt_id"] = "model_autoresearch_campaign_execution:other"
+    tampered_gate = _write_json(tmp_path / "runtime", "tampered_gate.json", gate_payload)
+
+    result = run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=files["execution"],
+        promotion_gate_supply_receipt_path=tampered_gate,
+        output_path=files["output"],
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_cycle_receipt_invalid" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_cycle_receipt_bootstrap_rejects_malformed_execution_payload(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    bad_execution = _write_json(tmp_path / "runtime", "bad_execution.json", {})
+
+    result = run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=bad_execution,
+        promotion_gate_supply_receipt_path=files["gate"],
+        output_path=files["output"],
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_cycle_receipt_invalid" in result.rejection_reasons
+    assert not files["output"].exists()
+
+
+def test_cycle_receipt_bootstrap_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH` as a profile-derived
+  resident runtime path.
+- Wired `main.py` to optionally run model AutoResearch cycle receipt supply
+  after plan, campaign execution, and promotion-gate supply artifacts exist.
+- Successful supply updates `REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH` so
+  later resident planning or feedback stages can consume the single cycle
+  evidence object.
+- The hook is disabled by default and only consumes outside-repo receipts.
+- Boundary remains constrained: no provider call, benchmark execution,
+  HoloIndex re-index, PatternMemory write, model promotion, runtime binding,
+  worker spawn, source mutation, PR publication, reward settlement, shell
+  execution, or merge authority was added.
+
 ## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -108,6 +108,7 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH": (
         "model_autoresearch_campaign_promotion_policies.json"
     ),
+    "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH": "model_autoresearch_cycle_receipt.json",
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": "principal_authority_record.json",
     "REDDOG_PERMISSION_SNAPSHOT_PATH": "permission_snapshot.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -832,6 +832,133 @@ def test_main_preflight_enforced_model_autoresearch_campaign_gate_supply_blocks_
             assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
 
 
+def test_main_preflight_model_autoresearch_cycle_receipt_supply_runs_before_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    cycle_result = type(
+        "AutoResearchCycleResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED",
+            "cycle_receipt_id": "model_autoresearch_cycle:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_cycle_receipt.json"),
+            "source_plan_receipt_id": "model_autoresearch_plan:runtime",
+            "campaign_execution_receipt_id": "model_autoresearch_campaign_execution:runtime",
+            "promotion_gate_supply_receipt_id": "model_autoresearch_campaign_promotion_gate_supply:runtime",
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt_supply_bootstrap.run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap",
+        return_value=cycle_result,
+    ) as cycle_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH"] == str(
+                    runtime_root / "model_autoresearch_cycle_receipt.json"
+                )
+
+    cycle_supply.assert_called_once()
+    cycle_kwargs = cycle_supply.call_args.kwargs
+    assert cycle_kwargs["plan_receipt_path"] == str(runtime_root / "model_autoresearch_plan_receipt.json")
+    assert cycle_kwargs["campaign_execution_receipt_path"] == str(
+        runtime_root / "model_autoresearch_campaign_execution_receipt.json"
+    )
+    assert cycle_kwargs["promotion_gate_supply_receipt_path"] == str(
+        runtime_root / "model_autoresearch_promotion_gate_receipts.json"
+    )
+    assert cycle_kwargs["output_path"] == str(runtime_root / "model_autoresearch_cycle_receipt.json")
+    promote.assert_called_once()
+
+
+def test_main_preflight_enforced_model_autoresearch_cycle_receipt_supply_blocks_startup(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    cycle_result = type(
+        "AutoResearchCycleResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_NOT_READY",
+            "cycle_receipt_id": None,
+            "output_path": None,
+            "source_plan_receipt_id": None,
+            "campaign_execution_receipt_id": None,
+            "promotion_gate_supply_receipt_id": None,
+            "rejection_reasons": ("missing_model_autoresearch_cycle_gate_supply_receipt_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt_supply_bootstrap.run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap",
+        return_value=cycle_result,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY": "1",
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_ENFORCED": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+
 def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add disabled-by-default RedDog startup supply for model AutoResearch cycle receipts
- bind outside-repo plan, campaign execution, and promotion-gate supply receipts into a single cycle receipt
- add profile path, main.py hook, focused tests, and ModLog entries

## Validation
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_receipt_supply_bootstrap.py main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
- pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_receipt_supply_bootstrap.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q
- pytest modules/ai_intelligence/ai_gateway/tests -q
- git diff --check

## Truth Boundary
- no provider calls
- no benchmark execution
- no model promotion
- no PatternMemory writes
- no HoloIndex re-index
- no runtime binding
- no worker spawn
- no shell execution
- no source mutation beyond this bootstrap wiring
