### PR TITLE
feat(ai-gateway): chain autoresearch cycle feedback admission

### DIFF
--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,41 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Chain Bootstrap
+
+**Who:** 0102 Codex
+**Type:** Runtime Evidence Chain
+**Slice:** MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_PHASE1
+
+**What:** Added an outside-repo bootstrap that chains existing model
+AutoResearch artifacts from campaign execution through promotion-gate supply,
+cycle receipt creation, and cycle feedback ledger admission.
+
+**Why:** The model AutoResearch loop now has content-bearing semantic
+verification, promotion-gate supply, and feedback admission primitives. This
+slice proves they can be composed as one configured runtime chain without
+manual artifact stitching.
+
+**Files:**
+- `src/model_autoresearch_cycle_feedback_chain_bootstrap.py` - orchestrates
+  promotion-gate supply, cycle receipt supply, and feedback ledger admission
+  from outside-repo runtime artifacts.
+- `tests/test_model_autoresearch_cycle_feedback_chain_bootstrap.py` - covers
+  semantic-accepted and semantic-rejected configured gateway campaigns,
+  inside-repo path rejection, malformed policy rejection, duplicate output
+  path rejection, and AST authority boundaries.
+
+**Truth Boundary:**
+- IMPLEMENTED: one configured post-execution chain from semantic campaign
+  output to feedback ledger admission.
+- NOT IMPLEMENTED: direct provider calls, benchmark execution, model
+  promotion, catalog mutation, PatternMemory writes, HoloIndex re-indexing,
+  runtime model binding, worker spawn, shell execution, source mutation, or
+  extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Semantic Verifier Promotion Chain Regression
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_chain_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_cycle_feedback_chain_bootstrap.py
@@ -1,0 +1,294 @@
+"""Configured runtime chain for model AutoResearch feedback admission.
+
+Slice: MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_PHASE1
+
+This adapter chains existing outside-repo artifacts:
+
+plan + campaign execution + promotion policies
+-> promotion-gate supply
+-> cycle receipt
+-> cycle feedback ledger admission
+
+It does not call providers, run benchmarks, promote models, mutate catalogs,
+write PatternMemory, re-index HoloIndex, bind runtime defaults, spawn workers,
+execute commands, or write inside the repository.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply import (
+    MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ACCEPT,
+    run_reddog_model_autoresearch_campaign_promotion_gate_supply,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_ledger_admission_bootstrap import (
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED,
+    run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_receipt_supply_bootstrap import (
+    MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED,
+    run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap,
+)
+
+
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED = (
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED"
+)
+MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY = (
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY"
+)
+
+
+@dataclass(frozen=True)
+class ModelAutoResearchCycleFeedbackChainBootstrapResult:
+    accepted: bool
+    status: str
+    promotion_gate_supply_receipt_id: Optional[str]
+    cycle_receipt_id: Optional[str]
+    feedback_admission_id: Optional[str]
+    feedback_record_id: Optional[str]
+    promotion_gate_output_path: Optional[str]
+    cycle_receipt_output_path: Optional[str]
+    feedback_ledger_output_path: Optional[str]
+    rejection_reasons: tuple[str, ...]
+    no_direct_provider_call_performed: bool = True
+    no_benchmark_run_performed: bool = True
+    no_model_promotion_performed: bool = True
+    no_catalog_mutation_performed: bool = True
+    no_pattern_memory_write_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_runtime_binding_performed: bool = True
+    no_command_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_worker_spawn_performed: bool = True
+    no_extension_mutation_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+    *,
+    repo_root: Path | str,
+    plan_receipt_path: Path | str | None,
+    campaign_execution_receipt_path: Path | str | None,
+    promotion_policies_path: Path | str | None,
+    promotion_gate_output_path: Path | str | None,
+    cycle_receipt_output_path: Path | str | None,
+    feedback_ledger_output_path: Path | str | None,
+    promotion_authority_receipt_id: str | None = None,
+    signed_promotion_receipt_id: str | None = None,
+) -> ModelAutoResearchCycleFeedbackChainBootstrapResult:
+    """Run the post-execution AutoResearch feedback chain."""
+
+    root = Path(repo_root).resolve()
+    plan_payload, plan_reasons = _read_json_outside_repo(
+        root,
+        plan_receipt_path,
+        missing_reason="missing_model_autoresearch_chain_plan_receipt_path",
+        inside_reason="model_autoresearch_chain_plan_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_chain_plan_receipt",
+    )
+    execution_payload, execution_reasons = _read_json_outside_repo(
+        root,
+        campaign_execution_receipt_path,
+        missing_reason="missing_model_autoresearch_chain_execution_receipt_path",
+        inside_reason="model_autoresearch_chain_execution_receipt_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_chain_execution_receipt",
+    )
+    policies_payload, policy_reasons = _read_json_outside_repo(
+        root,
+        promotion_policies_path,
+        missing_reason="missing_model_autoresearch_chain_promotion_policies_path",
+        inside_reason="model_autoresearch_chain_promotion_policies_path_inside_repo",
+        malformed_reason="malformed_model_autoresearch_chain_promotion_policies",
+    )
+    reasons = [
+        *plan_reasons,
+        *execution_reasons,
+        *policy_reasons,
+        *_output_path_reasons(root, promotion_gate_output_path, "model_autoresearch_chain_promotion_gate_output_path_invalid"),
+        *_output_path_reasons(root, cycle_receipt_output_path, "model_autoresearch_chain_cycle_receipt_output_path_invalid"),
+        *_output_path_reasons(root, feedback_ledger_output_path, "model_autoresearch_chain_feedback_ledger_output_path_invalid"),
+    ]
+    output_paths = _resolved_output_paths(
+        root,
+        promotion_gate_output_path,
+        cycle_receipt_output_path,
+        feedback_ledger_output_path,
+    )
+    if output_paths is not None and len(set(output_paths)) != len(output_paths):
+        reasons.append("model_autoresearch_chain_output_paths_must_be_distinct")
+    policies = _promotion_policy_list(policies_payload)
+    if policies_payload is not None and policies is None:
+        reasons.append("malformed_model_autoresearch_chain_promotion_policies")
+    if plan_payload is not None and not isinstance(plan_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_chain_plan_receipt")
+    if execution_payload is not None and not isinstance(execution_payload, Mapping):
+        reasons.append("malformed_model_autoresearch_chain_execution_receipt")
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _not_ready(deduped)
+
+    assert isinstance(plan_payload, Mapping)
+    assert isinstance(execution_payload, Mapping)
+    assert policies is not None
+    assert output_paths is not None
+    gate_output, cycle_output, feedback_output = output_paths
+
+    gate = run_reddog_model_autoresearch_campaign_promotion_gate_supply(
+        repo_root=root,
+        campaign_execution_receipt=execution_payload,
+        promotion_policies=policies,
+        output_path=gate_output,
+        promotion_authority_receipt_id=promotion_authority_receipt_id,
+        signed_promotion_receipt_id=signed_promotion_receipt_id,
+    )
+    if gate.status != MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ACCEPT:
+        return _not_ready(gate.rejection_reasons or ("model_autoresearch_chain_promotion_gate_rejected",))
+
+    cycle = run_reddog_model_autoresearch_cycle_receipt_supply_bootstrap(
+        repo_root=root,
+        plan_receipt_path=plan_receipt_path,
+        campaign_execution_receipt_path=campaign_execution_receipt_path,
+        promotion_gate_supply_receipt_path=gate_output,
+        output_path=cycle_output,
+    )
+    if cycle.status != MODEL_AUTORESEARCH_CYCLE_RECEIPT_BOOTSTRAP_APPLIED:
+        return _not_ready(cycle.rejection_reasons or ("model_autoresearch_chain_cycle_receipt_rejected",))
+
+    feedback = run_reddog_model_autoresearch_cycle_feedback_ledger_admission_bootstrap(
+        repo_root=root,
+        plan_receipt_path=plan_receipt_path,
+        cycle_receipt_path=cycle_output,
+        output_path=feedback_output,
+    )
+    if feedback.status != MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_BOOTSTRAP_APPLIED:
+        return _not_ready(feedback.rejection_reasons or ("model_autoresearch_chain_feedback_admission_rejected",))
+
+    return ModelAutoResearchCycleFeedbackChainBootstrapResult(
+        accepted=True,
+        status=MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED,
+        promotion_gate_supply_receipt_id=gate.supply_receipt_id,
+        cycle_receipt_id=cycle.cycle_receipt_id,
+        feedback_admission_id=feedback.admission_id,
+        feedback_record_id=feedback.feedback_record_id,
+        promotion_gate_output_path=str(gate_output),
+        cycle_receipt_output_path=str(cycle_output),
+        feedback_ledger_output_path=str(feedback_output),
+        rejection_reasons=(),
+    )
+
+
+def _read_json_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    *,
+    missing_reason: str,
+    inside_reason: str,
+    malformed_reason: str,
+) -> tuple[Any | None, tuple[str, ...]]:
+    if not value:
+        return None, (missing_reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (inside_reason,)
+    if not resolved.exists() or not resolved.is_file():
+        return None, (missing_reason,)
+    try:
+        payload = json.loads(resolved.read_text(encoding="utf-8"))
+    except Exception:
+        return None, (malformed_reason,)
+    if not isinstance(payload, (Mapping, list)):
+        return None, (malformed_reason,)
+    return payload, ()
+
+
+def _promotion_policy_list(payload: Any | None) -> list[Mapping[str, Any]] | None:
+    if payload is None:
+        return None
+    if isinstance(payload, list) and all(isinstance(item, Mapping) for item in payload):
+        return list(payload)
+    if isinstance(payload, Mapping):
+        values = payload.get("promotion_policies")
+        if isinstance(values, list) and all(isinstance(item, Mapping) for item in values):
+            return list(values)
+    return None
+
+
+def _output_path_reasons(repo_root: Path, value: Path | str | None, reason: str) -> tuple[str, ...]:
+    resolved = _resolve_output_path(repo_root, value)
+    if resolved is None or _is_inside(resolved, repo_root):
+        return (reason,)
+    return ()
+
+
+def _resolved_output_paths(
+    repo_root: Path,
+    promotion_gate_output_path: Path | str | None,
+    cycle_receipt_output_path: Path | str | None,
+    feedback_ledger_output_path: Path | str | None,
+) -> tuple[Path, Path, Path] | None:
+    paths = (
+        _resolve_output_path(repo_root, promotion_gate_output_path),
+        _resolve_output_path(repo_root, cycle_receipt_output_path),
+        _resolve_output_path(repo_root, feedback_ledger_output_path),
+    )
+    if any(path is None for path in paths):
+        return None
+    gate, cycle, feedback = paths
+    assert gate is not None
+    assert cycle is not None
+    assert feedback is not None
+    return gate, cycle, feedback
+
+
+def _resolve_output_path(repo_root: Path, value: Path | str | None) -> Path | None:
+    if not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        path = repo_root.parent / path
+    return path.resolve()
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _not_ready(
+    reasons: Sequence[str],
+) -> ModelAutoResearchCycleFeedbackChainBootstrapResult:
+    return ModelAutoResearchCycleFeedbackChainBootstrapResult(
+        accepted=False,
+        status=MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY,
+        promotion_gate_supply_receipt_id=None,
+        cycle_receipt_id=None,
+        feedback_admission_id=None,
+        feedback_record_id=None,
+        promotion_gate_output_path=None,
+        cycle_receipt_output_path=None,
+        feedback_ledger_output_path=None,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value or "").strip()))
+
+
+__all__ = [
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED",
+    "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY",
+    "ModelAutoResearchCycleFeedbackChainBootstrapResult",
+    "run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_chain_bootstrap.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_chain_bootstrap.py
@@ -1,0 +1,240 @@
+"""Tests for MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_execution_artifact_supply_bootstrap import (
+    MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+    MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
+    run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_campaign_promotion_gate_supply import (
+    rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_chain_bootstrap import (
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED,
+    MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY,
+    run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap,
+)
+from modules.ai_intelligence.ai_gateway.src.model_promotion_gate import ModelPromotionGateDecision
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution import REPO_ROOT
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_execution_artifact_supply_bootstrap import (
+    _configured_semantic_inputs,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_autoresearch_campaign_promotion_gate_supply import (
+    _policies,
+)
+
+
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "ai_intelligence"
+    / "ai_gateway"
+    / "src"
+    / "model_autoresearch_cycle_feedback_chain_bootstrap.py"
+)
+
+
+def _write_json(root: Path, name: str, payload: object) -> Path:
+    path = root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _semantic_execution_files(tmp_path: Path, *, required_term: str = "configured;gateway;answer") -> dict[str, Path]:
+    files, gateway = _configured_semantic_inputs(tmp_path)
+    tasks_payload = json.loads(files["tasks"].read_text(encoding="utf-8"))
+    tasks_payload["tasks"][0]["metadata"] = {"expected_answer_contains": required_term}
+    files["tasks"].write_text(json.dumps(tasks_payload, sort_keys=True), encoding="utf-8")
+    result = run_reddog_model_autoresearch_campaign_execution_artifact_supply_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        candidate_pool_path=files["candidates"],
+        tasks_path=files["tasks"],
+        prompt_records_path=files["prompts"],
+        output_evidence_path=files["evidence"],
+        output_path=files["output"],
+        verifier_digest="sha256:verifier",
+        held_out_split_id="heldout-v1",
+        runner_mode=MODEL_AUTORESEARCH_CAMPAIGN_CONFIGURED_GATEWAY_RUNNER,
+        verifier_mode=MODEL_AUTORESEARCH_CAMPAIGN_OUTPUT_EVIDENCE_SEMANTIC_VERIFIER,
+        runner_allowed_providers="provider",
+        runner_max_prompt_chars=2000,
+        runner_max_calls_per_sample=1,
+        runner_max_cost_estimate_usd_per_sample=1.0,
+        gateway=gateway,
+    )
+    assert result.accepted is True
+    execution = json.loads(files["output"].read_text(encoding="utf-8"))
+    files["policies"] = _write_json(
+        tmp_path / "runtime",
+        "promotion_policies.json",
+        {"promotion_policies": list(_policies(execution, min_pass_rate=1.0, min_sample_count=1))},
+    )
+    files["gate_output"] = tmp_path / "runtime" / "promotion_gates.json"
+    files["cycle_output"] = tmp_path / "runtime" / "cycle_receipt.json"
+    files["feedback_output"] = tmp_path / "runtime" / "feedback.jsonl"
+    return files
+
+
+def test_cycle_feedback_chain_admits_semantic_verified_campaign(tmp_path: Path) -> None:
+    files = _semantic_execution_files(tmp_path)
+
+    result = run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=files["output"],
+        promotion_policies_path=files["policies"],
+        promotion_gate_output_path=files["gate_output"],
+        cycle_receipt_output_path=files["cycle_output"],
+        feedback_ledger_output_path=files["feedback_output"],
+        promotion_authority_receipt_id="authority:semantic",
+        signed_promotion_receipt_id="signed:semantic",
+    )
+
+    assert result.accepted is True
+    assert result.status == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED
+    assert result.promotion_gate_supply_receipt_id
+    assert result.cycle_receipt_id
+    assert result.feedback_admission_id
+    assert result.feedback_record_id
+    assert result.no_model_promotion_performed is True
+    assert result.no_pattern_memory_write_performed is True
+    assert result.no_holoindex_reindex_performed is True
+
+    gate = rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt(
+        json.loads(files["gate_output"].read_text(encoding="utf-8"))
+    )
+    assert gate.promotion_gate_receipts[0].decision == ModelPromotionGateDecision.PROMOTE_CHAMPION
+
+    records = [json.loads(line) for line in files["feedback_output"].read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 1
+    assert records[0]["cycle_receipt_id"] == result.cycle_receipt_id
+    assert records[0]["source_plan_context_bound"] is True
+
+
+def test_cycle_feedback_chain_admits_verified_negative_outcome_without_promotion(tmp_path: Path) -> None:
+    files = _semantic_execution_files(tmp_path, required_term="missing-term")
+
+    result = run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=files["output"],
+        promotion_policies_path=files["policies"],
+        promotion_gate_output_path=files["gate_output"],
+        cycle_receipt_output_path=files["cycle_output"],
+        feedback_ledger_output_path=files["feedback_output"],
+        promotion_authority_receipt_id="authority:semantic",
+        signed_promotion_receipt_id="signed:semantic",
+    )
+
+    assert result.accepted is True
+    gate = rehydrate_model_autoresearch_campaign_promotion_gate_supply_receipt(
+        json.loads(files["gate_output"].read_text(encoding="utf-8"))
+    )
+    assert gate.promotion_gate_receipts[0].decision == ModelPromotionGateDecision.KEEP_CHALLENGER
+    assert gate.promotion_gate_receipts[0].promotion_evidence_receipt is None
+    records = [json.loads(line) for line in files["feedback_output"].read_text(encoding="utf-8").splitlines()]
+    assert records[0]["cycle_receipt_id"] == result.cycle_receipt_id
+
+
+def test_cycle_feedback_chain_rejects_inside_repo_inputs_and_outputs(tmp_path: Path) -> None:
+    files = _semantic_execution_files(tmp_path)
+    repo_plan = REPO_ROOT / "model_autoresearch_plan_receipt.json"
+    repo_output = REPO_ROOT / "model_autoresearch_feedback.jsonl"
+    repo_plan.write_text("{}", encoding="utf-8")
+    try:
+        result = run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+            repo_root=REPO_ROOT,
+            plan_receipt_path=repo_plan,
+            campaign_execution_receipt_path=files["output"],
+            promotion_policies_path=files["policies"],
+            promotion_gate_output_path=repo_output,
+            cycle_receipt_output_path=files["cycle_output"],
+            feedback_ledger_output_path=files["feedback_output"],
+            promotion_authority_receipt_id="authority:semantic",
+            signed_promotion_receipt_id="signed:semantic",
+        )
+    finally:
+        repo_plan.unlink(missing_ok=True)
+        repo_output.unlink(missing_ok=True)
+
+    assert result.accepted is False
+    assert result.status == MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY
+    assert "model_autoresearch_chain_plan_receipt_path_inside_repo" in result.rejection_reasons
+    assert "model_autoresearch_chain_promotion_gate_output_path_invalid" in result.rejection_reasons
+    assert not files["cycle_output"].exists()
+    assert not files["feedback_output"].exists()
+
+
+def test_cycle_feedback_chain_rejects_malformed_policy_payload(tmp_path: Path) -> None:
+    files = _semantic_execution_files(tmp_path)
+    bad_policies = _write_json(tmp_path / "runtime", "bad_policies.json", {"promotion_policies": ["bad"]})
+
+    result = run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=files["output"],
+        promotion_policies_path=bad_policies,
+        promotion_gate_output_path=files["gate_output"],
+        cycle_receipt_output_path=files["cycle_output"],
+        feedback_ledger_output_path=files["feedback_output"],
+        promotion_authority_receipt_id="authority:semantic",
+        signed_promotion_receipt_id="signed:semantic",
+    )
+
+    assert result.accepted is False
+    assert "malformed_model_autoresearch_chain_promotion_policies" in result.rejection_reasons
+    assert not files["gate_output"].exists()
+    assert not files["cycle_output"].exists()
+    assert not files["feedback_output"].exists()
+
+
+def test_cycle_feedback_chain_rejects_duplicate_output_paths(tmp_path: Path) -> None:
+    files = _semantic_execution_files(tmp_path)
+
+    result = run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+        repo_root=REPO_ROOT,
+        plan_receipt_path=files["plan"],
+        campaign_execution_receipt_path=files["output"],
+        promotion_policies_path=files["policies"],
+        promotion_gate_output_path=files["gate_output"],
+        cycle_receipt_output_path=files["gate_output"],
+        feedback_ledger_output_path=files["feedback_output"],
+        promotion_authority_receipt_id="authority:semantic",
+        signed_promotion_receipt_id="signed:semantic",
+    )
+
+    assert result.accepted is False
+    assert "model_autoresearch_chain_output_paths_must_be_distinct" in result.rejection_reasons
+    assert not files["gate_output"].exists()
+    assert not files["feedback_output"].exists()
+
+
+def test_cycle_feedback_chain_module_has_no_provider_network_command_runtime_or_holoindex_imports() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "socket",
+        "openai",
+        "holo_index",
+        "pattern_memory",
+        "git",
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            assert node.func.id not in banned_calls


