### PR TITLE
feat(ai-gateway): admit autoresearch cycle feedback

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -117,6 +117,23 @@ The default in-memory and JSONL stores are append-only adapters. The API is
 explicit-invoke only and does not call providers, run benchmarks, promote
 models, write PatternMemory, mutate HoloIndex, or bind RedDog runtime defaults.
 
+#### Model AutoResearch Cycle Feedback Ledger Admission
+
+```python
+rehydrate_model_autoresearch_cycle_receipt(...) -> ModelAutoResearchCycleReceipt
+admit_model_autoresearch_cycle_feedback(...) -> ModelAutoResearchCycleFeedbackLedgerAdmissionResult
+```
+
+The admission layer accepts a serialized or typed
+`ModelAutoResearchCycleReceipt`, recomputes its deterministic receipt ID,
+requires executed candidate and promotion-gate evidence, and writes a minimal
+cycle feedback record through an injected
+`ModelAutoResearchCycleFeedbackLedgerStore`.
+
+The default in-memory and JSONL stores are append-only adapters. The API is
+explicit-invoke only and does not call providers, run benchmarks, promote
+models, write PatternMemory, mutate HoloIndex, or bind RedDog runtime defaults.
+
 #### Model Combination Benchmark Harness
 
 ```python

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,37 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Ledger Admission
+
+**Who:** 0102 Codex
+**Type:** Feedback Ledger Admission
+**Slice:** MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_PHASE1
+
+**What:** Added an explicit-invoke admission guard for verified model
+AutoResearch cycle receipts.
+
+**Why:** The recursive model-improvement loop needs to retain completed
+AutoResearch cycles as durable learning input without promoting models or
+changing runtime bindings.
+
+**Files:**
+- `src/model_autoresearch_cycle_feedback_ledger.py` - rehydrates cycle
+  receipts, builds minimal cycle feedback records, writes through an injected
+  store, and emits a digest-bound admission receipt.
+- `tests/test_model_autoresearch_cycle_feedback_ledger.py` - verifies admission,
+  JSONL output, explicit invoke/store requirements, tamper rejection,
+  eligibility checks, secret-marker rejection, store-failure handling, JSON
+  serialization, and AST import/call denylist controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: explicit-invoke AutoResearch cycle feedback ledger admission.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, queue-stage
+  wiring, worker spawn, shell execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Receipt Supply Bootstrap
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -60,6 +60,20 @@ intelligence feedback. It does not call providers, run benchmarks, promote
 models, write PatternMemory, mutate HoloIndex, or change RedDog runtime model
 defaults.
 
+## Model AutoResearch Cycle Feedback Ledger Admission
+
+`src/model_autoresearch_cycle_feedback_ledger.py` admits verified
+`ModelAutoResearchCycleReceipt` records into an injected AutoResearch cycle
+feedback ledger. It rehydrates serialized cycle receipts, recomputes their
+deterministic IDs, verifies that the cycle contains executed candidates and
+promotion-gate receipts, scans the feedback record for secret markers, and emits
+a digest-bound admission receipt.
+
+This layer lets the recursive model-improvement loop retain which campaign was
+run and which promotion-gate receipts resulted. It does not call providers, run
+benchmarks, promote models, write PatternMemory, mutate HoloIndex, or change
+RedDog runtime model defaults.
+
 ## Model Combination Benchmark Harness
 
 `src/model_combination_benchmark_harness.py` runs deterministic held-out

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger.py
@@ -1,0 +1,292 @@
+"""AutoResearch cycle feedback ledger admission.
+
+This module admits verified model AutoResearch cycle receipts into an injected
+feedback ledger. It does not call providers, run benchmarks, promote models,
+execute commands, write PatternMemory, mutate HoloIndex, or change RedDog
+runtime model defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence
+
+from .model_autoresearch_cycle_receipt import (
+    ModelAutoResearchCycleReceipt,
+    rehydrate_model_autoresearch_cycle_receipt,
+)
+
+
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT = (
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT"
+)
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT = (
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT"
+)
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE = "model_autoresearch_cycle_feedback"
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_SCHEMA = (
+    "model_autoresearch_cycle_feedback_record.v1"
+)
+
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+class ModelAutoResearchCycleFeedbackLedgerAdmissionReason:
+    EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MISSING"
+    STORE_REQUIRED = "REJECT_INJECTED_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_STORE_REQUIRED"
+    CYCLE_RECEIPT_INVALID = "REJECT_AUTORESEARCH_CYCLE_RECEIPT_INVALID"
+    CYCLE_NOT_FEEDBACK_ELIGIBLE = "REJECT_AUTORESEARCH_CYCLE_NOT_FEEDBACK_ELIGIBLE"
+    SECRET_IN_RECORD = "REJECT_SECRET_IN_AUTORESEARCH_CYCLE_FEEDBACK_RECORD"
+    STORE_WRITE_FAILED = "REJECT_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_STORE_WRITE_FAILED"
+
+
+class ModelAutoResearchCycleFeedbackLedgerStore(Protocol):
+    def append(self, record: Mapping[str, Any]) -> str:
+        ...
+
+
+class InMemoryModelAutoResearchCycleFeedbackLedgerStore:
+    """Test/local store for model AutoResearch cycle feedback records."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    def append(self, record: Mapping[str, Any]) -> str:
+        payload = dict(record)
+        self.records.append(payload)
+        return f"model-autoresearch-cycle-feedback-record-{len(self.records)}"
+
+
+class JsonlModelAutoResearchCycleFeedbackLedgerStore:
+    """Append-only JSONL store for model AutoResearch cycle feedback records."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def append(self, record: Mapping[str, Any]) -> str:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+        with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(line + "\n")
+        return str(record["feedback_record_id"])
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt:
+    admission_id: str
+    cycle_receipt_id: str
+    source_plan_receipt_id: str
+    campaign_execution_receipt_id: str
+    promotion_gate_supply_receipt_id: str
+    executed_candidate_ids: List[str]
+    promotion_gate_receipt_ids: List[str]
+    feedback_record_id: Optional[str]
+    feedback_record_digest: str
+    rejection_reasons: List[str]
+    no_provider_call_performed: bool = True
+    no_benchmark_execution_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCycleFeedbackLedgerAdmissionResult:
+    decision: str
+    rejection_reasons: List[str] = field(default_factory=list)
+    receipt: Optional[ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt] = None
+    explicit_autoresearch_cycle_feedback_ledger_admission_requested: bool = False
+    feedback_write_performed: bool = False
+    no_provider_call_performed: bool = True
+    no_benchmark_execution_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["receipt"] = self.receipt.to_dict() if self.receipt else None
+        return payload
+
+
+def admit_model_autoresearch_cycle_feedback(
+    *,
+    explicit_autoresearch_cycle_feedback_ledger_admission_requested: bool,
+    cycle_receipt: ModelAutoResearchCycleReceipt | Mapping[str, Any],
+    store: Optional[ModelAutoResearchCycleFeedbackLedgerStore],
+) -> ModelAutoResearchCycleFeedbackLedgerAdmissionResult:
+    """Admit one verified AutoResearch cycle receipt into an injected ledger."""
+
+    if explicit_autoresearch_cycle_feedback_ledger_admission_requested is not True:
+        return _reject(
+            [ModelAutoResearchCycleFeedbackLedgerAdmissionReason.EXPLICIT_INVOKE_MISSING],
+            explicit_requested=False,
+        )
+    if store is None:
+        return _reject(
+            [ModelAutoResearchCycleFeedbackLedgerAdmissionReason.STORE_REQUIRED],
+            explicit_requested=True,
+        )
+
+    try:
+        cycle = _cycle_receipt(cycle_receipt)
+    except Exception as exc:
+        return _reject(
+            [
+                ModelAutoResearchCycleFeedbackLedgerAdmissionReason.CYCLE_RECEIPT_INVALID,
+                f"cycle_error:{type(exc).__name__}",
+            ],
+            explicit_requested=True,
+        )
+
+    record: Dict[str, Any] = {}
+    reasons: List[str] = []
+    if not cycle.executed_candidate_ids or not cycle.promotion_gate_receipt_ids:
+        reasons.append(ModelAutoResearchCycleFeedbackLedgerAdmissionReason.CYCLE_NOT_FEEDBACK_ELIGIBLE)
+    if not reasons:
+        record = _feedback_record(cycle)
+        if _contains_secret(record):
+            reasons.append(ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SECRET_IN_RECORD)
+    if reasons:
+        receipt = _admission_receipt(cycle=cycle, record=record, record_id=None, reasons=reasons)
+        return _reject(reasons, explicit_requested=True, receipt=receipt)
+
+    try:
+        record_id = store.append(record)
+    except Exception:
+        receipt = _admission_receipt(
+            cycle=cycle,
+            record=record,
+            record_id=None,
+            reasons=[ModelAutoResearchCycleFeedbackLedgerAdmissionReason.STORE_WRITE_FAILED],
+        )
+        return _reject(
+            [ModelAutoResearchCycleFeedbackLedgerAdmissionReason.STORE_WRITE_FAILED],
+            explicit_requested=True,
+            receipt=receipt,
+        )
+
+    receipt = _admission_receipt(cycle=cycle, record=record, record_id=str(record_id or ""), reasons=[])
+    return ModelAutoResearchCycleFeedbackLedgerAdmissionResult(
+        decision=MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT,
+        rejection_reasons=[],
+        receipt=receipt,
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        feedback_write_performed=True,
+    )
+
+
+def _cycle_receipt(
+    value: ModelAutoResearchCycleReceipt | Mapping[str, Any],
+) -> ModelAutoResearchCycleReceipt:
+    if isinstance(value, ModelAutoResearchCycleReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_autoresearch_cycle_receipt(value)
+    raise ValueError("invalid_autoresearch_cycle_receipt")
+
+
+def _feedback_record(cycle: ModelAutoResearchCycleReceipt) -> Dict[str, Any]:
+    record = {
+        "record_type": MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE,
+        "schema_version": MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_SCHEMA,
+        "cycle_receipt_id": cycle.receipt_id,
+        "source_plan_receipt_id": cycle.source_plan_receipt_id,
+        "campaign_execution_receipt_id": cycle.campaign_execution_receipt_id,
+        "promotion_gate_supply_receipt_id": cycle.promotion_gate_supply_receipt_id,
+        "executed_candidate_ids": list(cycle.executed_candidate_ids),
+        "promotion_gate_receipt_ids": list(cycle.promotion_gate_receipt_ids),
+    }
+    record["feedback_record_id"] = "model_autoresearch_cycle_feedback_" + _digest(record).removeprefix("sha256:")[:16]
+    return record
+
+
+def _admission_receipt(
+    *,
+    cycle: ModelAutoResearchCycleReceipt,
+    record: Mapping[str, Any],
+    record_id: Optional[str],
+    reasons: Sequence[str],
+) -> ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt:
+    deduped = _dedupe(reasons)
+    seed = {
+        "cycle_receipt_id": cycle.receipt_id,
+        "record": record,
+        "record_id": record_id,
+        "rejection_reasons": deduped,
+    }
+    return ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt(
+        admission_id="model_autoresearch_cycle_feedback_admission_" + _digest(seed).removeprefix("sha256:")[:16],
+        cycle_receipt_id=cycle.receipt_id,
+        source_plan_receipt_id=cycle.source_plan_receipt_id,
+        campaign_execution_receipt_id=cycle.campaign_execution_receipt_id,
+        promotion_gate_supply_receipt_id=cycle.promotion_gate_supply_receipt_id,
+        executed_candidate_ids=list(cycle.executed_candidate_ids),
+        promotion_gate_receipt_ids=list(cycle.promotion_gate_receipt_ids),
+        feedback_record_id=record_id,
+        feedback_record_digest=_digest(record),
+        rejection_reasons=deduped,
+    )
+
+
+def _reject(
+    reasons: Sequence[str],
+    *,
+    explicit_requested: bool,
+    receipt: Optional[ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt] = None,
+) -> ModelAutoResearchCycleFeedbackLedgerAdmissionResult:
+    return ModelAutoResearchCycleFeedbackLedgerAdmissionResult(
+        decision=MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT,
+        rejection_reasons=_dedupe(reasons),
+        receipt=receipt,
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=explicit_requested,
+        feedback_write_performed=False,
+    )
+
+
+def _dedupe(values: Sequence[str]) -> List[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value or "").strip()))
+
+
+def _contains_secret(value: Any) -> bool:
+    text = json.dumps(value, sort_keys=True, default=str).lower()
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "InMemoryModelAutoResearchCycleFeedbackLedgerStore",
+    "JsonlModelAutoResearchCycleFeedbackLedgerStore",
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT",
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT",
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE",
+    "ModelAutoResearchCycleFeedbackLedgerAdmissionReason",
+    "ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt",
+    "ModelAutoResearchCycleFeedbackLedgerAdmissionResult",
+    "ModelAutoResearchCycleFeedbackLedgerStore",
+    "admit_model_autoresearch_cycle_feedback",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger.py
@@ -1,0 +1,222 @@
+"""Tests for model AutoResearch cycle feedback ledger admission."""
+
+from __future__ import annotations
+
+import ast
+import json
+from dataclasses import replace
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger import (
+    InMemoryModelAutoResearchCycleFeedbackLedgerStore,
+    JsonlModelAutoResearchCycleFeedbackLedgerStore,
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT,
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT,
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE,
+    ModelAutoResearchCycleFeedbackLedgerAdmissionReason,
+    admit_model_autoresearch_cycle_feedback,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import (
+    build_model_autoresearch_cycle_receipt,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import REPO_ROOT
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_cycle_receipt import (
+    _cycle_sources,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_cycle_feedback_ledger.py"
+)
+
+
+class FailingCycleFeedbackLedgerStore(InMemoryModelAutoResearchCycleFeedbackLedgerStore):
+    def append(self, record):
+        raise RuntimeError("store failed")
+
+
+def _cycle(tmp_path: Path):
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    return build_model_autoresearch_cycle_receipt(
+        plan_receipt=plan,
+        campaign_execution_receipt=execution,
+        promotion_gate_supply_receipt=gate_supply,
+    )
+
+
+def test_admits_autoresearch_cycle_receipt_to_injected_ledger_store(tmp_path: Path) -> None:
+    cycle = _cycle(tmp_path)
+    store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
+
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle.to_dict(),
+        store=store,
+    )
+
+    assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT
+    assert result.rejection_reasons == []
+    assert result.feedback_write_performed is True
+    assert result.receipt is not None
+    assert result.receipt.cycle_receipt_id == cycle.receipt_id
+    assert result.receipt.source_plan_receipt_id == cycle.source_plan_receipt_id
+    assert result.receipt.no_provider_call_performed is True
+    assert result.receipt.no_model_promotion_performed is True
+    assert result.receipt.no_holoindex_reindex_performed is True
+    assert len(store.records) == 1
+    assert store.records[0]["record_type"] == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE
+    assert store.records[0]["cycle_receipt_id"] == cycle.receipt_id
+    assert store.records[0]["executed_candidate_ids"] == list(cycle.executed_candidate_ids)
+
+
+def test_jsonl_store_writes_one_feedback_record(tmp_path: Path) -> None:
+    cycle = _cycle(tmp_path)
+    path = tmp_path / "cycle_feedback.jsonl"
+    store = JsonlModelAutoResearchCycleFeedbackLedgerStore(path)
+
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle,
+        store=store,
+    )
+
+    assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT
+    records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 1
+    assert records[0]["cycle_receipt_id"] == cycle.receipt_id
+
+
+def test_explicit_request_and_store_are_required(tmp_path: Path) -> None:
+    cycle = _cycle(tmp_path)
+    store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
+
+    missing_request = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=False,
+        cycle_receipt=cycle.to_dict(),
+        store=store,
+    )
+    missing_store = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle.to_dict(),
+        store=None,
+    )
+
+    assert missing_request.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert (
+        ModelAutoResearchCycleFeedbackLedgerAdmissionReason.EXPLICIT_INVOKE_MISSING
+        in missing_request.rejection_reasons
+    )
+    assert missing_store.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelAutoResearchCycleFeedbackLedgerAdmissionReason.STORE_REQUIRED in missing_store.rejection_reasons
+    assert store.records == []
+
+
+def test_tampered_serialized_cycle_receipt_rejects_before_store_write(tmp_path: Path) -> None:
+    cycle = _cycle(tmp_path).to_dict()
+    cycle["executed_candidate_ids"] = ["provider/tampered"]
+    store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
+
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle,
+        store=store,
+    )
+
+    assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelAutoResearchCycleFeedbackLedgerAdmissionReason.CYCLE_RECEIPT_INVALID in result.rejection_reasons
+    assert store.records == []
+
+
+def test_non_feedback_eligible_cycle_never_enters_ledger(tmp_path: Path) -> None:
+    cycle = replace(_cycle(tmp_path), executed_candidate_ids=())
+    store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
+
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle,
+        store=store,
+    )
+
+    assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert (
+        ModelAutoResearchCycleFeedbackLedgerAdmissionReason.CYCLE_NOT_FEEDBACK_ELIGIBLE
+        in result.rejection_reasons
+    )
+    assert store.records == []
+
+
+def test_secret_marker_in_cycle_feedback_record_rejects_before_store_write(tmp_path: Path) -> None:
+    cycle = replace(_cycle(tmp_path), executed_candidate_ids=("provider/token=leak",))
+    store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
+
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle,
+        store=store,
+    )
+
+    assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SECRET_IN_RECORD in result.rejection_reasons
+    assert store.records == []
+
+
+def test_store_failure_rejects_with_receipt_and_no_write_claim(tmp_path: Path) -> None:
+    cycle = _cycle(tmp_path)
+
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle.to_dict(),
+        store=FailingCycleFeedbackLedgerStore(),
+    )
+
+    assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert ModelAutoResearchCycleFeedbackLedgerAdmissionReason.STORE_WRITE_FAILED in result.rejection_reasons
+    assert result.feedback_write_performed is False
+    assert result.receipt is not None
+    assert result.receipt.feedback_record_id is None
+
+
+def test_result_is_json_serializable(tmp_path: Path) -> None:
+    cycle = _cycle(tmp_path)
+    result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle.to_dict(),
+        store=InMemoryModelAutoResearchCycleFeedbackLedgerStore(),
+    )
+
+    payload = result.to_dict()
+    assert payload["decision"] == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT
+    json.dumps(payload, sort_keys=True)
+
+
+def test_cycle_feedback_ledger_module_has_no_provider_network_command_or_runtime_imports() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "os",
+        "shutil",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "sqlite3",
+        "holo_index",
+        "git",
+        "pattern_memory",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary
- add explicit-invoke model AutoResearch cycle feedback ledger admission
- support in-memory and append-only JSONL stores
- reject missing explicit invoke/store, tampered cycle receipts, non-feedback-eligible cycles, secret markers, and store failures
- document the API in README/INTERFACE/ModLog

## Validation
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger.py
- pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger.py
- pytest modules/ai_intelligence/ai_gateway/tests -q
- git diff --check

## Truth Boundary
- no provider calls
- no benchmark execution
- no model promotion
- no PatternMemory writes
- no HoloIndex re-index
- no runtime binding
- no queue-stage wiring yet
- no worker spawn
- no shell execution
