### PR TITLE
feat(ai-gateway): consume AutoResearch cycle feedback in planner

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -184,6 +184,11 @@ The planner consumes promotion-gate receipts, a candidate pool, and
 The policy binds task family, catalog snapshot ID, maximum campaign items,
 optional verifier digest, and a required cost-budget receipt. Missing source gate
 receipts, verifier mismatch, or missing budget evidence fails closed. The planner
+may consume verified selection-outcome feedback records and context-bound
+AutoResearch cycle feedback records as bounded priority signals. Cycle feedback
+is accepted only when its source plan context is bound, task family and catalog
+snapshot match the policy, source-plan digest is present, and executed
+candidates plus promotion-gate receipt IDs are nonempty. The planner
 does not execute benchmarks, call providers, write PatternMemory, mutate
 catalogs, or bind runtime defaults.
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,38 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Planner Input
+
+**Who:** 0102 Codex
+**Type:** Planner Feedback Integration
+**Slice:** MODEL_AUTORESEARCH_CYCLE_FEEDBACK_PLANNER_INPUT_PHASE1
+
+**What:** Extended the model champion/challenger AutoResearch planner to accept
+context-bound `model_autoresearch_cycle_feedback_record.v1` records as bounded
+feedback input.
+
+**Why:** Completed AutoResearch cycles now need to influence the next
+benchmark plan without trusting unbound ledger records or changing runtime
+model bindings.
+
+**Files:**
+- `src/model_champion_challenger_autoresearch.py` - normalizes cycle feedback
+  only when source-plan context, task family, catalog snapshot, source-plan
+  digest, executed candidates, and promotion-gate receipts are present.
+- `tests/test_model_champion_challenger_autoresearch.py` - verifies bounded
+  priority influence plus fail-closed rejection for unbound, mismatched, and
+  incomplete cycle feedback records.
+
+**Truth Boundary:**
+- IMPLEMENTED: planner consumption of context-bound cycle feedback as a
+  priority signal for existing candidates.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn,
+  shell execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Context Binding
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -105,8 +105,11 @@ benchmarking untested candidates or rebenchmarking challengers, but it does not
 execute those campaigns.
 
 The planner requires source promotion-gate receipts and a cost-budget receipt.
-It does not call providers, run benchmarks, mutate catalogs, write
-PatternMemory, or bind RedDog runtime defaults.
+It can use verified selection-outcome feedback and context-bound AutoResearch
+cycle feedback as bounded priority signals for existing candidates. Cycle
+feedback must be source-plan-bound and policy-matched before it can influence
+the next campaign. It does not call providers, run benchmarks, mutate catalogs,
+write PatternMemory, or bind RedDog runtime defaults.
 
 ## RedDog Runtime Model Binding
 

--- a/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py
@@ -20,6 +20,10 @@ from .model_promotion_gate import ModelPromotionGateDecision, ModelPromotionGate
 
 AUTORESEARCH_SCHEMA_VERSION = "model_champion_challenger_autoresearch_plan.v1"
 AUTORESEARCH_POLICY_SCHEMA_VERSION = "model_autoresearch_policy.v1"
+MODEL_SELECTION_FEEDBACK_RECORD_TYPE = "model_selection_outcome_feedback"
+MODEL_SELECTION_FEEDBACK_RECORD_SCHEMA = "model_feedback_ledger_record.v1"
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_RECORD_TYPE = "model_autoresearch_cycle_feedback"
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_RECORD_SCHEMA = "model_autoresearch_cycle_feedback_record.v1"
 
 
 class ModelAutoResearchAction(str, Enum):
