### PR TITLE
feat(reddog): auto-select resident queue profile

### DIFF
--- a/main.py
+++ b/main.py
@@ -1641,6 +1641,35 @@ def _reddog_resident_architect_intent_id(
     return f"sha256:{digest}"
 
 
+def _reddog_resident_architect_auto_queue_profile(result: Any) -> str:
+    if "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" in os.environ:
+        return ""
+    if not getattr(result, "accepted", False):
+        return ""
+    if str(getattr(result, "architect_action", "") or "").strip().upper() != "FIX":
+        return ""
+    if int(getattr(result, "queue_candidate_count", 0) or 0) != 1:
+        return ""
+
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
+            RESIDENT_QUEUE_PROFILES,
+        )
+    except Exception:
+        return ""
+
+    raw = os.getenv(
+        "REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE",
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR,
+    ).strip().lower()
+    if raw in {"0", "false", "off", "none"}:
+        return ""
+    if raw in {"", "1"}:
+        raw = PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR
+    return raw if raw in RESIDENT_QUEUE_PROFILES else ""
+
+
 def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bool:
     """
     Optionally run one durable AgentDB resident RedDog architect cycle.
@@ -1665,6 +1694,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         REDDOG_RESIDENT_ARCHITECT_RETRY=0                  Retry failed/cancelled cycle
         REDDOG_RESIDENT_ARCHITECT_CANCEL=0                 Cancel running cycle
         REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF=1        Auto-arm safe FIX handoff after accepted FIX
+        REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE        Optional downstream queue profile, default draft-PR
         REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH             Approved external snapshot JSON
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Existing work-state JSON
         HOLOINDEX_FRESHNESS_RECEIPT                        Existing HoloIndex receipt
@@ -1734,6 +1764,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         and os.getenv("REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF", "1") != "0"
         and "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
     )
+    auto_queue_profile = _reddog_resident_architect_auto_queue_profile(result)
     print(
         f"[REDDOG-RESIDENT-CYCLE] preflight={status} status={result.status} "
         f"intent={result.intent_id} cycle={result.cycle_id} snapshot={result.snapshot_id or '(none)'} "
@@ -1742,7 +1773,8 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         f"duplicate={result.duplicate_intent_reused} architect_action={result.architect_action or '(none)'} "
         f"architect_next_slice={result.architect_next_slice or '(none)'} "
         f"architect_determination={result.architect_determination_id or '(none)'} "
-        f"queue_candidates={result.queue_candidate_count} auto_fix_handoff={auto_fix_handoff} reasons={reasons}"
+        f"queue_candidates={result.queue_candidate_count} auto_fix_handoff={auto_fix_handoff} "
+        f"auto_queue_profile={auto_queue_profile or '(none)'} reasons={reasons}"
     )
     print(
         "[REDDOG-RESIDENT-CYCLE] "
@@ -1760,6 +1792,8 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] = result.intent_id
         if auto_fix_handoff:
             os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] = "1"
+        if auto_queue_profile:
+            os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] = auto_queue_profile
         return True
 
     if enforced:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RESIDENT_ARCHITECT_QUEUE_PROFILE_AUTOWIRE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Updated the durable resident RedDog architect preflight to auto-select the
+  existing signed resident queue binding profile after an accepted FIX
+  determination with exactly one queue candidate.
+- Default profile is `signed_0102_bounded_code_fusion_worktree_draft_pr`,
+  which enables the existing bounded code, Fusion artifact, isolated worktree,
+  independent evidence, and verified draft-PR control-plane stages while
+  leaving PatternMemory, merge, shell, reward, HoloIndex re-index, and live
+  enqueue disabled.
+- Explicit `REDDOG_RESIDENT_QUEUE_BINDING_PROFILE` remains authoritative, and
+  `REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE=0` disables auto-selection.
+- Invalid auto-profile values and non-FIX or non-single-candidate outcomes fail
+  closed by leaving the queue profile unset.
+
 ## 2026-07-17: REDDOG_RESIDENT_ARCHITECT_FIX_HANDOFF_AUTOWIRE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -946,7 +946,14 @@ def test_main_preflight_e2e_runtime_reject_blocks_when_enforced(capsys) -> None:
     assert "Startup blocked by REDDOG_READONLY_OPERATIONAL_BOOTSTRAP_ENFORCED=1" in output
 
 
-def _resident_cycle_result(*, accepted: bool = True):
+def _resident_cycle_result(
+    *,
+    accepted: bool = True,
+    architect_action: str | None = None,
+    queue_candidate_count: int | None = None,
+):
+    action = architect_action if architect_action is not None else ("FIX" if accepted else None)
+    candidates = queue_candidate_count if queue_candidate_count is not None else (1 if accepted else 0)
     return SimpleNamespace(
         accepted=accepted,
         status="DETERMINED" if accepted else "REJECT",
@@ -959,10 +966,10 @@ def _resident_cycle_result(*, accepted: bool = True):
         task_status_counts={"completed": 2} if accepted else {},
         openclaw_claims=({"task_id": "task-1"}, {"task_id": "task-2"}) if accepted else (),
         final_bootstrap=None,
-        architect_action="FIX" if accepted else None,
+        architect_action=action,
         architect_next_slice="REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1" if accepted else None,
         architect_determination_id="sha256:architect-main-resident" if accepted else None,
-        queue_candidate_count=1 if accepted else 0,
+        queue_candidate_count=candidates,
         duplicate_intent_reused=False,
         recovered_existing_cycle=False,
         retry_count=0,
@@ -1027,6 +1034,10 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
             assert os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] == "sha256:intent-main-resident"
             assert os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] == "1"
+            assert (
+                os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"]
+                == "signed_0102_bounded_code_fusion_worktree_draft_pr"
+            )
 
     kwargs = mocked.call_args.kwargs
     assert kwargs["repo_root"] == REPO_ROOT
@@ -1050,9 +1061,125 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
     assert "architect_action=FIX" in output
     assert "queue_candidates=1" in output
     assert "auto_fix_handoff=True" in output
+    assert "auto_queue_profile=signed_0102_bounded_code_fusion_worktree_draft_pr" in output
     assert "read_only_authority=True" in output
     assert "no_repo_mutation=True" in output
     assert "no_holoindex_reindex=True" in output
+
+
+def test_main_preflight_resident_cycle_respects_explicit_queue_profile(tmp_path) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] == "signed_0102_bounded_code"
+
+
+def test_main_preflight_resident_cycle_can_disable_auto_queue_profile(tmp_path) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE": "0",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" not in os.environ
+
+
+def test_main_preflight_resident_cycle_rejects_invalid_auto_queue_profile(tmp_path, capsys) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE": "unsafe_profile",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" not in os.environ
+
+    output = capsys.readouterr().out
+    assert "auto_queue_profile=(none)" in output
+
+
+def test_main_preflight_resident_cycle_requires_fix_queue_candidate_for_auto_profile(tmp_path) -> None:
+    import main
+
+    external_snapshot = tmp_path / "external_research_snapshot.json"
+    external_snapshot.write_text(json.dumps({"snapshots": []}), encoding="utf-8")
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(architect_action="STOP", queue_candidate_count=1),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" not in os.environ
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(architect_action="FIX", queue_candidate_count=0),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" not in os.environ
 
 
 def test_main_preflight_resident_cycle_respects_auto_fix_handoff_opt_out(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Auto-select the existing resident queue binding profile after an accepted resident RedDog FIX cycle with exactly one queue candidate.
- Default profile: signed_0102_bounded_code_fusion_worktree_draft_pr.
- Preserve explicit REDDOG_RESIDENT_QUEUE_BINDING_PROFILE, support REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE=0 opt-out, and fail closed on invalid profiles or non-FIX/non-single-candidate outcomes.

## WSP_97 Truth Boundary
- OBSERVED: Existing profile helpers already encode bounded-code, Fusion artifact, isolated worktree, independent evidence, and verified draft-PR stages.
- OBSERVED: This slice only sets the profile environment variable after an accepted FIX determination and one candidate queue item.
- OBSERVED: PatternMemory profile is not selected by default.
- NOT IMPLEMENTED: no shell execution, merge authority, reward settlement, HoloIndex re-index, live enqueue, or PatternMemory promotion added.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -> 38 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -> 100 passed, 1 skipped
- pytest \\$files = Get-ChildItem modules/communication/moltbot_bridge/tests/test_reddog_main_*.py ...\\ -> 190 passed, 1 skipped
- git diff --check -> clean
- added_lines_non_ascii=0