### PR TITLE
feat(main): default AutoResearch feedback to cycle ledger

### DIFF
--- a/main.py
+++ b/main.py
@@ -1906,12 +1906,19 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
                 run_reddog_model_autoresearch_plan_artifact_supply_bootstrap,
             )
 
+            configured_feedback_path = os.getenv("REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH", "").strip()
+            model_autoresearch_feedback_records_path = configured_feedback_path or None
+            if model_autoresearch_feedback_records_path is None:
+                cycle_feedback_path = Path(model_autoresearch_cycle_feedback_ledger_path)
+                if cycle_feedback_path.exists() and cycle_feedback_path.is_file():
+                    model_autoresearch_feedback_records_path = str(cycle_feedback_path)
+
             autoresearch_supply = run_reddog_model_autoresearch_plan_artifact_supply_bootstrap(
                 repo_root=repo_root,
                 promotion_gate_receipts_path=model_autoresearch_promotion_gate_receipts_path or None,
                 candidate_pool_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH", "") or None,
                 policy_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_POLICY_PATH", "") or None,
-                feedback_records_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH", "") or None,
+                feedback_records_path=model_autoresearch_feedback_records_path,
                 output_path=model_autoresearch_plan_receipt_path,
             )
         except Exception as exc:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_DEFAULT_INPUT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Updated the RedDog model AutoResearch plan startup hook to use the existing
+  outside-repo cycle feedback ledger as the default feedback input when
+  `REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH` is not explicitly set.
+- Explicit feedback paths still take precedence, and a missing cycle feedback
+  ledger remains optional so startup does not fail closed on absent feedback.
+- Added main-preflight coverage for default feedback path selection and
+  explicit override behavior.
+- Boundary remains constrained: no provider call, benchmark execution,
+  HoloIndex re-index, PatternMemory write, model promotion, runtime binding,
+  worker spawn, source mutation, PR publication, reward settlement, shell
+  execution, or merge authority was added.
+
+## 2026-07-17: MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CONTEXT_BINDING_PHASE1
+
 ## 2026-07-17: MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CONTEXT_BINDING_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -537,6 +537,169 @@ def test_main_preflight_model_autoresearch_plan_supply_runs_before_promotion(
     promote.assert_called_once()
 
 
+def test_main_preflight_defaults_autoresearch_feedback_to_existing_cycle_feedback_ledger(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    cycle_feedback = runtime_root / "model_autoresearch_cycle_feedback.jsonl"
+    cycle_feedback.write_text('{"record_type":"model_autoresearch_cycle_feedback"}\n', encoding="utf-8")
+    autoresearch_supply_result = type(
+        "AutoResearchSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED",
+            "plan_receipt_id": "model_autoresearch_plan:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_plan_receipt.json"),
+            "source_gate_receipt_ids": ("model_promotion_gate:1",),
+            "source_feedback_record_ids": ("model_autoresearch_cycle_feedback_runtime",),
+            "campaign_item_count": 1,
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply_bootstrap.run_reddog_model_autoresearch_plan_artifact_supply_bootstrap",
+        return_value=autoresearch_supply_result,
+    ) as autoresearch_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ):
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH": str(
+                        tmp_path / "promotion_gates.json"
+                    ),
+                    "REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH": str(tmp_path / "candidates.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_POLICY_PATH": str(tmp_path / "autoresearch_policy.json"),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+
+    autoresearch_kwargs = autoresearch_supply.call_args.kwargs
+    assert autoresearch_kwargs["feedback_records_path"] == str(cycle_feedback)
+
+
+def test_main_preflight_explicit_autoresearch_feedback_path_overrides_cycle_feedback_default(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    cycle_feedback = runtime_root / "model_autoresearch_cycle_feedback.jsonl"
+    explicit_feedback = runtime_root / "explicit_feedback.jsonl"
+    cycle_feedback.write_text('{"record_type":"model_autoresearch_cycle_feedback"}\n', encoding="utf-8")
+    explicit_feedback.write_text('{"record_type":"model_selection_outcome_feedback"}\n', encoding="utf-8")
+    autoresearch_supply_result = type(
+        "AutoResearchSupplyResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_PLAN_ARTIFACT_BOOTSTRAP_APPLIED",
+            "plan_receipt_id": "model_autoresearch_plan:runtime",
+            "output_path": str(runtime_root / "model_autoresearch_plan_receipt.json"),
+            "source_gate_receipt_ids": ("model_promotion_gate:1",),
+            "source_feedback_record_ids": ("model_feedback_runtime",),
+            "campaign_item_count": 1,
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_plan_artifact_supply_bootstrap.run_reddog_model_autoresearch_plan_artifact_supply_bootstrap",
+        return_value=autoresearch_supply_result,
+    ) as autoresearch_supply:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ):
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH": str(
+                        tmp_path / "promotion_gates.json"
+                    ),
+                    "REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH": str(tmp_path / "candidates.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_POLICY_PATH": str(tmp_path / "autoresearch_policy.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH": str(explicit_feedback),
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+
+    autoresearch_kwargs = autoresearch_supply.call_args.kwargs
+    assert autoresearch_kwargs["feedback_records_path"] == str(explicit_feedback)
+
+
 def test_main_preflight_enforced_model_autoresearch_plan_supply_blocks_startup(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Slice
REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_DEFAULT_INPUT_PHASE1

## Summary
- Make the RedDog AutoResearch plan startup hook use the existing outside-repo cycle feedback ledger as the default feedback input when no explicit feedback-record path is configured.
- Preserve explicit `REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH` precedence.
- Do not make absent feedback fail startup; missing cycle ledger remains optional.

## Validation
- `python -m py_compile main.py`
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 27 passed
- `pytest modules/ai_intelligence/ai_gateway/tests -q` -> 183 passed
- `git diff --check` -> clean (CRLF warnings only)

## WSP_97 Truth Boundary
IMPLEMENTED: resident startup can automatically feed the prior cycle feedback ledger into AutoResearch plan supply on the next run.

NOT IMPLEMENTED: provider calls, benchmark execution, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime binding, worker spawn, shell execution, source mutation, extension mutation, or merge authority.