### PR TITLE
feat(reddog): resolve supervisor queue readiness via profile paths

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -819,12 +819,15 @@ def _openclaw_queue_stage_tasks_enabled_from_env() -> bool:
 def _signed_0102_bounded_code_stage_ready_from_env(
     context: Mapping[str, Any] | None,
     env: Mapping[str, str],
+    *,
+    repo_root: Path | str | None = None,
 ) -> bool:
     """Return True only when a coding task may safely drive the artifact stage."""
 
     from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
         resident_queue_artifact_generator_mode,
         resident_queue_binding_enabled,
+        resident_queue_runtime_file_path,
         resident_queue_runtime_flag_enabled,
     )
 
@@ -842,8 +845,18 @@ def _signed_0102_bounded_code_stage_ready_from_env(
         return False
     if str(env.get("REDDOG_ARTIFACT_CONTENTS_PATH") or "").strip():
         return False
-    work_state_path = str(env.get("REDDOG_AUTHORITATIVE_WORK_STATE_PATH") or "").strip()
-    chain_results_path = str(env.get("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH") or "").strip()
+    work_state_path = _resident_queue_runtime_input_path(
+        env,
+        repo_root=repo_root,
+        env_name="REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+        resolver=resident_queue_runtime_file_path,
+    )
+    chain_results_path = _resident_queue_runtime_input_path(
+        env,
+        repo_root=repo_root,
+        env_name="REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+        resolver=resident_queue_runtime_file_path,
+    )
     if not work_state_path or not chain_results_path:
         return False
     queue_item_id = str(context.get("queue_item_id") or "").strip()
@@ -877,10 +890,13 @@ def _signed_0102_bounded_code_stage_ready_from_env(
 def _openclaw_queue_stage_progress_ready_from_env(
     context: Mapping[str, Any] | None,
     env: Mapping[str, str],
+    *,
+    repo_root: Path | str | None = None,
 ) -> bool:
     """Return True only when a queue-stage worker may claim a post-code stage."""
 
     from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+        resident_queue_runtime_file_path,
         resident_queue_runtime_flag_enabled,
     )
 
@@ -888,8 +904,18 @@ def _openclaw_queue_stage_progress_ready_from_env(
         return False
     if not resident_queue_runtime_flag_enabled(env, "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER"):
         return False
-    work_state_path = str(env.get("REDDOG_AUTHORITATIVE_WORK_STATE_PATH") or "").strip()
-    chain_results_path = str(env.get("REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH") or "").strip()
+    work_state_path = _resident_queue_runtime_input_path(
+        env,
+        repo_root=repo_root,
+        env_name="REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+        resolver=resident_queue_runtime_file_path,
+    )
+    chain_results_path = _resident_queue_runtime_input_path(
+        env,
+        repo_root=repo_root,
+        env_name="REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+        resolver=resident_queue_runtime_file_path,
+    )
     if not work_state_path or not chain_results_path:
         return False
     queue_item_id = str(context.get("queue_item_id") or "").strip()
@@ -931,6 +957,26 @@ def _read_json_mapping(path: Path) -> Mapping[str, Any]:
     return payload if isinstance(payload, Mapping) else {}
 
 
+def _resident_queue_runtime_input_path(
+    env: Mapping[str, str],
+    *,
+    repo_root: Path | str | None,
+    env_name: str,
+    resolver: Callable[[Mapping[str, str], Path | str, str], str],
+) -> str:
+    """Return an explicit/profile-derived input path only when it exists."""
+
+    raw = str(env.get(env_name) or "").strip()
+    if raw:
+        return raw
+    if repo_root is None:
+        return ""
+    path = str(resolver(env, repo_root, env_name) or "").strip()
+    if path and Path(path).is_file():
+        return path
+    return ""
+
+
 def _resident_queue_stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapping[str, Any]]:
     raw = state.get("stage_results") if state.get("schema_version") == "reddog_resident_queue_chain_results.v1" else state
     if not isinstance(raw, Mapping):
@@ -938,7 +984,11 @@ def _resident_queue_stage_results(state: Mapping[str, Any]) -> Mapping[str, Mapp
     return {str(key): value for key, value in raw.items() if isinstance(value, Mapping)}
 
 
-def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
+def _has_pending_reddog_signed_worker_dispatch_task(
+    limit: int = 50,
+    *,
+    repo_root: Path | str | None = None,
+) -> bool:
     from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
         SIGNED_WORKER_DISPATCH_TASK_SOURCE,
     )
@@ -967,12 +1017,20 @@ def _has_pending_reddog_signed_worker_dispatch_task(limit: int = 50) -> bool:
             or (
                 include_0102_bounded_code
                 and is_0102_bounded_code_change_signed_worker_context(normalized)
-                and _signed_0102_bounded_code_stage_ready_from_env(normalized, os.environ)
+                and _signed_0102_bounded_code_stage_ready_from_env(
+                    normalized,
+                    os.environ,
+                    repo_root=repo_root,
+                )
             )
             or (
                 include_queue_stage_progress
                 and is_openclaw_queue_stage_progress_signed_worker_context(normalized)
-                and _openclaw_queue_stage_progress_ready_from_env(normalized, os.environ)
+                and _openclaw_queue_stage_progress_ready_from_env(
+                    normalized,
+                    os.environ,
+                    repo_root=repo_root,
+                )
             )
         ):
             return True
