### PR TITLE
feat(reddog): supply resident memory context

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional, Dict, Any, Mapping
+from typing import Optional, Dict, Any, Mapping, Sequence
 
 # Load environment variables for DAEs (API keys, ports, feature flags).
 # Managed mode builds `.env.managed` from `.env` (last duplicate wins) for
@@ -1602,6 +1602,119 @@ def _reddog_truthy_env_value(value: str | None) -> bool:
     return raw not in {"", "0", "false", "off", "no"}
 
 
+def _reddog_digest_payload(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _reddog_bounded_json_file(path: Path, *, max_bytes: int = 262_144) -> Any | None:
+    try:
+        if not path.is_file() or path.stat().st_size > max_bytes:
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _reddog_mapping_sequence(payload: Any, keys: Sequence[str], *, limit: int) -> tuple[Mapping[str, Any], ...]:
+    source: Any = payload
+    if isinstance(payload, Mapping):
+        for key in keys:
+            candidate = payload.get(key)
+            if isinstance(candidate, list):
+                source = candidate
+                break
+    if not isinstance(source, list):
+        return ()
+    records: list[Mapping[str, Any]] = []
+    for item in source:
+        if isinstance(item, Mapping):
+            records.append(dict(item))
+            if len(records) >= limit:
+                break
+    return tuple(records)
+
+
+def _reddog_resident_memory_limit() -> int:
+    return _reddog_positive_int_env("REDDOG_RESIDENT_MEMORY_MAX_RECORDS", 20)
+
+
+def _reddog_resident_brain_state_from_artifacts() -> Mapping[str, Any] | None:
+    if not _reddog_truthy_env_value(os.getenv("REDDOG_RESIDENT_BRAIN_CONTEXT", "1")):
+        return None
+
+    raw_path = os.getenv("REDDOG_RESIDENT_BRAIN_STATE_PATH", "").strip()
+    if raw_path:
+        path = Path(raw_path)
+    else:
+        try:
+            from modules.infrastructure.wre_core.scripts.extract_brain_artifacts import (
+                DEFAULT_OUTPUT_DIR,
+                DEFAULT_STATE_FILE,
+            )
+
+            path = DEFAULT_OUTPUT_DIR / DEFAULT_STATE_FILE
+        except Exception:
+            return None
+
+    payload = _reddog_bounded_json_file(path)
+    if not isinstance(payload, Mapping):
+        return None
+
+    signature = payload.get("signature") if isinstance(payload.get("signature"), Mapping) else {}
+    summary = payload.get("summary") if isinstance(payload.get("summary"), Mapping) else {}
+    record_count = (
+        payload.get("conversations")
+        or signature.get("conversation_count", 0)
+        or summary.get("total_artifacts", 0)
+        or 0
+    )
+    try:
+        normalized_count = int(record_count)
+    except (TypeError, ValueError):
+        normalized_count = 0
+
+    return {
+        "available": True,
+        "signature_digest": _reddog_digest_payload(signature),
+        "summary_digest": _reddog_digest_payload(summary),
+        "record_count": normalized_count,
+        "source": "brain_artifact_state",
+        "updated_at": str(payload.get("updated_at", "")),
+    }
+
+
+def _reddog_resident_breadcrumbs_from_runtime(*, work_focus: str, foundup_id: str) -> tuple[Mapping[str, Any], ...]:
+    if not _reddog_truthy_env_value(os.getenv("REDDOG_RESIDENT_BREADCRUMBS_CONTEXT", "1")):
+        return ()
+
+    limit = _reddog_resident_memory_limit()
+    raw_path = os.getenv("REDDOG_RESIDENT_BREADCRUMBS_PATH", "").strip()
+    if raw_path:
+        payload = _reddog_bounded_json_file(Path(raw_path))
+        return _reddog_mapping_sequence(payload, ("breadcrumbs", "records", "items"), limit=limit)
+
+    try:
+        from modules.communication.moltbot_bridge.src.openclaw_memory_queries import search_breadcrumbs
+
+        topic = os.getenv("REDDOG_RESIDENT_MEMORY_QUERY", "").strip() or work_focus or foundup_id
+        return tuple(dict(item) for item in search_breadcrumbs(topic, limit=limit) if isinstance(item, Mapping))
+    except Exception:
+        return ()
+
+
+def _reddog_resident_workspace_memory_notes_from_env() -> tuple[Mapping[str, Any], ...]:
+    raw_path = os.getenv("REDDOG_RESIDENT_WORKSPACE_MEMORY_NOTES_PATH", "").strip()
+    if not raw_path:
+        return ()
+    payload = _reddog_bounded_json_file(Path(raw_path))
+    return _reddog_mapping_sequence(
+        payload,
+        ("workspace_memory_notes", "notes", "records", "items"),
+        limit=_reddog_resident_memory_limit(),
+    )
+
+
 def _reddog_resident_architect_cycle_requested() -> bool:
     explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE")
     if explicit is not None and str(explicit).strip():
@@ -1743,6 +1856,12 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         REDDOG_RESIDENT_ARCHITECT_CANCEL=0                 Cancel running cycle
         REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF=1        Auto-arm safe FIX handoff after accepted FIX
         REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE        Optional downstream queue profile, default draft-PR
+        REDDOG_RESIDENT_BRAIN_CONTEXT=1                     Attach read-only Brain artifact state metadata
+        REDDOG_RESIDENT_BRAIN_STATE_PATH                    Optional Brain artifact state JSON override
+        REDDOG_RESIDENT_BREADCRUMBS_CONTEXT=1               Attach read-only AgentDB breadcrumb metadata
+        REDDOG_RESIDENT_BREADCRUMBS_PATH                    Optional breadcrumb JSON override
+        REDDOG_RESIDENT_WORKSPACE_MEMORY_NOTES_PATH         Optional workspace memory note JSON
+        REDDOG_RESIDENT_MEMORY_MAX_RECORDS=20               Max breadcrumb/workspace records supplied
         REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH             Approved external snapshot JSON
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Existing work-state JSON
         HOLOINDEX_FRESHNESS_RECEIPT                        Existing HoloIndex receipt
@@ -1768,6 +1887,16 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         work_focus=work_focus,
         cycle_bucket=cycle_bucket,
     )
