### PR TITLE
feat(ai-gateway): persist model autoresearch output evidence

### DIFF
--- a/main.py
+++ b/main.py
@@ -1626,6 +1626,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_PLAN_RECEIPT_PATH          Outside-repo AutoResearch plan output JSON
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH        Outside-repo held-out campaign tasks JSON
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMPTS_PATH      Outside-repo held-out prompt records JSON
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_PATH Outside-repo raw output evidence JSONL for configured_gateway
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_RECEIPT_PATH Outside-repo campaign execution output JSON
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST   Verifier digest required by plan policy
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID Held-out split ID for benchmark receipt
@@ -1977,6 +1978,11 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
                     candidate_pool_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH", "") or None,
                     tasks_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH", "") or None,
                     prompt_records_path=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMPTS_PATH", "") or None,
+                    output_evidence_path=os.getenv(
+                        "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_PATH",
+                        "",
+                    )
+                    or None,
                     output_path=model_autoresearch_campaign_execution_receipt_path,
                     verifier_digest=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST", ""),
                     held_out_split_id=os.getenv("REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID", ""),

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -139,6 +139,7 @@ models, write PatternMemory, mutate HoloIndex, or bind RedDog runtime defaults.
 ```python
 build_configured_gateway_benchmark_runner(...) -> BenchmarkRunner
 AIGatewayConfiguredModelCaller(gateway).call_model(...)
+JsonlModelAutoResearchOutputEvidenceStore(path, repo_root=...)
 ```
 
 The configured runner consumes a digest-bound prompt source and an explicit
@@ -146,6 +147,13 @@ provider/model gateway caller, then produces `ModelBenchmarkTaskOutput` records
 for the benchmark harness. It verifies `ModelBenchmarkTask.prompt_digest`
 against the supplied prompt before any call and emits only content digests,
 runner receipt IDs, and bounded metrics.
+
+When supplied with a `ModelAutoResearchOutputEvidenceStore`, the runner writes
+each raw role response as a digest-bound
+`ModelAutoResearchOutputEvidenceRecord` and binds the evidence record ID into
+the runner receipt. JSONL evidence stores must resolve outside the repository
+because they contain raw model output. Records rehydrate by recomputing response
+digests and record IDs, and secret-bearing output is rejected before append.
 
 The `AIGatewayConfiguredModelCaller` adapter reuses the existing `AIGateway`
 provider registry to target the candidate's exact role assignment. It is not
@@ -155,8 +163,9 @@ repository mutation.
 
 The campaign execution bootstrap accepts this runner only through the explicit
 `configured_gateway` mode, an outside-repo prompt-record file, an explicit
-provider allowlist, and the `exact_output_digest` verifier mode. Default startup
-behavior remains `deterministic_fixture`.
+provider allowlist, an outside-repo output-evidence JSONL path, and the
+`exact_output_digest` verifier mode. Default startup behavior remains
+`deterministic_fixture`.
 
 #### Model Combination Benchmark Harness
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,41 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Output Evidence Bundle
+
+**Who:** 0102 Codex
+**Type:** Runtime Benchmark Evidence
+**Slice:** MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_BUNDLE_PHASE1
+
+**What:** Added content-bearing output evidence records for configured gateway
+AutoResearch benchmark calls and required an outside-repo JSONL evidence path
+when resident startup uses `configured_gateway` mode.
+
+**Why:** The configured runner returned only output digests. An independent
+semantic verifier cannot inspect or cite a model answer if raw output is not
+preserved as governed evidence.
+
+**Files:**
+- `src/model_autoresearch_output_evidence_bundle.py` - digest-bound output
+  evidence records, rehydration, secret scan, and outside-repo JSONL store.
+- `src/model_autoresearch_configured_gateway_runner.py` - optional evidence
+  store injection and evidence-record ID binding into runner receipts.
+- `src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` -
+  configured-mode output evidence path requirement.
+- `tests/test_model_autoresearch_output_evidence_bundle.py` and adjacent tests
+  - tamper rejection, secret rejection, outside-repo guard, configured runner,
+  bootstrap, and `main.py` pass-through coverage.
+
+**Truth Boundary:**
+- IMPLEMENTED: content-bearing benchmark output evidence, digest rehydration,
+  outside-repo persistence, and configured startup evidence-path enforcement.
+- NOT IMPLEMENTED: semantic answer verification, model promotion, PatternMemory
+  writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell
+  execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Configured Gateway Runner
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -83,6 +83,12 @@ the exact provider/model role assignment in the candidate, supports panel role
 calls, and returns only digest-bound output and runner receipts to the benchmark
 harness.
 