@@ -1473,7 +1531,7 @@ class OpenClawSupervisor:
             if max_claims_error:
                 return {"kind": "escalate", "reason": max_claims_error}
             try:
-                if _has_pending_reddog_signed_worker_dispatch_task():
+                if _has_pending_reddog_signed_worker_dispatch_task(repo_root=self.repo_root):
                     return {
                         "kind": "action",
                         "reason": "signed_worker_task_pending",

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -1,3 +1,4 @@
+import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +7,9 @@ import pytest
 from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
     OpenClawSupervisor,
     SupervisorState,
+)
+from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
+    allocate_reddog_wsp15_receipt,
 )
 from modules.infrastructure.database.src.db_manager import DatabaseManager
 
@@ -16,6 +20,100 @@ def isolated_agent_db(tmp_path, monkeypatch):
     DatabaseManager.reset_for_tests()
     yield
     DatabaseManager.reset_for_tests()
+
+
+def _queue_wsp15_allocation_receipt() -> dict[str, object]:
+    return allocate_reddog_wsp15_receipt(
+        requested_operation="create_foundup",
+        prompt_text="RedDog resident queue runtime authority worktree execution",
+        changed_paths=("modules/communication/moltbot_bridge/src/openclaw_supervisor.py",),
+        allowed_read_targets=("modules/communication/moltbot_bridge/src/openclaw_supervisor.py",),
+    ).to_dict()
+
+
+def _queue_snapshot() -> dict[str, object]:
+    allocation = _queue_wsp15_allocation_receipt()
+    return {
+        "schema_version": "reddog_authoritative_work_state.v1",
+        "freshness_receipts": [{"receipt_id": "fresh-1", "fresh": True}],
+        "worker_claims": [
+            {
+                "claim_id": "claim-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "worker_id": "reddog-0102",
+                "status": "ACTIVE",
+                "expires_at": "2026-07-14T01:00:00+00:00",
+                "freshness_receipt_id": "fresh-1",
+            }
+        ],
+        "wre_queue_items": [
+            {
+                "queue_item_id": "queue-1",
+                "slice_id": "REDDOG_TEST_SLICE_PHASE1",
+                "claim_id": "claim-1",
+                "worker_id": "reddog-0102",
+                "status": "QUEUED",
+                "evidence_refs": [
+                    "claim:claim-1",
+                    "freshness:fresh-1",
+                    f"wsp15_allocation:{allocation['receipt_id']}",
+                ],
+                "wsp15_allocation_receipt": allocation,
+                "no_execution_performed": True,
+            }
+        ],
+    }
+
+
+def _accepted_results_through(stage_key: str) -> dict[str, dict[str, object]]:
+    values = {
+        "authority_request": {"status": "QUEUE_AUTHORITY_REQUEST_DRYRUN_ACCEPT"},
+        "authority_runtime": {"decision": "QUEUE_AUTHORITY_RUNTIME_INVOKE_ACCEPT"},
+        "authority_verification": {"decision": "QUEUE_AUTHORITY_VERIFICATION_INVOKE_ACCEPT"},
+        "worker_dispatch_dryrun": {
+            "decision": "SIGNED_AUTHORITY_WORKER_DISPATCH_DRYRUN_ACCEPT"
+        },
+        "worker_dispatch_runtime": {
+            "decision": "SIGNED_AUTHORITY_WORKER_DISPATCH_RUNTIME_ACCEPT"
+        },
+        "work_order_invocation": {
+            "decision": "QUEUE_VERIFIED_AUTHORITY_WORK_ORDER_INVOKE_ACCEPT"
+        },
+        "executor_plan": {"decision": "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"},
+        "execution_valve": {"decision": "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"},
+        "worktree_create": {"decision": "QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT"},
+        "bounded_worker_pilot": {
+            "decision": "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT"
+        },
+    }
+    ordered: dict[str, dict[str, object]] = {}
+    for key, value in values.items():
+        ordered[key] = value
+        if key == stage_key:
+            break
+    return ordered
+
+
+def _write_runtime_queue_state(
+    runtime_root,
+    *,
+    accepted_through: str,
+) -> None:
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    (runtime_root / "authoritative_work_state.json").write_text(
+        json.dumps(_queue_snapshot(), sort_keys=True),
+        encoding="utf-8",
+    )
+    (runtime_root / "resident_queue_chain_results.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "reddog_resident_queue_chain_results.v1",
+                "stage_results": _accepted_results_through(accepted_through),
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_run_cycle_starts_openclaw_when_resident_runtime_is_down(tmp_path):
@@ -236,6 +334,207 @@ def test_run_cycle_claims_signed_worker_tasks_when_profile_enables_supervisor_lo
         max_claims=3
     )
     assert result["verify"]["ok"] is True
