### PR TITLE
feat(reddog): diagnose startup blockers before exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1024,6 +1024,30 @@ def run_wre_dashboard_preflight(repo_root: Path, *, interactive_menu: bool = Tru
         )
 
         if critical_count > 0 and enforced:
+            try:
+                from modules.ai_intelligence.ai_overseer.src.preflight_resolution import (
+                    on_preflight_fail,
+                )
+
+                on_preflight_fail(
+                    component="wre_dashboard",
+                    severity="critical",
+                    payload={
+                        "critical": critical_count,
+                        "warnings": warning_count,
+                        "samples": total_executions,
+                        "min_samples": min_samples,
+                        "healthy": healthy,
+                        "in_watch": in_watch,
+                        "auto_enforced": auto_enforced,
+                        "manual_enforced": manual_enforced,
+                        "enforced": enforced,
+                        "automation_candidate": True,
+                    },
+                    source="main:run_wre_dashboard_preflight",
+                )
+            except Exception as dispatch_exc:
+                logger.debug(f"[WRE-DASHBOARD] dispatch skipped: {dispatch_exc}")
             enforce_source = "AUTO" if auto_enforced else "MANUAL"
             print(f"[WRE-DASHBOARD] Startup blocked by {enforce_source} enforcement")
             return False
@@ -1988,6 +2012,82 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         print("[REDDOG-RESIDENT-CYCLE] Startup blocked by REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1")
         return False
     return True
+
+
+def _reddog_startup_blocker_token(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in {"_", "-", "."} else "_" for ch in value.strip())
+    return (cleaned or "unknown")[:64]
+
+
+def _run_reddog_startup_blocker_diagnostic(repo_root: Path, *, component: str, stage: str) -> None:
+    """
+    Best-effort resident RedDog diagnostic for startup blockers.
+
+    The blocker still blocks. This bridge only gives the resident architect a
+    read-only opportunity to inspect preflight artifacts and queue a future
+    governed repair path, with FIX handoff and queue profile disabled so a
+    blocker diagnostic cannot advance the execution chain by itself.
+    """
+    if not _reddog_truthy_env_value(os.getenv("REDDOG_STARTUP_BLOCKER_DIAGNOSTIC", "1")):
+        return
+    if _reddog_truthy_env_value(os.getenv("REDDOG_STARTUP_BLOCKER_DIAGNOSTIC_ACTIVE", "0")):
+        return
+
+    component_token = _reddog_startup_blocker_token(component)
+    stage_token = _reddog_startup_blocker_token(stage)
+    work_focus = (
+        f"Diagnose startup blocker {component_token} from {stage_token}. "
+        "Read current alerts/preflight artifacts, Brain, Breadcrumbs, HoloIndex freshness, "
+        "and authoritative work state. Apply WSP_15 and WSP_97. Recommend the next safe "
+        "repair slice only. Do not mutate source, run shell commands, reindex HoloIndex, "
+        "dispatch Hermes, create a worktree, open a PR, or enqueue live work."
+    )
+
+    override_keys = (
+        "REDDOG_STARTUP_BLOCKER_DIAGNOSTIC_ACTIVE",
+        "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE",
+        "REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS",
+        "REDDOG_RESIDENT_ARCHITECT_INTENT_ID",
+        "REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET",
+        "REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF",
+        "REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE",
+        "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF",
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE",
+    )
+    previous = {key: os.environ.get(key) for key in override_keys}
+    try:
+        os.environ["REDDOG_STARTUP_BLOCKER_DIAGNOSTIC_ACTIVE"] = "1"
+        os.environ["REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE"] = "1"
+        os.environ["REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS"] = work_focus
+        os.environ["REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET"] = (
+            f"startup_blocker:{component_token}:{stage_token}"
+        )
+        os.environ["REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF"] = "0"
+        os.environ["REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE"] = "0"
+        os.environ.pop("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", None)
+        os.environ.pop("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF", None)
+        os.environ.pop("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", None)
+        result = run_reddog_resident_architect_durable_cycle_preflight(repo_root)
+        print(
+            "[REDDOG-STARTUP-BLOCKER] "
+            f"diagnostic={'PASS' if result else 'WARN'} component={component_token} stage={stage_token}"
+        )
+    except Exception as exc:
+        logger.debug(f"[REDDOG-STARTUP-BLOCKER] diagnostic skipped: {exc}")
+        print(
+            "[REDDOG-STARTUP-BLOCKER] "
+            f"diagnostic=WARN component={component_token} stage={stage_token} error={type(exc).__name__}"
+        )
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _handle_startup_blocker(repo_root: Path, *, component: str, stage: str) -> None:
+    _run_reddog_startup_blocker_diagnostic(repo_root, component=component, stage=stage)
 
 
 def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
@@ -3702,20 +3802,60 @@ def main():
             logger.error(f"[PREFLIGHT] Failed to initialize AI Overseer: {exc}")
 
     if not run_env_hygiene_preflight(repo_root):