@@ -377,53 +381,112 @@ def _normalize_feedback_records(
         if not isinstance(record, Mapping):
             raise ValueError("invalid_feedback_record")
         candidate = dict(record)
-        if candidate.get("record_type") != "model_selection_outcome_feedback":
+        record_type = candidate.get("record_type")
+        if record_type == MODEL_SELECTION_FEEDBACK_RECORD_TYPE:
+            normalized_record = _normalize_model_selection_feedback_record(candidate, policy)
+        elif record_type == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_RECORD_TYPE:
+            normalized_record = _normalize_autoresearch_cycle_feedback_record(candidate, policy)
+        else:
             raise ValueError("invalid_feedback_record_type")
-        if candidate.get("schema_version") != "model_feedback_ledger_record.v1":
-            raise ValueError("invalid_feedback_record_schema")
-        record_id = _required("feedback_record_id", candidate.get("feedback_record_id"))
-        if not record_id.startswith("model_feedback_"):
-            raise ValueError("invalid_feedback_record_id")
-        for field in (
-            "outcome_receipt_id",
-            "selection_receipt_id",
-            "catalog_snapshot_id",
-            "task_family",
-            "source_ratchet_id",
-            "source_ratchet_digest",
-        ):
-            _required(field, candidate.get(field))
-        if candidate["task_family"] != policy.task_family:
-            raise ValueError("feedback_task_family_mismatch")
-        if candidate["catalog_snapshot_id"] != policy.catalog_snapshot_id:
-            raise ValueError("feedback_catalog_snapshot_mismatch")
-        selected_model_ids = tuple(str(value).strip() for value in candidate.get("selected_model_ids") or ())
-        if not selected_model_ids or any(not value for value in selected_model_ids):
-            raise ValueError("feedback_selected_model_ids_missing")
-        verification_receipt_ids = tuple(
-            str(value).strip() for value in candidate.get("verification_receipt_ids") or ()
-        )
-        if not verification_receipt_ids or any(not value for value in verification_receipt_ids):
-            raise ValueError("feedback_verification_receipts_missing")
-        if not _is_digest(candidate.get("source_ratchet_digest")):
-            raise ValueError("feedback_source_ratchet_digest_invalid")
-        normalized.append(
-            {
-                "feedback_record_id": record_id,
-                "outcome_receipt_id": str(candidate["outcome_receipt_id"]),
-                "selection_receipt_id": str(candidate["selection_receipt_id"]),
-                "catalog_snapshot_id": str(candidate["catalog_snapshot_id"]),
-                "task_family": str(candidate["task_family"]),
-                "selected_model_ids": list(selected_model_ids),
-                "verification_receipt_ids": list(verification_receipt_ids),
-                "source_ratchet_id": str(candidate["source_ratchet_id"]),
-                "source_ratchet_digest": str(candidate["source_ratchet_digest"]),
-            }
-        )
+        normalized.append(normalized_record)
+        record_id = str(normalized_record["feedback_record_id"])
         record_ids.append(record_id)
     if len(set(record_ids)) != len(record_ids):
         raise ValueError("duplicate_feedback_record_ids")
     return tuple(sorted(normalized, key=lambda item: item["feedback_record_id"]))
+
+
+def _normalize_model_selection_feedback_record(
+    candidate: Mapping[str, Any],
+    policy: ModelAutoResearchPolicy,
+) -> dict[str, Any]:
+    if candidate.get("schema_version") != MODEL_SELECTION_FEEDBACK_RECORD_SCHEMA:
+        raise ValueError("invalid_feedback_record_schema")
+    record_id = _required("feedback_record_id", candidate.get("feedback_record_id"))
+    if not record_id.startswith("model_feedback_"):
+        raise ValueError("invalid_feedback_record_id")
+    for field in (
+        "outcome_receipt_id",
+        "selection_receipt_id",
+        "catalog_snapshot_id",
+        "task_family",
+        "source_ratchet_id",
+        "source_ratchet_digest",
+    ):
+        _required(field, candidate.get(field))
+    if candidate["task_family"] != policy.task_family:
+        raise ValueError("feedback_task_family_mismatch")
+    if candidate["catalog_snapshot_id"] != policy.catalog_snapshot_id:
+        raise ValueError("feedback_catalog_snapshot_mismatch")
+    selected_model_ids = _nonempty_string_tuple("selected_model_ids", candidate.get("selected_model_ids"))
+    verification_receipt_ids = _nonempty_string_tuple(
+        "verification_receipt_ids",
+        candidate.get("verification_receipt_ids"),
+    )
+    if not _is_digest(candidate.get("source_ratchet_digest")):
+        raise ValueError("feedback_source_ratchet_digest_invalid")
+    return {
+        "feedback_record_id": record_id,
+        "record_type": MODEL_SELECTION_FEEDBACK_RECORD_TYPE,
+        "schema_version": MODEL_SELECTION_FEEDBACK_RECORD_SCHEMA,
+        "outcome_receipt_id": str(candidate["outcome_receipt_id"]),
+        "selection_receipt_id": str(candidate["selection_receipt_id"]),
+        "catalog_snapshot_id": str(candidate["catalog_snapshot_id"]),
+        "task_family": str(candidate["task_family"]),
+        "selected_model_ids": list(selected_model_ids),
+        "verification_receipt_ids": list(verification_receipt_ids),
+        "source_ratchet_id": str(candidate["source_ratchet_id"]),
+        "source_ratchet_digest": str(candidate["source_ratchet_digest"]),
+    }
+
+
+def _normalize_autoresearch_cycle_feedback_record(
+    candidate: Mapping[str, Any],
+    policy: ModelAutoResearchPolicy,
+) -> dict[str, Any]:
+    if candidate.get("schema_version") != MODEL_AUTORESEARCH_CYCLE_FEEDBACK_RECORD_SCHEMA:
+        raise ValueError("invalid_feedback_record_schema")
+    record_id = _required("feedback_record_id", candidate.get("feedback_record_id"))
+    if not record_id.startswith("model_autoresearch_cycle_feedback_"):
+        raise ValueError("invalid_feedback_record_id")
+    if candidate.get("source_plan_context_bound") is not True:
+        raise ValueError("feedback_source_plan_context_unbound")
+    for field in (
+        "cycle_receipt_id",
+        "source_plan_receipt_id",
+        "campaign_execution_receipt_id",
+        "promotion_gate_supply_receipt_id",
+        "catalog_snapshot_id",
+        "task_family",
+        "source_plan_receipt_digest",
+    ):
+        _required(field, candidate.get(field))
+    if candidate["task_family"] != policy.task_family:
+        raise ValueError("feedback_task_family_mismatch")
+    if candidate["catalog_snapshot_id"] != policy.catalog_snapshot_id:
+        raise ValueError("feedback_catalog_snapshot_mismatch")
+    executed_candidate_ids = _nonempty_string_tuple("executed_candidate_ids", candidate.get("executed_candidate_ids"))
+    promotion_gate_receipt_ids = _nonempty_string_tuple(
+        "promotion_gate_receipt_ids",
+        candidate.get("promotion_gate_receipt_ids"),
+    )
+    if not _is_digest(candidate.get("source_plan_receipt_digest")):
+        raise ValueError("feedback_source_plan_receipt_digest_invalid")
+    return {
+        "feedback_record_id": record_id,
+        "record_type": MODEL_AUTORESEARCH_CYCLE_FEEDBACK_RECORD_TYPE,
+        "schema_version": MODEL_AUTORESEARCH_CYCLE_FEEDBACK_RECORD_SCHEMA,
+        "cycle_receipt_id": str(candidate["cycle_receipt_id"]),
+        "source_plan_receipt_id": str(candidate["source_plan_receipt_id"]),
+        "source_plan_context_bound": True,
+        "campaign_execution_receipt_id": str(candidate["campaign_execution_receipt_id"]),
+        "promotion_gate_supply_receipt_id": str(candidate["promotion_gate_supply_receipt_id"]),
+        "catalog_snapshot_id": str(candidate["catalog_snapshot_id"]),
+        "task_family": str(candidate["task_family"]),
+        "selected_model_ids": list(executed_candidate_ids),
+        "verification_receipt_ids": list(promotion_gate_receipt_ids),
+        "source_plan_receipt_digest": str(candidate["source_plan_receipt_digest"]),
+    }
 
 
 def _feedback_model_ids(feedback_records: tuple[dict[str, Any], ...]) -> set[str]:
@@ -461,6 +524,13 @@ def _string_tuple(name: str, value: Any) -> tuple[str, ...]:
     records = tuple(_required(name, item) for item in raw)
     if len(set(records)) != len(records):
         raise ValueError(f"duplicate_{name}")
+    return records
+
+
+def _nonempty_string_tuple(name: str, value: Any) -> tuple[str, ...]:
+    records = _string_tuple(name, value)
+    if not records:
+        raise ValueError(f"invalid_{name}")
     return records
 
 

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py
@@ -135,6 +135,24 @@ def _feedback_record(model_id: str, *, suffix: str = "1") -> dict:
     }
 
 