+
+
+def test_run_cycle_claims_signed_0102_bounded_code_task_with_profile_runtime_paths(tmp_path):
+    from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+        SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime_root = tmp_path / "resident-runtime"
+    _write_runtime_queue_state(runtime_root, accepted_through="worktree_create")
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True, "recent_events": []}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 12,
+        "latest_sequence_id": 12,
+    }
+    supervisor = OpenClawSupervisor(
+        repo_root=repo,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: None,
+        self_audit_factory=lambda repo_root: MagicMock(scan_once=MagicMock(return_value=0)),
+    )
+    supervisor._bootstrapped = True
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle = MagicMock(
+        return_value={
+            "accepted": True,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT",
+            "claimed_count": 1,
+            "completed_task_ids": ("task-code",),
+            "failed_task_ids": (),
+            "rejection_reasons": (),
+        }
+    )
+    pending_task = {
+        "task_id": "task-code",
+        "discovered_by": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        "context": {
+            "source": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            "worker_runtime": "0102",
+            "capability": "bounded_code_change",
+            "queue_item_id": "queue-1",
+        },
+    }
+
+    with patch.dict(
+        os.environ,
+        {
+            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion",
+            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            "REDDOG_RESIDENT_QUEUE_NOW_ISO": "2026-07-14T00:00:00+00:00",
+        },
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = [pending_task]
+        result = supervisor.run_cycle()
+
+    assert result["plan"]["action"] == "claim_signed_worker_tasks_until_idle"
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle.assert_called_once_with(
+        max_claims=1
+    )
+    assert result["verify"]["completed_task_ids"] == ("task-code",)
+
+
+def test_run_cycle_claims_queue_stage_progress_task_with_profile_runtime_paths(tmp_path):
+    from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+        SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime_root = tmp_path / "resident-runtime"
+    _write_runtime_queue_state(runtime_root, accepted_through="bounded_worker_pilot")
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True, "recent_events": []}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 13,
+        "latest_sequence_id": 13,
+    }
+    supervisor = OpenClawSupervisor(
+        repo_root=repo,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: None,
+        self_audit_factory=lambda repo_root: MagicMock(scan_once=MagicMock(return_value=0)),
+    )
+    supervisor._bootstrapped = True
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle = MagicMock(
+        return_value={
+            "accepted": True,
+            "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT",
+            "claimed_count": 1,
+            "completed_task_ids": ("task-stage",),
+            "failed_task_ids": (),
+            "rejection_reasons": (),
+        }
+    )
+    pending_task = {
+        "task_id": "task-stage",
+        "discovered_by": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        "context": {
+            "source": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            "worker_runtime": "openclaw",
+            "capability": "queue_stage_progress",
+            "queue_item_id": "queue-1",
+        },
+    }
+
+    with patch.dict(
+        os.environ,
+        {
+            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
+            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            "REDDOG_RESIDENT_QUEUE_NOW_ISO": "2026-07-14T00:00:00+00:00",
+        },
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = [pending_task]
+        result = supervisor.run_cycle()
+
+    assert result["plan"]["action"] == "claim_signed_worker_tasks_until_idle"
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle.assert_called_once_with(
+        max_claims=1
+    )
+    assert result["verify"]["completed_task_ids"] == ("task-stage",)
+
+
+def test_run_cycle_does_not_claim_queue_stage_task_when_profile_runtime_files_missing(tmp_path):
+    from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
+        SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime_root = tmp_path / "resident-runtime"
+    broker = MagicMock()
+    broker.get_runtime_status.side_effect = lambda dae_id: {
+        "registered": True,
+        "running": True,
+        "state": "running",
+        "last_error": "",
+        "enabled": True,
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True, "recent_events": []}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 14,
+        "latest_sequence_id": 14,
+    }
+    supervisor = OpenClawSupervisor(
+        repo_root=repo,
+        broker=broker,
+        observer=observer,
+        action_reporter=lambda action, result, details: None,
+        self_audit_factory=lambda repo_root: MagicMock(scan_once=MagicMock(return_value=0)),
+    )
+    supervisor._bootstrapped = True
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle = MagicMock()
+    pending_task = {
+        "task_id": "task-stage-missing",
+        "discovered_by": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+        "context": {
+            "source": SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            "worker_runtime": "openclaw",
+            "capability": "queue_stage_progress",
+            "queue_item_id": "queue-1",
+        },
+    }
+
+    with patch.dict(
+        os.environ,
+        {
+            "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
+            "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+            "REDDOG_RESIDENT_QUEUE_NOW_ISO": "2026-07-14T00:00:00+00:00",
+            "OPENCLAW_AUTO_TASKS_ENABLED": "0",
+        },
+    ), patch("modules.infrastructure.database.src.agent_db.AgentDB") as mock_db:
+        mock_db.return_value.get_autonomous_tasks.return_value = [pending_task]
+        result = supervisor.run_cycle()
+
+    assert result["triage"]["kind"] == "idle"
+    supervisor.claim_reddog_signed_worker_dispatch_tasks_until_idle.assert_not_called()
 
 
 def test_run_cycle_explicit_zero_disables_profile_signed_worker_loop(tmp_path):


