### PR TITLE
feat(ai-gateway): verify autoresearch output evidence

### DIFF
--- a/main.py
+++ b/main.py
@@ -1631,7 +1631,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_DIGEST   Verifier digest required by plan policy
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_HELD_OUT_SPLIT_ID Held-out split ID for benchmark receipt
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE       deterministic_fixture or configured_gateway
-        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture or exact_output_digest
+        REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_VERIFIER_MODE     deterministic_fixture, exact_output_digest, or output_evidence_semantic
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_ALLOWED_PROVIDERS ; or , separated allowlist
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_PROMPT_CHARS Optional positive int
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MAX_CALLS_PER_SAMPLE Optional positive int

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -140,6 +140,7 @@ models, write PatternMemory, mutate HoloIndex, or bind RedDog runtime defaults.
 build_configured_gateway_benchmark_runner(...) -> BenchmarkRunner
 AIGatewayConfiguredModelCaller(gateway).call_model(...)
 JsonlModelAutoResearchOutputEvidenceStore(path, repo_root=...)
+build_model_autoresearch_output_evidence_semantic_verifier(...) -> BenchmarkVerifier
 ```
 
 The configured runner consumes a digest-bound prompt source and an explicit
@@ -164,8 +165,12 @@ repository mutation.
 The campaign execution bootstrap accepts this runner only through the explicit
 `configured_gateway` mode, an outside-repo prompt-record file, an explicit
 provider allowlist, an outside-repo output-evidence JSONL path, and the
-`exact_output_digest` verifier mode. Default startup behavior remains
-`deterministic_fixture`.
+`exact_output_digest` or `output_evidence_semantic` verifier mode. The semantic
+mode is deterministic: it rehydrates output-evidence records, recomputes runner
+output/receipt digests, and checks explicit task metadata keys
+`expected_answer_contains` and `expected_answer_excludes`. It fails closed when
+required terms are absent or no semantic requirements are supplied. Default
+startup behavior remains `deterministic_fixture`.
 
 #### Model Combination Benchmark Harness
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,41 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Output Evidence Semantic Verifier
+
+**Who:** 0102 Codex
+**Type:** Runtime Benchmark Verifier
+**Slice:** MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_SEMANTIC_VERIFIER_PHASE1
+
+**What:** Added a deterministic verifier over configured-gateway output
+evidence records and exposed it through the campaign execution bootstrap as
+`output_evidence_semantic` verifier mode.
+
+**Why:** The benchmark path can now preserve raw model output, but promotion
+still needs a verifier that checks actual content rather than output digest
+shape alone.
+
+**Files:**
+- `src/model_autoresearch_semantic_verifier.py` - rehydrates output evidence,
+  recomputes configured-runner output/receipt digests, and checks task-declared
+  required/forbidden answer terms.
+- `src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` -
+  adds `output_evidence_semantic` as an explicit configured-gateway verifier
+  mode.
+- `tests/test_model_autoresearch_semantic_verifier.py` and bootstrap tests -
+  acceptance, missing evidence, missing requirements, forbidden term, digest
+  mismatch, panel-role evidence, and startup coverage.
+
+**Truth Boundary:**
+- IMPLEMENTED: deterministic output-evidence verifier for task-declared
+  semantic requirements.
+- NOT IMPLEMENTED: free-form LLM verifier, model promotion, PatternMemory
+  writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell
+  execution, source mutation, or extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Output Evidence Bundle
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -89,6 +89,13 @@ injected, each raw model response is written to an outside-repo JSONL record
 whose response digest and record ID can be rehydrated later by an independent
 verifier. Secret-bearing output is rejected before persistence.
 
+`src/model_autoresearch_semantic_verifier.py` is the first deterministic
+content verifier over those evidence records. It does not call a model; it
+rehydrates the output evidence, recomputes the configured-runner output and
+receipt digests, then checks explicit task metadata requirements:
+`expected_answer_contains` and `expected_answer_excludes`. Missing requirements
+fail closed.
+
 This creates a real provider-call seam for AutoResearch benchmarks without
 turning it on at resident startup. It does not choose candidates, verify model
 answers, promote models, mutate catalogs, write PatternMemory, re-index
@@ -99,8 +106,8 @@ defaults.
 use this runner only when `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE` is
 set to `configured_gateway`, prompt records are supplied from outside the repo,
 providers are explicitly allowlisted, an outside-repo output evidence path is
-supplied, and verifier mode is `exact_output_digest`. The default remains
-deterministic fixture execution.
+supplied, and verifier mode is `exact_output_digest` or
+`output_evidence_semantic`. The default remains deterministic fixture execution.
 
 ## Model Combination Benchmark Harness
 

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -31,6 +31,10 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gatewa
 )
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_output_evidence_bundle import (
     JsonlModelAutoResearchOutputEvidenceStore,
+    read_model_autoresearch_output_evidence_jsonl,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_semantic_verifier import (
+    build_model_autoresearch_output_evidence_semantic_verifier,
 )
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution import (
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ACCEPT,
@@ -58,6 +62,7 @@ MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER = "deterministic_fixture"
 MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER = "deterministic_fixture"
 MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER = "configured_gateway"
 MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER = "exact_output_digest"
+MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER = "output_evidence_semantic"
 
 
 @dataclass(frozen=True)
@@ -207,7 +212,15 @@ def run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
                 repo_root=root,
             ),
         )
-        verifier = _exact_output_digest_verifier
+        if verifier_mode_text == MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER:
+            verifier = build_model_autoresearch_output_evidence_semantic_verifier(
+                evidence_records=lambda: read_model_autoresearch_output_evidence_jsonl(
+                    evidence_path,
+                    repo_root=root,
+                )
+            )
+        else:
+            verifier = _exact_output_digest_verifier
         no_provider_call = False
     execution = run_reddog_model_autoresearch_campaign_execution(
         repo_root=root,
@@ -434,6 +447,10 @@ def _mode_reasons(runner_mode: str, verifier_mode: str) -> tuple[str, ...]:
             MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
             MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
         ),
+        (
+            MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+            MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
+        ),
     }
     if runner not in {
         MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER,
@@ -443,6 +460,7 @@ def _mode_reasons(runner_mode: str, verifier_mode: str) -> tuple[str, ...]:
     if verifier not in {
         MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER,
         MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+        MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
     }:
         reasons.append("unsupported_model_autoresearch_campaign_verifier_mode")
     if not reasons and (runner, verifier) not in valid_pairs:
@@ -559,6 +577,7 @@ __all__ = [
     "MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER",
     "MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_RUNNER",
     "MODEL_AUTORESEARCH_CAMPAIGN_FIXTURE_VERIFIER",
+    "MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER",
     "ModelAutoResearchCampaignExecutionBootstrapResult",
     "run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap",
 ]

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_semantic_verifier.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_semantic_verifier.py
@@ -1,0 +1,348 @@
+"""Deterministic output-evidence verifier for model AutoResearch benchmarks.
+
+The verifier consumes content-bearing output evidence records produced by the
+configured gateway runner. It verifies that evidence records match the
+candidate/task/output digest and then applies explicit task metadata
+requirements. It does not call a model, infer unstated semantics, promote
+models, write PatternMemory, mutate HoloIndex, execute commands, or bind RedDog
+runtime defaults.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from .model_autoresearch_configured_gateway_runner import CONFIGURED_GATEWAY_RUNNER_SCHEMA_VERSION
+from .model_autoresearch_output_evidence_bundle import (
+    ModelAutoResearchOutputEvidenceRecord,
+    rehydrate_model_autoresearch_output_evidence_record,
+)
+from .model_combination_benchmark_harness import (
+    ModelBenchmarkCandidate,
+    ModelBenchmarkTask,
+    ModelBenchmarkTaskOutput,
+    ModelBenchmarkVerifierResult,
+)
+from .model_intelligence_outcomes import VerifierDecision
+
+
+MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER_SCHEMA = (
+    "model_autoresearch_output_evidence_semantic_verifier.v1"
+)
+REQUIRED_TERMS_METADATA_KEY = "expected_answer_contains"
+FORBIDDEN_TERMS_METADATA_KEY = "expected_answer_excludes"
+
+OutputEvidenceRecords = (
+    Sequence[ModelAutoResearchOutputEvidenceRecord | Mapping[str, object]]
+    | Callable[[], Sequence[ModelAutoResearchOutputEvidenceRecord | Mapping[str, object]]]
+)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchSemanticVerifierPolicy:
+    """Task-metadata keys that define deterministic semantic expectations."""
+
+    required_terms_metadata_key: str = REQUIRED_TERMS_METADATA_KEY
+    forbidden_terms_metadata_key: str = FORBIDDEN_TERMS_METADATA_KEY
+    schema_version: str = MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER_SCHEMA
+
+    def normalized(self) -> "ModelAutoResearchSemanticVerifierPolicy":
+        return ModelAutoResearchSemanticVerifierPolicy(
+            required_terms_metadata_key=_clean_token(self.required_terms_metadata_key),
+            forbidden_terms_metadata_key=_clean_token(self.forbidden_terms_metadata_key),
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        policy = self.normalized()
+        return {
+            "schema_version": policy.schema_version,
+            "required_terms_metadata_key": policy.required_terms_metadata_key,
+            "forbidden_terms_metadata_key": policy.forbidden_terms_metadata_key,
+        }
+
+
+def build_model_autoresearch_output_evidence_semantic_verifier(
+    *,
+    evidence_records: OutputEvidenceRecords,
+    policy: ModelAutoResearchSemanticVerifierPolicy | None = None,
+):
+    """Return a benchmark verifier over configured-gateway output evidence."""
+
+    normalized_policy = (policy or ModelAutoResearchSemanticVerifierPolicy()).normalized()
+    policy_digest = _digest_prefixed("model_autoresearch_semantic_verifier_policy", normalized_policy.to_dict())
+
+    def _verifier(
+        task: ModelBenchmarkTask,
+        candidate: ModelBenchmarkCandidate,
+        output: ModelBenchmarkTaskOutput,
+    ) -> ModelBenchmarkVerifierResult:
+        try:
+            normalized_task = task.normalized()
+            normalized_output = output.normalized()
+            records = _records(evidence_records)
+            relevant_records = _records_for_sample(
+                records=records,
+                task=normalized_task,
+                candidate=candidate,
+            )
+            required_terms = _terms(
+                normalized_task.metadata.get(normalized_policy.required_terms_metadata_key, "")
+            )
+            forbidden_terms = _terms(
+                normalized_task.metadata.get(normalized_policy.forbidden_terms_metadata_key, "")
+            )
+            reasons: list[str] = []
+            if not required_terms:
+                reasons.append("semantic_verifier_required_terms_missing")
+            if len(relevant_records) != len(candidate.role_assignments):
+                reasons.append("semantic_verifier_evidence_record_count_mismatch")
+            role_reasons = _role_binding_rejections(candidate, relevant_records)
+            reasons.extend(role_reasons)
+            if relevant_records and not role_reasons:
+                reasons.extend(
+                    _runner_digest_rejections(
+                        task=normalized_task,
+                        candidate=candidate,
+                        output=normalized_output,
+                        records=relevant_records,
+                    )
+                )
+            text = "\n".join(record.response_text for record in relevant_records).lower()
+            for term in required_terms:
+                if term.lower() not in text:
+                    reasons.append(f"semantic_verifier_required_term_missing:{_clean_reason(term)}")
+            for term in forbidden_terms:
+                if term.lower() in text:
+                    reasons.append(f"semantic_verifier_forbidden_term_present:{_clean_reason(term)}")
+            reasons = _dedupe(reasons)
+            accepted = not reasons
+            return ModelBenchmarkVerifierResult(
+                decision=VerifierDecision.ACCEPT if accepted else VerifierDecision.REJECT,
+                verifier_receipt_id=_verifier_receipt_id(
+                    task=normalized_task,
+                    candidate=candidate,
+                    output=normalized_output,
+                    records=relevant_records,
+                    required_terms=required_terms,
+                    forbidden_terms=forbidden_terms,
+                    policy_digest=policy_digest,
+                    accepted=accepted,
+                    rejection_reasons=reasons,
+                ),
+                evidence_correct=accepted,
+                rejection_reasons=tuple(reasons),
+            )
+        except Exception as exc:
+            reason = f"semantic_verifier_error:{type(exc).__name__}"
+            return ModelBenchmarkVerifierResult(
+                decision=VerifierDecision.ERROR,
+                verifier_receipt_id=_digest_prefixed(
+                    "model_autoresearch_semantic_verifier_error",
+                    {
+                        "task_id": getattr(task, "task_id", ""),
+                        "candidate_id": getattr(candidate, "candidate_id", ""),
+                        "output_digest": getattr(output, "output_digest", ""),
+                        "reason": reason,
+                        "policy_digest": policy_digest,
+                    },
+                ),
+                evidence_correct=False,
+                rejection_reasons=(reason,),
+            )
+
+    return _verifier
+
+
+def _records(source: OutputEvidenceRecords) -> tuple[ModelAutoResearchOutputEvidenceRecord, ...]:
+    raw = source() if callable(source) else source
+    records = tuple(
+        item
+        if isinstance(item, ModelAutoResearchOutputEvidenceRecord)
+        else rehydrate_model_autoresearch_output_evidence_record(item)
+        for item in raw
+    )
+    record_ids = [record.record_id for record in records]
+    if len(set(record_ids)) != len(record_ids):
+        raise ValueError("duplicate_output_evidence_records")
+    return records
+
+
+def _records_for_sample(
+    *,
+    records: Sequence[ModelAutoResearchOutputEvidenceRecord],
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+) -> tuple[ModelAutoResearchOutputEvidenceRecord, ...]:
+    matching = [
+        record
+        for record in records
+        if record.task_id == task.task_id
+        and record.prompt_digest == task.prompt_digest
+        and record.candidate_id == candidate.candidate_id
+        and record.candidate_topology_digest == candidate.topology_digest
+    ]
+    by_role = {record.role: record for record in matching}
+    ordered: list[ModelAutoResearchOutputEvidenceRecord] = []
+    for assignment in candidate.role_assignments:
+        record = by_role.get(assignment.role)
+        if record is not None:
+            ordered.append(record)
+    return tuple(ordered)
+
+
+def _role_binding_rejections(
+    candidate: ModelBenchmarkCandidate,
+    records: Sequence[ModelAutoResearchOutputEvidenceRecord],
+) -> list[str]:
+    reasons: list[str] = []
+    by_role = {record.role: record for record in records}
+    if len(by_role) != len(records):
+        reasons.append("semantic_verifier_duplicate_role_evidence")
+    for assignment in candidate.role_assignments:
+        record = by_role.get(assignment.role)
+        if record is None:
+            reasons.append(f"semantic_verifier_role_evidence_missing:{_clean_reason(assignment.role)}")
+            continue
+        if record.provider != assignment.provider:
+            reasons.append(f"semantic_verifier_provider_mismatch:{_clean_reason(assignment.role)}")
+        expected_model = _model_name_for_provider(assignment.model_id, assignment.provider)
+        if record.model != expected_model:
+            reasons.append(f"semantic_verifier_model_mismatch:{_clean_reason(assignment.role)}")
+    return reasons
+
+
+def _runner_digest_rejections(
+    *,
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+    output: ModelBenchmarkTaskOutput,
+    records: Sequence[ModelAutoResearchOutputEvidenceRecord],
+) -> list[str]:
+    policy_digests = {record.policy_digest for record in records}
+    if len(policy_digests) != 1:
+        return ["semantic_verifier_policy_digest_mismatch"]
+    runner_body = {
+        "schema_version": CONFIGURED_GATEWAY_RUNNER_SCHEMA_VERSION,
+        "task_id": task.task_id,
+        "prompt_digest": task.prompt_digest,
+        "candidate_id": candidate.candidate_id,
+        "candidate_topology_digest": candidate.topology_digest,
+        "policy_digest": next(iter(policy_digests)),
+        "calls": [
+            {
+                "role": record.role,
+                "provider": record.provider,
+                "model": record.model,
+                "response_digest": record.response_digest,
+                "latency_ms": record.latency_ms,
+                "input_tokens": record.input_tokens,
+                "output_tokens": record.output_tokens,
+                "cost_estimate_usd": record.cost_estimate_usd,
+                "output_evidence_record_id": record.record_id,
+            }
+            for record in records
+        ],
+    }
+    expected_output = _digest_prefixed("configured_gateway_benchmark_output", runner_body)
+    expected_runner = _digest_prefixed("configured_gateway_benchmark_runner", runner_body)
+    reasons: list[str] = []
+    if not hmac.compare_digest(output.output_digest, expected_output):
+        reasons.append("semantic_verifier_output_digest_mismatch")
+    if not hmac.compare_digest(output.runner_receipt_id, expected_runner):
+        reasons.append("semantic_verifier_runner_receipt_mismatch")
+    return reasons
+
+
+def _verifier_receipt_id(
+    *,
+    task: ModelBenchmarkTask,
+    candidate: ModelBenchmarkCandidate,
+    output: ModelBenchmarkTaskOutput,
+    records: Sequence[ModelAutoResearchOutputEvidenceRecord],
+    required_terms: Sequence[str],
+    forbidden_terms: Sequence[str],
+    policy_digest: str,
+    accepted: bool,
+    rejection_reasons: Sequence[str],
+) -> str:
+    return _digest_prefixed(
+        "model_autoresearch_semantic_verifier",
+        {
+            "schema_version": MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER_SCHEMA,
+            "task_id": task.task_id,
+            "candidate_id": candidate.candidate_id,
+            "output_digest": output.output_digest,
+            "runner_receipt_id": output.runner_receipt_id,
+            "evidence_record_ids": [record.record_id for record in records],
+            "required_terms": list(required_terms),
+            "forbidden_terms": list(forbidden_terms),
+            "policy_digest": policy_digest,
+            "accepted": accepted,
+            "rejection_reasons": list(rejection_reasons),
+        },
+    )
+
+
+def _terms(value: object) -> tuple[str, ...]:
+    raw = str(value or "").strip()
+    if not raw:
+        return ()
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+        except Exception as exc:
+            raise ValueError("invalid_semantic_verifier_terms") from exc
+        if not isinstance(parsed, list):
+            raise ValueError("invalid_semantic_verifier_terms")
+        values = [str(item).strip() for item in parsed]
+    else:
+        values = [item.strip() for item in raw.replace("\n", ";").replace(",", ";").split(";")]
+    return tuple(dict.fromkeys(item for item in values if item))
+
+
+def _model_name_for_provider(model_id: str, provider: str) -> str:
+    raw = _required("model_id", model_id)
+    prefix = f"{provider}/"
+    if raw.startswith(prefix):
+        raw = raw[len(prefix) :]
+    return _required("model", raw)
+
+
+def _digest_prefixed(prefix: str, value: Mapping[str, object]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _required(name: str, value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"missing_{name}")
+    return text
+
+
+def _clean_token(value: object) -> str:
+    text = _required("token", value)
+    return "".join(ch if ch.isalnum() or ch in {"_", "-", ".", "/"} else "_" for ch in text)
+
+
+def _clean_reason(value: object) -> str:
+    text = str(value or "").strip().lower()
+    cleaned = "".join(ch if ch.isalnum() or ch in {"_", "-", ".", "/"} else "_" for ch in text)
+    return cleaned[:64] or "unknown"
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value)))
+
+
+__all__ = [
+    "FORBIDDEN_TERMS_METADATA_KEY",
+    "MODEL_AUTORESEARCH_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER_SCHEMA",
+    "ModelAutoResearchSemanticVerifierPolicy",
+    "REQUIRED_TERMS_METADATA_KEY",
+    "build_model_autoresearch_output_evidence_semantic_verifier",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py
@@ -27,12 +27,14 @@ from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_executio
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_APPLIED,
     MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_BOOTSTRAP_NOT_READY,
     MODEL_AUTORESEARCH_CAMPAIGN_EXACT_OUTPUT_DIGEST_VERIFIER,
+    MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
     run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap,
 )
 from modules.ai_intelligence.ai_gateway.src.model_champion_challenger_autoresearch import (
     ModelAutoResearchPolicy,
     plan_model_champion_challenger_autoresearch,
 )
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import VerifierDecision
 from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
     REPO_ROOT,
     _plan,
@@ -172,6 +174,15 @@ def _configured_inputs(tmp_path: Path) -> tuple[dict[str, Path], FakeGateway]:
     )
 
 
+def _configured_semantic_inputs(tmp_path: Path) -> tuple[dict[str, Path], FakeGateway]:
+    files, gateway = _configured_inputs(tmp_path)
+    tasks_payload = json.loads(files["tasks"].read_text(encoding="utf-8"))
+    tasks_payload["tasks"][0]["expected_output_digest"] = "sha256:not-used-by-semantic-verifier"
+    tasks_payload["tasks"][0]["metadata"] = {"expected_answer_contains": "configured;gateway;answer"}
+    files["tasks"].write_text(json.dumps(tasks_payload, sort_keys=True), encoding="utf-8")
+    return files, gateway
+
+
 def test_campaign_execution_bootstrap_materializes_rehydratable_receipt(tmp_path: Path) -> None:
     files = _inputs(tmp_path)
 
@@ -240,6 +251,75 @@ def test_campaign_execution_bootstrap_configured_gateway_mode_materializes_recei
     assert len(evidence_records) == 1
     assert evidence_records[0].response_text == "configured gateway answer"
     assert evidence_records[0].task_id == receipt.benchmark_run_receipt.samples[0].task_id
+
+
+def test_campaign_execution_bootstrap_configured_gateway_semantic_verifier_accepts(
+    tmp_path: Path,
+) -> None:
+    files, gateway = _configured_semantic_inputs(tmp_path)
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        prompt_records_path=files["prompts"],
+        output_evidence_path=files["evidence"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
+        runner_allowed_providers="provider",
+        runner_max_prompt_chars=2000,
+        runner_max_calls_per_sample=1,
+        runner_max_cost_estimate_usd_per_sample=1.0,
+        gateway=gateway,
+    )
+
+    assert result.accepted is True
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
+    sample = receipt.benchmark_run_receipt.samples[0]
+    assert sample.accepted is True
+    assert sample.verifier_receipt_id
+    assert sample.verifier_receipt_id.startswith("model_autoresearch_semantic_verifier:")
+
+
+def test_campaign_execution_bootstrap_configured_gateway_semantic_verifier_rejects(
+    tmp_path: Path,
+) -> None:
+    files, gateway = _configured_semantic_inputs(tmp_path)
+    tasks_payload = json.loads(files["tasks"].read_text(encoding="utf-8"))
+    tasks_payload["tasks"][0]["metadata"] = {"expected_answer_contains": "missing-term"}
+    files["tasks"].write_text(json.dumps(tasks_payload, sort_keys=True), encoding="utf-8")
+
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        prompt_records_path=files["prompts"],
+        output_evidence_path=files["evidence"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
+        runner_allowed_providers="provider",
+        runner_max_prompt_chars=2000,
+        runner_max_calls_per_sample=1,
+        runner_max_cost_estimate_usd_per_sample=1.0,
+        gateway=gateway,
+    )
+
+    assert result.accepted is True
+    payload = json.loads(files["output"].read_text(encoding="utf-8"))
+    receipt = rehydrate_model_autoresearch_campaign_execution_receipt(payload)
+    sample = receipt.benchmark_run_receipt.samples[0]
+    assert sample.accepted is False
+    assert sample.decision == VerifierDecision.REJECT
+    assert "semantic_verifier_required_term_missing:missing-term" in sample.rejection_reasons
 
 
 def test_campaign_execution_bootstrap_configured_gateway_requires_prompt_records(tmp_path: Path) -> None:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_semantic_verifier.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_semantic_verifier.py
@@ -1,0 +1,247 @@
+"""Tests for model AutoResearch output-evidence semantic verifier."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gateway_runner import (
+    ConfiguredGatewayRunnerPolicy,
+    GatewayModelCallResult,
+    MappingPromptSource,
+    build_configured_gateway_benchmark_runner,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_output_evidence_bundle import (
+    InMemoryModelAutoResearchOutputEvidenceStore,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_semantic_verifier import (
+    build_model_autoresearch_output_evidence_semantic_verifier,
+)
+from modules.ai_intelligence.ai_gateway.src.model_combination_benchmark_harness import (
+    ModelBenchmarkRoleAssignment,
+    ModelBenchmarkTask,
+    build_model_benchmark_candidate,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import VerifierDecision
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import (
+    REPO_ROOT,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_semantic_verifier.py"
+)
+
+
+def _digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _task(
+    *,
+    prompt: str = "Audit RedDog evidence handling.",
+    contains: str = "evidence;bounded",
+    excludes: str = "",
+) -> ModelBenchmarkTask:
+    metadata = {"expected_answer_contains": contains}
+    if excludes:
+        metadata["expected_answer_excludes"] = excludes
+    return ModelBenchmarkTask(
+        task_id="task-001",
+        task_family="architecture",
+        prompt_digest=_digest(prompt),
+        expected_output_digest="sha256:not-used-by-semantic-verifier",
+        verifier_contract_digest="sha256:semantic-verifier",
+        metadata=metadata,
+    )
+
+
+def _candidate(*roles: str):
+    assignments = tuple(
+        ModelBenchmarkRoleAssignment(
+            role=role,
+            model_id=f"provider/{role}-model",
+            provider="provider",
+        )
+        for role in (roles or ("principal",))
+    )
+    return build_model_benchmark_candidate(assignments)
+
+
+class FakeConfiguredCaller:
+    def __init__(self, responses: dict[str, str] | None = None) -> None:
+        self.responses = responses or {"principal": "bounded evidence answer"}
+
+    def call_model(self, *, provider: str, model: str, prompt: str, task_type: str) -> GatewayModelCallResult:
+        role = prompt.split("Role: ", 1)[1].splitlines()[0]
+        response = self.responses.get(role, self.responses.get("principal", "bounded evidence answer"))
+        return GatewayModelCallResult(
+            success=True,
+            provider=provider,
+            model=model,
+            response_text=response,
+            latency_ms=10,
+            input_tokens=5,
+            output_tokens=len(response.split()),
+            cost_estimate_usd=0.01,
+        )
+
+
+def _run_sample(
+    *,
+    task: ModelBenchmarkTask | None = None,
+    candidate=None,
+    responses: dict[str, str] | None = None,
+):
+    prompt = "Audit RedDog evidence handling."
+    task = task or _task(prompt=prompt)
+    candidate = candidate or _candidate()
+    store = InMemoryModelAutoResearchOutputEvidenceStore()
+    runner = build_configured_gateway_benchmark_runner(
+        caller=FakeConfiguredCaller(responses),
+        prompt_source=MappingPromptSource({task.task_id: prompt}),
+        policy=ConfiguredGatewayRunnerPolicy(
+            allowed_providers=("provider",),
+            max_calls_per_sample=4,
+            max_cost_estimate_usd_per_sample=1.0,
+        ),
+        output_evidence_store=store,
+    )
+    output = runner(task, candidate)
+    verifier = build_model_autoresearch_output_evidence_semantic_verifier(
+        evidence_records=store.records,
+    )
+    return task, candidate, output, store, verifier
+
+
+def test_semantic_verifier_accepts_rehydrated_output_evidence() -> None:
+    task, candidate, output, _store, verifier = _run_sample()
+
+    result = verifier(task, candidate, output)
+
+    assert result.decision == VerifierDecision.ACCEPT
+    assert result.evidence_correct is True
+    assert result.rejection_reasons == ()
+    assert result.verifier_receipt_id.startswith("model_autoresearch_semantic_verifier:")
+
+
+def test_semantic_verifier_rejects_missing_required_term() -> None:
+    task = _task(contains="evidence;missing-term")
+    task, candidate, output, _store, verifier = _run_sample(task=task)
+
+    result = verifier(task, candidate, output)
+
+    assert result.decision == VerifierDecision.REJECT
+    assert result.evidence_correct is False
+    assert "semantic_verifier_required_term_missing:missing-term" in result.rejection_reasons
+
+
+def test_semantic_verifier_rejects_forbidden_term() -> None:
+    task = _task(contains="evidence", excludes="unsafe")
+    task, candidate, output, _store, verifier = _run_sample(
+        task=task,
+        responses={"principal": "bounded evidence unsafe answer"},
+    )
+
+    result = verifier(task, candidate, output)
+
+    assert result.decision == VerifierDecision.REJECT
+    assert "semantic_verifier_forbidden_term_present:unsafe" in result.rejection_reasons
+
+
+def test_semantic_verifier_rejects_missing_task_requirements() -> None:
+    task = _task(contains="")
+    task, candidate, output, _store, verifier = _run_sample(task=task)
+
+    result = verifier(task, candidate, output)
+
+    assert result.decision == VerifierDecision.REJECT
+    assert "semantic_verifier_required_terms_missing" in result.rejection_reasons
+
+
+def test_semantic_verifier_rejects_missing_evidence_records() -> None:
+    task, candidate, output, _store, _verifier = _run_sample()
+    verifier = build_model_autoresearch_output_evidence_semantic_verifier(evidence_records=())
+
+    result = verifier(task, candidate, output)
+
+    assert result.decision == VerifierDecision.REJECT
+    assert "semantic_verifier_evidence_record_count_mismatch" in result.rejection_reasons
+    assert "semantic_verifier_role_evidence_missing:principal" in result.rejection_reasons
+
+
+def test_semantic_verifier_rejects_digest_only_output_without_evidence_id_binding() -> None:
+    prompt = "Audit RedDog evidence handling."
+    task = _task(prompt=prompt)
+    candidate = _candidate()
+    evidence_store = InMemoryModelAutoResearchOutputEvidenceStore()
+    evidence_output = build_configured_gateway_benchmark_runner(
+        caller=FakeConfiguredCaller(),
+        prompt_source=MappingPromptSource({task.task_id: prompt}),
+        policy=ConfiguredGatewayRunnerPolicy(allowed_providers=("provider",)),
+        output_evidence_store=evidence_store,
+    )(task, candidate)
+    digest_only_output = build_configured_gateway_benchmark_runner(
+        caller=FakeConfiguredCaller(),
+        prompt_source=MappingPromptSource({task.task_id: prompt}),
+        policy=ConfiguredGatewayRunnerPolicy(allowed_providers=("provider",)),
+    )(task, candidate)
+    assert evidence_output.output_digest != digest_only_output.output_digest
+    verifier = build_model_autoresearch_output_evidence_semantic_verifier(
+        evidence_records=evidence_store.records,
+    )
+
+    result = verifier(task, candidate, digest_only_output)
+
+    assert result.decision == VerifierDecision.REJECT
+    assert "semantic_verifier_output_digest_mismatch" in result.rejection_reasons
+    assert "semantic_verifier_runner_receipt_mismatch" in result.rejection_reasons
+
+
+def test_semantic_verifier_requires_each_panel_role_evidence() -> None:
+    candidate = _candidate("principal", "critic")
+    task, candidate, output, _store, verifier = _run_sample(
+        candidate=candidate,
+        responses={
+            "principal": "bounded evidence principal",
+            "critic": "bounded evidence critic",
+        },
+    )
+
+    result = verifier(task, candidate, output)
+
+    assert result.decision == VerifierDecision.ACCEPT
+    assert result.evidence_correct is True
+
+
+def test_semantic_verifier_module_has_no_network_command_runtime_or_holoindex_imports() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls
+
+    assert "extension.js" not in source


### PR DESCRIPTION
## Slice
MODEL_AUTORESEARCH_CONFIGURED_GATEWAY_SEMANTIC_VERIFIER_PHASE1

## WSP_97 Truth Boundary
- OBSERVED: #1234 added content-bearing configured-gateway output evidence; before that a semantic verifier would have had only digests.
- IMPLEMENTED: Added deterministic `output_evidence_semantic` verifier mode over rehydrated output evidence records.
- IMPLEMENTED: Verifier recomputes configured-runner output/receipt digests, requires role/provider/model evidence for each candidate role, and checks explicit task metadata `expected_answer_contains` / `expected_answer_excludes`.
- IMPLEMENTED: Missing evidence, missing requirements, forbidden terms, and digest-only outputs fail closed.
- SPECIFIED_NOT_IMPLEMENTED: free-form LLM verifier, model promotion, PatternMemory writes, HoloIndex re-indexing, runtime model binding, worker spawn, shell execution, source mutation, extension mutation.

## Validation
- `python -m py_compile modules/ai_intelligence/ai_gateway/src/model_autoresearch_semantic_verifier.py modules/ai_intelligence/ai_gateway/src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py main.py`
- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_semantic_verifier.py modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_campaign_execution_artifact_supply_bootstrap.py -q` -> 20 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 216 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 27 passed
- `git diff --check` -> clean
- Added lines ASCII-clean

## Sequence
Next slice after this lands: wire successful semantic-verifier benchmark runs into promotion-gate/cycle feedback policy, or build a richer independent verifier only after the deterministic evidence path is proven.