+def _cycle_feedback_record(model_id: str, *, suffix: str = "1") -> dict:
+    return {
+        "record_type": "model_autoresearch_cycle_feedback",
+        "schema_version": "model_autoresearch_cycle_feedback_record.v1",
+        "feedback_record_id": f"model_autoresearch_cycle_feedback_{suffix}",
+        "cycle_receipt_id": f"model_autoresearch_cycle:{suffix}",
+        "source_plan_receipt_id": f"model_autoresearch_plan:{suffix}",
+        "source_plan_context_bound": True,
+        "campaign_execution_receipt_id": f"model_autoresearch_campaign_execution:{suffix}",
+        "promotion_gate_supply_receipt_id": f"model_autoresearch_promotion_gate_supply:{suffix}",
+        "catalog_snapshot_id": "model_catalog_snapshot:1",
+        "task_family": "architecture",
+        "executed_candidate_ids": [model_id],
+        "promotion_gate_receipt_ids": [f"model_promotion_gate:{suffix}"],
+        "source_plan_receipt_digest": "sha256:" + suffix[0].rjust(64, "0"),
+    }
+
+
 def test_autoresearch_plans_new_candidate_and_rebenchmark_challenger():
     champion_gate = _gate("provider/champion", pass_all=True)
     challenger_gate = _gate("provider/challenger", pass_all=False)
@@ -177,6 +195,30 @@ def test_autoresearch_uses_feedback_records_as_bounded_priority_signal():
     assert receipt.rejection_reasons == ()
     assert receipt.source_feedback_record_ids == ("model_feedback_2",)
     assert receipt.feedback_ledger_digest.startswith("model_autoresearch_feedback_ledger:")