+        _handle_startup_blocker(
+            repo_root,
+            component="env_hygiene",
+            stage="run_env_hygiene_preflight",
+        )
         return
     if not run_brain_artifact_preflight(repo_root):
+        _handle_startup_blocker(
+            repo_root,
+            component="brain_artifact",
+            stage="run_brain_artifact_preflight",
+        )
         return
     if not run_ironclaw_runtime_preflight(repo_root):
+        _handle_startup_blocker(
+            repo_root,
+            component="ironclaw_runtime",
+            stage="run_ironclaw_runtime_preflight",
+        )
         return
     if not run_openclaw_security_preflight(repo_root, overseer=overseer):
+        _handle_startup_blocker(
+            repo_root,
+            component="openclaw_security",
+            stage="run_openclaw_security_preflight",
+        )
         return
     if not run_dependency_security_preflight(repo_root):
+        _handle_startup_blocker(
+            repo_root,
+            component="dep_security",
+            stage="run_dependency_security_preflight",
+        )
         return
     if not run_wre_dashboard_preflight(repo_root):
+        _handle_startup_blocker(
+            repo_root,
+            component="wre_dashboard",
+            stage="run_wre_dashboard_preflight",
+        )
         return
     if not run_wsp_framework_preflight(repo_root, overseer=overseer):
+        _handle_startup_blocker(
+            repo_root,
+            component="wsp_framework",
+            stage="run_wsp_framework_preflight",
+        )
         return
     if not run_git_main_merge_sentinel_preflight(repo_root):
+        _handle_startup_blocker(
+            repo_root,
+            component="git_main_merge_sentinel",
+            stage="run_git_main_merge_sentinel_preflight",
+        )
         return
     if not run_reddog_authoritative_work_state_refresh_preflight(repo_root):
         return

--- a/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
+++ b/modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py
@@ -351,17 +351,24 @@ def test_main_py_wre_dashboard_critical_alert_blocks_for_explicit_menu_enforceme
         ) as mock_monitor:
             mock_monitor.return_value.is_in_watch_period.return_value = False
             with patch("builtins.print") as mock_print:
-                with patch.dict(
-                    "os.environ",
-                    {
-                        "WRE_DASHBOARD_PREFLIGHT": "1",
-                        "WRE_DASHBOARD_AUTO_ENFORCE": "1",
-                    },
-                    clear=True,
-                ):
-                    result = main.run_wre_dashboard_preflight(Path("."))
+                with patch(
+                    "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+                ) as mock_dispatch:
+                    with patch.dict(
+                        "os.environ",
+                        {
+                            "WRE_DASHBOARD_PREFLIGHT": "1",
+                            "WRE_DASHBOARD_AUTO_ENFORCE": "1",
+                        },
+                        clear=True,
+                    ):
+                        result = main.run_wre_dashboard_preflight(Path("."))
 
     assert result is False
+    mock_dispatch.assert_called_once()
+    assert mock_dispatch.call_args.kwargs["component"] == "wre_dashboard"
+    assert mock_dispatch.call_args.kwargs["severity"] == "critical"
+    assert mock_dispatch.call_args.kwargs["payload"]["automation_candidate"] is True
     printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
     assert "preflight=FAIL (STABLE, ENFORCED)" in printed
     assert "Startup blocked by AUTO enforcement" in printed
@@ -387,17 +394,24 @@ def test_main_py_wre_dashboard_critical_alert_blocks_for_autonomous_24x7_runtime
         ) as mock_monitor:
             mock_monitor.return_value.is_in_watch_period.return_value = False
             with patch("builtins.print") as mock_print:
