### PR TITLE
feat(reddog): add resident queue control loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,8 @@ _original_stderr = sys.stderr
 # Solution: Set env flag, modules should check before wrapping
 os.environ['FOUNDUPS_UTF8_WRAPPED'] = '1'
 
-if sys.platform.startswith('win'):
+# Do not replace pytest's capture streams when tests import this entrypoint as a module.
+if sys.platform.startswith('win') and "pytest" not in sys.modules:
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace', line_buffering=True)
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', errors='replace', line_buffering=True)
 
@@ -3563,6 +3564,68 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
     return True
 
 
+def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
+    """
+    Drive the resident queue through bounded serial/claim rounds.
+
+    Env:
+        REDDOG_RESIDENT_QUEUE_CONTROL_LOOP                 Enable bounded alternation (profile may default ON)
+        REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS=8    Max serial/claim rounds
+        REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED=0      Block startup if a round fails
+
+    This function creates no authority, tasks, worktrees, shell commands,
+    source mutations, PRs, PatternMemory writes, rewards, or HoloIndex re-index.
+    It only repeats the already-governed serial-loop and OpenClaw signed-worker
+    claim-loop preflights so one resident startup can advance more than one
+    queue stage without requiring 012 to restart the host.
+    """
+
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+        resident_queue_runtime_flag_enabled,
+    )
+
+    requested = resident_queue_runtime_flag_enabled(
+        os.environ,
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP",
+    )
+    if not requested:
+        if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
+            return False
+        return run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root)
+
+    enforced = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED", "0") != "0"
+    raw_rounds = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "8").strip()
+    try:
+        max_rounds = int(raw_rounds or "8")
+    except ValueError:
+        max_rounds = 0
+    if max_rounds < 1:
+        print("[REDDOG-QUEUE-CONTROL] preflight=FAIL error=invalid_max_rounds")
+        return not enforced
+
+    completed_rounds = 0
+    for round_index in range(1, max_rounds + 1):
+        if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
+            print(
+                f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} "
+                "stage=serial_loop"
+            )
+            return not enforced
+        if not run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root):
+            print(
+                f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} "
+                "stage=openclaw_claim_loop"
+            )
+            return not enforced
+        completed_rounds = round_index
+
+    print(
+        f"[REDDOG-QUEUE-CONTROL] preflight=PASS rounds={completed_rounds} "
+        f"max_rounds={max_rounds}"
+    )
+    return True
+
+
 def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> bool:
     """
     Optionally let OpenClaw claim signed RedDog worker-dispatch AgentDB tasks.
@@ -3869,9 +3932,7 @@ def main():
         return
     if not run_reddog_resident_queue_next_stage_dispatch_preflight(repo_root):
         return
-    if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
-        return
-    if not run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root):
+    if not run_reddog_resident_queue_control_loop_preflight(repo_root):
         return
     if not run_reddog_readonly_operational_bootstrap_preflight(repo_root):
         return

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -86,6 +86,7 @@ PROFILE_RUNTIME_FLAGS = frozenset(
         "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP",
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER",
         "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP",
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP",
     }
 )
 
@@ -316,9 +317,12 @@ def resident_queue_pattern_memory_admission_db_path(
 def resident_queue_materializer_mode(env: Mapping[str, str]) -> str:
     """Return explicit/default work-order materializer mode for the profile."""
 
+    has_explicit_mode = "REDDOG_WORK_ORDER_MATERIALIZER_MODE" in env
     raw = str(env.get("REDDOG_WORK_ORDER_MATERIALIZER_MODE") or "").strip()
     if raw:
         return raw
+    if not has_explicit_mode and str(env.get("REDDOG_WORK_ORDERS_PATH") or "").strip():
+        return ""
     if resident_queue_binding_profile(env) in RESIDENT_QUEUE_PROFILES:
         return "authority_profile"
     return ""

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -44,6 +44,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_signed_worker_dispat
     _publish_agentdb_task,
     _publish_agentdb_task_with_allocation,
 )
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+    resident_queue_materializer_mode,
+)
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
 
@@ -53,6 +56,25 @@ CLAIM_LOOP = (
     "modules.communication.moltbot_bridge.src.openclaw_supervisor."
     "claim_reddog_signed_worker_dispatch_tasks_until_idle"
 )
+
+
+def test_profile_materializer_default_does_not_conflict_with_explicit_work_orders() -> None:
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
+        "REDDOG_WORK_ORDERS_PATH": "O:/runtime/work_orders.json",
+    }
+
+    assert resident_queue_materializer_mode(env) == ""
+
+
+def test_explicit_blank_materializer_mode_preserves_profile_default() -> None:
+    env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
+        "REDDOG_WORK_ORDERS_PATH": "O:/runtime/work_orders.json",
+        "REDDOG_WORK_ORDER_MATERIALIZER_MODE": "",
+    }
+
+    assert resident_queue_materializer_mode(env) == "authority_profile"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -214,11 +214,9 @@ def test_main_resident_red_dog_chain_passes_profile_to_downstream_preflights(mon
         "run_reddog_resident_queue_next_stage_dispatch_preflight",
         profile_bound_step("next_stage_dispatch"),
     ), patch.object(
-        main, "run_reddog_resident_queue_serial_loop_preflight", profile_bound_step("serial_loop")
-    ), patch.object(
         main,
-        "run_reddog_openclaw_signed_worker_claim_loop_preflight",
-        profile_bound_step("openclaw_claim_loop"),
+        "run_reddog_resident_queue_control_loop_preflight",
+        profile_bound_step("queue_control_loop"),
     ), patch.object(
         main, "run_reddog_readonly_operational_bootstrap_preflight", pass_step("readonly_bootstrap")
     ), patch.object(
@@ -244,12 +242,69 @@ def test_main_resident_red_dog_chain_passes_profile_to_downstream_preflights(mon
         "queue_consumer",
         "queue_orchestration",
         "next_stage_dispatch",
-        "serial_loop",
-        "openclaw_claim_loop",
+        "queue_control_loop",
         "readonly_bootstrap",
         "dae_bootstrap",
         "menu",
     ]
+
+
+def test_reddog_queue_control_loop_profile_repeats_serial_and_claim(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setenv(
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE",
+        "signed_0102_bounded_code_fusion_worktree_draft_pr",
+    )
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "3")
+
+    with patch.object(
+        main,
+        "run_reddog_resident_queue_serial_loop_preflight",
+        side_effect=lambda _repo_root: calls.append("serial") or True,
+    ), patch.object(
+        main,
+        "run_reddog_openclaw_signed_worker_claim_loop_preflight",
+        side_effect=lambda _repo_root: calls.append("claim") or True,
+    ):
+        assert main.run_reddog_resident_queue_control_loop_preflight(Path("O:/Foundups-Agent")) is True
+
+    assert calls == ["serial", "claim", "serial", "claim", "serial", "claim"]
+
+
+def test_reddog_queue_control_loop_without_profile_preserves_legacy_single_pass(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.delenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", raising=False)
+    monkeypatch.delenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP", raising=False)
+
+    with patch.object(
+        main,
+        "run_reddog_resident_queue_serial_loop_preflight",
+        side_effect=lambda _repo_root: calls.append("serial") or True,
+    ), patch.object(
+        main,
+        "run_reddog_openclaw_signed_worker_claim_loop_preflight",
+        side_effect=lambda _repo_root: calls.append("claim") or True,
+    ):
+        assert main.run_reddog_resident_queue_control_loop_preflight(Path("O:/Foundups-Agent")) is True
+
+    assert calls == ["serial", "claim"]
+
+
+def test_reddog_queue_control_loop_invalid_rounds_fail_closed_when_enforced(monkeypatch):
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "0")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED", "1")
+
+    with patch.object(main, "run_reddog_resident_queue_serial_loop_preflight") as serial, patch.object(
+        main,
+        "run_reddog_openclaw_signed_worker_claim_loop_preflight",
+    ) as claim:
+        assert main.run_reddog_resident_queue_control_loop_preflight(Path("O:/Foundups-Agent")) is False
+
+    serial.assert_not_called()
+    claim.assert_not_called()
 
 
 def test_main_dependency_security_blocker_runs_reddog_diagnostic_before_return(monkeypatch):


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED:
- Adds `run_reddog_resident_queue_control_loop_preflight()` to repeat existing resident queue serial-loop and OpenClaw signed-worker claim-loop preflights in bounded rounds.
- Enables `REDDOG_RESIDENT_QUEUE_CONTROL_LOOP` through resident queue binding profiles.
- Preserves the legacy no-profile behavior: one serial-loop preflight followed by one OpenClaw claim-loop preflight.
- Prevents implicit profile materializer defaults from conflicting with an explicit `REDDOG_WORK_ORDERS_PATH`, while preserving existing explicit blank materializer behavior.
- Guards `main.py` Windows UTF-8 stream wrapping during pytest imports so cross-file capture remains stable.

SPECIFIED_NOT_IMPLEMENTED / OUT OF SCOPE:
- No new authority creation.
- No new task creation.
- No worktree, shell, PR, merge, PatternMemory, reward, or HoloIndex re-index behavior.
- No OpenClaw/Hermes execution semantics are widened.

Validation:
- `python -m pytest tests/test_main_runtime_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 27 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py -q` -> 108 passed, 1 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 12 passed
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py` -> pass
- `git diff --check` -> clean