+`src/model_autoresearch_output_evidence_bundle.py` provides the content-bearing
+evidence layer for those configured runs. When an output evidence store is
+injected, each raw model response is written to an outside-repo JSONL record
+whose response digest and record ID can be rehydrated later by an independent
+verifier. Secret-bearing output is rejected before persistence.
+
 This creates a real provider-call seam for AutoResearch benchmarks without
 turning it on at resident startup. It does not choose candidates, verify model
 answers, promote models, mutate catalogs, write PatternMemory, re-index
@@ -92,8 +98,9 @@ defaults.
 `src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` can
 use this runner only when `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE` is
 set to `configured_gateway`, prompt records are supplied from outside the repo,
-providers are explicitly allowlisted, and verifier mode is
-`exact_output_digest`. The default remains deterministic fixture execution.
+providers are explicitly allowlisted, an outside-repo output evidence path is
+supplied, and verifier mode is `exact_output_digest`. The default remains
+deterministic fixture execution.
 
 ## Model Combination Benchmark Harness
 

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -29,6 +29,9 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gatewa
     MappingPromptSource,
     build_configured_gateway_benchmark_runner,
 )
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_output_evidence_bundle import (
+    JsonlModelAutoResearchOutputEvidenceStore,
+)
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
     run_reddog_model_autoresearch_campaign_execution,
@@ -65,6 +68,7 @@ class ModelAutoResearchCampaignExecutionBootstrapResult:
     source_plan_receipt_id: Optional[str]
     benchmark_run_receipt_id: Optional[str]
     output_path: Optional[str]
+    output_evidence_path: Optional[str]
     executed_candidate_ids: tuple[str, ...]
     task_count: int
     rejection_reasons: tuple[str, ...]
@@ -95,6 +99,7 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
     runner_mode: str = MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER,
     verifier_mode: str = MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER,
     prompt_records_path: Path | str | None = None,
+    output_evidence_path: Path | str | None = None,
     runner_allowed_providers: str | Sequence[str] | None = None,
     runner_max_prompt_chars: int | str = 20000,
     runner_max_calls_per_sample: int | str = 4,
@@ -143,6 +148,11 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
         *task_reasons,
         *prompt_reasons,
         *_output_path_reasons(root, output_path),
+        *_configured_output_evidence_path_reasons(
+            root,
+            output_evidence_path,
+            runner_mode=runner_mode_text,
+        ),
         *_mode_reasons(runner_mode_text, verifier_mode_text),
     ]
     verifier_text = str(verifier_digest or "").strip()
@@ -182,13 +192,20 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
     runner = _fixture_runner
     verifier = _fixture_verifier
     no_provider_call = True
+    resolved_output_evidence_path: Optional[str] = None
     if runner_mode_text == MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER:
         assert prompts is not None
         assert policy is not None
+        evidence_path = _runtime_path(root, output_evidence_path)
+        resolved_output_evidence_path = str(evidence_path)
         runner = build_configured_gateway_benchmark_runner(
             caller=AIGatewayConfiguredModelCaller(gateway or AIGateway()),
             prompt_source=MappingPromptSource(prompts),
             policy=policy,
+            output_evidence_store=JsonlModelAutoResearchOutputEvidenceStore(
+                evidence_path,
+                repo_root=root,
+            ),
         )
         verifier = _exact_output_digest_verifier
         no_provider_call = False
@@ -214,6 +231,7 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
         source_plan_receipt_id=execution.source_plan_receipt_id,
         benchmark_run_receipt_id=execution.benchmark_run_receipt_id,
         output_path=execution.output_path,
+        output_evidence_path=resolved_output_evidence_path,
         executed_candidate_ids=execution.executed_candidate_ids,
         task_count=execution.task_count,
         rejection_reasons=(),
@@ -383,6 +401,29 @@ def _output_path_reasons(repo_root: Path, value: Path | str | None) -> tuple[str
     return ()
 
 
+def _configured_output_evidence_path_reasons(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    runner_mode: str,
+) -> tuple[str, ...]:
+    if runner_mode != MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER:
+        return ()
+    if not value:
+        return ("missing_model_autoresearch_campaign_output_evidence_path",)
+    resolved = _runtime_path(repo_root, value)
+    if _is_inside(resolved, repo_root):
+        return ("model_autoresearch_campaign_output_evidence_path_inside_repo",)
+    return ()
+
+
+def _runtime_path(repo_root: Path, value: Path | str | None) -> Path:
+    path = Path(value or "")
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    return path.resolve()
+
+
 def _mode_reasons(runner_mode: str, verifier_mode: str) -> tuple[str, ...]:
     reasons: list[str] = []
     runner = str(runner_mode or "").strip()
@@ -504,6 +545,7 @@ def _not_ready(
         source_plan_receipt_id=None,
         benchmark_run_receipt_id=None,
         output_path=None,
+        output_evidence_path=None,
         executed_candidate_ids=(),
         task_count=0,
         rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason))),

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
@@ -26,6 +26,10 @@ from .model_combination_benchmark_harness import (
     ModelBenchmarkTaskOutput,
     build_model_benchmark_candidate,
 )
