### PR TITLE
feat(ai-gateway): expose autoresearch feedback chain preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -1607,6 +1607,8 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY=0 Execute campaign fixture or configured gateway
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=0 Block startup if rejected
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN=0 Run gate->cycle->feedback chain
+        REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_ENFORCED=0 Block startup if chain rejected
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY=0 Materialize campaign promotion-gate receipts
         REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY_ENFORCED=0 Block startup if rejected
         REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY=0 Materialize campaign cycle receipt
@@ -2042,6 +2044,82 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             print(
                 "[REDDOG-MODEL-AUTORESEARCH-CAMPAIGN] Startup blocked by "
                 "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY_ENFORCED=1"
+            )
+            return False
+
+    autoresearch_chain_requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN",
+    )
+    autoresearch_chain_enforced = (
+        os.getenv("REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_ENFORCED", "0") != "0"
+    )
+    if autoresearch_chain_requested:
+        try:
+            from modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_chain_bootstrap import (
+                run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap,
+            )
+
+            autoresearch_chain = run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap(
+                repo_root=repo_root,
+                plan_receipt_path=model_autoresearch_plan_receipt_path,
+                campaign_execution_receipt_path=model_autoresearch_campaign_execution_receipt_path,
+                promotion_policies_path=model_autoresearch_campaign_promotion_policies_path or None,
+                promotion_gate_output_path=model_autoresearch_promotion_gate_receipts_path,
+                cycle_receipt_output_path=model_autoresearch_cycle_receipt_path,
+                feedback_ledger_output_path=model_autoresearch_cycle_feedback_ledger_path,
+                promotion_authority_receipt_id=os.getenv(
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID",
+                    "",
+                )
+                or None,
+                signed_promotion_receipt_id=os.getenv(
+                    "REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID",
+                    "",
+                )
+                or None,
+            )
+        except Exception as exc:
+            logger.error(f"[REDDOG-MODEL-AUTORESEARCH-CHAIN] Startup chain failed: {exc}")
+            if autoresearch_chain_enforced:
+                print(f"[REDDOG-MODEL-AUTORESEARCH-CHAIN] preflight=FAIL error={type(exc).__name__}")
+                return False
+            print(f"[REDDOG-MODEL-AUTORESEARCH-CHAIN] preflight=WARN error={type(exc).__name__}")
+            return True
+
+        chain_status = "PASS" if autoresearch_chain.accepted else "WARN"
+        chain_reasons = (
+            ",".join(autoresearch_chain.rejection_reasons)
+            if autoresearch_chain.rejection_reasons
+            else "(none)"
+        )
+        print(
+            f"[REDDOG-MODEL-AUTORESEARCH-CHAIN] preflight={chain_status} "
+            f"status={autoresearch_chain.status} "
+            f"gate={autoresearch_chain.promotion_gate_supply_receipt_id or '(none)'} "
+            f"cycle={autoresearch_chain.cycle_receipt_id or '(none)'} "
+            f"admission={autoresearch_chain.feedback_admission_id or '(none)'} "
+            f"record={autoresearch_chain.feedback_record_id or '(none)'} "
+            f"reasons={chain_reasons}"
+        )
+        if autoresearch_chain.accepted:
+            if autoresearch_chain.promotion_gate_output_path:
+                model_autoresearch_promotion_gate_receipts_path = autoresearch_chain.promotion_gate_output_path
+                os.environ["REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH"] = (
+                    model_autoresearch_promotion_gate_receipts_path
+                )
+            if autoresearch_chain.cycle_receipt_output_path:
+                model_autoresearch_cycle_receipt_path = autoresearch_chain.cycle_receipt_output_path
+                os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH"] = model_autoresearch_cycle_receipt_path
+            if autoresearch_chain.feedback_ledger_output_path:
+                model_autoresearch_cycle_feedback_ledger_path = autoresearch_chain.feedback_ledger_output_path
+                os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH"] = (
+                    model_autoresearch_cycle_feedback_ledger_path
+                )
+        elif autoresearch_chain_enforced:
+            print(
+                "[REDDOG-MODEL-AUTORESEARCH-CHAIN] Startup blocked by "
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_ENFORCED=1"
             )
             return False
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,36 @@
 # AI Gateway Module Change Log
 
