### PR TITLE
feat(reddog): thread profile paths into signed worker claims

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -293,6 +293,7 @@ def claim_reddog_signed_worker_dispatch_task_once(
             include_0102_bounded_code=_signed_0102_bounded_code_tasks_enabled_from_env(),
             include_queue_stage_progress=_openclaw_queue_stage_tasks_enabled_from_env(),
             env=os.environ,
+            repo_root=repo_root,
         )
     except Exception as exc:
         return _signed_worker_claim_result(
@@ -540,6 +541,7 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
     include_0102_bounded_code: bool = False,
     include_queue_stage_progress: bool = False,
     env: Mapping[str, str] | None = None,
+    repo_root: Path | str | None = None,
 ) -> Optional[Dict[str, Any]]:
     from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
         is_0102_bounded_code_change_signed_worker_context,
@@ -580,12 +582,20 @@ def _claim_pending_reddog_signed_worker_dispatch_task(
                 or (
                     include_0102_bounded_code
                     and is_0102_bounded_code_change_signed_worker_context(candidate_context)
-                    and _signed_0102_bounded_code_stage_ready_from_env(candidate_context, env or os.environ)
+                    and _signed_0102_bounded_code_stage_ready_from_env(
+                        candidate_context,
+                        env or os.environ,
+                        repo_root=repo_root,
+                    )
                 )
                 or (
                     include_queue_stage_progress
                     and is_openclaw_queue_stage_progress_signed_worker_context(candidate_context)
-                    and _openclaw_queue_stage_progress_ready_from_env(candidate_context, env or os.environ)
+                    and _openclaw_queue_stage_progress_ready_from_env(
+                        candidate_context,
+                        env or os.environ,
+                        repo_root=repo_root,
+                    )
                 )
             ):
                 row = candidate

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -35,6 +35,9 @@ from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task
     SignedWorkerDispatchTaskExecutorReason,
     execute_reddog_signed_worker_dispatch_task,
 )
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+    resident_queue_runtime_file_path,
+)
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
     SIGNED_0102_READONLY_REVIEW_BINDING_ACCEPT,
     Signed0102ReadOnlyReviewBindingReason,
@@ -60,6 +63,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_main_resident_queue_
     _outcome_ratchet_request,
     _pattern_memory_admission_request,
     _pilot_allowed_paths,
+    _pilot_bounded_worker_plan,
     _pilot_path_overrides,
     _pilot_payloads,
     _pilot_worktree_path,
@@ -1591,11 +1595,15 @@ def test_openclaw_claim_env_bound_queue_loop_runner_reaches_held_out_regression_
     monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
 
-    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=ctx["repo"])
+    result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+        repo_root=ctx["repo"],
+        max_claims=2,
+    )
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
-    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
-    assert result["task_id"] == task_id
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT
+    assert result["claimed_count"] == 2
+    assert result["requeued_task_ids"] == (task_id, task_id)
     assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
     stored = json.loads(Path(ctx["chain"]).read_text(encoding="utf-8"))
@@ -1788,19 +1796,27 @@ def test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues(
 
     result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
         repo_root=repo,
-        max_claims=7,
+        max_claims=8,
     )
 
     assert result["accepted"] is True, json.dumps(result, sort_keys=True)
     assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT
