### PR TITLE
feat(ai-gateway): admit autoresearch cycle feedback at startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1611,6 +1611,8 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY=0 Materialize campaign cycle receipt
         REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_ENFORCED=0 Block startup if rejected
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION=0 Admit cycle receipt to feedback ledger
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_CATALOG_SNAPSHOT_PATH                   Outside-repo model catalog snapshot JSON
         REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH         Outside-repo signed production evidence bundle JSON
         REDDOG_MODEL_SELECTION_REQUIREMENTS_PATH             Outside-repo selection requirements JSON
@@ -1630,6 +1632,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture only
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH Outside-repo promotion policies JSON
         REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH         Outside-repo AutoResearch cycle receipt JSON
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH Outside-repo AutoResearch cycle feedback JSONL
         REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID Optional promotion authority receipt ID
         REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID Optional signed promotion receipt ID
         REDDOG_MODEL_EVIDENCE_TRUSTED_KEYS_PATH              Outside-repo trusted model evidence public keys JSON
@@ -1706,6 +1709,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         os.environ,
         repo_root,
         "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH",
+    )
+    model_autoresearch_cycle_feedback_ledger_path = resident_queue_runtime_file_path(
+        os.environ,
+        repo_root,
+        "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH",
     )
     model_runtime_binding_receipt_path_supplied = bool(
         os.getenv("REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH", "").strip()
@@ -2116,6 +2124,60 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print(
                 "[REDDOG-MODEL-AUTORESEARCH-CYCLE] Startup blocked by "
                 "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_ENFORCED=1"
+            )
+            return False
+
+    autoresearch_cycle_feedback_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION",
+    )
+    autoresearch_cycle_feedback_enforced = (
+        os.getenv("REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ENFORCED", "0") != "0"
+    )
+    if autoresearch_cycle_feedback_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger_admission_bootstrap import (
+                run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap,
+            )
+
+            autoresearch_cycle_feedback = (
+                run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+                    repo_root=repo_root,
+                    cycle_receipt_path=model_autoresearch_cycle_receipt_path,
+                    output_path=model_autoresearch_cycle_feedback_ledger_path,
+                )
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-AUTORESEARCH-CYCLE-FEEDBACK] Startup admission failed: {exc}")
+            if autoresearch_cycle_feedback_enforced:
+                print(f"[REDDOG-MODEL-AUTORESEARCH-CYCLE-FEEDBACK] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-AUTORESEARCH-CYCLE-FEEDBACK] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        cycle_feedback_status = "PASS" if autoresearch_cycle_feedback.accepted else "WARN"
+        cycle_feedback_reasons = (
+            ",".join(autoresearch_cycle_feedback.rejection_reasons)
+            if autoresearch_cycle_feedback.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-AUTORESEARCH-CYCLE-FEEDBACK] preflight={cycle_feedback_status} "
+            f"status={autoresearch_cycle_feedback.status} "
+            f"admission={autoresearch_cycle_feedback.admission_id or '(none)'} "
+            f"cycle={autoresearch_cycle_feedback.cycle_receipt_id or '(none)'} "
+            f"record={autoresearch_cycle_feedback.feedback_record_id or '(none)'} "
+            f"reasons={cycle_feedback_reasons}"
+        )
+        if autoresearch_cycle_feedback.accepted and autoresearch_cycle_feedback.output_path:
+            model_autoresearch_cycle_feedback_ledger_path = autoresearch_cycle_feedback.output_path
+            os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH"] = (
+                model_autoresearch_cycle_feedback_ledger_path
+            )
+        elif autoresearch_cycle_feedback_enforced:
+            print(
+                "[REDDOG-MODEL-AUTORESEARCH-CYCLE-FEEDBACK] Startup blocked by "
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ENFORCED=1"
             )
             return False
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,37 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Ledger Admission Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Preflight Adapter
+**Slice:** REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MAIN_PREFLIGHT_PHASE1
+
+**What:** Added a disabled-by-default bootstrap for admitting an outside-repo
+model AutoResearch cycle receipt into an outside-repo cycle feedback ledger.
+
+**Why:** The model AutoResearch loop can now persist completed cycle evidence
+as durable feedback input without changing runtime model bindings or promoting
+models.
+
+**Files:**
+- `src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py` - reads
+  an outside-repo cycle receipt, invokes the cycle feedback admission guard, and
+  appends to an outside-repo JSONL ledger.
+- `tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py`
+  - verifies successful append, inside-repo path rejection, tamper rejection,
+  missing output rejection, and AST import/call denylist controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: opt-in AutoResearch cycle feedback ledger admission from an
+  outside-repo cycle receipt.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, queue-stage
+  wiring, worker spawn, shell execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Ledger Admission
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
@@ -1,0 +1,183 @@
+"""Main-startup bootstrap for model AutoResearch cycle feedback admission.
+
+Slice: REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MAIN_PREFLIGHT_PHASE1
+
+This adapter reads an outside-repo AutoResearch cycle receipt and appends a
+feedback record to an outside-repo AutoResearch cycle feedback ledger.
+
+It does not call providers, run benchmarks, promote models, mutate catalogs,
+write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers,
+execute commands, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger import (
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT,
+    JsonlModelAutoResearchCycleFeedbackLedgerStore,
+    admit_model_autoresearch_cycle_feedback,
+)
+
+
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED = (
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED"
+)
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY = (
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY"
+)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCycleFeedbackLedgerBootstrapResult:
+    accepted: bool
+    status: str
+    admission_id: Optional[str]
+    cycle_receipt_id: Optional[str]
+    feedback_record_id: Optional[str]
+    output_path: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_direct_provider_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+    *,
+    repo_root: Path | str,
+    cycle_receipt_path: Path | str | None,
+    output_path: Path | str | None,
+) -> ModelAutoResearchCycleFeedbackLedgerBootstrapResult:
+    """Append a verified AutoResearch cycle receipt into an outside-repo ledger."""
+
+    root = Path(repo_root).resolve()
+    cycle_payload, cycle_reasons = _read_json_outside_repo(
+        root,
+        cycle_receipt_path,
+        missing_reason="missing_model_autoresearch_cycle_receipt_path",
+        inside_reason="model_autoresearch_cycle_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_cycle_receipt",
+    )
+    reasons = [
+        *cycle_reasons,
+        *_output_path_reasons(root, output_path),
+    ]
+    if cycle_payload is not None and not isinstance(cycle_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_cycle_receipt")
+    if reasons:
+        return _not_ready(reasons)
+
+    assert isinstance(cycle_payload, Mapping)
+    output = _resolve_output_path(root, output_path)
+    assert output is not None
+    try:
+        admission = admit_model_autoresearch_cycle_feedback(
+            explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+            cycle_receipt=cycle_payload,
+            store=JsonlModelAutoResearchCycleFeedbackLedgerStore(output),
+        )
+    except Exception as exc:
+        return _not_ready(("model_autoresearch_cycle_feedback_admission_invalid", f"admission_error:{type(exc).__name__}"))
+
+    if admission.decision != MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT or not admission.receipt:
+        return _not_ready(
+            tuple(admission.rejection_reasons)
+            or ("model_autoresearch_cycle_feedback_admission_rejected",)
+        )
+    return ModelAutoResearchCycleFeedbackLedgerBootstrapResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED,
+        admission_id=admission.receipt.admission_id,
+        cycle_receipt_id=admission.receipt.cycle_receipt_id,
+        feedback_record_id=admission.receipt.feedback_record_id,
+        output_path=str(output),
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str, ...]:
+    if not value:
+        return ("model_autoresearch_cycle_feedback_ledger_output_path_invalid",)
+    resolved = _resolve_output_path(repo_root, value)
+    if resolved is None or _is_inside(resolved, repo_root):
+        return ("model_autoresearch_cycle_feedback_ledger_output_path_invalid",)
+    return ()
+
+
+def _resolve_output_path(repo_root: Path, value: Path | str | None) -> Path | None:
+    if not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    return path.resolve()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: tuple[str, ...] | list[str],
+) -> ModelAutoResearchCycleFeedbackLedgerBootstrapResult:
+    return ModelAutoResearchCycleFeedbackLedgerBootstrapResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY,
+        admission_id=None,
+        cycle_receipt_id=None,
+        feedback_record_id=None,
+        output_path=None,
+        rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),
+    )
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED",
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY",
+    "ModelAutoResearchCycleFeedbackLedgerBootstrapResult",
+    "run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
@@ -1,0 +1,146 @@
+"""Tests for REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MAIN_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger_admission_bootstrap import (
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED,
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY,
+    run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import (
+    build_model_autoresearch_cycle_receipt,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import REPO_ROOT
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_cycle_receipt import (
+    _cycle_sources,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _cycle_payload(tmp_path: Path) -> dict:
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    return build_model_autoresearch_cycle_receipt(
+        plan_receipt=plan,
+        campaign_execution_receipt=execution,
+        promotion_gate_supply_receipt=gate_supply,
+    ).to_dict()
+
+
+def test_cycle_feedback_bootstrap_appends_cycle_feedback_record(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    cycle_payload = _cycle_payload(tmp_path)
+    cycle_path = _write_json(runtime, "cycle_receipt.json", cycle_payload)
+    output_path = runtime / "cycle_feedback.jsonl"
+
+    result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+        repo_root=REPO_ROOT,
+        cycle_receipt_path=cycle_path,
+        output_path=output_path,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED
+    assert result.admission_id
+    assert result.cycle_receipt_id == cycle_payload["receipt_id"]
+    assert result.feedback_record_id
+    assert result.no_model_promotion_performed is True
+    assert result.no_holoindex_reindex_performed is True
+    records = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 1
+    assert records[0]["cycle_receipt_id"] == cycle_payload["receipt_id"]
+
+
+def test_cycle_feedback_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
+    repo_cycle = REPO_ROOT / "model_autoresearch_cycle_receipt.json"
+    repo_output = REPO_ROOT / "model_autoresearch_cycle_feedback.jsonl"
+    repo_cycle.write_text("{}", encoding="utf-8")
+    try:
+        result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+            repo_root=REPO_ROOT,
+            cycle_receipt_path=repo_cycle,
+            output_path=repo_output,
+        )
+    finally:
+        repo_cycle.unlink(missing_ok=True)
+        repo_output.unlink(missing_ok=True)
+
+    assert result.accepted is False
+    assert result.status == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_cycle_receipt_path_inside_repo" in result.rejection_reasons
+    assert "model_autoresearch_cycle_feedback_ledger_output_path_invalid" in result.rejection_reasons
+
+
+def test_cycle_feedback_bootstrap_rejects_tampered_cycle_receipt(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    cycle_payload = _cycle_payload(tmp_path)
+    cycle_payload["executed_candidate_ids"] = ["provider/tampered"]
+    cycle_path = _write_json(runtime, "tampered_cycle_receipt.json", cycle_payload)
+    output_path = runtime / "cycle_feedback.jsonl"
+
+    result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+        repo_root=REPO_ROOT,
+        cycle_receipt_path=cycle_path,
+        output_path=output_path,
+    )
+
+    assert result.accepted is False
+    assert "REJECT_AUTORESEARCH_CYCLE_RECEIPT_INVALID" in result.rejection_reasons
+    assert not output_path.exists()
+
+
+def test_cycle_feedback_bootstrap_rejects_missing_output_path(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    cycle_path = _write_json(runtime, "cycle_receipt.json", _cycle_payload(tmp_path))
+
+    result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+        repo_root=REPO_ROOT,
+        cycle_receipt_path=cycle_path,
+        output_path=None,
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_cycle_feedback_ledger_output_path_invalid" in result.rejection_reasons
+
+
+def test_cycle_feedback_bootstrap_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MAIN_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added `REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH` as a
+  profile-derived resident runtime path.
+- Wired `main.py` to optionally admit an outside-repo model AutoResearch cycle
+  receipt into an outside-repo cycle feedback ledger after cycle receipt supply.
+- Successful admission updates `REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH`
+  so later planning/feedback slices can consume the durable cycle record.
+- The hook is disabled by default and only consumes outside-repo receipts.
+- Boundary remains constrained: no provider call, benchmark execution,
+  HoloIndex re-index, PatternMemory write, model promotion, runtime binding,
+  worker spawn, source mutation, PR publication, reward settlement, shell
+  execution, or merge authority was added.
+
 ## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -109,6 +109,9 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
         "model_autoresearch_campaign_promotion_policies.json"
     ),
     "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH": "model_autoresearch_cycle_receipt.json",
+    "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH": (
+        "model_autoresearch_cycle_feedback.jsonl"
+    ),
     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": "memex_supply_receipt.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORD_PATH": "principal_authority_record.json",
     "REDDOG_PERMISSION_SNAPSHOT_PATH": "permission_snapshot.json",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -959,6 +959,130 @@ def test_main_preflight_enforced_model_autoresearch_cycle_receipt_supply_blocks_
             assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
 
 
+def test_main_preflight_model_autoresearch_cycle_feedback_admission_runs_before_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    cycle_feedback_result = type(
+        "AutoResearchCycleFeedbackResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED",
+            "admission_id": "model_autoresearch_cycle_feedback_admission:runtime",
+            "cycle_receipt_id": "model_autoresearch_cycle:runtime",
+            "feedback_record_id": "model_autoresearch_cycle_feedback:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_cycle_feedback.jsonl"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger_admission_bootstrap.run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap",
+        return_value=cycle_feedback_result,
+    ) as cycle_feedback:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH"] == str(
+                    runtime_root / "model_autoresearch_cycle_feedback.jsonl"
+                )
+
+    cycle_feedback.assert_called_once()
+    cycle_feedback_kwargs = cycle_feedback.call_args.kwargs
+    assert cycle_feedback_kwargs["cycle_receipt_path"] == str(
+        runtime_root / "model_autoresearch_cycle_receipt.json"
+    )
+    assert cycle_feedback_kwargs["output_path"] == str(
+        runtime_root / "model_autoresearch_cycle_feedback.jsonl"
+    )
+    promote.assert_called_once()
+
+
+def test_main_preflight_enforced_model_autoresearch_cycle_feedback_admission_blocks_startup(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    cycle_feedback_result = type(
+        "AutoResearchCycleFeedbackResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY",
+            "admission_id": None,
+            "cycle_receipt_id": None,
+            "feedback_record_id": None,
+            "output_path": None,
+            "rejection_reasons": ("missing_model_autoresearch_cycle_receipt_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger_admission_bootstrap.run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap",
+        return_value=cycle_feedback_result,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION": "1",
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ENFORCED": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+
 def test_main_preflight_enforced_model_runtime_binding_supply_blocks_promotion(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add disabled-by-default startup bootstrap for AutoResearch cycle feedback ledger admission
- derive outside-repo cycle feedback ledger path from the resident profile
- wire main.py to append verified cycle receipts into the outside-repo JSONL ledger when explicitly enabled
- add focused bootstrap and main preflight coverage

## Validation
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
- pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q
- pytest modules/ai_intelligence/ai_gateway/tests -q
- git diff --check

## Truth Boundary
- no provider calls
- no benchmark execution
- no model promotion
- no PatternMemory writes
- no HoloIndex re-index
- no runtime binding
- no worker spawn
- no shell execution
- no repo mutation beyond this bootstrap wiring