+    assert [item.candidate_id for item in receipt.campaign_items] == [
+        "provider/new",
+        "provider/challenger",
+    ]
+    assert receipt.campaign_items[0].priority == "P0"
+    assert receipt.campaign_items[0].reason == "verified_runtime_feedback_unbenchmarked_candidate"
+
+
+def test_autoresearch_uses_context_bound_cycle_feedback_as_bounded_priority_signal():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    feedback = _cycle_feedback_record("provider/new", suffix="3")
+
+    receipt = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(challenger_gate,),
+        candidate_pool=(
+            _candidate("provider/challenger"),
+            _candidate("provider/new"),
+        ),
+        policy=_policy(),
+        feedback_records=(feedback,),
+    )
+
+    assert receipt.rejection_reasons == ()
+    assert receipt.source_feedback_record_ids == ("model_autoresearch_cycle_feedback_3",)
     assert [item.candidate_id for item in receipt.campaign_items] == [
         "provider/new",
         "provider/challenger",
@@ -297,6 +339,60 @@ def test_autoresearch_rejects_malformed_or_mismatched_feedback_records():
             assert str(exc) == expected
         else:
             raise AssertionError("feedback record was accepted")
+
+
+def test_autoresearch_rejects_unbound_or_mismatched_cycle_feedback_records():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    unbound = _cycle_feedback_record("provider/new")
+    unbound["source_plan_context_bound"] = False
+    mismatched_task = _cycle_feedback_record("provider/new", suffix="2")
+    mismatched_task["task_family"] = "security"
+    mismatched_catalog = _cycle_feedback_record("provider/new", suffix="3")
+    mismatched_catalog["catalog_snapshot_id"] = "model_catalog_snapshot:other"
+    bad_digest = _cycle_feedback_record("provider/new", suffix="4")
+    bad_digest["source_plan_receipt_digest"] = "not-a-digest"
+
+    for record, expected in (
+        (unbound, "feedback_source_plan_context_unbound"),
+        (mismatched_task, "feedback_task_family_mismatch"),
+        (mismatched_catalog, "feedback_catalog_snapshot_mismatch"),
+        (bad_digest, "feedback_source_plan_receipt_digest_invalid"),
+    ):
+        try:
+            plan_model_champion_challenger_autoresearch(
+                promotion_gate_receipts=(challenger_gate,),
+                candidate_pool=(_candidate("provider/new"),),
+                policy=_policy(),
+                feedback_records=(record,),
+            )
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError("cycle feedback record was accepted")
+
+
+def test_autoresearch_rejects_cycle_feedback_missing_candidates_or_gate_receipts():
+    challenger_gate = _gate("provider/challenger", pass_all=False)
+    missing_candidates = _cycle_feedback_record("provider/new")
+    missing_candidates["executed_candidate_ids"] = []
+    missing_gates = _cycle_feedback_record("provider/new", suffix="2")
+    missing_gates["promotion_gate_receipt_ids"] = []
+
+    for record, expected in (
+        (missing_candidates, "invalid_executed_candidate_ids"),
+        (missing_gates, "invalid_promotion_gate_receipt_ids"),
+    ):
+        try:
+            plan_model_champion_challenger_autoresearch(
+                promotion_gate_receipts=(challenger_gate,),
+                candidate_pool=(_candidate("provider/new"),),
+                policy=_policy(),
+                feedback_records=(record,),
+            )
+        except ValueError as exc:
+            assert str(exc) == expected
+        else:
+            raise AssertionError("cycle feedback record was accepted")
 
 
 def test_autoresearch_feedback_cannot_invent_candidate():


### PR DESCRIPTION
## Slice
MODEL_AUTORESEARCH_CYCLE_FEEDBACK_PLANNER_INPUT_PHASE1

## Summary
- Teach the champion/challenger AutoResearch planner to accept context-bound `model_autoresearch_cycle_feedback_record.v1` records.
- Preserve existing selection-outcome feedback behavior while requiring cycle feedback to be source-plan-bound, task-family/catalog matched, digest-bearing, and nonempty for executed candidates and promotion-gate receipts.
- Update AI gateway README, INTERFACE, and ModLog truth boundary.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_champion_challenger_autoresearch.py`
- `pytest modules/ai_intelligence/ai_gateway/tests/test_model_champion_challenger_autoresearch.py -q` -> 16 passed
- `pytest modules/ai_intelligence/ai_gateway/tests -q` -> 181 passed
- `git diff --check` -> clean (CRLF warnings only)

## WSP_97 Truth Boundary
IMPLEMENTED: planner consumption of context-bound cycle feedback as a bounded priority signal for existing candidate campaigns.

NOT IMPLEMENTED: provider calls, benchmark execution, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn, shell execution, source mutation, or extension mutation.