-    assert result["claimed_count"] == 6
-    assert result["requeued_task_ids"] == (task_id, task_id, task_id, task_id, task_id)
+    assert result["claimed_count"] == 7
+    assert result["requeued_task_ids"] == (
+        task_id,
+        task_id,
+        task_id,
+        task_id,
+        task_id,
+        task_id,
+    )
     assert result["completed_task_ids"] == (task_id,)
     assert result["failed_task_ids"] == ()
     assert result["idle"] is True
     assert result["max_claims_reached"] is False
     assert result["claim_results"][-1]["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
     assert [claim["status"] for claim in result["claim_results"][:-1]] == [
+        SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
         SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
         SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
         SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
@@ -1816,6 +1832,7 @@ def test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues(
         "slice_verifier",
         "verified_draft_pr_publish",
         "verified_outcome_ratchet",
+        "model_feedback_admission",
         "held_out_regression_gate",
         "pattern_memory_admission",
     ):
@@ -1834,6 +1851,180 @@ def test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues(
         count = conn.execute("SELECT COUNT(*) FROM skill_outcomes").fetchone()[0]
     assert count == 1
     assert not (repo / "runtime" / "pattern_memory.db").exists()
+
+
+def test_openclaw_claim_uses_profile_paths_for_bounded_code_readiness(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo = _repo(tmp_path)
+    profile_env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion",
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(tmp_path / "resident-runtime"),
+        "REDDOG_RESIDENT_QUEUE_NOW_ISO": BOOTSTRAP_NOW,
+    }
+
+    def _write_profile_file(env_name: str, payload: object) -> Path:
+        path = Path(resident_queue_runtime_file_path(profile_env, repo, env_name))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        return path
+
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_profile_file("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", _bootstrap_snapshot())
+    profile = _write_profile_file(
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+        _bootstrap_profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+        ),
+    )
+    snapshots = _write_profile_file("REDDOG_PERMISSION_SNAPSHOTS_PATH", _snapshots())
+    principals = _write_profile_file(
+        "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH",
+        _principals(principal_public),
+    )
+    valve_env = _write_profile_file("REDDOG_EXECUTION_VALVE_ENV_PATH", _valve_environment())
+    work_order = _work_order(
+        **pilot_overrides,
+        bounded_worker_plan=_pilot_bounded_worker_plan(),
+    )
+    work_order["holoindex_evidence"] = {
+        **dict(work_order["holoindex_evidence"]),
+        "holoindex_freshness_receipt_digest": "sha256:holo-fresh",
+    }
+    work_orders_path = tmp_path / "resident-runtime" / "work_orders.json"
+    work_orders_path.parent.mkdir(parents=True, exist_ok=True)
+    work_orders_path.write_text(
+        json.dumps(
+            {"work_orders": {str(work_order["work_order_id"]): work_order}},
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    chain = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+        )
+    )
+    authority_state = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_AUTHORITY_RUNTIME_STATE_PATH",
+        )
+    )
+    socket_path = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_SIGNER_SOCKET_PATH",
+        )
+    )
+
+    seed = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_orders_path=work_orders_path,
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worker_dispatch_writer=runtime.AgentDbSignedWorkerDispatchTaskWriter(),
+        worktree_runner=_FakeWorktreeRunner(),
+        now_iso=BOOTSTRAP_NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=9,
+    )
+    assert seed.accepted is True
+    assert seed.dispatched_stages[-1] == "worktree_create"
+
+    pending = [
+        task
+        for task in AgentDB().get_autonomous_tasks(status="pending", limit=10)
+        if task.get("discovered_by") == runtime.SIGNED_WORKER_DISPATCH_TASK_SOURCE
+    ]
+    assert len(pending) == 2
+    coding_task_id = next(
+        task["task_id"]
+        for task in pending
+        if task["context"]["worker_runtime"] == "0102"
+        and task["context"]["capability"] == "bounded_code_change"
+    )
+
+    from modules.communication.moltbot_bridge.src import (
+        reddog_bounded_artifact_generation_runtime as artifact_runtime,
+    )
+
+    fusion_calls: list[dict[str, object]] = []
+
+    def _fake_fusion(api_key, user_payload, messages, payload):
+        fusion_calls.append(
+            {
+                "api_key": api_key,
+                "user_payload": user_payload,
+                "messages": messages,
+                "payload": payload,
+            }
+        )
+        return {
+            "ok": True,
+            "content": json.dumps(
+                {
+                    "artifact_contents": {
+                        PILOT_ARTIFACT: "# Generated By Fusion\n\nprofile path claim\n"
+                    }
+                },
+                sort_keys=True,
+            ),
+            "review_packet": {"receipt_id": "fusion-artifact-receipt-profile-path"},
+        }
+
+    monkeypatch.setattr(
+        artifact_runtime,
+        "_load_foundups_fusion_runner",
+        lambda: _fake_fusion,
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+    for env_name in (
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH",
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+        "REDDOG_WORK_ORDERS_PATH",
+        "REDDOG_ARTIFACT_GENERATION_REQUEST_PATH",
+        "REDDOG_ARTIFACT_CONTENTS_PATH",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    for key, value in profile_env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("REDDOG_WORK_ORDERS_PATH", str(work_orders_path))
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+
+    result = claim_reddog_signed_worker_dispatch_task_once(repo_root=repo)
+
+    assert result["accepted"] is True, json.dumps(result, sort_keys=True)
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == coding_task_id
+    assert result["worker_runtime"] == "0102"
+    assert result["capability"] == "bounded_code_change"
+    assert AgentDB().get_autonomous_task_by_id(coding_task_id)["status"] == "completed"
+    assert fusion_calls
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    assert stored["stage_results"]["bounded_worker_pilot"]["decision"] == (
+        "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT"
+    )
 
 
 def test_openclaw_claims_signed_worker_task_once_and_completes_it(tmp_path: Path) -> None:


### PR DESCRIPTION
## WSP_97 Summary

OBSERVED: #1255 made the resident profile publish signed worker-dispatch tasks through AgentDB, but the OpenClaw claim filter still failed to pass `repo_root` into the readiness predicates that resolve profile-derived runtime files.

OBSERVED: This meant profile-only runtime paths could be present on disk while 0102 bounded-code / queue-stage-progress tasks were skipped unless explicit path env vars were also set.

IMPLEMENTED: Thread `repo_root` through `_claim_pending_reddog_signed_worker_dispatch_task()` into `_signed_0102_bounded_code_stage_ready_from_env()` and `_openclaw_queue_stage_progress_ready_from_env()`.

IMPLEMENTED: Add regression coverage proving a profile/runtime-root-only setup can claim a 0102 bounded-code task and drive `bounded_worker_pilot` through the Fusion artifact path without explicit work-state/chain/profile path env vars.

BOUNDARY: No new authority, no shell execution, no repo mutation, no worker-spawn widening, no HoloIndex re-index. This only repairs readiness path resolution for already-gated signed worker tasks.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py::test_openclaw_claim_uses_profile_paths_for_bounded_code_readiness -q` -> PASS
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 43 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 119 passed
- `python -m py_compile modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py` -> PASS
- `git diff --check` -> clean (Windows LF/CRLF warnings only)