+    brain_state = _reddog_resident_brain_state_from_artifacts()
+    breadcrumbs = _reddog_resident_breadcrumbs_from_runtime(work_focus=work_focus, foundup_id=foundup_id)
+    workspace_memory_notes = _reddog_resident_workspace_memory_notes_from_env()
+    memory_context = {
+        "brain_available": bool(brain_state),
+        "brain_record_count": int(brain_state.get("record_count", 0)) if brain_state else 0,
+        "breadcrumbs_count": len(breadcrumbs),
+        "workspace_memory_notes_count": len(workspace_memory_notes),
+    }
+    memory_context["memory_context_digest"] = _reddog_digest_payload(memory_context)
     red_dog_intent = {
         "schema_version": "reddog_intent.v1",
         "intent_id": intent_id,
@@ -1778,6 +1907,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         "requested_authority": "read_only_audit",
         "origin": "main.py",
         "submits_executable_authority": False,
+        "memory_context": memory_context,
     }
 
     try:
@@ -1793,6 +1923,9 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
             holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
             requested_operation="main_resident_architect_cycle",
             prompt_text=work_focus,
+            breadcrumbs=breadcrumbs,
+            brain_state=brain_state,
+            workspace_memory_notes=workspace_memory_notes,
             external_research_retriever=_reddog_external_research_retriever_from_env(),
             max_claims=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS", 8),
             timeout_seconds=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS", 60),
@@ -1826,7 +1959,10 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         f"architect_next_slice={result.architect_next_slice or '(none)'} "
         f"architect_determination={result.architect_determination_id or '(none)'} "
         f"queue_candidates={result.queue_candidate_count} auto_fix_handoff={auto_fix_handoff} "
