### PR TITLE
test(ai-gateway): prove cycle feedback plan supply

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,36 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Plan Supply Regression
+
+**Who:** 0102 Codex
+**Type:** Runtime Supply Regression
+**Slice:** REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_PLAN_SUPPLY_REGRESSION_PHASE1
+
+**What:** Added direct supplier and startup-bootstrap regression coverage proving
+context-bound cycle feedback JSONL records flow into AutoResearch plan
+artifact supply.
+
+**Why:** The planner can consume cycle feedback and the bootstrap can read JSONL
+feedback, but the runtime boundary needed an explicit proof that cycle feedback
+from the feedback ledger can influence the next benchmark plan.
+
+**Files:**
+- `tests/test_model_autoresearch_plan_artifact_supply.py` - verifies direct
+  supplier priority from cycle feedback.
+- `tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py` - verifies
+  startup JSONL feedback supply with the cycle feedback shape.
+
+**Truth Boundary:**
+- IMPLEMENTED: regression proof that context-bound cycle feedback reaches
+  AutoResearch plan supply through direct and bootstrap paths.
+- NOT IMPLEMENTED: provider calls, benchmark execution, model promotion,
+  PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn,
+  shell execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Planner Input
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py
@@ -146,6 +146,24 @@ def _feedback_record(model_id: str) -> dict:
     }
 
 
+def _cycle_feedback_record(model_id: str) -> dict:
+    return {
+        "record_type": "model_autoresearch_cycle_feedback",
+        "schema_version": "model_autoresearch_cycle_feedback_record.v1",
+        "feedback_record_id": "model_autoresearch_cycle_feedback_runtime",
+        "cycle_receipt_id": "model_autoresearch_cycle:runtime",
+        "source_plan_receipt_id": "model_autoresearch_plan:runtime",
+        "source_plan_context_bound": True,
+        "campaign_execution_receipt_id": "model_autoresearch_campaign_execution:runtime",
+        "promotion_gate_supply_receipt_id": "model_autoresearch_promotion_gate_supply:runtime",
+        "catalog_snapshot_id": "model_catalog_snapshot:1",
+        "task_family": "architecture",
+        "executed_candidate_ids": [model_id],
+        "promotion_gate_receipt_ids": ["model_promotion_gate:runtime"],
+        "source_plan_receipt_digest": "sha256:" + "2" * 64,
+    }
+
+
 def test_supplier_writes_plan_from_serialized_inputs_and_feedback(tmp_path: Path):
     challenger = _gate("provider/challenger", pass_all=False)
     output = tmp_path / "runtime" / "autoresearch_plan.json"
@@ -172,6 +190,32 @@ def test_supplier_writes_plan_from_serialized_inputs_and_feedback(tmp_path: Path
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["receipt_id"] == result.plan_receipt_id
     assert payload["campaign_items"][0]["candidate_id"] == "provider/new"
+    assert payload["campaign_items"][0]["reason"] == "verified_runtime_feedback_unbenchmarked_candidate"
+
+
+def test_supplier_writes_plan_from_context_bound_cycle_feedback(tmp_path: Path):
+    challenger = _gate("provider/challenger", pass_all=False)
+    output = tmp_path / "runtime" / "autoresearch_plan.json"
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts=(challenger.to_dict(),),
+        candidate_pool=(
+            _candidate("provider/challenger").to_dict(),
+            _candidate("provider/new").to_dict(),
+        ),
+        policy=_policy(),
+        feedback_records=(_cycle_feedback_record("provider/new"),),
+        output_path=output,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ACCEPT
+    assert result.source_feedback_record_ids == ("model_autoresearch_cycle_feedback_runtime",)
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["source_feedback_record_ids"] == ["model_autoresearch_cycle_feedback_runtime"]
+    assert payload["campaign_items"][0]["candidate_id"] == "provider/new"
+    assert payload["campaign_items"][0]["priority"] == "P0"
     assert payload["campaign_items"][0]["reason"] == "verified_runtime_feedback_unbenchmarked_candidate"
 
 

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py
@@ -14,6 +14,7 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_sup
 from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_plan_artifact_supply import (
     REPO_ROOT,
     _candidate,
+    _cycle_feedback_record,
     _feedback_record,
     _gate,
     _policy,
@@ -97,6 +98,33 @@ def test_bootstrap_materializes_autoresearch_plan_with_jsonl_feedback(tmp_path: 
         item["reason"] == "verified_runtime_feedback_unbenchmarked_candidate"
         for item in payload["campaign_items"]
     )
+
+
+def test_bootstrap_materializes_autoresearch_plan_with_cycle_feedback_jsonl(tmp_path: Path) -> None:
+    files = _inputs(tmp_path)
+    cycle_feedback = _write_jsonl(
+        tmp_path / "runtime",
+        "cycle_feedback.jsonl",
+        (_cycle_feedback_record("provider/new"),),
+    )
+
+    result = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        promotion_gate_receipts_path=files["gates"],
+        candidate_pool_path=files["candidates"],
+        policy_path=files["policy"],
+        feedback_records_path=cycle_feedback,
+        output_path=files["output"],
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED
+    assert result.source_feedback_record_ids == ("model_autoresearch_cycle_feedback_runtime",)
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    assert payload["source_feedback_record_ids"] == ["model_autoresearch_cycle_feedback_runtime"]
+    assert payload["campaign_items"][0]["candidate_id"] == "provider/new"
+    assert payload["campaign_items"][0]["priority"] == "P0"
+    assert payload["campaign_items"][0]["reason"] == "verified_runtime_feedback_unbenchmarked_candidate"
 
 
 def test_bootstrap_accepts_missing_optional_feedback_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Slice
REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_PLAN_SUPPLY_REGRESSION_PHASE1

## Summary
- Add direct supplier coverage proving context-bound cycle feedback records influence AutoResearch plan artifact supply.
- Add startup bootstrap JSONL coverage proving the configured feedback-record path accepts the cycle feedback shape.
- Record the runtime-supply proof in the AI gateway ModLog.

## Validation
- `pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_plan_artifact_supply_bootstrap.py -q` -> 13 passed
- `pytest modules/ai_intelligence/ai_gateway/tests -q` -> 183 passed
- `git diff --check` -> clean (CRLF warnings only)

## WSP_97 Truth Boundary
IMPLEMENTED: regression proof that context-bound cycle feedback reaches AutoResearch plan supply through direct and bootstrap paths.

NOT IMPLEMENTED: provider calls, benchmark execution, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn, shell execution, source mutation, or extension mutation.