+## [2026-07-17] - Model AutoResearch Cycle Feedback Chain Main Preflight
+
+**Who:** 0102 Codex
+**Type:** Runtime Startup Wiring
+**Slice:** MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_MAIN_PREFLIGHT_PHASE1
+
+**What:** Exposed the model AutoResearch cycle feedback chain through the
+main resident preflight as `REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN`.
+
+**Why:** The chain bootstrap must be reachable from startup without requiring
+operators to manually enable three separate post-execution artifact steps.
+
+**Files:**
+- `main.py` - adds disabled-by-default chain flag, enforced mode, startup
+  logging, and environment path propagation.
+- `modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py`
+  - covers successful chain execution before promotion and enforced startup
+  failure.
+
+**Truth Boundary:**
+- IMPLEMENTED: explicit startup wiring for the already-merged post-execution
+  AutoResearch chain.
+- NOT IMPLEMENTED: direct provider calls, benchmark execution, model
+  promotion, catalog mutation, PatternMemory writes, HoloIndex re-indexing,
+  runtime model binding, worker spawn, shell execution, source mutation, or
+  extension mutation.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 97.
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Chain Bootstrap
 
 **Who:** 0102 Codex

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -975,6 +975,153 @@ def test_main_preflight_model_autoresearch_campaign_gate_supply_runs_before_prom
     promote.assert_called_once()
 
 
