### PR TITLE
feat(ai-gateway): bind autoresearch cycle feedback context

### DIFF
--- a/main.py
+++ b/main.py
@@ -2143,6 +2143,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             autoresearch_cycle_feedback = (
                 run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
                     repo_root=repo_root,
+                    plan_receipt_path=model_autoresearch_plan_receipt_path,
                     cycle_receipt_path=model_autoresearch_cycle_receipt_path,
                     output_path=model_autoresearch_cycle_feedback_ledger_path,
                 )

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,39 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Context Binding
+
+**Who:** 0102 Codex
+**Type:** Feedback Ledger Hardening
+**Slice:** MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CONTEXT_BINDING_PHASE1
+
+**What:** Hardened AutoResearch cycle feedback admission so a supplied source
+plan receipt is rehydrated, matched to the cycle receipt, and bound into the
+feedback record.
+
+**Why:** Cycle feedback records need task-family and catalog-snapshot context
+before any later planner-consumption slice can safely use them as recursive
+model-improvement input.
+
+**Files:**
+- `src/model_autoresearch_cycle_feedback_ledger.py` - accepts optional source
+  plan receipts, rejects tampered/mismatched plans, and records bound plan
+  context.
+- `src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py` -
+  requires the outside-repo plan receipt path and passes it into admission.
+- Tests updated for context-bound records, plan tamper rejection, and main
+  preflight argument binding.
+
+**Truth Boundary:**
+- IMPLEMENTED: context-bound cycle feedback records.
+- NOT IMPLEMENTED: planner consumption of cycle feedback records, provider
+  calls, benchmark execution, model promotion, PatternMemory writes, HoloIndex
+  re-indexing, runtime binding, worker spawn, shell execution, source mutation,
+  or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Ledger Admission Bootstrap
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger.py
@@ -18,6 +18,10 @@ from .model_autoresearch_cycle_receipt import (
     ModelAutoResearchCycleReceipt,
     rehydrate_model_autoresearch_cycle_receipt,
 )
+from .model_champion_challenger_autoresearch import (
+    ModelAutoResearchPlanReceipt,
+    rehydrate_model_autoresearch_plan_receipt,
+)
 
 
 MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_ACCEPT = (
@@ -48,6 +52,8 @@ class ModelAutoResearchCycleFeedbackLedgerAdmissionReason:
     EXPLICIT_INVOKE_MISSING = "REJECT_EXPLICIT_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MISSING"
     STORE_REQUIRED = "REJECT_INJECTED_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_STORE_REQUIRED"
     CYCLE_RECEIPT_INVALID = "REJECT_AUTORESEARCH_CYCLE_RECEIPT_INVALID"
+    SOURCE_PLAN_RECEIPT_INVALID = "REJECT_AUTORESEARCH_CYCLE_SOURCE_PLAN_RECEIPT_INVALID"
+    SOURCE_PLAN_RECEIPT_MISMATCH = "REJECT_AUTORESEARCH_CYCLE_SOURCE_PLAN_RECEIPT_MISMATCH"
     CYCLE_NOT_FEEDBACK_ELIGIBLE = "REJECT_AUTORESEARCH_CYCLE_NOT_FEEDBACK_ELIGIBLE"
     SECRET_IN_RECORD = "REJECT_SECRET_IN_AUTORESEARCH_CYCLE_FEEDBACK_RECORD"
     STORE_WRITE_FAILED = "REJECT_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_STORE_WRITE_FAILED"
@@ -91,6 +97,9 @@ class ModelAutoResearchCycleFeedbackLedgerAdmissionReceipt:
     source_plan_receipt_id: str
     campaign_execution_receipt_id: str
     promotion_gate_supply_receipt_id: str
+    task_family: Optional[str]
+    catalog_snapshot_id: Optional[str]
+    source_plan_receipt_digest: str
     executed_candidate_ids: List[str]
     promotion_gate_receipt_ids: List[str]
     feedback_record_id: Optional[str]
@@ -134,6 +143,7 @@ def admit_model_autoresearch_cycle_feedback(
     explicit_autoresearch_cycle_feedback_ledger_admission_requested: bool,
     cycle_receipt: ModelAutoResearchCycleReceipt | Mapping[str, Any],
     store: Optional[ModelAutoResearchCycleFeedbackLedgerStore],
+    source_plan_receipt: ModelAutoResearchPlanReceipt | Mapping[str, Any] | None = None,
 ) -> ModelAutoResearchCycleFeedbackLedgerAdmissionResult:
     """Admit one verified AutoResearch cycle receipt into an injected ledger."""
 
@@ -158,13 +168,38 @@ def admit_model_autoresearch_cycle_feedback(
             ],
             explicit_requested=True,
         )
