### PR TITLE
feat(reddog): default resident architect product mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -1596,6 +1596,19 @@ def _reddog_positive_int_env(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def _reddog_truthy_env_value(value: str | None) -> bool:
+    raw = str(value or "").strip().lower()
+    return raw not in {"", "0", "false", "off", "no"}
+
+
+def _reddog_resident_architect_cycle_requested() -> bool:
+    explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE")
+    if explicit is not None and str(explicit).strip():
+        return _reddog_truthy_env_value(explicit)
+    product_mode = os.getenv("REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE", "1")
+    return _reddog_truthy_env_value(product_mode)
+
+
 class _RedDogConfiguredExternalResearchRetriever:
     """File-backed approved external research snapshot retriever for resident preflight."""
 
@@ -1683,7 +1696,8 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
     or live FoundUp enqueue.
 
     Env:
-        REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE=0          Enable resident cycle
+        REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE=1           Auto-run resident cycle when low-level flag unset
+        REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE            Explicit enable/disable override
         REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=0 Block startup if rejected
         REDDOG_RESIDENT_ARCHITECT_INTENT_ID                Optional stable intent ID
         REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS               Work focus submitted to RedDog
@@ -1701,7 +1715,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         HOLOINDEX_SSD_PATH                                 HoloIndex SSD path
     """
 
-    if os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "0") == "0":
+    if not _reddog_resident_architect_cycle_requested():
         logger.info("[REDDOG-RESIDENT-CYCLE] Startup preflight disabled")
         return True
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MAIN_RESIDENT_PRODUCT_MODE_ACTIVATION_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added a product-mode activation policy for the durable resident RedDog
+  architect cycle in `main.py`.
+- When `REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE` is unset, resident RedDog now
+  defaults to running one read-only architect cycle at startup via
+  `REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE=1`.
+- Explicit `REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE=0` remains a hard opt-out,
+  and `REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE=0` disables the product default
+  without blocking explicit low-level enablement.
+- Boundary remains constrained: this does not add shell execution, repository
+  mutation, worktree operations, PR creation, HoloIndex re-index, Hermes
+  dispatch, live FoundUp enqueue, PatternMemory promotion, reward settlement, or
+  merge authority.
+
 ## 2026-07-17: REDDOG_RESIDENT_EXTERNAL_RESEARCH_NOOP_RETRIEVER_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -1003,6 +1003,77 @@ def test_main_preflight_durable_resident_cycle_disabled_is_inert() -> None:
     mocked.assert_not_called()
 
 
+def test_main_preflight_durable_resident_cycle_product_mode_runs_by_default(capsys) -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict("os.environ", {}, clear=True):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+            assert os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] == "sha256:intent-main-resident"
+            assert os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] == "1"
+            assert (
+                os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"]
+                == "signed_0102_bounded_code_fusion_worktree_draft_pr"
+            )
+
+    kwargs = mocked.call_args.kwargs
+    assert kwargs["requested_operation"] == "main_resident_architect_cycle"
+    assert kwargs["prompt_text"] == "main.py resident RedDog architect cycle"
+    assert kwargs["external_research_retriever"] is None
+    assert kwargs["red_dog_intent"]["requested_authority"] == "read_only_audit"
+    assert kwargs["red_dog_intent"]["submits_executable_authority"] is False
+    output = capsys.readouterr().out
+    assert "[REDDOG-RESIDENT-CYCLE] preflight=PASS" in output
+    assert "no_repo_mutation=True" in output
+    assert "no_holoindex_reindex=True" in output
+    assert "no_hermes_dispatch=True" in output
+    assert "no_worktree=True" in output
+    assert "no_pr=True" in output
+
+
+def test_main_preflight_durable_resident_cycle_product_mode_can_opt_out() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {"REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE": "0"},
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    mocked.assert_not_called()
+
+
+def test_main_preflight_durable_resident_cycle_explicit_enable_overrides_product_mode_off() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE": "0",
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    mocked.assert_called_once()
+
+
 def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_path, capsys) -> None:
     import main
 


### PR DESCRIPTION
## Summary
- Enable resident RedDog architect cycle by product-mode default when the low-level durable-cycle flag is unset.
- Preserve explicit opt-outs: `REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE=0` and `REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE=0`.
- Keep the cycle read-only: no shell, repo mutation, worktree, PR, HoloIndex re-index, Hermes dispatch, live enqueue, PatternMemory, reward, or merge authority.

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py` -> 41 passed
- `pytest @files` for `modules/communication/moltbot_bridge/tests/test_reddog_main_*.py` -> 193 passed, 1 skipped
- `pytest tests/test_main_runtime_bootstrap.py` -> 10 passed
- `git diff --check` -> clean
- added-lines non-ASCII -> 0

## WSP_97 Truth Boundary
- OBSERVED: the resident chain already exists and is tested through main.py.
- OBSERVED: before this slice it required a low-level enable flag, so RedDog still did not run as product behavior.
- IMPLEMENTED: product-mode default activation for the read-only resident architect cycle.
- NOT IMPLEMENTED: shell execution, worktree mutation, PR creation, merge authority, PatternMemory promotion, HoloIndex re-index, reward settlement, or live FoundUp enqueue.