### PR TITLE
feat(reddog): wire durable resident architect cycle preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,8 +33,10 @@ import sys
 import logging
 import io
 import atexit
+import hashlib
+import json
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Mapping
 
 # Load environment variables for DAEs (API keys, ports, feature flags).
 # Managed mode builds `.env.managed` from `.env` (last duplicate wins) for
@@ -1583,6 +1585,178 @@ def _reddog_env_sequence(name: str) -> tuple[str, ...]:
         return ()
     normalized = raw.replace("\n", ";").replace(",", ";")
     return tuple(item.strip() for item in normalized.split(";") if item.strip())
+
+
+def _reddog_positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+class _RedDogConfiguredExternalResearchRetriever:
+    """File-backed approved external research snapshot retriever for resident preflight."""
+
+    def __init__(self, snapshot_path: Path) -> None:
+        self.snapshot_path = snapshot_path
+
+    def fetch(self, target: Mapping[str, Any]) -> Mapping[str, Any]:
+        try:
+            payload = json.loads(self.snapshot_path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        if isinstance(payload, dict) and isinstance(payload.get("snapshots"), list):
+            url = str(target.get("url") or target.get("target") or "")
+            for item in payload["snapshots"]:
+                if isinstance(item, dict) and str(item.get("source_url") or item.get("url") or "") == url:
+                    return item
+        return payload if isinstance(payload, dict) else {}
+
+
+def _reddog_external_research_retriever_from_env() -> Any | None:
+    raw_path = os.getenv("REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH", "").strip()
+    if not raw_path:
+        return None
+    path = Path(raw_path)
+    return _RedDogConfiguredExternalResearchRetriever(path) if path.is_file() else None
+
+
+def _reddog_resident_architect_intent_id(
+    *,
+    principal_ref: str,
+    foundup_id: str,
+    work_focus: str,
+) -> str:
+    explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "").strip()
+    if explicit:
+        return explicit
+    payload = {
+        "foundup_id": foundup_id,
+        "principal_ref": principal_ref,
+        "work_focus": work_focus,
+    }
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bool:
+    """
+    Optionally run one durable AgentDB resident RedDog architect cycle.
+
+    This is the resident RedDog runtime bridge for main.py. It submits a
+    reddog_intent.v1 request to the durable AgentDB cycle, lets OpenClaw claim
+    read-only audit/research tasks, persists the backend architect
+    determination, and exposes the intent ID for the downstream FIX promotion
+    handoff. It performs no source mutation, shell work, worktree operations,
+    PR creation, HoloIndex re-index, Hermes dispatch, PatternMemory promotion,
+    or live FoundUp enqueue.
+
+    Env:
+        REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE=0          Enable resident cycle
+        REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=0 Block startup if rejected
+        REDDOG_RESIDENT_ARCHITECT_INTENT_ID                Optional stable intent ID
+        REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS               Work focus submitted to RedDog
+        REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF            Principal reference, default 012
+        REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID               FoundUp scope, default foundups_agent
+        REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS               Max OpenClaw claims, default 8
+        REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS          Cycle timeout, default 60
+        REDDOG_RESIDENT_ARCHITECT_RETRY=0                  Retry failed/cancelled cycle
+        REDDOG_RESIDENT_ARCHITECT_CANCEL=0                 Cancel running cycle
+        REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH             Approved external snapshot JSON
+        REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Existing work-state JSON
+        HOLOINDEX_FRESHNESS_RECEIPT                        Existing HoloIndex receipt
+        HOLOINDEX_SSD_PATH                                 HoloIndex SSD path
+    """
+
+    if os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "0") == "0":
+        logger.info("[REDDOG-RESIDENT-CYCLE] Startup preflight disabled")
+        return True
+
+    enforced = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0") != "0"
+    principal_ref = os.getenv("REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF", "012").strip() or "012"
+    foundup_id = os.getenv("REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID", "foundups_agent").strip() or "foundups_agent"
+    work_focus = (
+        os.getenv("REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS", "").strip()
+        or "main.py resident RedDog architect cycle"
+    )
+    intent_id = _reddog_resident_architect_intent_id(
+        principal_ref=principal_ref,
+        foundup_id=foundup_id,
+        work_focus=work_focus,
+    )
+    red_dog_intent = {
+        "schema_version": "reddog_intent.v1",
+        "intent_id": intent_id,
+        "principal_ref": principal_ref,
+        "foundup_id": foundup_id,
+        "work_focus": work_focus,
+        "requested_authority": "read_only_audit",
+        "origin": "main.py",
+        "submits_executable_authority": False,
+    }
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+            run_reddog_resident_architect_durable_agentdb_cycle,
+        )
+
+        result = run_reddog_resident_architect_durable_agentdb_cycle(
+            repo_root=repo_root,
+            red_dog_intent=red_dog_intent,
+            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+            holoindex_receipt_path=os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
+            holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
+            requested_operation="main_resident_architect_cycle",
+            prompt_text=work_focus,
+            external_research_retriever=_reddog_external_research_retriever_from_env(),
+            max_claims=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS", 8),
+            timeout_seconds=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS", 60),
+            cancel_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_CANCEL", "0") != "0",
+            retry_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_RETRY", "0") != "0",
+        )
+    except Exception as exc:
+        logger.error(f"[REDDOG-RESIDENT-CYCLE] Startup runtime failed: {exc}")
+        if enforced:
+            print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-RESIDENT-CYCLE] preflight=WARN error={type(exc).__name__}")
+        return True
+
+    status = "PASS" if result.accepted else "WARN"
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    completed = int(result.task_status_counts.get("completed", 0))
+    print(
+        f"[REDDOG-RESIDENT-CYCLE] preflight={status} status={result.status} "
+        f"intent={result.intent_id} cycle={result.cycle_id} snapshot={result.snapshot_id or '(none)'} "
+        f"swarm={result.swarm_id or '(none)'} tasks={len(result.task_ids)} completed={completed} "
+        f"claims={len(result.openclaw_claims)} recovered={result.recovered_existing_cycle} "
+        f"duplicate={result.duplicate_intent_reused} architect_action={result.architect_action or '(none)'} "
+        f"architect_next_slice={result.architect_next_slice or '(none)'} "
+        f"architect_determination={result.architect_determination_id or '(none)'} "
+        f"queue_candidates={result.queue_candidate_count} reasons={reasons}"
+    )
+    print(
+        "[REDDOG-RESIDENT-CYCLE] "
+        f"read_only_authority={result.read_only_authority_only} "
+        f"no_shell={result.no_shell_command_executed} "
+        f"no_repo_mutation={result.no_repo_mutation_performed} "
+        f"no_holoindex_reindex={result.no_holoindex_reindex_performed} "
+        f"no_hermes_dispatch={result.no_hermes_dispatch_performed} "
+        f"no_worktree={result.no_worktree_operation_performed} "
+        f"no_pr={result.no_pr_created} "
+        f"no_pattern_memory={result.no_pattern_memory_promotion_performed} "
+        f"no_live_foundup_enqueue={result.no_live_foundup_enqueue_performed}"
+    )
+    if result.accepted:
+        os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] = result.intent_id
+        return True
+
+    if enforced:
+        print("[REDDOG-RESIDENT-CYCLE] Startup blocked by REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1")
+        return False
+    return True
 
 
 def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
