### PR TITLE
feat(reddog): auto-arm resident fix handoff

### DIFF
--- a/main.py
+++ b/main.py
@@ -1664,6 +1664,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS          Cycle timeout, default 60
         REDDOG_RESIDENT_ARCHITECT_RETRY=0                  Retry failed/cancelled cycle
         REDDOG_RESIDENT_ARCHITECT_CANCEL=0                 Cancel running cycle
+        REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF=1        Auto-arm safe FIX handoff after accepted FIX
         REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH             Approved external snapshot JSON
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Existing work-state JSON
         HOLOINDEX_FRESHNESS_RECEIPT                        Existing HoloIndex receipt
@@ -1727,6 +1728,12 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
     status = "PASS" if result.accepted else "WARN"
     reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
     completed = int(result.task_status_counts.get("completed", 0))
+    auto_fix_handoff = (
+        result.accepted
+        and str(result.architect_action or "").strip().upper() == "FIX"
+        and os.getenv("REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF", "1") != "0"
+        and "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+    )
     print(
         f"[REDDOG-RESIDENT-CYCLE] preflight={status} status={result.status} "
         f"intent={result.intent_id} cycle={result.cycle_id} snapshot={result.snapshot_id or '(none)'} "
@@ -1735,7 +1742,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         f"duplicate={result.duplicate_intent_reused} architect_action={result.architect_action or '(none)'} "
         f"architect_next_slice={result.architect_next_slice or '(none)'} "
         f"architect_determination={result.architect_determination_id or '(none)'} "
-        f"queue_candidates={result.queue_candidate_count} reasons={reasons}"
+        f"queue_candidates={result.queue_candidate_count} auto_fix_handoff={auto_fix_handoff} reasons={reasons}"
     )
     print(
         "[REDDOG-RESIDENT-CYCLE] "
@@ -1751,6 +1758,8 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
     )
     if result.accepted:
         os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] = result.intent_id
+        if auto_fix_handoff:
+            os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] = "1"
         return True
 
     if enforced:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RESIDENT_ARCHITECT_FIX_HANDOFF_AUTOWIRE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Updated the durable resident RedDog architect preflight to auto-arm the
+  existing resident FIX promotion handoff when the cycle accepts a FIX
+  determination.
+- The bridge sets `REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=1` only when it was not
+  explicitly provided and `REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF` is not
+  disabled.
+- This removes a manual toggle between the resident determination and the
+  already-gated promotion preflight while preserving downstream rejection and
+  enforcement behavior.
+- Boundary remains constrained: no signing, worker spawn, shell command, repo
+  mutation, worktree operation, PR creation, HoloIndex re-index, PatternMemory
+  promotion, Hermes dispatch, live FoundUp enqueue, reward settlement, or merge
+  authority was added.
+
 ## 2026-07-17: REDDOG_MAIN_RESIDENT_ARCHITECT_DURABLE_CYCLE_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -1026,6 +1026,7 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
         ):
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
             assert os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] == "sha256:intent-main-resident"
+            assert os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] == "1"
 
     kwargs = mocked.call_args.kwargs
     assert kwargs["repo_root"] == REPO_ROOT
@@ -1048,9 +1049,58 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
     assert "completed=2" in output
     assert "architect_action=FIX" in output
     assert "queue_candidates=1" in output
+    assert "auto_fix_handoff=True" in output
     assert "read_only_authority=True" in output
     assert "no_repo_mutation=True" in output
     assert "no_holoindex_reindex=True" in output
+
+
+def test_main_preflight_resident_cycle_respects_auto_fix_handoff_opt_out(tmp_path) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF": "0",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+
+
+def test_main_preflight_resident_cycle_does_not_override_explicit_fix_handoff(tmp_path) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] == "0"
 
 
 def test_main_preflight_resident_cycle_reject_is_nonblocking_by_default(capsys) -> None:


### PR DESCRIPTION
## Summary

Implements `REDDOG_RESIDENT_ARCHITECT_FIX_HANDOFF_AUTOWIRE_PHASE1`.

After the durable resident RedDog architect preflight accepts a `FIX` determination, `main.py` now auto-arms the already-built resident FIX promotion handoff by setting `REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=1` when the variable was not explicitly provided.

This removes the second manual toggle between an accepted resident determination and the existing promotion preflight. Operators can disable the behavior with `REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF=0`, and an explicit `REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=0` is preserved.

## Boundary

- No signing
- No worker spawn
- No shell command execution
- No repo mutation
- No worktree operation
- No PR creation from this path
- No HoloIndex re-index
- No PatternMemory promotion
- No Hermes dispatch
- No live FoundUp enqueue
- No reward settlement
- No merge authority

## Local validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q` -> 34 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 90 passed, 1 skipped
- `git diff --check` -> clean

## WSP_97 truth boundary

OBSERVED: the resident FIX promotion handoff already exists and is gated by downstream artifact validation.

OBSERVED: this slice only auto-arms that handoff after an accepted resident `FIX` determination, and only when the operator did not explicitly set the handoff variable.

SPECIFIED_NOT_IMPLEMENTED: signed work-order execution, coding worker spawn, shell execution, worktree mutation, PR publication, live enqueue, HoloIndex re-index, PatternMemory promotion, reward settlement and autonomous merge remain blocked by later gates.