+    plan: Optional[ModelAutoResearchPlanReceipt] = None
+    if source_plan_receipt is not None:
+        try:
+            plan = _plan_receipt(source_plan_receipt)
+        except Exception as exc:
+            return _reject(
+                [
+                    ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SOURCE_PLAN_RECEIPT_INVALID,
+                    f"plan_error:{type(exc).__name__}",
+                ],
+                explicit_requested=True,
+            )
+        if plan.receipt_id != cycle.source_plan_receipt_id:
+            receipt = _admission_receipt(
+                cycle=cycle,
+                plan=plan,
+                record={},
+                record_id=None,
+                reasons=[ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SOURCE_PLAN_RECEIPT_MISMATCH],
+            )
+            return _reject(
+                [ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SOURCE_PLAN_RECEIPT_MISMATCH],
+                explicit_requested=True,
+                receipt=receipt,
+            )
 
     record: Dict[str, Any] = {}
     reasons: List[str] = []
     if not cycle.executed_candidate_ids or not cycle.promotion_gate_receipt_ids:
         reasons.append(ModelAutoResearchCycleFeedbackLedgerAdmissionReason.CYCLE_NOT_FEEDBACK_ELIGIBLE)
     if not reasons:
-        record = _feedback_record(cycle)
+        record = _feedback_record(cycle, plan)
         if _contains_secret(record):
             reasons.append(ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SECRET_IN_RECORD)
     if reasons:
@@ -206,17 +241,35 @@ def _cycle_receipt(
     raise ValueError("invalid_autoresearch_cycle_receipt")
 
 
-def _feedback_record(cycle: ModelAutoResearchCycleReceipt) -> Dict[str, Any]:
+def _plan_receipt(
+    value: ModelAutoResearchPlanReceipt | Mapping[str, Any],
+) -> ModelAutoResearchPlanReceipt:
+    if isinstance(value, ModelAutoResearchPlanReceipt):
+        return value
+    if isinstance(value, Mapping):
+        return rehydrate_model_autoresearch_plan_receipt(value)
+    raise ValueError("invalid_autoresearch_plan_receipt")
+
+
+def _feedback_record(
+    cycle: ModelAutoResearchCycleReceipt,
+    plan: Optional[ModelAutoResearchPlanReceipt],
+) -> Dict[str, Any]:
     record = {
         "record_type": MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE,
         "schema_version": MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_SCHEMA,
         "cycle_receipt_id": cycle.receipt_id,
         "source_plan_receipt_id": cycle.source_plan_receipt_id,
+        "source_plan_context_bound": plan is not None,
         "campaign_execution_receipt_id": cycle.campaign_execution_receipt_id,
         "promotion_gate_supply_receipt_id": cycle.promotion_gate_supply_receipt_id,
         "executed_candidate_ids": list(cycle.executed_candidate_ids),
         "promotion_gate_receipt_ids": list(cycle.promotion_gate_receipt_ids),
     }
+    if plan is not None:
+        record["task_family"] = plan.policy.task_family
+        record["catalog_snapshot_id"] = plan.policy.catalog_snapshot_id
+        record["source_plan_receipt_digest"] = _digest(plan.to_dict())
     record["feedback_record_id"] = "model_autoresearch_cycle_feedback_" + _digest(record).removeprefix("sha256:")[:16]
     return record
 
@@ -224,6 +277,7 @@ def _feedback_record(cycle: ModelAutoResearchCycleReceipt) -> Dict[str, Any]:
 def _admission_receipt(
     *,
     cycle: ModelAutoResearchCycleReceipt,
+    plan: Optional[ModelAutoResearchPlanReceipt] = None,
     record: Mapping[str, Any],
     record_id: Optional[str],
     reasons: Sequence[str],
@@ -241,6 +295,9 @@ def _admission_receipt(
         source_plan_receipt_id=cycle.source_plan_receipt_id,
         campaign_execution_receipt_id=cycle.campaign_execution_receipt_id,
         promotion_gate_supply_receipt_id=cycle.promotion_gate_supply_receipt_id,
+        task_family=plan.policy.task_family if plan is not None else None,
+        catalog_snapshot_id=plan.policy.catalog_snapshot_id if plan is not None else None,
+        source_plan_receipt_digest=_digest(plan.to_dict()) if plan is not None else "",
         executed_candidate_ids=list(cycle.executed_candidate_ids),
         promotion_gate_receipt_ids=list(cycle.promotion_gate_receipt_ids),
         feedback_record_id=record_id,

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
@@ -2,8 +2,9 @@
 
 Slice: REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MAIN_PREFLIGHT_PHASE1
 
-This adapter reads an outside-repo AutoResearch cycle receipt and appends a
-feedback record to an outside-repo AutoResearch cycle feedback ledger.
+This adapter reads outside-repo AutoResearch plan and cycle receipts, verifies
+their binding, and appends a feedback record to an outside-repo AutoResearch
+cycle feedback ledger.
 
 It does not call providers, run benchmarks, promote models, mutate catalogs,
 write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers,
@@ -60,12 +61,20 @@ class ModelAutoResearchCycleFeedbackLedgerBootstrapResult:
 def run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
     *,
     repo_root: Path | str,
+    plan_receipt_path: Path | str | None,
     cycle_receipt_path: Path | str | None,
     output_path: Path | str | None,
 ) -> ModelAutoResearchCycleFeedbackLedgerBootstrapResult:
     """Append a verified AutoResearch cycle receipt into an outside-repo ledger."""
 
     root = Path(repo_root).resolve()
+    plan_payload, plan_reasons = _read_json_outside_repo(
+        root,
+        plan_receipt_path,
+        missing_reason="missing_model_autoresearch_cycle_feedback_plan_receipt_path",
+        inside_reason="model_autoresearch_cycle_feedback_plan_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_cycle_feedback_plan_receipt",
+    )
     cycle_payload, cycle_reasons = _read_json_outside_repo(
         root,
         cycle_receipt_path,
@@ -74,14 +83,18 @@ def run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
         malformed_reason="malformed_model_autoresearch_cycle_receipt",
     )
     reasons = [
+        *plan_reasons,
         *cycle_reasons,
         *_output_path_reasons(root, output_path),
     ]
+    if plan_payload is not None and not isinstance(plan_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_cycle_feedback_plan_receipt")
     if cycle_payload is not None and not isinstance(cycle_payload, Mapping):
         reasons.append("malformed_model_autoresearch_cycle_receipt")
     if reasons:
         return _not_ready(reasons)
 
+    assert isinstance(plan_payload, Mapping)
     assert isinstance(cycle_payload, Mapping)
     output = _resolve_output_path(root, output_path)
     assert output is not None
@@ -89,6 +102,7 @@ def run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
         admission = admit_model_autoresearch_cycle_feedback(
             explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
             cycle_receipt=cycle_payload,
+            source_plan_receipt=plan_payload,
             store=JsonlModelAutoResearchCycleFeedbackLedgerStore(output),
         )
     except Exception as exc:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger.py
@@ -16,9 +16,7 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_le
     ModelAutoResearchCycleFeedbackLedgerAdmissionReason,
     admit_model_autoresearch_cycle_feedback,
 )
-from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import (
-    build_model_autoresearch_cycle_receipt,
-)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt import build_model_autoresearch_cycle_receipt
 from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import REPO_ROOT
 from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_cycle_receipt import (
     _cycle_sources,
@@ -49,13 +47,24 @@ def _cycle(tmp_path: Path):
     )
 
 
+def _cycle_with_plan(tmp_path: Path):
+    plan, execution, gate_supply = _cycle_sources(tmp_path)
+    cycle = build_model_autoresearch_cycle_receipt(
+        plan_receipt=plan,
+        campaign_execution_receipt=execution,
+        promotion_gate_supply_receipt=gate_supply,
+    )
+    return cycle, plan
+
+
 def test_admits_autoresearch_cycle_receipt_to_injected_ledger_store(tmp_path: Path) -> None:
-    cycle = _cycle(tmp_path)
+    cycle, plan = _cycle_with_plan(tmp_path)
     store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
 
     result = admit_model_autoresearch_cycle_feedback(
         explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
         cycle_receipt=cycle.to_dict(),
+        source_plan_receipt=plan.to_dict(),
         store=store,
     )
 
@@ -71,17 +80,22 @@ def test_admits_autoresearch_cycle_receipt_to_injected_ledger_store(tmp_path: Pa
     assert len(store.records) == 1
     assert store.records[0]["record_type"] == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_RECORD_TYPE
     assert store.records[0]["cycle_receipt_id"] == cycle.receipt_id
+    assert store.records[0]["source_plan_context_bound"] is True
+    assert store.records[0]["task_family"] == plan.policy.task_family
+    assert store.records[0]["catalog_snapshot_id"] == plan.policy.catalog_snapshot_id
+    assert store.records[0]["source_plan_receipt_digest"].startswith("sha256:")
     assert store.records[0]["executed_candidate_ids"] == list(cycle.executed_candidate_ids)
 
 
 def test_jsonl_store_writes_one_feedback_record(tmp_path: Path) -> None:
-    cycle = _cycle(tmp_path)
+    cycle, plan = _cycle_with_plan(tmp_path)
     path = tmp_path / "cycle_feedback.jsonl"
     store = JsonlModelAutoResearchCycleFeedbackLedgerStore(path)
 
     result = admit_model_autoresearch_cycle_feedback(
         explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
         cycle_receipt=cycle,
+        source_plan_receipt=plan,
         store=store,
     )
 
@@ -89,20 +103,23 @@ def test_jsonl_store_writes_one_feedback_record(tmp_path: Path) -> None:
     records = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
     assert len(records) == 1
     assert records[0]["cycle_receipt_id"] == cycle.receipt_id
+    assert records[0]["source_plan_context_bound"] is True
 
 
 def test_explicit_request_and_store_are_required(tmp_path: Path) -> None:
-    cycle = _cycle(tmp_path)
+    cycle, plan = _cycle_with_plan(tmp_path)
     store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
 
     missing_request = admit_model_autoresearch_cycle_feedback(
         explicit_autoresearch_cycle_feedback_ledger_admission_requested=False,
         cycle_receipt=cycle.to_dict(),
+        source_plan_receipt=plan.to_dict(),
         store=store,
     )
     missing_store = admit_model_autoresearch_cycle_feedback(
         explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
         cycle_receipt=cycle.to_dict(),
+        source_plan_receipt=plan.to_dict(),
         store=None,
     )
 
@@ -117,18 +134,59 @@ def test_explicit_request_and_store_are_required(tmp_path: Path) -> None:
 
 
 def test_tampered_serialized_cycle_receipt_rejects_before_store_write(tmp_path: Path) -> None:
-    cycle = _cycle(tmp_path).to_dict()
-    cycle["executed_candidate_ids"] = ["provider/tampered"]
+    cycle, plan = _cycle_with_plan(tmp_path)
+    cycle_payload = cycle.to_dict()
+    cycle_payload["executed_candidate_ids"] = ["provider/tampered"]
     store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
 
     result = admit_model_autoresearch_cycle_feedback(
         explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
-        cycle_receipt=cycle,
+        cycle_receipt=cycle_payload,
+        source_plan_receipt=plan.to_dict(),
         store=store,
     )
 
     assert result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
     assert ModelAutoResearchCycleFeedbackLedgerAdmissionReason.CYCLE_RECEIPT_INVALID in result.rejection_reasons
+    assert store.records == []
+
+
+def test_mismatched_source_plan_rejects_before_store_write(tmp_path: Path) -> None:
+    cycle, plan = _cycle_with_plan(tmp_path)
+    mismatched_plan = plan.to_dict()
+    mismatched_plan["policy"] = {
+        **mismatched_plan["policy"],
+        "task_family": "security",
+    }
+    # Rehydration rejects this as digest tamper before the mismatch check.
+    store = InMemoryModelAutoResearchCycleFeedbackLedgerStore()
+    tampered_result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle.to_dict(),
+        source_plan_receipt=mismatched_plan,
+        store=store,
+    )
+    assert tampered_result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert (
+        ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SOURCE_PLAN_RECEIPT_INVALID
+        in tampered_result.rejection_reasons
+    )
+
+    other_plan = replace(
+        plan,
+        receipt_id="model_autoresearch_plan:other",
+    )
+    mismatch_result = admit_model_autoresearch_cycle_feedback(
+        explicit_autoresearch_cycle_feedback_ledger_admission_requested=True,
+        cycle_receipt=cycle,
+        source_plan_receipt=other_plan,
+        store=store,
+    )
+    assert mismatch_result.decision == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_REJECT
+    assert (
+        ModelAutoResearchCycleFeedbackLedgerAdmissionReason.SOURCE_PLAN_RECEIPT_MISMATCH
+        in mismatch_result.rejection_reasons
+    )
     assert store.records == []
 
 

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
@@ -37,23 +37,26 @@ def _write_json(root: Path, name: str, payload: object) -> Path:
     return path
 
 
-def _cycle_payload(tmp_path: Path) -> dict:
+def _cycle_payload(tmp_path: Path) -> tuple[dict, dict]:
     plan, execution, gate_supply = _cycle_sources(tmp_path)
-    return build_model_autoresearch_cycle_receipt(
+    cycle = build_model_autoresearch_cycle_receipt(
         plan_receipt=plan,
         campaign_execution_receipt=execution,
         promotion_gate_supply_receipt=gate_supply,
-    ).to_dict()
+    )
+    return cycle.to_dict(), plan.to_dict()
 
 
 def test_cycle_feedback_bootstrap_appends_cycle_feedback_record(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
-    cycle_payload = _cycle_payload(tmp_path)
+    cycle_payload, plan_payload = _cycle_payload(tmp_path)
+    plan_path = _write_json(runtime, "plan_receipt.json", plan_payload)
     cycle_path = _write_json(runtime, "cycle_receipt.json", cycle_payload)
     output_path = runtime / "cycle_feedback.jsonl"
 
     result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
         repo_root=REPO_ROOT,
+        plan_receipt_path=plan_path,
         cycle_receipt_path=cycle_path,
         output_path=output_path,
     )
@@ -68,6 +71,8 @@ def test_cycle_feedback_bootstrap_appends_cycle_feedback_record(tmp_path: Path) 
     records = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
     assert len(records) == 1
     assert records[0]["cycle_receipt_id"] == cycle_payload["receipt_id"]
+    assert records[0]["source_plan_context_bound"] is True
+    assert records[0]["task_family"] == plan_payload["policy"]["task_family"]
 
 
 def test_cycle_feedback_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
@@ -77,6 +82,7 @@ def test_cycle_feedback_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path
     try:
         result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
             repo_root=REPO_ROOT,
+            plan_receipt_path=repo_cycle,
             cycle_receipt_path=repo_cycle,
             output_path=repo_output,
         )
@@ -86,19 +92,22 @@ def test_cycle_feedback_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path
 
     assert result.accepted is False
     assert result.status == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_cycle_feedback_plan_receipt_path_inside_repo" in result.rejection_reasons
     assert "model_autoresearch_cycle_receipt_path_inside_repo" in result.rejection_reasons
     assert "model_autoresearch_cycle_feedback_ledger_output_path_invalid" in result.rejection_reasons
 
 
 def test_cycle_feedback_bootstrap_rejects_tampered_cycle_receipt(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
-    cycle_payload = _cycle_payload(tmp_path)
+    cycle_payload, plan_payload = _cycle_payload(tmp_path)
+    plan_path = _write_json(runtime, "plan_receipt.json", plan_payload)
     cycle_payload["executed_candidate_ids"] = ["provider/tampered"]
     cycle_path = _write_json(runtime, "tampered_cycle_receipt.json", cycle_payload)
     output_path = runtime / "cycle_feedback.jsonl"
 
     result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
         repo_root=REPO_ROOT,
+        plan_receipt_path=plan_path,
         cycle_receipt_path=cycle_path,
         output_path=output_path,
     )
@@ -110,16 +119,39 @@ def test_cycle_feedback_bootstrap_rejects_tampered_cycle_receipt(tmp_path: Path)
 
 def test_cycle_feedback_bootstrap_rejects_missing_output_path(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
-    cycle_path = _write_json(runtime, "cycle_receipt.json", _cycle_payload(tmp_path))
+    cycle_payload, plan_payload = _cycle_payload(tmp_path)
+    plan_path = _write_json(runtime, "plan_receipt.json", plan_payload)
+    cycle_path = _write_json(runtime, "cycle_receipt.json", cycle_payload)
 
     result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
         repo_root=REPO_ROOT,
+        plan_receipt_path=plan_path,
         cycle_receipt_path=cycle_path,
         output_path=None,
     )
 
     assert result.accepted is False
     assert "model_autoresearch_cycle_feedback_ledger_output_path_invalid" in result.rejection_reasons
+
+
+def test_cycle_feedback_bootstrap_rejects_tampered_plan_receipt(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    cycle_payload, plan_payload = _cycle_payload(tmp_path)
+    plan_payload["policy"]["task_family"] = "security"
+    plan_path = _write_json(runtime, "tampered_plan_receipt.json", plan_payload)
+    cycle_path = _write_json(runtime, "cycle_receipt.json", cycle_payload)
+    output_path = runtime / "cycle_feedback.jsonl"
+
+    result = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=plan_path,
+        cycle_receipt_path=cycle_path,
+        output_path=output_path,
+    )
+
+    assert result.accepted is False
+    assert "REJECT_AUTORESEARCH_CYCLE_SOURCE_PLAN_RECEIPT_INVALID" in result.rejection_reasons
+    assert not output_path.exists()
 
 
 def test_cycle_feedback_bootstrap_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CONTEXT_BINDING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Updated the RedDog model AutoResearch cycle-feedback startup hook to pass the
+  outside-repo plan receipt into feedback admission.
+- The feedback bootstrap now fails closed if the source plan receipt is missing,
+  malformed, inside the repo, tampered, or mismatched with the cycle receipt.
+- This binds task-family and catalog-snapshot context into the cycle feedback
+  record before any later planner-consumption work.
+- Boundary remains constrained: no provider call, benchmark execution,
+  HoloIndex re-index, PatternMemory write, model promotion, runtime binding,
+  worker spawn, source mutation, PR publication, reward settlement, shell
+  execution, or merge authority was added.
+
 ## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION_MAIN_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -1036,6 +1036,7 @@ def test_main_preflight_model_autoresearch_cycle_feedback_admission_runs_before_
 
     cycle_feedback.assert_called_once()
     cycle_feedback_kwargs = cycle_feedback.call_args.kwargs
+    assert cycle_feedback_kwargs["plan_receipt_path"] == str(runtime_root / "model_autoresearch_plan_receipt.json")
     assert cycle_feedback_kwargs["cycle_receipt_path"] == str(
         runtime_root / "model_autoresearch_cycle_receipt.json"
     )


### PR DESCRIPTION
## Summary
- bind source AutoResearch plan receipts into cycle feedback admission
- reject tampered or mismatched source plans before ledger writes
- require the startup cycle-feedback bootstrap to read and pass the outside-repo plan receipt
- record task-family/catalog-snapshot context in cycle feedback records

## Validation
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py main.py
- pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_ledger_admission_bootstrap.py
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q
- pytest modules/ai_intelligence/ai_gateway/tests -q
- git diff --check

## Truth Boundary
- no planner consumption of cycle feedback records yet
- no provider calls
- no benchmark execution
- no model promotion
- no PatternMemory writes
- no HoloIndex re-index
- no runtime binding
- no worker spawn
- no shell execution
