### PR TITLE
feat(ai-gateway): enable configured AutoResearch campaign bootstrap

### DIFF
--- a/main.py
+++ b/main.py
@@ -1605,7 +1605,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY=0       Materialize runtime binding receipt from signed evidence
         REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY=0     Materialize model AutoResearch plan from verified receipts
         REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
-        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY=0 Execute deterministic campaign fixture
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY=0 Execute campaign fixture or configured gateway
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY=0 Materialize campaign promotion-gate receipts
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=0 Block startup if rejected
@@ -1625,11 +1625,16 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_FEEDBACK_RECORDS_PATH      Optional outside-repo feedback JSON/JSONL
         REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH          Outside-repo AutoResearch plan output JSON
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH        Outside-repo held-out campaign tasks JSON
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMPTS_PATH      Outside-repo held-out prompt records JSON
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH Outside-repo campaign execution output JSON
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST   Verifier digest required by plan policy
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID Held-out split ID for benchmark receipt
-        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE       deterministic_fixture only
-        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture only
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE       deterministic_fixture or configured_gateway
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture or exact_output_digest
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_ALLOWED_PROVIDERS ; or , separated allowlist
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_PROMPT_CHARS Optional positive int
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_CALLS_PER_SAMPLE Optional positive int
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_COST_USD_PER_SAMPLE Optional positive float
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_POLICIES_PATH Outside-repo promotion policies JSON
         REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH         Outside-repo AutoResearch cycle receipt JSON
         REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH Outside-repo AutoResearch cycle feedback JSONL
@@ -1971,6 +1976,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
                     plan_receipt_path=model_autoresearch_plan_receipt_path,
                     candidate_pool_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH", "") or None,
                     tasks_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH", "") or None,
+                    prompt_records_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMPTS_PATH", "") or None,
                     output_path=model_autoresearch_campaign_execution_receipt_path,
                     verifier_digest=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST", ""),
                     held_out_split_id=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID", ""),
@@ -1981,6 +1987,22 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
                     verifier_mode=os.getenv(
                         "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE",
                         "deterministic_fixture",
+                    ),
+                    runner_allowed_providers=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_ALLOWED_PROVIDERS",
+                        "",
+                    ),
+                    runner_max_prompt_chars=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_PROMPT_CHARS",
+                        "20000",
+                    ),
+                    runner_max_calls_per_sample=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_CALLS_PER_SAMPLE",
+                        "4",
+                    ),
+                    runner_max_cost_estimate_usd_per_sample=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_COST_USD_PER_SAMPLE",
+                        "1.0",
                     ),
                 )
             )

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -153,6 +153,11 @@ enabled automatically by `main.py` and does not perform verification, promotion,
 PatternMemory writes, HoloIndex mutation, runtime binding, command execution, or
 repository mutation.
 