+def test_main_preflight_model_autoresearch_cycle_feedback_chain_runs_before_promotion(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    work_state = _write_json(tmp_path, "authoritative_work_state.json", _work_state())
+    determination = _write_json(tmp_path, "architect_determination.json", _determination())
+    memex = _write_json(tmp_path, "memex_supply_receipt.json", _memex_supply())
+    authority_source = _write_json(tmp_path, "authority_profile_source.json", _authority_profile())
+    chain_result = type(
+        "AutoResearchChainResult",
+        (),
+        {
+            "accepted": True,
+            "status": "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_APPLIED",
+            "promotion_gate_supply_receipt_id": "model_autoresearch_campaign_promotion_gate_supply:runtime",
+            "cycle_receipt_id": "model_autoresearch_cycle:runtime",
+            "feedback_admission_id": "model_autoresearch_cycle_feedback_admission:runtime",
+            "feedback_record_id": "model_autoresearch_cycle_feedback:runtime",
+            "promotion_gate_output_path": str(runtime_root / "model_autoresearch_promotion_gate_receipts.json"),
+            "cycle_receipt_output_path": str(runtime_root / "model_autoresearch_cycle_receipt.json"),
+            "feedback_ledger_output_path": str(runtime_root / "model_autoresearch_cycle_feedback.jsonl"),
+            "rejection_reasons": (),
+        },
+    )()
+    promotion_result = type(
+        "PromotionResult",
+        (),
+        {
+            "accepted": True,
+            "status": REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
+            "promotion_receipt_id": "sha256:promotion",
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "selected_slice": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
+            "authority_profile_path": str(runtime_root / "authority_profile.json"),
+            "committed_revision": "sha256:revision",
+            "rejection_reasons": (),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_chain_bootstrap.run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap",
+        return_value=chain_result,
+    ) as chain:
+        with patch(
+            "modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap.run_reddog_main_architect_fix_promotion_bootstrap",
+            return_value=promotion_result,
+        ) as promote:
+            with patch.dict(
+                "os.environ",
+                {
+                    "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN": "1",
+                    "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION": "0",
+                    "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
+                    "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                    "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+                    "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                    "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
+                    "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
+                    "REDDOG_MODEL_AUTORESEARCH_PROMOTION_AUTHORITY_RECEIPT_ID": "authority:1",
+                    "REDDOG_MODEL_AUTORESEARCH_SIGNED_PROMOTION_RECEIPT_ID": "signed:1",
+                },
+                clear=True,
+            ):
+                assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_PROMOTION_GATE_RECEIPTS_PATH"] == str(
+                    runtime_root / "model_autoresearch_promotion_gate_receipts.json"
+                )
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_PATH"] == str(
+                    runtime_root / "model_autoresearch_cycle_receipt.json"
+                )
+                assert main.os.environ["REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_PATH"] == str(
+                    runtime_root / "model_autoresearch_cycle_feedback.jsonl"
+                )
+
+    chain.assert_called_once()
+    chain_kwargs = chain.call_args.kwargs
+    assert chain_kwargs["plan_receipt_path"] == str(runtime_root / "model_autoresearch_plan_receipt.json")
+    assert chain_kwargs["campaign_execution_receipt_path"] == str(
+        runtime_root / "model_autoresearch_campaign_execution_receipt.json"
+    )
+    assert chain_kwargs["promotion_policies_path"] == str(
+        runtime_root / "model_autoresearch_campaign_promotion_policies.json"
+    )
+    assert chain_kwargs["promotion_gate_output_path"] == str(
+        runtime_root / "model_autoresearch_promotion_gate_receipts.json"
+    )
+    assert chain_kwargs["cycle_receipt_output_path"] == str(runtime_root / "model_autoresearch_cycle_receipt.json")
+    assert chain_kwargs["feedback_ledger_output_path"] == str(runtime_root / "model_autoresearch_cycle_feedback.jsonl")
+    assert chain_kwargs["promotion_authority_receipt_id"] == "authority:1"
+    assert chain_kwargs["signed_promotion_receipt_id"] == "signed:1"
+    promote.assert_called_once()
+
+
+def test_main_preflight_enforced_model_autoresearch_cycle_feedback_chain_blocks_startup(
+    tmp_path: Path,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    chain_result = type(
+        "AutoResearchChainResult",
+        (),
+        {
+            "accepted": False,
+            "status": "MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_BOOTSTRAP_NOT_READY",
+            "promotion_gate_supply_receipt_id": None,
+            "cycle_receipt_id": None,
+            "feedback_admission_id": None,
+            "feedback_record_id": None,
+            "promotion_gate_output_path": None,
+            "cycle_receipt_output_path": None,
+            "feedback_ledger_output_path": None,
+            "rejection_reasons": ("missing_model_autoresearch_chain_promotion_policies_path",),
+        },
+    )()
+
+    with patch(
+        "modules.ai_intelligence.ai_gateway.src.model_autoresearch_cycle_feedback_chain_bootstrap.run_reddog_model_autoresearch_cycle_feedback_chain_bootstrap",
+        return_value=chain_result,
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN": "1",
+                "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_ENFORCED": "1",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_architect_fix_promotion_preflight(repo) is False
+
+
 def test_main_preflight_enforced_model_autoresearch_campaign_gate_supply_blocks_startup(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Implements `MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN_MAIN_PREFLIGHT_PHASE1`.

This exposes the merged model AutoResearch post-execution chain through `main.py` as a single explicit startup flag:

```text
REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_CHAIN=1
```

It composes the existing promotion-gate supply, cycle receipt, and feedback-ledger admission path without changing default startup behavior.

## Scope

- Adds disabled-by-default main preflight flag and enforced mode.
- Propagates the resulting promotion-gate, cycle-receipt, and feedback-ledger paths into environment variables for later resident steps.
- Adds focused RedDog main-preflight tests for success and enforced rejection.
- Updates the AI Gateway ModLog.

## Truth Boundary

Implemented:
- Explicit startup wiring for the already-merged post-execution AutoResearch chain.
- Success path runs before architect FIX promotion and updates all three output paths.
- Enforced rejection blocks startup.

Not implemented:
- Direct provider calls.
- Benchmark execution.
- Model promotion or catalog mutation.
- PatternMemory writes.
- HoloIndex re-indexing.
- Runtime model binding.
- Worker spawn, shell execution, source mutation, or extension mutation.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 29 passed
- `python -m pytest modules/ai_intelligence/ai_gateway/tests -q` -> 224 passed
- `git diff --check` -> clean, only CRLF working-copy warnings
- Added diff lines ASCII clean -> 0 non-ASCII