### PR TITLE
feat(reddog): add resident architect cadence intent

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ import io
 import atexit
 import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Dict, Any, Mapping
 
@@ -1609,6 +1610,33 @@ def _reddog_resident_architect_cycle_requested() -> bool:
     return _reddog_truthy_env_value(product_mode)
 
 
+def _reddog_resident_architect_cycle_bucket() -> str:
+    explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET", "").strip()
+    if explicit:
+        return explicit
+    raw_hours = os.getenv("REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS", "24").strip()
+    try:
+        hours = int(raw_hours)
+    except (TypeError, ValueError):
+        hours = 24
+    if hours <= 0:
+        return ""
+    now = _reddog_resident_architect_now()
+    bucket = int(now.timestamp()) // (hours * 60 * 60)
+    return f"{hours}h:{bucket}"
+
+
+def _reddog_resident_architect_now() -> datetime:
+    raw = os.getenv("REDDOG_RESIDENT_ARCHITECT_NOW_ISO", "").strip()
+    if raw:
+        try:
+            value = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    return datetime.now(timezone.utc)
+
+
 class _RedDogConfiguredExternalResearchRetriever:
     """File-backed approved external research snapshot retriever for resident preflight."""
 
@@ -1641,6 +1669,7 @@ def _reddog_resident_architect_intent_id(
     principal_ref: str,
     foundup_id: str,
     work_focus: str,
+    cycle_bucket: str = "",
 ) -> str:
     explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "").strip()
     if explicit:
@@ -1650,6 +1679,8 @@ def _reddog_resident_architect_intent_id(
         "principal_ref": principal_ref,
         "work_focus": work_focus,
     }
+    if cycle_bucket:
+        payload["cycle_bucket"] = cycle_bucket
     digest = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
     return f"sha256:{digest}"
 
@@ -1698,6 +1729,9 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
     Env:
         REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE=1           Auto-run resident cycle when low-level flag unset
         REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE            Explicit enable/disable override
+        REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS=24         New intent cadence; 0 disables cadence
+        REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET             Optional explicit cadence bucket
+        REDDOG_RESIDENT_ARCHITECT_NOW_ISO                  Optional deterministic runtime clock
         REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=0 Block startup if rejected
         REDDOG_RESIDENT_ARCHITECT_INTENT_ID                Optional stable intent ID
         REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS               Work focus submitted to RedDog
@@ -1726,10 +1760,13 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         os.getenv("REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS", "").strip()
         or "main.py resident RedDog architect cycle"
     )