### PR DESCRIPTION
## WSP_97 Summary

OBSERVED: Resident queue profiles already derive runtime paths for startup serial loops and for queue runner construction, but OpenClaw supervisor readiness gates still checked only raw `REDDOG_AUTHORITATIVE_WORK_STATE_PATH` / `REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH` env vars.

OBSERVED: That meant `REDDOG_RESIDENT_RUNTIME_ROOT` + profile could build the runner but fail to make bounded-code or queue-stage tasks claimable in resident supervisor triage.

IMPLEMENTED: Threaded `repo_root` into the signed-worker pending-task probe and readiness helpers, resolving profile-derived existing input paths before reading queue state.

FAIL-CLOSED: Profile-derived paths must exist as files for readiness; missing runtime files remain idle and do not claim tasks.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 26 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 38 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 12 passed
- `python -m pytest tests/test_main_runtime_bootstrap.py -q` -> 16 passed, 1 existing warning
- Combined focused run for the four files above -> 92 passed, 1 existing warning
- `python -m py_compile modules/communication/moltbot_bridge/src/openclaw_supervisor.py` -> pass
- `git diff --check` -> clean (Windows CRLF notice only)

## Boundary

- No source mutation authority widened
- No shell execution added
- No OpenClaw enqueue or Hermes dispatch added
- No worktree/PR/pattern-memory/reward/HoloIndex re-index behavior added