### PR TITLE
feat(reddog): add WSP71 signer provider runtime mode

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_SIGNER_KEY_PROVIDER_WSP71_RUNTIME_MODE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added an explicit `WSP71_PERMISSIONED` signer key-provider mode alongside the
+  existing `TEST_ONLY_DRYRUN` mode.
+- Preserved default fail-closed behavior while allowing signer-owned runtime
+  wiring to accept an injected non-mock WSP-71-like resolver with a fresh
+  permission snapshot and no test-only override.
+- Rejected mock vault resolver use in `WSP71_PERMISSIONED` mode so the PoC
+  resolver cannot become a production credential authority.
+- Updated signer process and bounded signer service runtime wiring to call the
+  production-capable provider entrypoint name while keeping the old dry-run
+  function as a compatibility wrapper.
+- Boundary remains constrained: this does not configure a real vault, read
+  environment variables, load files, spawn a process, mutate source, enqueue
+  OpenClaw, dispatch Hermes, publish PRs, settle rewards, or re-index HoloIndex.
+
 ## 2026-07-17: REDDOG_SIGNER_SOCKET_RUNTIME_AVAILABILITY_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_process_entrypoint.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_process_entrypoint.py
@@ -25,7 +25,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
     SignerKeyProviderProfile,
     SignerKeyResolver,
