### PR TITLE
feat(reddog): allow resident cycle without external retriever

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RESIDENT_EXTERNAL_RESEARCH_NOOP_RETRIEVER_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a no-op external research retriever for durable resident RedDog cycles
+  when no approved external snapshot/retriever is configured.
+- The resident cycle no longer rejects before AgentDB enqueue solely because
+  the optional external retriever object is missing; it can still run repository,
+  HoloIndex, Brain/Breadcrumb, Memex, and work-state audits.
+- The no-op retriever performs no network I/O, returns no content-bearing
+  evidence, and marks external research as unconfigured/missing so workers
+  cannot mistake it for fresh external proof.
+- Boundary remains constrained: this does not add live web research, source
+  mutation, shell execution, worktree operations, PR creation, HoloIndex
+  re-index, PatternMemory promotion, live enqueue, reward settlement, or merge
+  authority.
+
 ## 2026-07-17: REDDOG_RESIDENT_ARCHITECT_QUEUE_PROFILE_AUTOWIRE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -105,6 +105,24 @@ class ResidentArchitectCycleStore(Protocol):
     def delete_cycle_tasks(self, task_ids: Sequence[str]) -> None: ...
 
 
+class NoopExternalResearchRetriever:
+    """Fail-closed external retriever used when no approved source is configured.
+
+    The resident cycle still needs an object implementing the retriever
+    protocol so the external-research worker can emit an explicit missing
+    evidence receipt. This retriever performs no network I/O and returns no
+    content-bearing evidence.
+    """
+
+    def fetch(self, target: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {
+            "source_url": str(target.get("url") or target.get("target") or ""),
+            "source_type": "unconfigured",
+            "finding_status": "missing",
+            "rejection_reasons": ["approved_external_research_retriever_not_configured"],
+        }
+
+
 @dataclass(frozen=True)
 class RedDogResidentArchitectCycleResult:
     accepted: bool
@@ -352,7 +370,7 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
     if reasons:
         return _reject(red_dog_intent, reasons)
     if external_research_retriever is None:
-        return _reject(red_dog_intent, (ResidentCycleReason.EXTERNAL_RESEARCH_RETRIEVER_MISSING,))
+        external_research_retriever = NoopExternalResearchRetriever()
 
     if retry_requested:
         retry_count = int(existing.get("retry_count", 0)) + 1 if existing else 1
@@ -672,6 +690,7 @@ def _now_iso() -> str:
 
 __all__ = [
     "AgentDbResidentArchitectCycleStore",
+    "NoopExternalResearchRetriever",
     "REDDOG_RESIDENT_CYCLE_ACCEPT",
     "REDDOG_RESIDENT_CYCLE_REJECT",
     "RedDogResidentArchitectCycleResult",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -26,6 +26,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_
     STATUS_DETERMINED,
     STATUS_TIMED_OUT,
     AgentDbResidentArchitectCycleStore,
+    NoopExternalResearchRetriever,
     ResidentCycleReason,
     run_reddog_resident_architect_durable_agentdb_cycle,
 )
@@ -361,15 +362,41 @@ def test_duplicate_intent_reconnects_to_persisted_cycle_without_new_claims() -> 
     assert AgentDB().get_autonomous_tasks(status="completed", limit=20)
 
 
-def test_missing_external_research_retriever_fails_before_agentdb_enqueue() -> None:
+def test_missing_external_research_retriever_uses_noop_receipt_instead_of_blocking_cycle() -> None:
+    audit_runner = _AuditModelRunner()
     result = run_reddog_resident_architect_durable_agentdb_cycle(
-        **_runtime_kwargs(external_research_retriever=None)
+        **_runtime_kwargs(
+            audit_model_runner=audit_runner,
+            external_research_retriever=None,
+        )
     )
 
-    assert result.accepted is False
-    assert result.decision == REDDOG_RESIDENT_CYCLE_REJECT
-    assert ResidentCycleReason.EXTERNAL_RESEARCH_RETRIEVER_MISSING in result.rejection_reasons
+    assert result.accepted is True
+    assert result.decision == REDDOG_RESIDENT_CYCLE_ACCEPT
+    assert result.status == STATUS_DETERMINED
+    assert result.task_status_counts == {"completed": 5}
+    assert ResidentCycleReason.EXTERNAL_RESEARCH_RETRIEVER_MISSING not in result.rejection_reasons
+    external_contexts = [
+        json.loads(call["context"])
+        for call in audit_runner.calls
+        if json.loads(call["prompt"])["assignment"]["lane_id"] == "external_research_audit"
+    ]
+    assert len(external_contexts) == 1
+    assert "external_research_query_receipt" not in external_contexts[0]
+    assert "untrusted_external_research_evidence" not in external_contexts[0]
     assert AgentDB().get_autonomous_tasks(status="pending", limit=10) == []
+
+
+def test_noop_external_research_retriever_returns_no_content_bearing_evidence() -> None:
+    payload = NoopExternalResearchRetriever().fetch(
+        {"url": "https://github.com/FOUNDUPS/Foundups-Agent"}
+    )
+
+    assert payload["source_type"] == "unconfigured"
+    assert payload["finding_status"] == "missing"
+    assert payload.get("content_text") in (None, "")
+    assert payload.get("content_sha256") in (None, "")
+    assert "approved_external_research_retriever_not_configured" in payload["rejection_reasons"]
 
 
 def test_timeout_when_openclaw_does_not_claim_tasks() -> None:


### PR DESCRIPTION
## Summary
- Add a no-op external research retriever for durable resident RedDog cycles when no approved retriever/snapshot is configured.
- Replace the pre-AgentDB hard reject with explicit no-content, missing-status retrieval behavior.
- Keep truth boundary visible: no fresh external evidence is fabricated and no untrusted external research bundle is injected unless a real approved retriever grounds targets.

## WSP_97 Truth Boundary
- OBSERVED: current durable cycle rejected before enqueue when external_research_retriever was None.
- OBSERVED: default resident audit may have no external targets; this slice unblocks repo/HoloIndex/Brain/Memex/work-state audits without claiming external freshness.
- NOT IMPLEMENTED: no live web search, no network retriever, no HoloIndex re-index, no PatternMemory promotion, no shell/worktree/PR/live enqueue/merge authority.

## Validation
- pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py -> 8 passed
- pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -> 38 passed
- pytest all modules/communication/moltbot_bridge/tests/test_reddog_main_*.py -> 190 passed, 1 skipped
- git diff --check -> clean
- added_lines_non_ascii=0