+The campaign execution bootstrap accepts this runner only through the explicit
+`configured_gateway` mode, an outside-repo prompt-record file, an explicit
+provider allowlist, and the `exact_output_digest` verifier mode. Default startup
+behavior remains `deterministic_fixture`.
+
 #### Model Combination Benchmark Harness
 
 ```python

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -32,6 +32,40 @@ improvement loop can measure current providers and fusion panels.
 
 ---
 
+## [2026-07-17] - Model AutoResearch Configured Gateway Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Benchmark Bootstrap
+**Slice:** MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_BOOTSTRAP_PHASE1
+
+**What:** Extended campaign execution artifact supply so resident startup can
+explicitly select `configured_gateway` runner mode with outside-repo prompt
+records, provider allowlist, bounded runner policy, and
+`exact_output_digest` verifier mode.
+
+**Why:** The configured runner was reusable but not reachable from the startup
+artifact supply path. RedDog needs an opt-in benchmark execution path that can
+call configured models without weakening the default fixture mode.
+
+**Files:**
+- `src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` -
+  configured runner mode, prompt-record loading, exact-output verifier, and
+  fail-closed policy parsing.
+- `tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py`
+  - configured-mode receipt materialization and prompt-record rejection tests.
+- `main.py` and `test_reddog_main_architect_fix_promotion_bootstrap.py` -
+  environment pass-through for configured runner controls.
+
+**Truth Boundary:**
+- IMPLEMENTED: explicit opt-in configured gateway benchmark execution bootstrap.
+- NOT IMPLEMENTED: open-ended semantic verifier, model promotion, PatternMemory
+  writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell
+  execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Plan Supply Regression
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -89,6 +89,12 @@ answers, promote models, mutate catalogs, write PatternMemory, re-index
 HoloIndex, execute commands, mutate the repository, or bind RedDog runtime
 defaults.
 
+`src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` can
+use this runner only when `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE` is
+set to `configured_gateway`, prompt records are supplied from outside the repo,
+providers are explicitly allowlisted, and verifier mode is
+`exact_output_digest`. The default remains deterministic fixture execution.
+
 ## Model Combination Benchmark Harness
 
 `src/model_combination_benchmark_harness.py` runs deterministic held-out

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -4,21 +4,31 @@ Slice: REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_MAIN_PREFLIG
 
 This adapter reads outside-repo runtime JSON inputs and materializes a
 ``ModelAutoResearchCampaignExecutionReceipt`` using the bounded campaign
-executor and deterministic fixture seams.
+executor and either deterministic fixture seams or an explicitly configured
+gateway runner.
 
-It does not call provider SDKs, execute commands, promote models, mutate
-catalogs, write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn
-workers, or write inside the repository.
+It does not import provider SDKs directly, execute commands, promote models,
+mutate catalogs, write PatternMemory, re-index HoloIndex, bind runtime defaults,
+spawn workers, or write inside the repository. Configured gateway mode may call
+the existing AIGateway provider seam only when explicitly selected.
 """
 
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Sequence
 
+from modules.ai_intelligence.ai_gateway.src.ai_gateway import AIGateway
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gateway_runner import (
+    AIGatewayConfiguredModelCaller,
+    ConfiguredGatewayRunnerPolicy,
+    MappingPromptSource,
+    build_configured_gateway_benchmark_runner,
+)
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
     run_reddog_model_autoresearch_campaign_execution,
@@ -43,6 +53,8 @@ MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY = (
 )
 MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER = "deterministic_fixture"
 MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER = "deterministic_fixture"
+MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER = "configured_gateway"
+MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER = "exact_output_digest"
 
 
 @dataclass(frozen=True)
@@ -82,10 +94,18 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
     held_out_split_id: str,
     runner_mode: str = MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER,
     verifier_mode: str = MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER,
+    prompt_records_path: Path | str | None = None,
+    runner_allowed_providers: str | Sequence[str] | None = None,
+    runner_max_prompt_chars: int | str = 20000,
+    runner_max_calls_per_sample: int | str = 4,
+    runner_max_cost_estimate_usd_per_sample: float | str = 1.0,
+    gateway: object | None = None,
 ) -> ModelAutoResearchCampaignExecutionBootstrapResult:
     """Materialize an AutoResearch campaign execution artifact from runtime files."""
 
     root = Path(repo_root).resolve()
+    runner_mode_text = str(runner_mode or "").strip()
+    verifier_mode_text = str(verifier_mode or "").strip()
     plan_payload, plan_reasons = _read_json_outside_repo(
         root,
         plan_receipt_path,
@@ -107,12 +127,23 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
         inside_reason="model_autoresearch_campaign_tasks_path_inside_repo",
         malformed_reason="malformed_model_autoresearch_campaign_tasks",
     )
+    prompt_payload: Any | None = None
+    prompt_reasons: tuple[str, ...] = ()
+    if runner_mode_text == MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER:
+        prompt_payload, prompt_reasons = _read_json_outside_repo(
+            root,
+            prompt_records_path,
+            missing_reason="missing_model_autoresearch_campaign_prompt_records_path",
+            inside_reason="model_autoresearch_campaign_prompt_records_path_inside_repo",
+            malformed_reason="malformed_model_autoresearch_campaign_prompt_records",
+        )
     reasons = [
         *plan_reasons,
         *candidate_reasons,
         *task_reasons,
+        *prompt_reasons,
         *_output_path_reasons(root, output_path),
-        *_mode_reasons(runner_mode, verifier_mode),
+        *_mode_reasons(runner_mode_text, verifier_mode_text),
     ]
     verifier_text = str(verifier_digest or "").strip()
     held_out_text = str(held_out_split_id or "").strip()
@@ -129,19 +160,45 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
         reasons.append("malformed_model_autoresearch_campaign_candidate_pool")
     if task_payload is not None and tasks is None:
         reasons.append("malformed_model_autoresearch_campaign_tasks")
+    prompts: Mapping[str, str] | None = None
+    if runner_mode_text == MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER:
+        prompts = _prompt_records(prompt_payload)
+        if prompts is None:
+            reasons.append("malformed_model_autoresearch_campaign_prompt_records")
+    policy, policy_reasons = _configured_runner_policy(
+        runner_mode=runner_mode_text,
+        runner_allowed_providers=runner_allowed_providers,
+        runner_max_prompt_chars=runner_max_prompt_chars,
+        runner_max_calls_per_sample=runner_max_calls_per_sample,
+        runner_max_cost_estimate_usd_per_sample=runner_max_cost_estimate_usd_per_sample,
+    )
+    reasons.extend(policy_reasons)
     if reasons:
         return _not_ready(reasons)
 
     assert isinstance(plan_payload, Mapping)
     assert candidate_pool is not None
     assert tasks is not None
+    runner = _fixture_runner
+    verifier = _fixture_verifier
+    no_provider_call = True
+    if runner_mode_text == MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER:
+        assert prompts is not None
+        assert policy is not None
+        runner = build_configured_gateway_benchmark_runner(
+            caller=AIGatewayConfiguredModelCaller(gateway or AIGateway()),
+            prompt_source=MappingPromptSource(prompts),
+            policy=policy,
+        )
+        verifier = _exact_output_digest_verifier
+        no_provider_call = False
     execution = run_reddog_model_autoresearch_campaign_execution(
         repo_root=root,
         plan_receipt=plan_payload,
         candidate_pool=candidate_pool,
         tasks=tasks,
-        runner=_fixture_runner,
-        verifier=_fixture_verifier,
+        runner=runner,
+        verifier=verifier,
         verifier_digest=verifier_text,
         held_out_split_id=held_out_text,
         output_path=output_path,
@@ -160,6 +217,7 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
         executed_candidate_ids=execution.executed_candidate_ids,
         task_count=execution.task_count,
         rejection_reasons=(),
+        no_direct_provider_call_performed=no_provider_call,
     )
 
 
@@ -221,6 +279,29 @@ def _fixture_verifier(
     )
 
 
+def _exact_output_digest_verifier(
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+    output: ModelBenchmarkTaskOutput,
+) -> ModelBenchmarkVerifierResult:
+    accepted = hmac.compare_digest(str(output.output_digest), str(task.expected_output_digest))
+    return ModelBenchmarkVerifierResult(
+        decision=VerifierDecision.ACCEPT if accepted else VerifierDecision.REJECT,
+        verifier_receipt_id=_digest(
+            "model_autoresearch_exact_output_digest_verifier",
+            {
+                "candidate_id": candidate.candidate_id,
+                "task_id": task.task_id,
+                "output_digest": output.output_digest,
+                "expected_output_digest": task.expected_output_digest,
+                "accepted": accepted,
+            },
+        ),
+        evidence_correct=accepted,
+        rejection_reasons=() if accepted else ("output_digest_mismatch",),
+    )
+
+
 def _read_json_outside_repo(
     repo_root: Path,
     value: Path | str | None,
@@ -262,6 +343,34 @@ def _mapping_list(value: Any, key: str) -> tuple[Mapping[str, Any], ...] | None:
     return tuple(records)
 
 
+def _prompt_records(value: Any) -> Mapping[str, str] | None:
+    if isinstance(value, Mapping) and "prompts" in value:
+        raw = value.get("prompts")
+    else:
+        raw = value
+    prompts: dict[str, str] = {}
+    if isinstance(raw, Mapping):
+        for task_id, prompt in raw.items():
+            if not str(task_id).strip() or not isinstance(prompt, str):
+                return None
+            prompts[str(task_id).strip()] = prompt
+        return prompts if prompts else None
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                return None
+            task_id = str(item.get("task_id") or "").strip()
+            prompt = item.get("prompt")
+            prompt_digest = str(item.get("prompt_digest") or "").strip()
+            if not task_id or not isinstance(prompt, str) or not prompt_digest:
+                return None
+            if not hmac.compare_digest(_content_digest(prompt), prompt_digest):
+                return None
+            prompts[task_id] = prompt
+        return prompts if prompts else None
+    return None
+
+
 def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str, ...]:
     if not value:
         return ("model_autoresearch_campaign_execution_output_path_invalid",)
@@ -276,11 +385,98 @@ def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str
 
 def _mode_reasons(runner_mode: str, verifier_mode: str) -> tuple[str, ...]:
     reasons: list[str] = []
-    if str(runner_mode or "").strip() != MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER:
+    runner = str(runner_mode or "").strip()
+    verifier = str(verifier_mode or "").strip()
+    valid_pairs = {
+        (MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER, MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER),
+        (
+            MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+            MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+        ),
+    }
+    if runner not in {
+        MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER,
+        MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+    }:
         reasons.append("unsupported_model_autoresearch_campaign_runner_mode")
-    if str(verifier_mode or "").strip() != MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER:
+    if verifier not in {
+        MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER,
+        MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+    }:
         reasons.append("unsupported_model_autoresearch_campaign_verifier_mode")
+    if not reasons and (runner, verifier) not in valid_pairs:
+        reasons.append("unsupported_model_autoresearch_campaign_runner_verifier_pair")
     return tuple(reasons)
+
+
+def _configured_runner_policy(
+    *,
+    runner_mode: str,
+    runner_allowed_providers: str | Sequence[str] | None,
+    runner_max_prompt_chars: int | str,
+    runner_max_calls_per_sample: int | str,
+    runner_max_cost_estimate_usd_per_sample: float | str,
+) -> tuple[ConfiguredGatewayRunnerPolicy | None, tuple[str, ...]]:
+    if runner_mode != MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER:
+        return None, ()
+    providers = _split_providers(runner_allowed_providers)
+    reasons: list[str] = []
+    if not providers:
+        reasons.append("missing_model_autoresearch_campaign_runner_allowed_providers")
+    prompt_chars, prompt_reason = _positive_int(
+        runner_max_prompt_chars,
+        "invalid_model_autoresearch_campaign_runner_max_prompt_chars",
+    )
+    calls, calls_reason = _positive_int(
+        runner_max_calls_per_sample,
+        "invalid_model_autoresearch_campaign_runner_max_calls_per_sample",
+    )
+    cost, cost_reason = _positive_float(
+        runner_max_cost_estimate_usd_per_sample,
+        "invalid_model_autoresearch_campaign_runner_max_cost_estimate_usd_per_sample",
+    )
+    reasons.extend(reason for reason in (prompt_reason, calls_reason, cost_reason) if reason)
+    if reasons:
+        return None, tuple(reasons)
+    return (
+        ConfiguredGatewayRunnerPolicy(
+            allowed_providers=providers,
+            max_prompt_chars=prompt_chars,
+            max_calls_per_sample=calls,
+            max_cost_estimate_usd_per_sample=cost,
+        ),
+        (),
+    )
+
+
+def _split_providers(value: str | Sequence[str] | None) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raw = value.replace(";", ",").split(",")
+    else:
+        raw = [str(item) for item in value]
+    return tuple(dict.fromkeys(item.strip() for item in raw if item.strip()))
+
+
+def _positive_int(value: int | str, reason: str) -> tuple[int, str | None]:
+    try:
+        parsed = int(value)
+    except Exception:
+        return 0, reason
+    if parsed <= 0:
+        return 0, reason
+    return parsed, None
+
+
+def _positive_float(value: float | str, reason: str) -> tuple[float, str | None]:
+    try:
+        parsed = float(value)
+    except Exception:
+        return 0.0, reason
+    if parsed <= 0.0:
+        return 0.0, reason
+    return parsed, None
 
 
 def _is_inside(child: Path, parent: Path) -> bool:
@@ -292,6 +488,10 @@ def _is_inside(child: Path, parent: Path) -> bool:
 def _digest(prefix: str, value: Mapping[str, Any]) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _content_digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(str(value).encode("utf-8")).hexdigest()
 
 
 def _not_ready(
@@ -313,6 +513,8 @@ def _not_ready(
 __all__ = [
     "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED",
     "MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY",
+    "MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER",
+    "MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER",
     "MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER",
     "MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER",
     "ModelAutoResearchCampaignExecutionBootstrapResult",

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -3,24 +3,41 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
+from dataclasses import replace
 from pathlib import Path
 
+from modules.ai_intelligence.ai_gateway.src.ai_gateway import ProviderConfig
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gateway_runner import (
+    AIGatewayConfiguredModelCaller,
+    ConfiguredGatewayRunnerPolicy,
+    MappingPromptSource,
+    build_configured_gateway_benchmark_runner,
+)
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
     rehydrate_model_autoresearch_campaign_execution_receipt,
 )
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution_artifact_supply_bootstrap import (
+    MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED,
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY,
+    MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
     run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.src.model_champion_challenger_autoresearch import (
+    ModelAutoResearchPolicy,
+    plan_model_champion_challenger_autoresearch,
 )
 from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
     REPO_ROOT,
     _plan,
-    _tasks,
 )
 from modules.ai_intelligence.ai_gateway.tests.test_model_champion_challenger_autoresearch import (
     _candidate,
+    _feedback_record,
+    _gate,
+    _tasks,
 )
 
 
@@ -60,6 +77,95 @@ def _inputs(tmp_path: Path) -> dict[str, Path]:
     }
 
 
+def _sha256(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class FakeGateway:
+    def __init__(self) -> None:
+        self.providers = {
+            "provider": ProviderConfig(
+                name="provider",
+                api_key="test-key",
+                base_url="https://example.invalid",
+                models={"quick": "wrong-default"},
+                cost_per_token=0.001,
+                rate_limit=1,
+            )
+        }
+        self.calls: list[dict[str, str]] = []
+
+    def _call_provider(self, provider: ProviderConfig, prompt: str, task_type: str) -> str:
+        self.calls.append(
+            {
+                "provider": provider.name,
+                "model": provider.models[task_type],
+                "prompt": prompt,
+                "task_type": task_type,
+            }
+        )
+        return "configured gateway answer"
+
+
+def _configured_inputs(tmp_path: Path) -> tuple[dict[str, Path], FakeGateway]:
+    runtime = tmp_path / "runtime"
+    prompt = "Audit the model AutoResearch gateway path."
+    candidate = _candidate("provider/new")
+    base_task = replace(
+        _tasks()[0],
+        prompt_digest=_sha256(prompt),
+        expected_output_digest="sha256:placeholder",
+    )
+    precompute_gateway = FakeGateway()
+    precompute_runner = build_configured_gateway_benchmark_runner(
+        caller=AIGatewayConfiguredModelCaller(precompute_gateway),
+        prompt_source=MappingPromptSource({base_task.task_id: prompt}),
+        policy=ConfiguredGatewayRunnerPolicy(
+            allowed_providers=("provider",),
+            max_prompt_chars=2000,
+            max_calls_per_sample=1,
+            max_cost_estimate_usd_per_sample=1.0,
+        ),
+    )
+    expected = precompute_runner(base_task, candidate).output_digest
+    task = replace(base_task, expected_output_digest=expected)
+    plan = plan_model_champion_challenger_autoresearch(
+        promotion_gate_receipts=(_gate("provider/challenger", pass_all=False),),
+        candidate_pool=(_candidate("provider/challenger"), candidate),
+        policy=ModelAutoResearchPolicy(
+            task_family="architecture",
+            catalog_snapshot_id="model_catalog_snapshot:1",
+            max_campaign_items=1,
+            required_verifier_digest="sha256:verifier",
+            cost_budget_receipt_id="cost_budget:1",
+        ),
+        feedback_records=(_feedback_record("provider/new", suffix="2"),),
+    )
+    return (
+        {
+            "plan": _write_json(runtime, "autoresearch_plan.json", plan.to_dict()),
+            "candidates": _write_json(
+                runtime,
+                "candidate_pool.json",
+                {
+                    "candidate_pool": [
+                        _candidate("provider/challenger").to_dict(),
+                        candidate.to_dict(),
+                    ]
+                },
+            ),
+            "tasks": _write_json(runtime, "tasks.json", {"tasks": [task.to_dict()]}),
+            "prompts": _write_json(
+                runtime,
+                "prompt_records.json",
+                {"prompts": [{"task_id": task.task_id, "prompt": prompt, "prompt_digest": _sha256(prompt)}]},
+            ),
+            "output": runtime / "campaign_execution.json",
+        },
+        FakeGateway(),
+    )
+
+
 def test_campaign_execution_bootstrap_materializes_rehydratable_receipt(tmp_path: Path) -> None:
     files = _inputs(tmp_path)
 
@@ -84,6 +190,64 @@ def test_campaign_execution_bootstrap_materializes_rehydratable_receipt(tmp_path
     payload = json.loads(files["output"].read_text(encoding="utf-8"))
     receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
     assert receipt.receipt_id == result.execution_receipt_id
+
+
+def test_campaign_execution_bootstrap_configured_gateway_mode_materializes_receipt(tmp_path: Path) -> None:
+    files, gateway = _configured_inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        prompt_records_path=files["prompts"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+        runner_allowed_providers="provider",
+        runner_max_prompt_chars=2000,
+        runner_max_calls_per_sample=1,
+        runner_max_cost_estimate_usd_per_sample=1.0,
+        gateway=gateway,
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED
+    assert result.executed_candidate_ids == ("provider/new",)
+    assert result.task_count == 1
+    assert result.no_direct_provider_call_performed is False
+    assert len(gateway.calls) == 1
+    assert gateway.calls[0]["provider"] == "provider"
+    assert gateway.calls[0]["model"] == "new"
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
+    assert receipt.receipt_id == result.execution_receipt_id
+    assert receipt.benchmark_run_receipt.samples[0].accepted is True
+
+
+def test_campaign_execution_bootstrap_configured_gateway_requires_prompt_records(tmp_path: Path) -> None:
+    files, gateway = _configured_inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+        runner_allowed_providers="provider",
+        gateway=gateway,
+    )
+
+    assert result.accepted is False
+    assert "missing_model_autoresearch_campaign_prompt_records_path" in result.rejection_reasons
+    assert not files["output"].exists()
+    assert gateway.calls == []
 
 
 def test_campaign_execution_bootstrap_rejects_inside_repo_inputs_and_output(tmp_path: Path) -> None:
@@ -169,7 +333,7 @@ def test_campaign_execution_bootstrap_rejects_non_fixture_modes(tmp_path: Path) 
     assert not files["output"].exists()
 
 
-def test_campaign_execution_bootstrap_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+def test_campaign_execution_bootstrap_module_has_no_direct_network_command_runtime_or_holoindex_imports() -> None:
     tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
     banned_import_roots = {
         "subprocess",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -807,8 +807,15 @@ def test_main_preflight_model_autoresearch_campaign_execution_supply_runs_before
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
                     "REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH": str(tmp_path / "candidates.json"),
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH": str(tmp_path / "tasks.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMPTS_PATH": str(tmp_path / "prompts.json"),
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST": "sha256:verifier",
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID": "heldout-v1",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE": "configured_gateway",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE": "exact_output_digest",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_ALLOWED_PROVIDERS": "openai;anthropic",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_PROMPT_CHARS": "1234",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_CALLS_PER_SAMPLE": "2",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_COST_USD_PER_SAMPLE": "0.25",
                 },
                 clear=True,
             ):
@@ -822,9 +829,16 @@ def test_main_preflight_model_autoresearch_campaign_execution_supply_runs_before
     assert campaign_kwargs["plan_receipt_path"] == str(runtime_root / "model_autoresearch_plan_receipt.json")
     assert campaign_kwargs["candidate_pool_path"] == str(tmp_path / "candidates.json")
     assert campaign_kwargs["tasks_path"] == str(tmp_path / "tasks.json")
+    assert campaign_kwargs["prompt_records_path"] == str(tmp_path / "prompts.json")
     assert campaign_kwargs["output_path"] == str(runtime_root / "model_autoresearch_campaign_execution_receipt.json")
     assert campaign_kwargs["verifier_digest"] == "sha256:verifier"
     assert campaign_kwargs["held_out_split_id"] == "heldout-v1"
+    assert campaign_kwargs["runner_mode"] == "configured_gateway"
+    assert campaign_kwargs["verifier_mode"] == "exact_output_digest"
+    assert campaign_kwargs["runner_allowed_providers"] == "openai;anthropic"
+    assert campaign_kwargs["runner_max_prompt_chars"] == "1234"
+    assert campaign_kwargs["runner_max_calls_per_sample"] == "2"
+    assert campaign_kwargs["runner_max_cost_estimate_usd_per_sample"] == "0.25"
     promote.assert_called_once()
 
 


### PR DESCRIPTION
## Slice
MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_BOOTSTRAP_PHASE1

## WSP_97 Truth Boundary
- IMPLEMENTED: campaign execution bootstrap supports explicit `configured_gateway` runner mode.
- IMPLEMENTED: outside-repo prompt-record ingestion with prompt digest validation.
- IMPLEMENTED: explicit provider allowlist, prompt/call/cost bounds, and `exact_output_digest` verifier mode.
- IMPLEMENTED: `main.py` preflight pass-through for configured runner controls.
- PRESERVED: default `deterministic_fixture` runner/verifier mode.
- NOT IMPLEMENTED: open-ended semantic verifier, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell execution, source mutation, or extension mutation.

## Validation
- python -m py_compile main.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
- python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py -q -> 18 passed
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q -> 27 passed
- python -m pytest modules/ai_intelligence/ai_gateway/tests -q -> 195 passed
- git diff --check -> clean
- added lines ASCII-clean

## Scope
`main.py`, ai_gateway campaign bootstrap/docs/tests, and focused resident preflight test only.