+from .model_autoresearch_output_evidence_bundle import (
+    ModelAutoResearchOutputEvidenceStore,
+    build_model_autoresearch_output_evidence_record,
+)
 from .model_intelligence_outcomes import ModelOutcomeMetrics
 
 
@@ -193,10 +197,12 @@ def build_configured_gateway_benchmark_runner(
     caller: GatewayModelCaller,
     prompt_source: PromptSource,
     policy: ConfiguredGatewayRunnerPolicy,
+    output_evidence_store: ModelAutoResearchOutputEvidenceStore | None = None,
 ) -> BenchmarkRunner:
     """Build a ``BenchmarkRunner`` backed by an explicit configured gateway."""
 
     normalized_policy = policy.normalized()
+    policy_digest = _policy_digest(normalized_policy)
 
     def _runner(
         task: ModelBenchmarkTask,
@@ -248,18 +254,37 @@ def build_configured_gateway_benchmark_runner(
             if result.provider != provider or result.model != model_name:
                 raise ValueError("configured_gateway_runner_call_route_mismatch")
             response_digest = _content_digest(result.response_text)
-            call_records.append(
-                {
-                    "role": assignment.role,
-                    "provider": result.provider,
-                    "model": result.model,
-                    "response_digest": response_digest,
-                    "latency_ms": result.latency_ms,
-                    "input_tokens": result.input_tokens,
-                    "output_tokens": result.output_tokens,
-                    "cost_estimate_usd": result.cost_estimate_usd,
-                }
-            )
+            evidence_record_id = None
+            if output_evidence_store is not None:
+                evidence = build_model_autoresearch_output_evidence_record(
+                    task_id=normalized_task.task_id,
+                    prompt_digest=normalized_task.prompt_digest,
+                    candidate_id=candidate.candidate_id,
+                    candidate_topology_digest=candidate.topology_digest,
+                    role=assignment.role,
+                    provider=result.provider,
+                    model=result.model,
+                    policy_digest=policy_digest,
+                    response_text=result.response_text,
+                    latency_ms=result.latency_ms,
+                    input_tokens=result.input_tokens,
+                    output_tokens=result.output_tokens,
+                    cost_estimate_usd=result.cost_estimate_usd,
+                )
+                evidence_record_id = output_evidence_store.append(evidence)
+            call_record = {
+                "role": assignment.role,
+                "provider": result.provider,
+                "model": result.model,
+                "response_digest": response_digest,
+                "latency_ms": result.latency_ms,
+                "input_tokens": result.input_tokens,
+                "output_tokens": result.output_tokens,
+                "cost_estimate_usd": result.cost_estimate_usd,
+            }
+            if evidence_record_id:
+                call_record["output_evidence_record_id"] = evidence_record_id
+            call_records.append(call_record)
             total_latency_ms += result.latency_ms
             total_input_tokens += result.input_tokens
             total_output_tokens += result.output_tokens
@@ -272,7 +297,7 @@ def build_configured_gateway_benchmark_runner(
             "prompt_digest": normalized_task.prompt_digest,
             "candidate_id": candidate.candidate_id,
             "candidate_topology_digest": candidate.topology_digest,
-            "policy_digest": _policy_digest(normalized_policy),
+            "policy_digest": policy_digest,
             "calls": call_records,
         }
         return ModelBenchmarkTaskOutput(

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_output_evidence_bundle.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_output_evidence_bundle.py
@@ -1,0 +1,293 @@
+"""Content-bearing output evidence for model AutoResearch benchmarks.
+
+This module stores configured-gateway model responses as digest-bound evidence
+records in an injected outside-repository store. The benchmark harness can keep
+digest-only receipts while an independent verifier can later rehydrate the raw
+answer text from a governed artifact.
+
+It does not call providers, run benchmarks, verify answers, promote models,
+write PatternMemory, mutate HoloIndex, execute commands, mutate the repository,
+or bind RedDog runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Protocol, Sequence
+
+
+MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SCHEMA_VERSION = (
+    "model_autoresearch_output_evidence_record.v1"
+)
+MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_RECORD_TYPE = "model_autoresearch_output_evidence"
+
+SECRET_MARKERS = (
+    "authorization:",
+    "bearer ",
+    "api_key",
+    "apikey",
+    "private_key",
+    "begin private key",
+    "secret=",
+    "token=",
+    "password=",
+)
+
+
+class ModelAutoResearchOutputEvidenceStore(Protocol):
+    """Injected store for content-bearing benchmark output evidence."""
+
+    def append(self, record: "ModelAutoResearchOutputEvidenceRecord") -> str:
+        ...
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchOutputEvidenceRecord:
+    """One digest-bound raw model response for a benchmark role call."""
+
+    record_id: str
+    task_id: str
+    prompt_digest: str
+    candidate_id: str
+    candidate_topology_digest: str
+    role: str
+    provider: str
+    model: str
+    policy_digest: str
+    response_text: str
+    response_digest: str
+    latency_ms: int
+    input_tokens: int
+    output_tokens: int
+    cost_estimate_usd: float
+    schema_version: str = MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SCHEMA_VERSION
+    record_type: str = MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_RECORD_TYPE
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class InMemoryModelAutoResearchOutputEvidenceStore:
+    """Test/local store for output evidence records."""
+
+    def __init__(self) -> None:
+        self.records: List[Dict[str, Any]] = []
+
+    def append(self, record: ModelAutoResearchOutputEvidenceRecord) -> str:
+        rehydrated = rehydrate_model_autoresearch_output_evidence_record(record.to_dict())
+        self.records.append(rehydrated.to_dict())
+        return rehydrated.record_id
+
+
+class JsonlModelAutoResearchOutputEvidenceStore:
+    """Append-only JSONL store for output evidence records.
+
+    The path must resolve outside the source repository because these records
+    contain raw model output. The store rehydrates every record before append so
+    caller-provided accepted flags or stale digests cannot be trusted.
+    """
+
+    def __init__(self, path: Path | str, *, repo_root: Path | str) -> None:
+        self.path = Path(path).resolve()
+        self.repo_root = Path(repo_root).resolve()
+        if _is_inside(self.path, self.repo_root):
+            raise ValueError("model_autoresearch_output_evidence_path_inside_repo")
+
+    def append(self, record: ModelAutoResearchOutputEvidenceRecord) -> str:
+        rehydrated = rehydrate_model_autoresearch_output_evidence_record(record.to_dict())
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(
+            rehydrated.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        )
+        with self.path.open("a", encoding="utf-8", newline="\n") as handle:
+            handle.write(line + "\n")
+        return rehydrated.record_id
+
+
+def build_model_autoresearch_output_evidence_record(
+    *,
+    task_id: str,
+    prompt_digest: str,
+    candidate_id: str,
+    candidate_topology_digest: str,
+    role: str,
+    provider: str,
+    model: str,
+    policy_digest: str,
+    response_text: str,
+    latency_ms: int,
+    input_tokens: int,
+    output_tokens: int,
+    cost_estimate_usd: float,
+) -> ModelAutoResearchOutputEvidenceRecord:
+    """Build one output evidence record and reject secret-bearing responses."""
+
+    response = str(response_text or "")
+    if _contains_secret(response):
+        raise ValueError("model_autoresearch_output_evidence_secret_detected")
+    response_digest = _content_digest(response)
+    fields = {
+        "schema_version": MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SCHEMA_VERSION,
+        "record_type": MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_RECORD_TYPE,
+        "task_id": _required("task_id", task_id),
+        "prompt_digest": _required("prompt_digest", prompt_digest),
+        "candidate_id": _required("candidate_id", candidate_id),
+        "candidate_topology_digest": _required(
+            "candidate_topology_digest",
+            candidate_topology_digest,
+        ),
+        "role": _clean_token(_required("role", role)),
+        "provider": _clean_token(_required("provider", provider)),
+        "model": _required("model", model),
+        "policy_digest": _required("policy_digest", policy_digest),
+        "response_text": response,
+        "response_digest": response_digest,
+        "latency_ms": _non_negative_int(latency_ms),
+        "input_tokens": _non_negative_int(input_tokens),
+        "output_tokens": _non_negative_int(output_tokens),
+        "cost_estimate_usd": _non_negative_float(cost_estimate_usd),
+    }
+    record_id = _record_id(fields)
+    record = ModelAutoResearchOutputEvidenceRecord(record_id=record_id, **fields)
+    if _contains_secret(record.to_dict()):
+        raise ValueError("model_autoresearch_output_evidence_secret_detected")
+    return record
+
+
+def rehydrate_model_autoresearch_output_evidence_record(
+    payload: Mapping[str, Any],
+) -> ModelAutoResearchOutputEvidenceRecord:
+    """Rehydrate a serialized output evidence record and verify every digest."""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("invalid_model_autoresearch_output_evidence_record")
+    if payload.get("schema_version") != MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SCHEMA_VERSION:
+        raise ValueError("invalid_model_autoresearch_output_evidence_schema")
+    if payload.get("record_type") != MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_RECORD_TYPE:
+        raise ValueError("invalid_model_autoresearch_output_evidence_type")
+    record_id = _required("record_id", payload.get("record_id"))
+    response_text = str(payload.get("response_text") or "")
+    response_digest = _required("response_digest", payload.get("response_digest"))
+    if not hmac.compare_digest(response_digest, _content_digest(response_text)):
+        raise ValueError("model_autoresearch_output_evidence_response_digest_mismatch")
+    record = build_model_autoresearch_output_evidence_record(
+        task_id=_required("task_id", payload.get("task_id")),
+        prompt_digest=_required("prompt_digest", payload.get("prompt_digest")),
+        candidate_id=_required("candidate_id", payload.get("candidate_id")),
+        candidate_topology_digest=_required(
+            "candidate_topology_digest",
+            payload.get("candidate_topology_digest"),
+        ),
+        role=_required("role", payload.get("role")),
+        provider=_required("provider", payload.get("provider")),
+        model=_required("model", payload.get("model")),
+        policy_digest=_required("policy_digest", payload.get("policy_digest")),
+        response_text=response_text,
+        latency_ms=_non_negative_int(payload.get("latency_ms")),
+        input_tokens=_non_negative_int(payload.get("input_tokens")),
+        output_tokens=_non_negative_int(payload.get("output_tokens")),
+        cost_estimate_usd=_non_negative_float(payload.get("cost_estimate_usd")),
+    )
+    if not hmac.compare_digest(record_id, record.record_id):
+        raise ValueError("model_autoresearch_output_evidence_record_id_mismatch")
+    return record
+
+
+def read_model_autoresearch_output_evidence_jsonl(
+    path: Path | str,
+    *,
+    repo_root: Path | str,
+) -> tuple[ModelAutoResearchOutputEvidenceRecord, ...]:
+    """Read an outside-repo JSONL evidence store and verify all records."""
+
+    resolved = Path(path).resolve()
+    root = Path(repo_root).resolve()
+    if _is_inside(resolved, root):
+        raise ValueError("model_autoresearch_output_evidence_path_inside_repo")
+    records: list[ModelAutoResearchOutputEvidenceRecord] = []
+    with resolved.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            text = line.strip()
+            if not text:
+                continue
+            records.append(
+                rehydrate_model_autoresearch_output_evidence_record(json.loads(text))
+            )
+    return tuple(records)
+
+
+def _record_id(fields: Mapping[str, Any]) -> str:
+    return _digest_prefixed("model_autoresearch_output_evidence", fields)
+
+
+def _content_digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _contains_secret(value: Any) -> bool:
+    text = json.dumps(value, sort_keys=True, default=str).lower()
+    return any(marker in text for marker in SECRET_MARKERS)
+
+
+def _required(name: str, value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"missing_{name}")
+    return text
+
+
+def _clean_token(value: object) -> str:
+    text = _required("token", value)
+    return "".join(ch if ch.isalnum() or ch in {"_", "-", ".", "/"} else "_" for ch in text)
+
+
+def _non_negative_int(value: object) -> int:
+    try:
+        result = int(value)
+    except Exception as exc:
+        raise ValueError("invalid_non_negative_int") from exc
+    if result < 0:
+        raise ValueError("invalid_non_negative_int")
+    return result
+
+
+def _non_negative_float(value: object) -> float:
+    try:
+        result = float(value)
+    except Exception as exc:
+        raise ValueError("invalid_non_negative_float") from exc
+    if result < 0.0:
+        raise ValueError("invalid_non_negative_float")
+    return result
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+__all__ = [
+    "InMemoryModelAutoResearchOutputEvidenceStore",
+    "JsonlModelAutoResearchOutputEvidenceStore",
+    "MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_RECORD_TYPE",
+    "MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SCHEMA_VERSION",
+    "ModelAutoResearchOutputEvidenceRecord",
+    "ModelAutoResearchOutputEvidenceStore",
+    "build_model_autoresearch_output_evidence_record",
+    "read_model_autoresearch_output_evidence_jsonl",
+    "rehydrate_model_autoresearch_output_evidence_record",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -15,6 +15,10 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gatewa
     MappingPromptSource,
     build_configured_gateway_benchmark_runner,
 )
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_output_evidence_bundle import (
+    InMemoryModelAutoResearchOutputEvidenceStore,
+    read_model_autoresearch_output_evidence_jsonl,
+)
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
     rehydrate_model_autoresearch_campaign_execution_receipt,
 )
@@ -126,6 +130,7 @@ def _configured_inputs(tmp_path: Path) -> tuple[dict[str, Path], FakeGateway]:
             max_calls_per_sample=1,
             max_cost_estimate_usd_per_sample=1.0,
         ),
+        output_evidence_store=InMemoryModelAutoResearchOutputEvidenceStore(),
     )
     expected = precompute_runner(base_task, candidate).output_digest
     task = replace(base_task, expected_output_digest=expected)
@@ -160,6 +165,7 @@ def _configured_inputs(tmp_path: Path) -> tuple[dict[str, Path], FakeGateway]:
                 "prompt_records.json",
                 {"prompts": [{"task_id": task.task_id, "prompt": prompt, "prompt_digest": _sha256(prompt)}]},
             ),
+            "evidence": runtime / "output_evidence.jsonl",
             "output": runtime / "campaign_execution.json",
         },
         FakeGateway(),
@@ -201,6 +207,7 @@ def test_campaign_execution_bootstrap_configured_gateway_mode_materializes_recei
         candidate_pool_path=files["candidates"],
         tasks_path=files["tasks"],
         prompt_records_path=files["prompts"],
+        output_evidence_path=files["evidence"],
         output_path=files["output"],
         verifier_digest="sha256:verifier",
         held_out_split_id="heldout-v1",
@@ -218,6 +225,7 @@ def test_campaign_execution_bootstrap_configured_gateway_mode_materializes_recei
     assert result.executed_candidate_ids == ("provider/new",)
     assert result.task_count == 1
     assert result.no_direct_provider_call_performed is False
+    assert result.output_evidence_path == str(files["evidence"].resolve())
     assert len(gateway.calls) == 1
     assert gateway.calls[0]["provider"] == "provider"
     assert gateway.calls[0]["model"] == "new"
@@ -225,6 +233,13 @@ def test_campaign_execution_bootstrap_configured_gateway_mode_materializes_recei
     receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
     assert receipt.receipt_id == result.execution_receipt_id
     assert receipt.benchmark_run_receipt.samples[0].accepted is True
+    evidence_records = read_model_autoresearch_output_evidence_jsonl(
+        files["evidence"],
+        repo_root=REPO_ROOT,
+    )
+    assert len(evidence_records) == 1
+    assert evidence_records[0].response_text == "configured gateway answer"
+    assert evidence_records[0].task_id == receipt.benchmark_run_receipt.samples[0].task_id
 
 
 def test_campaign_execution_bootstrap_configured_gateway_requires_prompt_records(tmp_path: Path) -> None:
@@ -246,7 +261,62 @@ def test_campaign_execution_bootstrap_configured_gateway_requires_prompt_records
 
     assert result.accepted is False
     assert "missing_model_autoresearch_campaign_prompt_records_path" in result.rejection_reasons
+    assert "missing_model_autoresearch_campaign_output_evidence_path" in result.rejection_reasons
     assert not files["output"].exists()
+    assert gateway.calls == []
+
+
+def test_campaign_execution_bootstrap_configured_gateway_requires_output_evidence_path(tmp_path: Path) -> None:
+    files, gateway = _configured_inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        prompt_records_path=files["prompts"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+        runner_allowed_providers="provider",
+        gateway=gateway,
+    )
+
+    assert result.accepted is False
+    assert "missing_model_autoresearch_campaign_output_evidence_path" in result.rejection_reasons
+    assert not files["output"].exists()
+    assert not files["evidence"].exists()
+    assert gateway.calls == []
+
+
+def test_campaign_execution_bootstrap_configured_gateway_rejects_inside_repo_output_evidence(
+    tmp_path: Path,
+) -> None:
+    files, gateway = _configured_inputs(tmp_path)
+    inside = REPO_ROOT / "model_autoresearch_output_evidence.jsonl"
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        prompt_records_path=files["prompts"],
+        output_evidence_path=inside,
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+        runner_allowed_providers="provider",
+        gateway=gateway,
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_campaign_output_evidence_path_inside_repo" in result.rejection_reasons
+    assert not files["output"].exists()
+    assert not inside.exists()
     assert gateway.calls == []
 
 

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py
@@ -15,6 +15,9 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gatewa
     MappingPromptSource,
     build_configured_gateway_benchmark_runner,
 )
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_output_evidence_bundle import (
+    InMemoryModelAutoResearchOutputEvidenceStore,
+)
 from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
     ModelBenchmarkRoleAssignment,
     ModelBenchmarkTask,
@@ -83,6 +86,7 @@ def _runner(
     prompt: str = "Audit the bounded RedDog runtime path.",
     caller: FakeConfiguredCaller | None = None,
     policy: ConfiguredGatewayRunnerPolicy | None = None,
+    output_evidence_store=None,
 ):
     return build_configured_gateway_benchmark_runner(
         caller=caller or FakeConfiguredCaller(),
@@ -92,6 +96,7 @@ def _runner(
             allowed_providers=("openai", "anthropic"),
             max_cost_estimate_usd_per_sample=1.0,
         ),
+        output_evidence_store=output_evidence_store,
     )
 
 
@@ -120,6 +125,50 @@ def test_configured_runner_calls_explicit_provider_model_and_returns_digest_only
     assert output.metrics.cost_estimate_usd == 0.01
     assert prompt not in output.output_digest
     assert "This answer is bounded." not in output.runner_receipt_id
+
+
+def test_configured_runner_writes_output_evidence_when_store_injected():
+    prompt = "Audit the bounded RedDog runtime path."
+    caller = FakeConfiguredCaller(response="Evidence-bearing answer.")
+    store = InMemoryModelAutoResearchOutputEvidenceStore()
+    runner = _runner(prompt=prompt, caller=caller, output_evidence_store=store)
+
+    output = runner(_task(prompt), _candidate("openai/gpt-5.2"))
+
+    assert len(store.records) == 1
+    record = store.records[0]
+    assert record["response_text"] == "Evidence-bearing answer."
+    assert record["task_id"] == "task-001"
+    assert record["candidate_id"] == "openai/gpt-5.2"
+    assert record["role"] == "principal"
+    assert record["provider"] == "openai"
+    assert record["model"] == "gpt-5.2"
+    digest_only_output = _runner(
+        prompt=prompt,
+        caller=FakeConfiguredCaller(response="Evidence-bearing answer."),
+    )(_task(prompt), _candidate("openai/gpt-5.2"))
+    assert output.output_digest != digest_only_output.output_digest
+    assert output.output_digest.startswith("configured_gateway_benchmark_output:")
+    assert record["record_id"] not in output.output_digest
+    assert record["record_id"] not in output.runner_receipt_id
+    assert "Evidence-bearing answer." not in output.output_digest
+    assert "Evidence-bearing answer." not in output.runner_receipt_id
+
+
+def test_configured_runner_secret_output_fails_before_evidence_store_write():
+    prompt = "Audit the bounded RedDog runtime path."
+    caller = FakeConfiguredCaller(response="token=abc123")
+    store = InMemoryModelAutoResearchOutputEvidenceStore()
+    runner = _runner(prompt=prompt, caller=caller, output_evidence_store=store)
+
+    try:
+        runner(_task(prompt), _candidate("openai/gpt-5.2"))
+    except ValueError as exc:
+        assert str(exc) == "model_autoresearch_output_evidence_secret_detected"
+    else:
+        raise AssertionError("expected secret output rejection")
+
+    assert store.records == []
 
 
 def test_configured_runner_integrates_with_combination_benchmark_harness():

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_output_evidence_bundle.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_output_evidence_bundle.py
@@ -1,0 +1,144 @@
+"""Tests for model AutoResearch output evidence bundles."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_output_evidence_bundle import (
+    InMemoryModelAutoResearchOutputEvidenceStore,
+    JsonlModelAutoResearchOutputEvidenceStore,
+    build_model_autoresearch_output_evidence_record,
+    read_model_autoresearch_output_evidence_jsonl,
+    rehydrate_model_autoresearch_output_evidence_record,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
+    REPO_ROOT,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_output_evidence_bundle.py"
+)
+
+
+def _record(response_text: str = "bounded answer"):
+    return build_model_autoresearch_output_evidence_record(
+        task_id="task-001",
+        prompt_digest="sha256:prompt",
+        candidate_id="model/panel",
+        candidate_topology_digest="model_panel_topology:123",
+        role="principal",
+        provider="provider",
+        model="model-a",
+        policy_digest="configured_gateway_runner_policy:abc",
+        response_text=response_text,
+        latency_ms=10,
+        input_tokens=5,
+        output_tokens=2,
+        cost_estimate_usd=0.01,
+    )
+
+
+def test_output_evidence_record_rehydrates_and_binds_response_digest() -> None:
+    record = _record("the cited answer")
+
+    rehydrated = rehydrate_model_autoresearch_output_evidence_record(record.to_dict())
+
+    assert rehydrated.record_id == record.record_id
+    assert rehydrated.response_text == "the cited answer"
+    assert rehydrated.response_digest.startswith("sha256:")
+
+
+def test_output_evidence_rejects_tampered_response_text() -> None:
+    payload = _record("original answer").to_dict()
+    payload["response_text"] = "changed answer"
+
+    try:
+        rehydrate_model_autoresearch_output_evidence_record(payload)
+    except ValueError as exc:
+        assert str(exc) == "model_autoresearch_output_evidence_response_digest_mismatch"
+    else:
+        raise AssertionError("expected response digest mismatch")
+
+
+def test_output_evidence_rejects_tampered_record_id() -> None:
+    payload = _record("original answer").to_dict()
+    payload["record_id"] = "model_autoresearch_output_evidence:forged"
+
+    try:
+        rehydrate_model_autoresearch_output_evidence_record(payload)
+    except ValueError as exc:
+        assert str(exc) == "model_autoresearch_output_evidence_record_id_mismatch"
+    else:
+        raise AssertionError("expected record id mismatch")
+
+
+def test_jsonl_store_writes_outside_repo_and_rehydrates_records(tmp_path: Path) -> None:
+    path = tmp_path / "runtime" / "model_outputs.jsonl"
+    store = JsonlModelAutoResearchOutputEvidenceStore(path, repo_root=REPO_ROOT)
+
+    record_id = store.append(_record("outside repo evidence"))
+    records = read_model_autoresearch_output_evidence_jsonl(path, repo_root=REPO_ROOT)
+
+    assert records[0].record_id == record_id
+    assert records[0].response_text == "outside repo evidence"
+    line = path.read_text(encoding="utf-8").strip()
+    assert json.loads(line)["record_id"] == record_id
+
+
+def test_jsonl_store_rejects_inside_repo_path() -> None:
+    inside = REPO_ROOT / "model_outputs.jsonl"
+
+    try:
+        JsonlModelAutoResearchOutputEvidenceStore(inside, repo_root=REPO_ROOT)
+    except ValueError as exc:
+        assert str(exc) == "model_autoresearch_output_evidence_path_inside_repo"
+    else:
+        raise AssertionError("expected inside-repo path rejection")
+
+
+def test_output_evidence_rejects_secret_markers_before_store_write() -> None:
+    store = InMemoryModelAutoResearchOutputEvidenceStore()
+
+    try:
+        store.append(_record("token=abc123"))
+    except ValueError as exc:
+        assert str(exc) == "model_autoresearch_output_evidence_secret_detected"
+    else:
+        raise AssertionError("expected secret rejection")
+
+    assert store.records == []
+
+
+def test_output_evidence_module_has_no_network_command_runtime_or_holoindex_imports() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    assert "extension.js" not in source

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -808,6 +808,9 @@ def test_main_preflight_model_autoresearch_campaign_execution_supply_runs_before
                     "REDDOG_MODEL_AUTORESEARCH_CANDIDATE_POOL_PATH": str(tmp_path / "candidates.json"),
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_TASKS_PATH": str(tmp_path / "tasks.json"),
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMPTS_PATH": str(tmp_path / "prompts.json"),
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_PATH": str(
+                        tmp_path / "output_evidence.jsonl"
+                    ),
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST": "sha256:verifier",
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID": "heldout-v1",
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE": "configured_gateway",
@@ -830,6 +833,7 @@ def test_main_preflight_model_autoresearch_campaign_execution_supply_runs_before
     assert campaign_kwargs["candidate_pool_path"] == str(tmp_path / "candidates.json")
     assert campaign_kwargs["tasks_path"] == str(tmp_path / "tasks.json")
     assert campaign_kwargs["prompt_records_path"] == str(tmp_path / "prompts.json")
+    assert campaign_kwargs["output_evidence_path"] == str(tmp_path / "output_evidence.jsonl")
     assert campaign_kwargs["output_path"] == str(runtime_root / "model_autoresearch_campaign_execution_receipt.json")
     assert campaign_kwargs["verifier_digest"] == "sha256:verifier"
     assert campaign_kwargs["held_out_split_id"] == "heldout-v1"


### PR DESCRIPTION
## Slice
MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_BUNDLE_PHASE1

## WSP_97 Truth Boundary
- OBSERVED: Configured gateway benchmark calls previously returned digest-only `ModelBenchmarkTaskOutput`; there was no content-bearing model response artifact for a later semantic verifier to inspect.
- IMPLEMENTED: Added digest-bound `ModelAutoResearchOutputEvidenceRecord` records, rehydration, secret-marker rejection, and outside-repo JSONL persistence.
- IMPLEMENTED: Configured gateway runner can inject an output evidence store and binds evidence record IDs into the runner receipt body without embedding raw output in benchmark receipts.
- IMPLEMENTED: Resident startup configured-gateway mode now requires `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_PATH` outside the repo.
- SPECIFIED_NOT_IMPLEMENTED: semantic answer verification, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell execution, source mutation, extension mutation.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_output_evidence_bundle.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py main.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_output_evidence_bundle.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py -q` -> 29 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 206 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 27 passed
- `git diff --check` -> clean
- Added lines ASCII-clean

## Sequence
Next slice after this lands: MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_SEMANTIC_VERIFIER_PHASE1, using the persisted output evidence rather than digest-only claims.