### PR TITLE
feat(reddog): materialize bounded worker plans from authority profiles

### DIFF
--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
@@ -663,6 +664,14 @@ def _materialize_work_orders_from_authority_profile(
     if holo_reasons:
         return None, holo_reasons
 
+    bounded_worker_plan, bounded_worker_plan_reasons = _bounded_worker_plan_from_authority_profile(
+        authority_profile=authority_profile,
+        allowed_paths=_string_list(request.get("allowed_paths")),
+        foundup_id=str(request.get("foundup_id") or authority_profile.get("foundup_id") or ""),
+    )
+    if bounded_worker_plan_reasons:
+        return None, bounded_worker_plan_reasons
+
     evidence_seed = {
         "queue_receipt": queue_receipt,
         "delegated_authority_request": request,
@@ -734,7 +743,107 @@ def _materialize_work_orders_from_authority_profile(
         ),
         "model_runtime_binding_digest": str(authority_profile.get("model_runtime_binding_digest") or ""),
     }
+    if bounded_worker_plan:
+        work_order["bounded_worker_plan"] = bounded_worker_plan
     return {work_order_id: work_order}, ()
+
+
+def _bounded_worker_plan_from_authority_profile(
+    *,
+    authority_profile: Mapping[str, Any],
+    allowed_paths: tuple[str, ...],
+    foundup_id: str,
+) -> tuple[dict[str, Any], tuple[str, ...]]:
+    raw_plan = authority_profile.get("bounded_worker_plan")
+    if raw_plan is not None and not isinstance(raw_plan, Mapping):
+        return {}, ("work_order_materializer_bounded_worker_plan_invalid:type",)
+    plan = _nested_mapping(authority_profile, "bounded_worker_plan")
+    if not plan:
+        return {}, ()
+    if not _is_ascii_json_safe(plan):
+        return {}, ("work_order_materializer_bounded_worker_plan_non_ascii",)
+
+    reasons: list[str] = []
+    required_fields = (
+        "operation",
+        "domain_id",
+        "domain_profile",
+        "planned_artifacts",
+        "shell_profile",
+        "shell_argv",
+        "selection_receipt",
+        "signed_receipt_chain",
+    )
+    for field_name in required_fields:
+        if field_name not in plan or plan.get(field_name) in (None, "", (), [], {}):
+            reasons.append(f"work_order_materializer_bounded_worker_plan_missing:{field_name}")
+
+    domain_id = str(plan.get("domain_id") or "").strip()
+    if foundup_id and domain_id and domain_id != foundup_id:
+        reasons.append("work_order_materializer_bounded_worker_plan_scope_mismatch:domain_id")
+
+    planned_artifacts = _string_list(plan.get("planned_artifacts"))
+    if not planned_artifacts:
+        reasons.append("work_order_materializer_bounded_worker_plan_invalid:planned_artifacts")
+    for artifact in planned_artifacts:
+        if not _relative_repo_path(artifact):
+            reasons.append("work_order_materializer_bounded_worker_plan_invalid_artifact_path")
+            continue
+        if not _path_allowed_by_patterns(artifact, allowed_paths):
+            reasons.append("work_order_materializer_bounded_worker_plan_artifact_outside_allowed_paths")
+
+    requested_allowed_paths = _string_list(plan.get("requested_allowed_paths"))
+    for requested in requested_allowed_paths:
+        if not _relative_repo_path(requested.rstrip("*")):
+            reasons.append("work_order_materializer_bounded_worker_plan_invalid_requested_allowed_path")
+            continue
+        if not _pattern_within_allowed_paths(requested, allowed_paths):
+            reasons.append("work_order_materializer_bounded_worker_plan_requested_path_outside_allowed_paths")
+
+    if not _string_list(plan.get("shell_argv")):
+        reasons.append("work_order_materializer_bounded_worker_plan_invalid:shell_argv")
+    for mapping_field in ("domain_profile", "shell_profile", "selection_receipt", "signed_receipt_chain"):
+        if not _nested_mapping(plan, mapping_field):
+            reasons.append(f"work_order_materializer_bounded_worker_plan_invalid:{mapping_field}")
+
+    if reasons:
+        return {}, tuple(dict.fromkeys(reasons))
+    return dict(plan), ()
+
+
+def _is_ascii_json_safe(value: Any) -> bool:
+    try:
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("ascii")
+    except (TypeError, UnicodeEncodeError, ValueError):
+        return False
+    return True
+
+
+def _relative_repo_path(value: str) -> bool:
+    raw = str(value or "").replace("\\", "/").strip()
+    if not raw or raw.startswith("/") or raw.startswith("../") or "/../" in raw or raw == "..":
+        return False
+    if ":" in raw:
+        return False
+    return True
+
+
+def _path_allowed_by_patterns(path: str, allowed_paths: tuple[str, ...]) -> bool:
+    normalized = str(path or "").replace("\\", "/").strip()
+    return any(fnmatchcase(normalized, pattern.replace("\\", "/")) for pattern in allowed_paths)
+
+
+def _pattern_within_allowed_paths(pattern: str, allowed_paths: tuple[str, ...]) -> bool:
+    normalized = str(pattern or "").replace("\\", "/").strip()
+    for allowed in allowed_paths:
+        allowed_normalized = allowed.replace("\\", "/").strip()
+        if normalized == allowed_normalized:
+            return True
+        if allowed_normalized.endswith("/**"):
+            root = allowed_normalized[:-3].rstrip("/")
+            if normalized == root or normalized.startswith(root + "/"):
+                return True
+    return False
 
 
 def _canonical_digest(payload: Any) -> str:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py
@@ -310,6 +310,86 @@ def test_authority_profile_materializer_carries_model_runtime_binding_receipt() 
     assert work_order["model_runtime_binding_receipt"]["receipt_id"] == runtime_binding["receipt_id"]
 
 
+def test_authority_profile_materializer_carries_scoped_bounded_worker_plan() -> None:
+    plan = _pilot_bounded_worker_plan()
+    profile = _profile(
+        requested_operation=PILOT_OPERATION,
+        allowed_paths=_pilot_allowed_paths(),
+        bounded_worker_plan=plan,
+    )
+
+    work_orders, reasons = _materialize_work_orders_from_authority_profile(
+        snapshot=_snapshot(),
+        authority_profile=profile,
+        requested_queue_item_id="queue-1",
+        now_iso=NOW,
+    )
+
+    assert reasons == ()
+    assert work_orders is not None
+    assert work_orders[WORK_ORDER_ID]["bounded_worker_plan"] == plan
+
+
+def test_authority_profile_materializer_rejects_bounded_worker_plan_outside_scope() -> None:
+    plan = _pilot_bounded_worker_plan()
+    plan["planned_artifacts"] = ["modules/foundups/other_foundup/README.md"]
+
+    work_orders, reasons = _materialize_work_orders_from_authority_profile(
+        snapshot=_snapshot(),
+        authority_profile=_profile(
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            bounded_worker_plan=plan,
+        ),
+        requested_queue_item_id="queue-1",
+        now_iso=NOW,
+    )
+
+    assert work_orders is None
+    assert "work_order_materializer_bounded_worker_plan_artifact_outside_allowed_paths" in reasons
+
+
+def test_authority_profile_materializer_rejects_bounded_worker_plan_domain_mismatch() -> None:
+    plan = _pilot_bounded_worker_plan()
+    plan["domain_id"] = "other_foundup"
+
+    work_orders, reasons = _materialize_work_orders_from_authority_profile(
+        snapshot=_snapshot(),
+        authority_profile=_profile(
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            bounded_worker_plan=plan,
+        ),
+        requested_queue_item_id="queue-1",
+        now_iso=NOW,
+    )
+
+    assert work_orders is None
+    assert "work_order_materializer_bounded_worker_plan_scope_mismatch:domain_id" in reasons
+
+
+def test_authority_profile_materializer_rejects_non_ascii_bounded_worker_plan() -> None:
+    plan = _pilot_bounded_worker_plan()
+    plan["operation"] = "résumé_patch"
+
+    work_orders, reasons = _materialize_work_orders_from_authority_profile(
+        snapshot=_snapshot(),
+        authority_profile=_profile(
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            bounded_worker_plan=plan,
+        ),
+        requested_queue_item_id="queue-1",
+        now_iso=NOW,
+    )
+
+    assert work_orders is None
+    assert (
+        "work_order_materializer_bounded_worker_plan_non_ascii" in reasons
+        or "work_order_materializer_authority:FAIL_PROFILE_NON_ASCII" in reasons
+    )
+
+
 def _work_orders(**overrides: object) -> dict[str, object]:
     order = _work_order(**overrides)
     return {"work_orders": {WORK_ORDER_ID: order}}
@@ -1689,6 +1769,69 @@ def test_bootstrap_serial_loop_materializes_work_order_from_authority_profile(
     assert stage_results["executor_plan"]["decision"] == "QUEUE_AUTHORIZED_EXECUTOR_PLAN_DRYRUN_ACCEPT"
     assert stage_results["execution_valve"]["decision"] == "QUEUE_AUTHORIZED_EXECUTION_VALVE_INVOKE_ACCEPT"
     assert "work_orders.json" not in json.dumps(stored, sort_keys=True)
+
+
+def test_bootstrap_serial_loop_materializes_bounded_worker_plan_from_authority_profile(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    principal_public, reddog_public, connector = _ed25519_signing_material()
+    state = _write_runtime_json(tmp_path, "work_state.json", _snapshot())
+    profile = _write_runtime_json(
+        tmp_path,
+        "profile.json",
+        _profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            bounded_worker_plan=_pilot_bounded_worker_plan(),
+        ),
+    )
+    snapshots = _write_runtime_json(tmp_path, "snapshots.json", _snapshots())
+    principals = _write_runtime_json(tmp_path, "principals.json", _principals(principal_public))
+    valve_env = _write_runtime_json(tmp_path, "valve_env.json", _valve_environment())
+    chain = tmp_path / "runtime" / "chain_results.json"
+    authority_state = tmp_path / "runtime" / "authority_state.json"
+    socket_path = tmp_path / "runtime" / "signer.sock"
+    artifact_generator = _FakeArtifactGenerator(content="# generated from profile plan\n")
+
+    result = run_reddog_main_resident_queue_serial_loop_bootstrap(
+        repo_root=repo,
+        work_state_path=state,
+        chain_results_path=chain,
+        authority_profile_path=profile,
+        work_order_materializer_mode="authority_profile",
+        valve_environment_path=valve_env,
+        authority_state_path=authority_state,
+        permission_snapshots_path=snapshots,
+        principal_authority_records_path=principals,
+        signer_socket_path=socket_path,
+        signer_socket_connector=connector,
+        signature_verifier_backend=REDDOG_SIGNATURE_VERIFIER_BACKEND_ED25519,
+        worker_dispatch_writer=_FakeWorkerDispatchTaskWriter(),
+        worktree_runner=_FakeWorktreeRunner(),
+        pilot_dryrun_binding_enabled=True,
+        artifact_generation_request_binding_enabled=True,
+        artifact_generator=artifact_generator,
+        now_iso=NOW,
+        now_epoch=1000,
+        requested_queue_item_id="queue-1",
+        max_steps=10,
+    )
+
+    assert result.accepted is True
+    assert result.dispatched_stages[-2:] == ("worktree_create", "bounded_worker_pilot")
+    assert result.next_action == "RUN_QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE"
+    assert artifact_generator.calls
+
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    stage_results = stored["stage_results"]
+    assert stage_results["bounded_worker_pilot"]["decision"] == (
+        "QUEUE_AUTHORIZED_BOUNDED_WORKER_PILOT_INVOKE_ACCEPT"
+    )
+    assert "work_orders.json" not in json.dumps(stored, sort_keys=True)
+    assert artifact_generator.calls[0]["binding"]["work_order_id"] == WORK_ORDER_ID
 
 
 def test_bootstrap_serial_loop_creates_worktree_only_with_explicit_runner(


### PR DESCRIPTION
## WSP_97 truth boundary

OBSERVED: the resident queue can now publish signed worker tasks into AgentDB and the OpenClaw claim loop can resolve profile-derived readiness paths.

OBSERVED: bounded-code pilot stages still required a separately supplied `work_orders.json` to carry `bounded_worker_plan`, keeping a manual file in the profile-driven resident path.

IMPLEMENTED: when `work_order_materializer_mode=authority_profile`, the authority-profile materializer now optionally carries `authority_profile.bounded_worker_plan` into the generated in-memory work order after fail-closed validation.

BOUNDARY: no shell execution, no HoloIndex re-index, no extension runtime changes, no merge authority, no new worker spawn widening. Profiles without `bounded_worker_plan` keep existing behavior.

## Validation

- `python -m py_compile modules/communication/moltbot_bridge/src/reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py`
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_authority_profile_materializer_carries_scoped_bounded_worker_plan modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_authority_profile_materializer_rejects_bounded_worker_plan_outside_scope modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_authority_profile_materializer_rejects_bounded_worker_plan_domain_mismatch modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_authority_profile_materializer_rejects_non_ascii_bounded_worker_plan modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py::test_bootstrap_serial_loop_materializes_bounded_worker_plan_from_authority_profile -q` -> 5 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 66 passed, 1 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 43 passed
- `python -m pytest tests/test_main_runtime_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py -q` -> 67 passed, 1 warning
- `git diff --check` -> clean except Windows LF/CRLF informational warnings