-    build_test_only_signer_backend_from_provider,
+    build_signer_backend_from_provider,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     KernelPeerCredentialAttestor,
@@ -115,7 +115,7 @@ def run_reddog_isolated_signer_process_once(
     if not _peer_policy_valid(config.peer_policy):
         return _reject(FAIL_SIGNER_PROCESS_PEER_POLICY_INVALID)
 
-    key_result = build_test_only_signer_backend_from_provider(
+    key_result = build_signer_backend_from_provider(
         config.key_provider_profile,
         resolver,
         provider_mode=config.provider_mode,

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -1,11 +1,11 @@
-"""Test-only RedDog signer key provider dry-run boundary.
+"""RedDog signer key provider boundary.
 
 Slice: REDDOG_SIGNER_KEY_PROVIDER_DRYRUN_PHASE1
 
-This module validates the signer key-provider contract with injected test-only
-resolver output. It can construct an ``Ed25519SignerBackend`` only when the
-caller explicitly enables the test-only dry-run mode and supplies a fresh
-permission snapshot. It does not connect to a real vault, read environment
+This module validates the signer key-provider contract with an injected
+WSP-71-like resolver. It can construct an ``Ed25519SignerBackend`` only when
+the caller explicitly selects a supported provider mode and supplies a fresh
+permission snapshot. It does not connect to a vault by itself, read environment
 variables, load files, bind sockets, spawn processes, mutate repository state,
 enqueue OpenClaw, dispatch Hermes, or re-index HoloIndex.
 """
@@ -41,6 +41,7 @@ from modules.infrastructure.secrets_mcp.src.vault_resolver import (
 
 
 PROVIDER_MODE_TEST_ONLY_DRYRUN = "TEST_ONLY_DRYRUN"
+PROVIDER_MODE_WSP71_PERMISSIONED = "WSP71_PERMISSIONED"
 
 FAIL_PROVIDER_PROFILE_INVALID = "FAIL_PROVIDER_PROFILE_INVALID"
 FAIL_PROVIDER_PERMISSION_DENIED = "FAIL_PROVIDER_PERMISSION_DENIED"
@@ -143,17 +144,22 @@ def build_test_only_signer_backend_from_provider(
     allow_test_only_key_material: bool = False,
     permission_snapshot_fresh: bool = False,
 ) -> SignerKeyProviderDryRunResult:
-    """Validate a signer profile and build a test-only Ed25519 signer backend.
+    """Validate a signer profile and build an Ed25519 signer backend.
 
     The default path rejects. A caller must explicitly opt into
-    ``TEST_ONLY_DRYRUN`` and provide a fresh permission snapshot. This prevents
-    accidental production use while allowing contract-driven tests to prove the
-    existing signer backend can be supplied from an injected resolver boundary.
+    ``TEST_ONLY_DRYRUN`` or ``WSP71_PERMISSIONED`` and provide a fresh
+    permission snapshot. ``TEST_ONLY_DRYRUN`` additionally requires
+    ``allow_test_only_key_material``. ``WSP71_PERMISSIONED`` rejects the mock
+    vault resolver and any test-only override flag.
     """
 
     if not isinstance(profile, SignerKeyProviderProfile):
         return _reject(FAIL_PROVIDER_PROFILE_INVALID)
-    if provider_mode != PROVIDER_MODE_TEST_ONLY_DRYRUN or not allow_test_only_key_material:
+    if not _provider_mode_authorized(
+        provider_mode,
+        allow_test_only_key_material=allow_test_only_key_material,
+        resolver=resolver,
+    ):
         return _reject(FAIL_PROVIDER_MOCK_IN_PRODUCTION, profile=profile)
     if not _profile_ascii_and_complete(profile):
         return _reject(FAIL_PROVIDER_PROFILE_INVALID, profile=profile)
@@ -209,6 +215,45 @@ def build_test_only_signer_backend_from_provider(
             audit_mac_builder=_HmacAuditMacBuilder(audit_key),
         ),
     )
+
+
+def build_signer_backend_from_provider(
+    profile: SignerKeyProviderProfile,
+    resolver: SignerKeyResolver,
+    *,
+    provider_mode: str = "",
+    allow_test_only_key_material: bool = False,
+    permission_snapshot_fresh: bool = False,
+) -> SignerKeyProviderDryRunResult:
+    """Compatibility wrapper with the production-capable boundary name."""
+
+    return build_test_only_signer_backend_from_provider(
+        profile,
+        resolver,
+        provider_mode=provider_mode,
+        allow_test_only_key_material=allow_test_only_key_material,
+        permission_snapshot_fresh=permission_snapshot_fresh,
+    )
+
+
+def _provider_mode_authorized(
+    provider_mode: str,
+    *,
+    allow_test_only_key_material: bool,
+    resolver: SignerKeyResolver,
+) -> bool:
+    if provider_mode == PROVIDER_MODE_TEST_ONLY_DRYRUN:
+        return bool(allow_test_only_key_material)
+    if provider_mode == PROVIDER_MODE_WSP71_PERMISSIONED:
+        if allow_test_only_key_material:
+            return False
+        return not _resolver_is_mock_vault(resolver)
+    return False
+
+
+def _resolver_is_mock_vault(resolver: object) -> bool:
+    cls = resolver.__class__
+    return cls.__name__ == "MockVaultResolver" or cls.__module__.endswith("vault_resolver")
 
 
 def _resolve(reference: str, requester_id: str, resolver: SignerKeyResolver) -> ResolveResult:
@@ -374,8 +419,10 @@ __all__ = [
     "FAIL_PROVIDER_RESOLVER_UNAVAILABLE",
     "FAIL_PROVIDER_TTL_EXPIRED",
     "PROVIDER_MODE_TEST_ONLY_DRYRUN",
+    "PROVIDER_MODE_WSP71_PERMISSIONED",
     "SIGNING_KEY_PREFIX",
     "SignerKeyProviderDryRunResult",
     "SignerKeyProviderProfile",
+    "build_signer_backend_from_provider",
     "build_test_only_signer_backend_from_provider",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -32,7 +32,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
     SignerKeyProviderProfile,
     SignerKeyResolver,
-    build_test_only_signer_backend_from_provider,
+    build_signer_backend_from_provider,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     KernelPeerCredentialAttestor,
@@ -114,7 +114,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
     if policy is None or not _peer_policy_valid(policy):
         return _reject(FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID)
 
-    key_result = build_test_only_signer_backend_from_provider(
+    key_result = build_signer_backend_from_provider(
         profile,
         resolver,
         provider_mode=config.provider_mode,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py
@@ -35,6 +35,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     AUDIT_KEY_PREFIX,
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
     SIGNING_KEY_PREFIX,
     SignerKeyProviderProfile,
 )
@@ -217,6 +218,28 @@ def test_entrypoint_composes_key_provider_attestor_and_service() -> None:
     response = backend.sign(_request(public_key), service.calls[0]["peer_attestor"].attest(_FakePeerCredSocket()))
     assert response.accepted is True
     assert Ed25519SignatureVerifier().verify(public_key, _request(public_key).signing_input, response.signature) is True
+
+
+def test_entrypoint_accepts_wsp71_permissioned_provider_mode_without_test_override() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingService()
+
+    result = run_reddog_isolated_signer_process_once(
+        _config(
+            public_key,
+            provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+            allow_test_only_key_material=False,
+            permission_snapshot_fresh=True,
+        ),
+        _resolver(private_key),
+        serve_once=service,
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_PROCESS_ENTRYPOINT_SERVED
+    assert result.key_provider_receipt["ok"] is True
+    assert len(service.calls) == 1
 
 
 class _FakePeerCredSocket:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py
@@ -34,11 +34,14 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     FAIL_PROVIDER_RESOLVER_UNAVAILABLE,
     FAIL_PROVIDER_TTL_EXPIRED,
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
     SIGNING_KEY_PREFIX,
     SignerKeyProviderProfile,
+    build_signer_backend_from_provider,
     build_test_only_signer_backend_from_provider,
 )
 from modules.infrastructure.secrets_mcp.src.vault_resolver import (
+    MockVaultResolver,
     ResolveErrorCode,
     ResolveResult,
     hash_reference,
@@ -196,6 +199,53 @@ def test_default_path_rejects_without_explicit_test_only_mode() -> None:
     assert result.ok is False
     assert result.rejection_code == FAIL_PROVIDER_MOCK_IN_PRODUCTION
     assert result.backend is None
+
+
+def test_wsp71_permissioned_mode_accepts_injected_non_mock_resolver_without_test_only_override() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    resolver = _resolver(private_key)
+
+    result = build_signer_backend_from_provider(
+        _profile(public_key),
+        resolver,
+        provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+        allow_test_only_key_material=False,
+        permission_snapshot_fresh=True,
+    )
+
+    assert result.ok is True
+    assert result.backend is not None
+    assert result.rejection_code is None
+    assert resolver.calls == [
+        ("op://test-vault/reddog-signing/private", "signer:reddog-authority"),
+        ("op://test-vault/reddog-audit/mac", "signer:reddog-authority"),
+    ]
+
+
+def test_wsp71_permissioned_mode_rejects_test_override_and_mock_vault_resolver() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+
+    test_override = build_signer_backend_from_provider(
+        _profile(public_key),
+        _resolver(private_key),
+        provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+        allow_test_only_key_material=True,
+        permission_snapshot_fresh=True,
+    )
+    mock_vault = build_signer_backend_from_provider(
+        _profile(public_key),
+        MockVaultResolver(),
+        provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+        allow_test_only_key_material=False,
+        permission_snapshot_fresh=True,
+    )
+
+    assert test_override.ok is False
+    assert test_override.rejection_code == FAIL_PROVIDER_MOCK_IN_PRODUCTION
+    assert mock_vault.ok is False
+    assert mock_vault.rejection_code == FAIL_PROVIDER_MOCK_IN_PRODUCTION
 
 
 def test_acceptance_builds_backend_and_receipt_excludes_secret_values() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
@@ -28,6 +28,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     AUDIT_KEY_PREFIX,
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
     SIGNING_KEY_PREFIX,
     SignerKeyProviderProfile,
 )
@@ -241,6 +242,33 @@ def test_runtime_wiring_composes_provider_attestor_and_bounded_service() -> None
     response = backend.sign(_request(public_key), _peer())
     assert response.accepted is True
     assert Ed25519SignatureVerifier().verify(public_key, _request(public_key).signing_input, response.signature) is True
+
+
+def test_runtime_wiring_accepts_wsp71_permissioned_provider_mode_without_test_override() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    resolver = _resolver(private_key)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+            allow_test_only_key_material=False,
+            permission_snapshot_fresh=True,
+        ),
+        resolver,
+        serve_bounded=service,
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_SOCKET_RUNTIME_WIRING_SERVED
+    assert result.key_provider_receipt["ok"] is True
+    assert len(service.calls) == 1
+    assert resolver.calls == [
+        ("op://test-vault/reddog-signing/private", "signer:reddog-authority"),
+        ("op://test-vault/reddog-audit/mac", "signer:reddog-authority"),
+    ]
 
 
 def test_mapping_config_normalizes_profile_and_peer_policy() -> None:


### PR DESCRIPTION
## WSP_97 Truth Boundary

OBSERVED: The signer key provider previously admitted only `TEST_ONLY_DRYRUN` with an explicit test-only override.
OBSERVED: The runtime signer service and isolated process composition depended on that provider, so they could prove mechanics but not a WSP-71-permissioned runtime mode.
OBSERVED: `MockVaultResolver` is labeled PoC/mock-only and must not become a production credential authority.

## Scope

- Add explicit `WSP71_PERMISSIONED` provider mode.
- Keep default and ambiguous provider paths fail-closed.
- Reject `MockVaultResolver` and test-only override flags in `WSP71_PERMISSIONED` mode.
- Add `build_signer_backend_from_provider()` as the production-capable provider entrypoint while preserving the existing dry-run wrapper.
- Update signer process and bounded signer service runtime wiring to use the generic provider entrypoint.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py -q` -> 34 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_process_entrypoint.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_client.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_resident_service.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py -q` -> 133 passed, 3 skipped
- `git diff --check` -> clean (CRLF warnings only)

## Boundary

No real vault configuration, no environment parsing, no file loading, no signer process spawn, no source mutation, no OpenClaw enqueue, no Hermes dispatch, no PR publication, no reward settlement, and no HoloIndex re-index.