-        f"auto_queue_profile={auto_queue_profile or '(none)'} reasons={reasons}"
+        f"auto_queue_profile={auto_queue_profile or '(none)'} "
+        f"brain_records={memory_context['brain_record_count']} "
+        f"breadcrumbs={memory_context['breadcrumbs_count']} "
+        f"workspace_memory={memory_context['workspace_memory_notes_count']} reasons={reasons}"
     )
     print(
         "[REDDOG-RESIDENT-CYCLE] "

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_MAIN_RESIDENT_MEMORY_CONTEXT_SUPPLY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97
+
+- Wired `main.py` resident RedDog startup to supply bounded read-only Brain,
+  Breadcrumb, and workspace-memory metadata into the existing durable resident
+  architect cycle.
+- Brain state is loaded from the existing extracted Brain artifact state unless
+  explicitly overridden or disabled; Breadcrumbs come from AgentDB search or an
+  explicit JSON fixture; workspace memory remains explicit JSON-only for this
+  slice.
+- Added intent-level memory context counts/digest plus startup telemetry so the
+  resident cycle can prove whether historical memory was available without
+  treating it as authority.
+- Boundary remains constrained: this does not add shell execution, repository
+  mutation, worktree operations, PR creation, HoloIndex re-index, Hermes
+  dispatch, live FoundUp enqueue, PatternMemory promotion, reward settlement, or
+  merge authority.
+
 ## 2026-07-17: REDDOG_RESIDENT_ARCHITECT_CADENCE_INTENT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -1249,6 +1249,106 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
     assert "no_holoindex_reindex=True" in output
 
 
+def test_main_preflight_durable_resident_cycle_supplies_memory_context(tmp_path, capsys) -> None:
+    import main
+
+    brain_state = tmp_path / "brain_artifact_state.json"
+    brain_state.write_text(
+        json.dumps(
+            {
+                "updated_at": "2026-07-17T00:00:00+00:00",
+                "signature": {"conversation_count": 7, "revision_files": 11},
+                "summary": {"total_artifacts": 13},
+                "conversations": 7,
+            }
+        ),
+        encoding="utf-8",
+    )
+    breadcrumbs = tmp_path / "breadcrumbs.json"
+    breadcrumbs.write_text(
+        json.dumps(
+            {
+                "breadcrumbs": [
+                    {"breadcrumb_id": "crumb-1", "continuity_id": "foundups_agent", "task_id": "task-1"},
+                    {"breadcrumb_id": "crumb-2", "continuity_id": "foundups_agent", "task_id": "task-2"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    workspace_notes = tmp_path / "workspace_memory.json"
+    workspace_notes.write_text(
+        json.dumps({"notes": [{"note_id": "note-1", "topic": "resident RedDog"}]}),
+        encoding="utf-8",
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_BRAIN_STATE_PATH": str(brain_state),
+                "REDDOG_RESIDENT_BREADCRUMBS_PATH": str(breadcrumbs),
+                "REDDOG_RESIDENT_WORKSPACE_MEMORY_NOTES_PATH": str(workspace_notes),
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    kwargs = mocked.call_args.kwargs
+    assert kwargs["brain_state"]["record_count"] == 7
+    assert kwargs["brain_state"]["signature_digest"].startswith("sha256:")
+    assert len(kwargs["breadcrumbs"]) == 2
+    assert kwargs["breadcrumbs"][0]["breadcrumb_id"] == "crumb-1"
+    assert len(kwargs["workspace_memory_notes"]) == 1
+    assert kwargs["workspace_memory_notes"][0]["note_id"] == "note-1"
+    intent_memory = kwargs["red_dog_intent"]["memory_context"]
+    assert intent_memory["brain_available"] is True
+    assert intent_memory["brain_record_count"] == 7
+    assert intent_memory["breadcrumbs_count"] == 2
+    assert intent_memory["workspace_memory_notes_count"] == 1
+    assert intent_memory["memory_context_digest"].startswith("sha256:")
+    output = capsys.readouterr().out
+    assert "brain_records=7" in output
+    assert "breadcrumbs=2" in output
+    assert "workspace_memory=1" in output
+
+
+def test_main_preflight_durable_resident_cycle_memory_context_can_be_disabled() -> None:
+    import main
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+        return_value=_resident_cycle_result(),
+    ) as mocked:
+        with patch.dict(
+            "os.environ",
+            {
+                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                "REDDOG_RESIDENT_BRAIN_CONTEXT": "0",
+                "REDDOG_RESIDENT_BREADCRUMBS_CONTEXT": "0",
+            },
+            clear=True,
+        ):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
+
+    kwargs = mocked.call_args.kwargs
+    assert kwargs["brain_state"] is None
+    assert kwargs["breadcrumbs"] == ()
+    assert kwargs["workspace_memory_notes"] == ()
+    intent_memory = kwargs["red_dog_intent"]["memory_context"]
+    assert intent_memory["brain_available"] is False
+    assert intent_memory["breadcrumbs_count"] == 0
+    assert intent_memory["workspace_memory_notes_count"] == 0
+
+
 def test_main_preflight_resident_cycle_respects_explicit_queue_profile(tmp_path) -> None:
     import main
 


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- `main.py` resident RedDog startup now supplies bounded read-only Brain artifact state, Breadcrumb metadata, and optional workspace-memory note metadata into the existing durable resident architect cycle.
- The resident intent records memory-context counts plus a digest, and startup output reports the supplied counts.
- Memory remains historical/observational evidence only; the existing operational snapshot still controls authority class and redaction.

SPECIFIED_NOT_IMPLEMENTED / OUT OF SCOPE:
- No shell execution, repository mutation, worktree operation, PR creation, HoloIndex re-index, Hermes dispatch, live FoundUp enqueue, PatternMemory promotion, reward settlement, or merge authority.
- Workspace memory auto-discovery beyond explicit JSON supply remains separate.

## Validation

- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q` -> 47 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py -q` -> 8 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py -q` -> 55 passed
- `pytest tests/test_main_runtime_bootstrap.py -q` -> 10 passed, 1 existing warning
- `python -m py_compile main.py` -> pass
- `git diff --check` -> no whitespace errors; Git CRLF warnings only

Note: one combined three-file pytest invocation tripped pytest capture teardown (`I/O operation on closed file`) after the individual suites passed; no test assertion in this slice failed under the focused suites.