+    explicit_intent_id = os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "").strip()
+    cycle_bucket = "" if explicit_intent_id else _reddog_resident_architect_cycle_bucket()
     intent_id = _reddog_resident_architect_intent_id(
         principal_ref=principal_ref,
         foundup_id=foundup_id,
         work_focus=work_focus,
+        cycle_bucket=cycle_bucket,
     )
     red_dog_intent = {
         "schema_version": "reddog_intent.v1",
@@ -1737,6 +1774,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         "principal_ref": principal_ref,
         "foundup_id": foundup_id,
         "work_focus": work_focus,
+        "cycle_bucket": cycle_bucket,
         "requested_authority": "read_only_audit",
         "origin": "main.py",
         "submits_executable_authority": False,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RESIDENT_ARCHITECT_CADENCE_INTENT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Added cadence-bound resident RedDog architect intent IDs for the `main.py`
+  product-mode cycle.
+- Default cadence is 24 hours via `REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS`;
+  repeated startups inside the same bucket reuse the same intent, while later
+  buckets create fresh resident architect cycles.
+- Explicit `REDDOG_RESIDENT_ARCHITECT_INTENT_ID` remains authoritative and
+  disables cadence bucketing; `REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS=0`
+  restores the legacy sticky intent behavior.
+- Boundary remains constrained: this changes cycle scheduling identity only and
+  does not add shell execution, repository mutation, worktree operations, PR
+  creation, HoloIndex re-index, Hermes dispatch, live FoundUp enqueue,
+  PatternMemory promotion, reward settlement, or merge authority.
+
 ## 2026-07-17: REDDOG_MAIN_RESIDENT_PRODUCT_MODE_ACTIVATION_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -1026,6 +1026,7 @@ def test_main_preflight_durable_resident_cycle_product_mode_runs_by_default(caps
     assert kwargs["external_research_retriever"] is None
     assert kwargs["red_dog_intent"]["requested_authority"] == "read_only_audit"
     assert kwargs["red_dog_intent"]["submits_executable_authority"] is False
+    assert kwargs["red_dog_intent"]["cycle_bucket"].startswith("24h:")
     output = capsys.readouterr().out
     assert "[REDDOG-RESIDENT-CYCLE] preflight=PASS" in output
     assert "no_repo_mutation=True" in output
@@ -1072,6 +1073,116 @@ def test_main_preflight_durable_resident_cycle_explicit_enable_overrides_product
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
 
     mocked.assert_called_once()
+
+
+def test_main_preflight_durable_resident_cycle_uses_stable_cadence_bucket() -> None:
+    import main
+
+    calls = []
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        side_effect=lambda **kwargs: calls.append(kwargs) or _resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
+                "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T18:00:00+00:00",
+                "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    first = calls[0]["red_dog_intent"]
+    second = calls[1]["red_dog_intent"]
+    assert first["cycle_bucket"] == second["cycle_bucket"]
+    assert first["intent_id"] == second["intent_id"]
+
+
+def test_main_preflight_durable_resident_cycle_rolls_intent_after_cadence() -> None:
+    import main
+
+    calls = []
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        side_effect=lambda **kwargs: calls.append(kwargs) or _resident_cycle_result(),
+    ):
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
+                "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-18T09:00:01+00:00",
+                "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    first = calls[0]["red_dog_intent"]
+    second = calls[1]["red_dog_intent"]
+    assert first["cycle_bucket"] != second["cycle_bucket"]
+    assert first["intent_id"] != second["intent_id"]
+
+
+def test_main_preflight_durable_resident_cycle_explicit_intent_disables_cadence_bucket() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:explicit-intent",
+                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    intent = mocked.call_args.kwargs["red_dog_intent"]
+    assert intent["intent_id"] == "sha256:explicit-intent"
+    assert intent["cycle_bucket"] == ""
+
+
+def test_main_preflight_durable_resident_cycle_can_disable_cadence_for_legacy_sticky_intent() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {"REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "0"},
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    intent = mocked.call_args.kwargs["red_dog_intent"]
+    assert intent["cycle_bucket"] == ""
 
 
 def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Add cadence-bound resident RedDog architect intent IDs for `main.py` product mode.
- Default cadence is 24 hours; repeated startup inside the same bucket reuses the same durable AgentDB cycle, while a later bucket creates a fresh resident architect cycle.
- Preserve explicit control: `REDDOG_RESIDENT_ARCHITECT_INTENT_ID` wins, `REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS=0` restores legacy sticky intent behavior, and `REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET` allows deterministic external bucketing.

## Validation
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py` -> 45 passed
- `pytest @files` for `modules/communication/moltbot_bridge/tests/test_reddog_main_*.py` -> 197 passed, 1 skipped
- `pytest tests/test_main_runtime_bootstrap.py` -> 10 passed
- `git diff --check` -> clean
- added-lines non-ASCII -> 0

## WSP_97 Truth Boundary
- OBSERVED: product-mode resident RedDog now runs by default, but deterministic intent IDs would otherwise make it sticky forever.
- IMPLEMENTED: cadence-bound intent bucketing for fresh resident architect cycles without manual env changes.
- NOT IMPLEMENTED: shell execution, worktree mutation, PR creation, merge authority, PatternMemory promotion, HoloIndex re-index, reward settlement, or live FoundUp enqueue.