@@ -3313,6 +3487,8 @@ def main():
     if not run_git_main_merge_sentinel_preflight(repo_root):
         return
     if not run_reddog_authoritative_work_state_refresh_preflight(repo_root):
+        return
+    if not run_reddog_resident_architect_durable_cycle_preflight(repo_root):
         return
     if not run_reddog_architect_fix_promotion_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MAIN_RESIDENT_ARCHITECT_DURABLE_CYCLE_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Wired `main.py` to optionally run one durable AgentDB-backed resident RedDog
+  architect cycle after authoritative work-state refresh and before FIX
+  promotion.
+- The preflight submits `reddog_intent.v1`, lets the existing OpenClaw resident
+  cycle claim read-only audit/research work, persists the architect
+  determination, and exposes `REDDOG_RESIDENT_ARCHITECT_INTENT_ID` for the
+  downstream handoff path.
+- The hook is disabled by default, warning-only unless explicitly enforced,
+  and requires the already-governed external-research snapshot retriever path.
+- Boundary remains constrained: no shell command, repo mutation, HoloIndex
+  re-index, Hermes dispatch, worktree operation, PR creation, PatternMemory
+  promotion, live FoundUp enqueue, merge authority, or coding-worker execution
+  was added.
+
 ## 2026-07-17: REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_DEFAULT_INPUT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -943,6 +944,161 @@ def test_main_preflight_e2e_runtime_reject_blocks_when_enforced(capsys) -> None:
     output = capsys.readouterr().out
     assert "[REDDOG-BOOTSTRAP-E2E] preflight=WARN" in output
     assert "Startup blocked by REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1" in output