-                with patch.dict(
-                    "os.environ",
-                    {
-                        "WRE_DASHBOARD_PREFLIGHT": "1",
-                        "OPENCLAW_24X7": "1",
-                    },
-                    clear=True,
-                ):
-                    result = main.run_wre_dashboard_preflight(Path("."), interactive_menu=False)
+                with patch(
+                    "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+                ) as mock_dispatch:
+                    with patch.dict(
+                        "os.environ",
+                        {
+                            "WRE_DASHBOARD_PREFLIGHT": "1",
+                            "OPENCLAW_24X7": "1",
+                        },
+                        clear=True,
+                    ):
+                        result = main.run_wre_dashboard_preflight(Path("."), interactive_menu=False)
 
     assert result is False
+    mock_dispatch.assert_called_once()
+    assert mock_dispatch.call_args.kwargs["component"] == "wre_dashboard"
+    assert mock_dispatch.call_args.kwargs["severity"] == "critical"
+    assert mock_dispatch.call_args.kwargs["payload"]["automation_candidate"] is True
     printed = "\n".join(str(call.args[0]) for call in mock_print.call_args_list)
     assert "preflight=FAIL (STABLE, ENFORCED)" in printed
     assert "Startup blocked by AUTO enforcement" in printed

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -252,6 +252,104 @@ def test_main_resident_red_dog_chain_passes_profile_to_downstream_preflights(mon
     ]
 
 
+def test_main_dependency_security_blocker_runs_reddog_diagnostic_before_return(monkeypatch):
+    """A pre-RedDog startup blocker must still give RedDog a read-only diagnostic turn."""
+
+    order: list[str] = []
+
+    def pass_step(name: str):
+        def _step(*_args, **_kwargs):
+            order.append(name)
+            return True
+
+        return _step
+
+    def fail_step(name: str):
+        def _step(*_args, **_kwargs):
+            order.append(name)
+            return False
+
+        return _step
+
+    def diagnostic(*_args, **kwargs):
+        order.append(f"diagnostic:{kwargs['component']}:{kwargs['stage']}")
+
+    monkeypatch.setenv("OPENCLAW_SECURITY_PREFLIGHT", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "1")
+    monkeypatch.setenv("WRE_DASHBOARD_PREFLIGHT", "0")
+    monkeypatch.setenv("WSP_FRAMEWORK_PREFLIGHT", "0")
+
+    with patch.object(main, "run_env_hygiene_preflight", pass_step("env_hygiene")), patch.object(
+        main, "run_brain_artifact_preflight", pass_step("brain")
+    ), patch.object(
+        main, "run_ironclaw_runtime_preflight", pass_step("ironclaw")
+    ), patch.object(
+        main, "run_openclaw_security_preflight", pass_step("security")
+    ), patch.object(
+        main, "run_dependency_security_preflight", fail_step("dep_security")
+    ), patch.object(
+        main, "_handle_startup_blocker", side_effect=diagnostic
+    ), patch.object(
+        main, "run_wre_dashboard_preflight", pass_step("dashboard")
+    ), patch.object(
+        main, "bootstrap_runtime_dae_launches", pass_step("dae_bootstrap")
+    ):
+        main.main()
+
+    assert order == [
+        "env_hygiene",
+        "brain",
+        "ironclaw",
+        "security",
+        "dep_security",
+        "diagnostic:dep_security:run_dependency_security_preflight",
+    ]
+
+
+def test_startup_blocker_diagnostic_is_read_only_and_restores_env(monkeypatch):
+    """The startup-blocker diagnostic cannot leak auto handoff/profile into the chain."""
+
+    observed: dict[str, str] = {}
+
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", "preexisting_profile")
+    monkeypatch.delenv("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF", raising=False)
+
+    def resident_cycle(_repo_root):
+        observed["durable_cycle"] = os.environ["REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE"]
+        observed["work_focus"] = os.environ["REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS"]
+        observed["auto_fix"] = os.environ["REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF"]
+        observed["auto_profile"] = os.environ["REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE"]
+        observed["cycle_bucket"] = os.environ["REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET"]
+        assert "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+        assert "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" not in os.environ
+        os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] = "1"
+        os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] = "leaked_profile"
+        return True
+
+    with patch.object(
+        main,
+        "run_reddog_resident_architect_durable_cycle_preflight",
+        side_effect=resident_cycle,
+    ):
+        main._run_reddog_startup_blocker_diagnostic(
+            Path("O:/Foundups-Agent"),
+            component="dep security",
+            stage="run_dependency_security_preflight",
+        )
+
+    assert observed["durable_cycle"] == "1"
+    assert observed["auto_fix"] == "0"
+    assert observed["auto_profile"] == "0"
+    assert observed["cycle_bucket"].startswith("startup_blocker:dep_security:")
+    assert "Diagnose startup blocker dep_security" in observed["work_focus"]
+    assert os.environ["REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF"] == "1"
+    assert os.environ["REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE"] == "1"
+    assert os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] == "preexisting_profile"
+    assert "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+
+
 # ---------------------------------------------------------------------------
 # Headless bootstrap seam (WRE_OPENCLAW_HERMES_AUTONOMOUS_BUILD_DRYRUN_PHASE1)
 #


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- Early startup preflights can block before the resident RedDog architect cycle runs.
- Dependency security already dispatched structured preflight artifacts before blocking.
- WRE dashboard critical enforcement did not dispatch a structured artifact before blocking.

IMPLEMENTED:
- WRE dashboard critical enforcement now emits a structured `wre_dashboard` preflight failure artifact before preserving the same hard block.
- `main.py` now runs one best-effort resident RedDog startup-blocker diagnostic before returning from pre-RedDog startup blockers.
- The diagnostic is read-only and temporarily disables auto FIX handoff and auto queue profile.
- The diagnostic restores resident env state, so it cannot leak execution authority into the normal chain.

NOT IMPLEMENTED:
- No preflight blocker is weakened or bypassed.
- No source mutation, shell execution, HoloIndex re-index, Hermes dispatch, worktree, PR creation, PatternMemory promotion, or live enqueue is added.
- No coding worker is dispatched by this slice.

## Validation

- `pytest tests/test_main_runtime_bootstrap.py -q` -> 12 passed
- `pytest modules/ai_intelligence/ai_overseer/tests/test_preflight_resolution.py -q` -> 22 passed
- `pytest modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q` -> 47 passed
- `python -m py_compile main.py` -> pass
- `git diff --check` -> clean (CRLF warnings only)

## WSP_15 Priority

P0: if dependency security or WRE dashboard blocks before RedDog runs, the resident architect cannot autonomously diagnose or queue the repair path.