### PR DESCRIPTION
## Summary

Implements `MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_PHASE1`.

This adds a configured post-execution bootstrap that chains existing model AutoResearch artifacts:

```text
plan + campaign execution + promotion policies
-> promotion-gate supply
-> cycle receipt
-> cycle feedback ledger admission
```

The slice composes existing verified primitives rather than adding new authority.

## Scope

- Adds `model_autoresearch_cycle_feedback_chain_bootstrap.py`.
- Adds focused chain tests for semantic-accepted and semantic-rejected configured gateway campaigns.
- Updates `modules/ai_intelligence/ai_gateway/ModLog.md`.

## Truth Boundary

Implemented:
- Outside-repo configured chain from semantic campaign output to feedback ledger admission.
- Positive semantic outcome can produce champion gate receipt and feedback record.
- Negative semantic outcome remains feedback-admissible but does not promote a model.
- Inside-repo paths, malformed policies, duplicate output paths, and authority-expanding imports fail closed.

Not implemented:
- Direct provider calls.
- Benchmark execution.
- Model promotion or catalog mutation.
- PatternMemory writes.
- HoloIndex re-indexing.
- Runtime model binding.
- Worker spawn, shell execution, source mutation, or extension mutation.

## Validation

- `python -m pytest modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_cycle_feedback_chain_bootstrap.py -q` -> 6 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 224 passed
- `git diff --check` -> clean, only CRLF warning on working copy
- new files ASCII/NUL check -> 0 non-ASCII / 0 NUL