+
+
+def _resident_cycle_result(*, accepted: bool = True):
+    return SimpleNamespace(
+        accepted=accepted,
+        status="DETERMINED" if accepted else "REJECT",
+        intent_id="sha256:intent-main-resident",
+        cycle_id="sha256:cycle-main-resident",
+        snapshot_id="sha256:snapshot-main-resident" if accepted else None,
+        determination_id="sha256:determination-main-resident" if accepted else None,
+        swarm_id="sha256:swarm-main-resident" if accepted else None,
+        task_ids=("task-1", "task-2") if accepted else (),
+        task_status_counts={"completed": 2} if accepted else {},
+        openclaw_claims=({"task_id": "task-1"}, {"task_id": "task-2"}) if accepted else (),
+        final_bootstrap=None,
+        architect_action="FIX" if accepted else None,
+        architect_next_slice="REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1" if accepted else None,
+        architect_determination_id="sha256:architect-main-resident" if accepted else None,
+        queue_candidate_count=1 if accepted else 0,
+        duplicate_intent_reused=False,
+        recovered_existing_cycle=False,
+        retry_count=0,
+        rejection_reasons=() if accepted else ("external_research_retriever_missing",),
+        no_shell_command_executed=True,
+        no_repo_mutation_performed=True,
+        no_holoindex_reindex_performed=True,
+        no_hermes_dispatch_performed=True,
+        no_worktree_operation_performed=True,
+        no_pr_created=True,
+        no_pattern_memory_promotion_performed=True,
+        no_live_foundup_enqueue_performed=True,
+        read_only_authority_only=True,
+    )
+
+
+def test_main_preflight_durable_resident_cycle_disabled_is_inert() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {"REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "0"},
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    mocked.assert_not_called()
+
+
+def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_path, capsys) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "0",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS": "resident main cycle",
+                "REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF": "012",
+                "REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID": "foundups_agent",
+                "REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS": "2",
+                "REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS": "30",
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "O:/state/work_state.json",
+                "HOLOINDEX_FRESHNESS_RECEIPT": "O:/state/holo_receipt.json",
+                "HOLOINDEX_SSD_PATH": "E:/HoloIndex",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] == "sha256:intent-main-resident"
+
+    kwargs = mocked.call_args.kwargs
+    assert kwargs["repo_root"] == REPO_ROOT
+    assert kwargs["work_state_path"] == "O:/state/work_state.json"
+    assert kwargs["holoindex_receipt_path"] == "O:/state/holo_receipt.json"
+    assert kwargs["holoindex_ssd_path"] == "E:/HoloIndex"
+    assert kwargs["requested_operation"] == "main_resident_architect_cycle"
+    assert kwargs["prompt_text"] == "resident main cycle"
+    assert kwargs["max_claims"] == 2
+    assert kwargs["timeout_seconds"] == 30
+    assert kwargs["external_research_retriever"] is not None
+    intent = kwargs["red_dog_intent"]
+    assert intent["schema_version"] == "reddog_intent.v1"
+    assert intent["intent_id"] == "sha256:intent-main-resident"
+    assert intent["submits_executable_authority"] is False
+    assert intent["requested_authority"] == "read_only_audit"
+    output = capsys.readouterr().out
+    assert "[REDDOG-RESIDENT-CYCLE] preflight=PASS" in output
+    assert "tasks=2" in output
+    assert "completed=2" in output
+    assert "architect_action=FIX" in output
+    assert "queue_candidates=1" in output
+    assert "read_only_authority=True" in output
+    assert "no_repo_mutation=True" in output
+    assert "no_holoindex_reindex=True" in output
+
+
+def test_main_preflight_resident_cycle_reject_is_nonblocking_by_default(capsys) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(accepted=False),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "0",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    output = capsys.readouterr().out
+    assert "[REDDOG-RESIDENT-CYCLE] preflight=WARN" in output
+    assert "reasons=external_research_retriever_missing" in output
+
+
+def test_main_preflight_resident_cycle_reject_blocks_when_enforced(capsys) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(accepted=False),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is False
+
+    output = capsys.readouterr().out
+    assert "[REDDOG-RESIDENT-CYCLE] preflight=WARN" in output
+    assert "Startup blocked by REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1" in output
 
 
 def test_main_preflight_enables_enqueue_when_openclaw_auto_tasks_enabled() -> None:


### PR DESCRIPTION
## Summary

Implements `REDDOG_MAIN_RESIDENT_ARCHITECT_DURABLE_CYCLE_PREFLIGHT_PHASE1`.

This wires `main.py` to optionally run one durable AgentDB-backed resident RedDog architect cycle after authoritative work-state refresh and before FIX promotion. The hook submits `reddog_intent.v1`, delegates to the existing durable resident cycle, exposes `REDDOG_RESIDENT_ARCHITECT_INTENT_ID` for downstream handoff, and remains disabled by default.

## Boundary

- No shell command execution
- No repo mutation
- No HoloIndex re-index
- No Hermes dispatch
- No worktree operation
- No PR creation from the runtime path
- No PatternMemory promotion
- No live FoundUp enqueue
- No coding-worker execution

## Local validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q` -> 32 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py -q` -> 7 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 90 passed, 1 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_authoritative_work_state_refresh_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_next_stage_dispatch_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_orchestration_plan_bootstrap.py -q` -> 62 passed
- `git diff --check` -> clean

## WSP_97 truth boundary

OBSERVED: existing durable AgentDB resident cycle already enforces the read-only/no-mutation runtime boundary.

OBSERVED: this slice adds only a disabled-by-default `main.py` preflight bridge plus focused startup tests.

SPECIFIED_NOT_IMPLEMENTED: coding worker dispatch, shell execution, worktree mutation, PR publication, live enqueue, HoloIndex re-index and PatternMemory promotion remain blocked for later slices.