### PR TITLE
feat(ai-gateway): add configured AutoResearch gateway runner

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -134,6 +134,25 @@ The default in-memory and JSONL stores are append-only adapters. The API is
 explicit-invoke only and does not call providers, run benchmarks, promote
 models, write PatternMemory, mutate HoloIndex, or bind RedDog runtime defaults.
 
+#### Model AutoResearch Configured Gateway Runner
+
+```python
+build_configured_gateway_benchmark_runner(...) -> BenchmarkRunner
+AIGatewayConfiguredModelCaller(gateway).call_model(...)
+```
+
+The configured runner consumes a digest-bound prompt source and an explicit
+provider/model gateway caller, then produces `ModelBenchmarkTaskOutput` records
+for the benchmark harness. It verifies `ModelBenchmarkTask.prompt_digest`
+against the supplied prompt before any call and emits only content digests,
+runner receipt IDs, and bounded metrics.
+
+The `AIGatewayConfiguredModelCaller` adapter reuses the existing `AIGateway`
+provider registry to target the candidate's exact role assignment. It is not
+enabled automatically by `main.py` and does not perform verification, promotion,
+PatternMemory writes, HoloIndex mutation, runtime binding, command execution, or
+repository mutation.
+
 #### Model Combination Benchmark Harness
 
 ```python

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,37 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Configured Gateway Runner
+
+**Who:** 0102 Codex
+**Type:** Runtime Benchmark Runner Seam
+**Slice:** MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_RUNNER_PHASE1
+
+**What:** Added a configured gateway benchmark runner adapter that verifies
+held-out prompt digests before provider calls and targets candidate
+provider/model role assignments through an injected gateway seam.
+
+**Why:** The AutoResearch campaign executor could run only deterministic
+fixtures. RedDog needs a real, governed benchmark-call seam before the model
+improvement loop can measure current providers and fusion panels.
+
+**Files:**
+- `src/model_autoresearch_configured_gateway_runner.py` - configured caller,
+  prompt-source, policy, and benchmark-runner adapter.
+- `tests/test_model_autoresearch_configured_gateway_runner.py` - verifies
+  digest-bound prompts, explicit provider/model routing, panel role calls,
+  cost/provider fail-closed paths, and AST no-network/no-command boundaries.
+
+**Truth Boundary:**
+- IMPLEMENTED: reusable configured gateway runner seam for benchmark campaigns.
+- NOT IMPLEMENTED: startup auto-enable, independent verifier runtime, model
+  promotion, PatternMemory writes, HoloIndex re-indexing, RedDog runtime model
+  binding, worker spawn, shell execution, source mutation, or extension
+  mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Plan Supply Regression
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -74,6 +74,21 @@ run and which promotion-gate receipts resulted. It does not call providers, run
 benchmarks, promote models, write PatternMemory, mutate HoloIndex, or change
 RedDog runtime model defaults.
 
+## Model AutoResearch Configured Gateway Runner
+
+`src/model_autoresearch_configured_gateway_runner.py` adapts a configured model
+gateway and digest-bound prompt source into the existing benchmark runner
+contract. It verifies the held-out prompt digest before any model call, targets
+the exact provider/model role assignment in the candidate, supports panel role
+calls, and returns only digest-bound output and runner receipts to the benchmark
+harness.
+
+This creates a real provider-call seam for AutoResearch benchmarks without
+turning it on at resident startup. It does not choose candidates, verify model
+answers, promote models, mutate catalogs, write PatternMemory, re-index
+HoloIndex, execute commands, mutate the repository, or bind RedDog runtime
+defaults.
+
 ## Model Combination Benchmark Harness
 
 `src/model_combination_benchmark_harness.py` runs deterministic held-out

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
@@ -1,0 +1,395 @@
+"""Configured gateway runner for model AutoResearch benchmarks.
+
+This module adapts a configured model-caller seam into the existing
+``BenchmarkRunner`` contract. It verifies held-out prompt digests before any
+model call and returns only digest-bound output receipts to the benchmark
+harness.
+
+It does not choose candidates, verify answers, promote models, mutate catalogs,
+write PatternMemory, re-index HoloIndex, execute commands, mutate the repo, or
+bind RedDog runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from dataclasses import dataclass, replace
+from typing import Callable, Mapping, Protocol, Sequence
+
+from .model_combination_benchmark_harness import (
+    BenchmarkRunner,
+    ModelBenchmarkCandidate,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    build_model_benchmark_candidate,
+)
+from .model_intelligence_outcomes import ModelOutcomeMetrics
+
+
+CONFIGURED_GATEWAY_RUNNER_SCHEMA_VERSION = "model_autoresearch_configured_gateway_runner.v1"
+
+
+class GatewayModelCaller(Protocol):
+    """Minimal callable seam for one explicit provider/model call."""
+
+    def call_model(
+        self,
+        *,
+        provider: str,
+        model: str,
+        prompt: str,
+        task_type: str,
+    ) -> "GatewayModelCallResult":
+        """Call one configured provider/model pair."""
+
+
+class PromptSource(Protocol):
+    """Digest-bound source for held-out benchmark prompt bodies."""
+
+    def prompt_for_task(self, task: ModelBenchmarkTask) -> str:
+        """Return the prompt body for ``task``."""
+
+
+@dataclass(frozen=True)
+class GatewayModelCallResult:
+    """Digest-safe result for one provider/model call."""
+
+    success: bool
+    provider: str
+    model: str
+    response_text: str
+    latency_ms: int
+    input_tokens: int
+    output_tokens: int
+    cost_estimate_usd: float
+
+    def normalized(self) -> "GatewayModelCallResult":
+        return GatewayModelCallResult(
+            success=bool(self.success),
+            provider=_clean_required("provider", self.provider),
+            model=_clean_required("model", self.model),
+            response_text=str(self.response_text or ""),
+            latency_ms=_non_negative_int(self.latency_ms),
+            input_tokens=_non_negative_int(self.input_tokens),
+            output_tokens=_non_negative_int(self.output_tokens),
+            cost_estimate_usd=_non_negative_float(self.cost_estimate_usd),
+        )
+
+
+@dataclass(frozen=True)
+class ConfiguredGatewayRunnerPolicy:
+    """Bounded policy for configured AutoResearch benchmark calls."""
+
+    allowed_providers: tuple[str, ...]
+    max_prompt_chars: int = 20000
+    max_calls_per_sample: int = 4
+    max_cost_estimate_usd_per_sample: float = 1.0
+    task_type: str = "model_autoresearch"
+    allow_panel_candidates: bool = True
+    schema_version: str = CONFIGURED_GATEWAY_RUNNER_SCHEMA_VERSION
+
+    def normalized(self) -> "ConfiguredGatewayRunnerPolicy":
+        providers = tuple(
+            dict.fromkeys(_clean_token(item) for item in self.allowed_providers if str(item).strip())
+        )
+        if not providers:
+            raise ValueError("configured_gateway_runner_allowed_providers_required")
+        max_prompt_chars = _positive_int("max_prompt_chars", self.max_prompt_chars)
+        max_calls = _positive_int("max_calls_per_sample", self.max_calls_per_sample)
+        max_cost = _positive_float(
+            "max_cost_estimate_usd_per_sample",
+            self.max_cost_estimate_usd_per_sample,
+        )
+        return ConfiguredGatewayRunnerPolicy(
+            allowed_providers=providers,
+            max_prompt_chars=max_prompt_chars,
+            max_calls_per_sample=max_calls,
+            max_cost_estimate_usd_per_sample=max_cost,
+            task_type=_clean_token(self.task_type or "model_autoresearch"),
+            allow_panel_candidates=bool(self.allow_panel_candidates),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        policy = self.normalized()
+        return {
+            "schema_version": policy.schema_version,
+            "allowed_providers": list(policy.allowed_providers),
+            "max_prompt_chars": policy.max_prompt_chars,
+            "max_calls_per_sample": policy.max_calls_per_sample,
+            "max_cost_estimate_usd_per_sample": policy.max_cost_estimate_usd_per_sample,
+            "task_type": policy.task_type,
+            "allow_panel_candidates": policy.allow_panel_candidates,
+        }
+
+
+@dataclass(frozen=True)
+class MappingPromptSource:
+    """In-memory prompt source for tests and bounded runtime adapters."""
+
+    prompts_by_task_id: Mapping[str, str]
+
+    def prompt_for_task(self, task: ModelBenchmarkTask) -> str:
+        task_id = _clean_required("task_id", task.task_id)
+        if task_id not in self.prompts_by_task_id:
+            raise ValueError("configured_gateway_runner_prompt_missing")
+        return str(self.prompts_by_task_id[task_id])
+
+
+@dataclass(frozen=True)
+class AIGatewayConfiguredModelCaller:
+    """Adapter for the existing ``AIGateway`` provider registry.
+
+    The adapter targets the exact provider/model role assignment supplied by the
+    benchmark candidate. It reuses ``AIGateway._call_provider`` rather than
+    importing provider SDKs or networking libraries here.
+    """
+
+    gateway: object
+
+    def call_model(
+        self,
+        *,
+        provider: str,
+        model: str,
+        prompt: str,
+        task_type: str,
+    ) -> GatewayModelCallResult:
+        provider_name = _clean_token(provider)
+        model_name = _clean_required("model", model)
+        task_name = _clean_token(task_type or "model_autoresearch")
+        providers = getattr(self.gateway, "providers", None)
+        if not isinstance(providers, Mapping):
+            raise ValueError("configured_gateway_runner_provider_registry_missing")
+        provider_config = providers.get(provider_name)
+        if provider_config is None or not getattr(provider_config, "api_key", None):
+            raise ValueError("configured_gateway_runner_provider_unavailable")
+        call_provider = getattr(self.gateway, "_call_provider", None)
+        if not callable(call_provider):
+            raise ValueError("configured_gateway_runner_call_provider_missing")
+        routed_config = replace(
+            provider_config,
+            models={task_name: model_name, "quick": model_name},
+        )
+        started = time.monotonic()
+        response = str(call_provider(routed_config, prompt, task_name) or "")
+        latency_ms = int(round((time.monotonic() - started) * 1000))
+        return GatewayModelCallResult(
+            success=bool(response.strip()),
+            provider=provider_name,
+            model=model_name,
+            response_text=response,
+            latency_ms=latency_ms,
+            input_tokens=_token_count(prompt),
+            output_tokens=_token_count(response),
+            cost_estimate_usd=float(_token_count(prompt)) * float(getattr(provider_config, "cost_per_token", 0.0)),
+        ).normalized()
+
+
+def build_configured_gateway_benchmark_runner(
+    *,
+    caller: GatewayModelCaller,
+    prompt_source: PromptSource,
+    policy: ConfiguredGatewayRunnerPolicy,
+) -> BenchmarkRunner:
+    """Build a ``BenchmarkRunner`` backed by an explicit configured gateway."""
+
+    normalized_policy = policy.normalized()
+
+    def _runner(
+        task: ModelBenchmarkTask,
+        candidate: ModelBenchmarkCandidate,
+    ) -> ModelBenchmarkTaskOutput:
+        normalized_task = task.normalized()
+        prompt = str(prompt_source.prompt_for_task(normalized_task))
+        _verify_prompt_digest(normalized_task.prompt_digest, prompt)
+        if len(prompt) > normalized_policy.max_prompt_chars:
+            raise ValueError("configured_gateway_runner_prompt_too_large")
+        assignments = tuple(item.normalized() for item in candidate.role_assignments)
+        if not assignments:
+            raise ValueError("configured_gateway_runner_missing_role_assignments")
+        expected_candidate = build_model_benchmark_candidate(assignments)
+        if (
+            expected_candidate.candidate_id != candidate.candidate_id
+            or expected_candidate.topology_digest != candidate.topology_digest
+        ):
+            raise ValueError("configured_gateway_runner_candidate_mismatch")
+        if len(assignments) > normalized_policy.max_calls_per_sample:
+            raise ValueError("configured_gateway_runner_call_budget_exceeded")
+        if len(assignments) > 1 and not normalized_policy.allow_panel_candidates:
+            raise ValueError("configured_gateway_runner_panel_disabled")
+
+        call_records: list[dict[str, object]] = []
+        total_latency_ms = 0
+        total_input_tokens = 0
+        total_output_tokens = 0
+        total_cost = 0.0
+        for assignment in assignments:
+            provider = _clean_token(assignment.provider)
+            if provider not in normalized_policy.allowed_providers:
+                raise ValueError("configured_gateway_runner_provider_not_allowed")
+            model_name = _model_name_for_provider(assignment.model_id, provider)
+            call_prompt = _role_prompt(
+                base_prompt=prompt,
+                role=assignment.role,
+                candidate_id=candidate.candidate_id,
+                task_id=normalized_task.task_id,
+            )
+            result = caller.call_model(
+                provider=provider,
+                model=model_name,
+                prompt=call_prompt,
+                task_type=normalized_policy.task_type,
+            ).normalized()
+            if not result.success or not result.response_text.strip():
+                raise ValueError("configured_gateway_runner_call_failed")
+            if result.provider != provider or result.model != model_name:
+                raise ValueError("configured_gateway_runner_call_route_mismatch")
+            response_digest = _content_digest(result.response_text)
+            call_records.append(
+                {
+                    "role": assignment.role,
+                    "provider": result.provider,
+                    "model": result.model,
+                    "response_digest": response_digest,
+                    "latency_ms": result.latency_ms,
+                    "input_tokens": result.input_tokens,
+                    "output_tokens": result.output_tokens,
+                    "cost_estimate_usd": result.cost_estimate_usd,
+                }
+            )
+            total_latency_ms += result.latency_ms
+            total_input_tokens += result.input_tokens
+            total_output_tokens += result.output_tokens
+            total_cost += result.cost_estimate_usd
+        if total_cost > normalized_policy.max_cost_estimate_usd_per_sample:
+            raise ValueError("configured_gateway_runner_cost_budget_exceeded")
+        runner_body = {
+            "schema_version": CONFIGURED_GATEWAY_RUNNER_SCHEMA_VERSION,
+            "task_id": normalized_task.task_id,
+            "prompt_digest": normalized_task.prompt_digest,
+            "candidate_id": candidate.candidate_id,
+            "candidate_topology_digest": candidate.topology_digest,
+            "policy_digest": _policy_digest(normalized_policy),
+            "calls": call_records,
+        }
+        return ModelBenchmarkTaskOutput(
+            output_digest=_digest_prefixed("configured_gateway_benchmark_output", runner_body),
+            runner_receipt_id=_digest_prefixed("configured_gateway_benchmark_runner", runner_body),
+            metrics=ModelOutcomeMetrics(
+                latency_ms=total_latency_ms,
+                input_tokens=total_input_tokens,
+                output_tokens=total_output_tokens,
+                cost_estimate_usd=round(total_cost, 8),
+            ),
+        ).normalized()
+
+    return _runner
+
+
+def _role_prompt(*, base_prompt: str, role: str, candidate_id: str, task_id: str) -> str:
+    return (
+        f"Task: {task_id}\n"
+        f"Candidate: {candidate_id}\n"
+        f"Role: {_clean_token(role)}\n"
+        "Return only the benchmark answer for this role.\n\n"
+        f"{base_prompt}"
+    )
+
+
+def _verify_prompt_digest(expected_digest: str, prompt: str) -> None:
+    expected = _clean_required("prompt_digest", expected_digest)
+    actual = _content_digest(prompt)
+    if not hmac.compare_digest(expected, actual):
+        raise ValueError("configured_gateway_runner_prompt_digest_mismatch")
+
+
+def _model_name_for_provider(model_id: str, provider: str) -> str:
+    raw = _clean_required("model_id", model_id)
+    prefix = f"{provider}/"
+    if raw.startswith(prefix):
+        raw = raw[len(prefix) :]
+    return _clean_required("model", raw)
+
+
+def _policy_digest(policy: ConfiguredGatewayRunnerPolicy) -> str:
+    return _digest_prefixed("configured_gateway_runner_policy", policy.to_dict())
+
+
+def _content_digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, object]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _clean_required(name: str, value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"missing_{name}")
+    return text
+
+
+def _clean_token(value: object) -> str:
+    text = _clean_required("token", value)
+    return "".join(ch if ch.isalnum() or ch in {"_", "-", ".", "/"} else "_" for ch in text)
+
+
+def _positive_int(name: str, value: object) -> int:
+    try:
+        result = int(value)
+    except Exception as exc:
+        raise ValueError(f"invalid_{name}") from exc
+    if result <= 0:
+        raise ValueError(f"invalid_{name}")
+    return result
+
+
+def _non_negative_int(value: object) -> int:
+    try:
+        result = int(value)
+    except Exception as exc:
+        raise ValueError("invalid_non_negative_int") from exc
+    if result < 0:
+        raise ValueError("invalid_non_negative_int")
+    return result
+
+
+def _positive_float(name: str, value: object) -> float:
+    try:
+        result = float(value)
+    except Exception as exc:
+        raise ValueError(f"invalid_{name}") from exc
+    if result <= 0.0:
+        raise ValueError(f"invalid_{name}")
+    return result
+
+
+def _non_negative_float(value: object) -> float:
+    try:
+        result = float(value)
+    except Exception as exc:
+        raise ValueError("invalid_non_negative_float") from exc
+    if result < 0.0:
+        raise ValueError("invalid_non_negative_float")
+    return result
+
+
+def _token_count(text: str) -> int:
+    return len(str(text).split())
+
+
+__all__ = [
+    "AIGatewayConfiguredModelCaller",
+    "CONFIGURED_GATEWAY_RUNNER_SCHEMA_VERSION",
+    "ConfiguredGatewayRunnerPolicy",
+    "GatewayModelCallResult",
+    "GatewayModelCaller",
+    "MappingPromptSource",
+    "PromptSource",
+    "build_configured_gateway_benchmark_runner",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py
@@ -1,0 +1,319 @@
+"""Tests for configured gateway benchmark runner."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from dataclasses import replace
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.ai_gateway import ProviderConfig
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gateway_runner import (
+    AIGatewayConfiguredModelCaller,
+    ConfiguredGatewayRunnerPolicy,
+    GatewayModelCallResult,
+    MappingPromptSource,
+    build_configured_gateway_benchmark_runner,
+)
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+    build_model_benchmark_candidate,
+    run_model_combination_benchmark,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import VerifierDecision
+
+
+def _digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _task(prompt: str = "Audit the bounded RedDog runtime path.") -> ModelBenchmarkTask:
+    return ModelBenchmarkTask(
+        task_id="task-001",
+        task_family="architecture",
+        prompt_digest=_digest(prompt),
+        expected_output_digest="sha256:expected-output",
+        verifier_contract_digest="sha256:verifier-contract",
+    )
+
+
+def _candidate(model_id: str = "openai/gpt-test"):
+    return build_model_benchmark_candidate(
+        (ModelBenchmarkRoleAssignment(role="principal", model_id=model_id, provider="openai"),)
+    )
+
+
+class FakeConfiguredCaller:
+    def __init__(
+        self,
+        *,
+        response: str = "bounded answer",
+        cost_estimate_usd: float = 0.01,
+    ) -> None:
+        self.response = response
+        self.cost_estimate_usd = cost_estimate_usd
+        self.calls: list[dict[str, str]] = []
+
+    def call_model(self, *, provider: str, model: str, prompt: str, task_type: str) -> GatewayModelCallResult:
+        self.calls.append(
+            {
+                "provider": provider,
+                "model": model,
+                "prompt": prompt,
+                "task_type": task_type,
+            }
+        )
+        return GatewayModelCallResult(
+            success=True,
+            provider=provider,
+            model=model,
+            response_text=self.response,
+            latency_ms=25,
+            input_tokens=len(prompt.split()),
+            output_tokens=len(self.response.split()),
+            cost_estimate_usd=self.cost_estimate_usd,
+        )
+
+
+def _runner(
+    *,
+    prompt: str = "Audit the bounded RedDog runtime path.",
+    caller: FakeConfiguredCaller | None = None,
+    policy: ConfiguredGatewayRunnerPolicy | None = None,
+):
+    return build_configured_gateway_benchmark_runner(
+        caller=caller or FakeConfiguredCaller(),
+        prompt_source=MappingPromptSource({"task-001": prompt}),
+        policy=policy
+        or ConfiguredGatewayRunnerPolicy(
+            allowed_providers=("openai", "anthropic"),
+            max_cost_estimate_usd_per_sample=1.0,
+        ),
+    )
+
+
+def _accepting_verifier(task, candidate, output: ModelBenchmarkTaskOutput):
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.ACCEPT,
+        verifier_receipt_id=f"verify:{candidate.candidate_id}:{task.task_id}",
+        evidence_correct=True,
+    )
+
+
+def test_configured_runner_calls_explicit_provider_model_and_returns_digest_only_output():
+    prompt = "Audit the bounded RedDog runtime path."
+    caller = FakeConfiguredCaller(response="This answer is bounded.")
+    runner = _runner(prompt=prompt, caller=caller)
+
+    output = runner(_task(prompt), _candidate("openai/gpt-5.2"))
+
+    assert caller.calls[0]["provider"] == "openai"
+    assert caller.calls[0]["model"] == "gpt-5.2"
+    assert caller.calls[0]["task_type"] == "model_autoresearch"
+    assert "Role: principal" in caller.calls[0]["prompt"]
+    assert output.output_digest.startswith("configured_gateway_benchmark_output:")
+    assert output.runner_receipt_id.startswith("configured_gateway_benchmark_runner:")
+    assert output.metrics.latency_ms == 25
+    assert output.metrics.cost_estimate_usd == 0.01
+    assert prompt not in output.output_digest
+    assert "This answer is bounded." not in output.runner_receipt_id
+
+
+def test_configured_runner_integrates_with_combination_benchmark_harness():
+    prompt = "Audit the bounded RedDog runtime path."
+    caller = FakeConfiguredCaller()
+    receipt = run_model_combination_benchmark(
+        tasks=(_task(prompt),),
+        candidates=(_candidate("openai/gpt-5.2"),),
+        runner=_runner(prompt=prompt, caller=caller),
+        verifier=_accepting_verifier,
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+    )
+
+    evidence = receipt.benchmark_evidence_receipts[0]
+    assert receipt.receipt_id.startswith("model_combination_benchmark_run:")
+    assert evidence.model_id == "openai/gpt-5.2"
+    assert evidence.sample_count == 1
+    assert evidence.verifier_pass_rate == 1.0
+    assert len(caller.calls) == 1
+
+
+def test_panel_candidate_calls_each_non_verifier_role_and_aggregates_metrics():
+    prompt = "Audit the bounded RedDog runtime path."
+    caller = FakeConfiguredCaller(cost_estimate_usd=0.1)
+    panel = build_model_benchmark_candidate(
+        (
+            ModelBenchmarkRoleAssignment(role="principal", model_id="openai/gpt-5.2", provider="openai"),
+            ModelBenchmarkRoleAssignment(role="critic", model_id="anthropic/claude-test", provider="anthropic"),
+        )
+    )
+
+    output = _runner(prompt=prompt, caller=caller)(_task(prompt), panel)
+
+    assert [call["provider"] for call in caller.calls] == ["openai", "anthropic"]
+    assert [call["model"] for call in caller.calls] == ["gpt-5.2", "claude-test"]
+    assert "Role: principal" in caller.calls[0]["prompt"]
+    assert "Role: critic" in caller.calls[1]["prompt"]
+    assert output.metrics.cost_estimate_usd == 0.2
+    assert output.metrics.latency_ms == 50
+
+
+def test_prompt_digest_mismatch_fails_before_model_call():
+    caller = FakeConfiguredCaller()
+    runner = _runner(prompt="different prompt", caller=caller)
+
+    try:
+        runner(_task("expected prompt"), _candidate())
+    except ValueError as exc:
+        assert str(exc) == "configured_gateway_runner_prompt_digest_mismatch"
+    else:
+        raise AssertionError("expected prompt digest mismatch")
+
+    assert caller.calls == []
+
+
+def test_disallowed_provider_fails_before_model_call():
+    caller = FakeConfiguredCaller()
+    policy = ConfiguredGatewayRunnerPolicy(allowed_providers=("anthropic",))
+    runner = _runner(caller=caller, policy=policy)
+
+    try:
+        runner(_task(), _candidate("openai/gpt-5.2"))
+    except ValueError as exc:
+        assert str(exc) == "configured_gateway_runner_provider_not_allowed"
+    else:
+        raise AssertionError("expected provider rejection")
+
+    assert caller.calls == []
+
+
+def test_candidate_id_or_topology_tamper_fails_before_model_call():
+    caller = FakeConfiguredCaller()
+    forged = replace(_candidate("openai/gpt-5.2"), candidate_id="openai/forged")
+    runner = _runner(caller=caller)
+
+    try:
+        runner(_task(), forged)
+    except ValueError as exc:
+        assert str(exc) == "configured_gateway_runner_candidate_mismatch"
+    else:
+        raise AssertionError("expected candidate mismatch")
+
+    assert caller.calls == []
+
+
+def test_panel_candidate_can_be_disabled_by_policy():
+    panel = build_model_benchmark_candidate(
+        (
+            ModelBenchmarkRoleAssignment(role="principal", model_id="openai/gpt-5.2", provider="openai"),
+            ModelBenchmarkRoleAssignment(role="critic", model_id="anthropic/claude-test", provider="anthropic"),
+        )
+    )
+    caller = FakeConfiguredCaller()
+    runner = _runner(
+        caller=caller,
+        policy=ConfiguredGatewayRunnerPolicy(
+            allowed_providers=("openai", "anthropic"),
+            allow_panel_candidates=False,
+        ),
+    )
+
+    try:
+        runner(_task(), panel)
+    except ValueError as exc:
+        assert str(exc) == "configured_gateway_runner_panel_disabled"
+    else:
+        raise AssertionError("expected panel rejection")
+
+    assert caller.calls == []
+
+
+def test_cost_budget_fails_closed_after_call_without_returning_successful_output():
+    caller = FakeConfiguredCaller(cost_estimate_usd=5.0)
+    runner = _runner(
+        caller=caller,
+        policy=ConfiguredGatewayRunnerPolicy(
+            allowed_providers=("openai",),
+            max_cost_estimate_usd_per_sample=0.01,
+        ),
+    )
+
+    try:
+        runner(_task(), _candidate())
+    except ValueError as exc:
+        assert str(exc) == "configured_gateway_runner_cost_budget_exceeded"
+    else:
+        raise AssertionError("expected cost budget rejection")
+
+    assert len(caller.calls) == 1
+
+
+def test_aigateway_adapter_targets_exact_provider_and_model_without_fallback():
+    class FakeGateway:
+        def __init__(self) -> None:
+            self.providers = {
+                "openai": ProviderConfig(
+                    name="openai",
+                    api_key="test-key",
+                    base_url="https://example.invalid",
+                    models={"quick": "wrong-default"},
+                    cost_per_token=0.25,
+                    rate_limit=1,
+                )
+            }
+            self.calls: list[tuple[ProviderConfig, str, str]] = []
+
+        def _call_provider(self, provider: ProviderConfig, prompt: str, task_type: str) -> str:
+            self.calls.append((provider, prompt, task_type))
+            assert provider.models[task_type] == "gpt-5.2"
+            return "gateway response"
+
+    gateway = FakeGateway()
+    caller = AIGatewayConfiguredModelCaller(gateway)
+
+    result = caller.call_model(
+        provider="openai",
+        model="gpt-5.2",
+        prompt="hello world",
+        task_type="model_autoresearch",
+    )
+
+    assert result.success is True
+    assert result.provider == "openai"
+    assert result.model == "gpt-5.2"
+    assert result.response_text == "gateway response"
+    assert result.input_tokens == 2
+    assert result.output_tokens == 2
+    assert result.cost_estimate_usd == 0.5
+    assert len(gateway.calls) == 1
+
+
+def test_configured_runner_module_has_no_direct_network_command_runtime_or_holoindex_imports():
+    source = Path(
+        "modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    banned_attr_roots = {"os", "subprocess", "requests", "urllib", "openai", "holo_index"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            assert not (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in banned_attr_roots
+            )
+
+    assert "subprocess" not in imported
+    assert "requests" not in imported
+    assert "urllib" not in imported
+    assert "openai" not in imported
+    assert "holo_index" not in imported
+    assert "pattern_memory" not in source
+    assert "extension.js" not in source


### PR DESCRIPTION
## Slice
MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_RUNNER_PHASE1

## WSP_97 Truth Boundary
- IMPLEMENTED: configured gateway benchmark runner seam for AutoResearch campaigns.
- IMPLEMENTED: digest-bound prompt source verification before provider/model calls.
- IMPLEMENTED: explicit candidate provider/model role routing, including panel role calls.
- IMPLEMENTED: cost, provider allowlist, prompt size, call-count, and candidate topology fail-closed guards.
- NOT IMPLEMENTED: startup auto-enable, independent verifier runtime, model promotion, PatternMemory writes, HoloIndex re-indexing, RedDog runtime binding, worker spawn, shell execution, source mutation, or extension mutation.

## Validation
- python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
- python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py -q -> 10 passed
- python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_combination_benchmark_harness.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py -q -> 39 passed
- python -m pytest modules/ai_intelligence/ai_gateway/tests -q -> 193 passed
- git diff --check -> clean
- new files ASCII/NUL clean

## Scope
Only modules/ai_intelligence/ai_gateway docs, source, and tests.