### PR TITLE
feat(reddog): add signer socket service cli

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_SIGNER_SOCKET_SERVICE_RUNTIME_CLI_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added a signer-owned CLI adapter for starting the bounded isolated signer
+  socket service from an outside-repo JSON config.
+- The CLI composes the existing runtime bootstrap with the WSP71
+  `OpCliSecretResolver`, emits only audit-safe JSON receipts, and returns
+  nonzero on bootstrap rejection.
+- Added tests for successful WSP71 resolver/service execution, unsafe config
+  rejection before service call, no secret serialization, and AST no-main/
+  no-OpenClaw/no-Hermes/no-HoloIndex/no-repo-mutation surface.
+- Boundary remains constrained: no `main.py` wiring, no RedDog model-output
+  invocation, no OpenClaw enqueue, no Hermes dispatch, no PR publication, no
+  reward settlement, and no HoloIndex re-index.
+
 ## 2026-07-17: REDDOG_MAIN_MISSING_SIGNER_SOCKET_FAIL_CLOSED_PROOF_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_cli.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_cli.py
@@ -1,0 +1,127 @@
+"""CLI adapter for the RedDog signer socket runtime service.
+
+Slice: REDDOG_SIGNER_SOCKET_SERVICE_RUNTIME_CLI_PHASE1
+
+This module is the signer-owned executable surface for starting the bounded
+isolated signer socket service from an outside-repo JSON config. It does not
+wire into ``main.py`` or RedDog model output. The RedDog resident queue still
+only consumes an already-available signer socket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Callable, Optional, Protocol, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
+    serve_reddog_isolated_signer_socket_bounded,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_bootstrap import (
+    SignerSocketServiceRuntimeBootstrapResult,
+    run_reddog_signer_socket_service_runtime_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
+    ServeSignerSocketBounded,
+)
+from modules.infrastructure.secrets_mcp.src.op_cli_secret_resolver import OpCliSecretResolver
+
+
+SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT = "SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT"
+SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT = "SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT"
+
+
+class ResolverFactory(Protocol):
+    """Factory for building the signer-owned WSP71 resolver."""
+
+    def __call__(
+        self,
+        *,
+        op_executable: str,
+        timeout_s: float,
+        ttl_seconds: int,
+        session_id: str,
+    ) -> object:
+        """Return a resolver implementing ``resolve(reference, requester_id)``."""
+
+
+def build_reddog_signer_socket_service_runtime_cli_parser() -> argparse.ArgumentParser:
+    """Build the signer-service CLI parser."""
+
+    parser = argparse.ArgumentParser(
+        prog="reddog-signer-socket-service",
+        description="Start the RedDog isolated signer socket service from a WSP71 config.",
+    )
+    parser.add_argument("--repo-root", required=True, help="Repository root used for path containment checks.")
+    parser.add_argument("--config", required=True, help="Outside-repo signer service JSON config.")
+    parser.add_argument("--op-executable", default="op", help="1Password CLI executable path/name.")
+    parser.add_argument("--op-timeout-s", type=float, default=10.0, help="op read timeout in seconds.")
+    parser.add_argument("--ttl-seconds", type=int, default=300, help="Credential TTL for resolver receipts.")
+    parser.add_argument("--session-id", default="op-cli-session", help="Audit session identifier.")
+    return parser
+
+
+def run_reddog_signer_socket_service_runtime_cli(
+    argv: Optional[Sequence[str]] = None,
+    *,
+    resolver_factory: ResolverFactory = OpCliSecretResolver,
+    serve_bounded: ServeSignerSocketBounded = serve_reddog_isolated_signer_socket_bounded,
+    emit: Callable[[str], None] = print,
+) -> int:
+    """Run the signer service CLI and emit an audit-safe JSON receipt."""
+
+    parser = build_reddog_signer_socket_service_runtime_cli_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    resolver = resolver_factory(
+        op_executable=args.op_executable,
+        timeout_s=float(args.op_timeout_s),
+        ttl_seconds=int(args.ttl_seconds),
+        session_id=str(args.session_id),
+    )
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=Path(args.repo_root),
+        config_path=Path(args.config),
+        resolver=resolver,  # type: ignore[arg-type]
+        serve_bounded=serve_bounded,
+    )
+    emit(_receipt_json(result))
+    return 0 if result.accepted else 2
+
+
+def _receipt_json(result: SignerSocketServiceRuntimeBootstrapResult) -> str:
+    payload = {
+        "status": (
+            SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT
+            if result.accepted
+            else SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT
+        ),
+        "result": result.to_dict(),
+        "no_main_runtime_wiring": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_pr_created": True,
+        "no_reward_settlement_performed": True,
+        "no_holoindex_reindex_performed": True,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Console entrypoint."""
+
+    return run_reddog_signer_socket_service_runtime_cli(argv)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main(sys.argv[1:]))
+
+
+__all__ = [
+    "SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT",
+    "SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT",
+    "build_reddog_signer_socket_service_runtime_cli_parser",
+    "main",
+    "run_reddog_signer_socket_service_runtime_cli",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py
@@ -1,0 +1,280 @@
+"""Tests for REDDOG_SIGNER_SOCKET_SERVICE_RUNTIME_CLI_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
+    SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
+    IsolatedSignerSocketResidentServiceResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    AUDIT_KEY_PREFIX,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+    SIGNING_KEY_PREFIX,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_cli import (
+    SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT,
+    SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT,
+    run_reddog_signer_socket_service_runtime_cli,
+)
+from modules.infrastructure.secrets_mcp.src.vault_resolver import ResolveResult, hash_reference
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signer_socket_service_runtime_cli.py"
+)
+
+
+pytest.importorskip("cryptography")
+
+
+class FakeResolver:
+    def __init__(self, values: dict[str, str], ttl: int = 60) -> None:
+        self.values = values
+        self.ttl = ttl
+        self.calls: list[tuple[str, str | None]] = []
+
+    def resolve(self, reference: str, requester_id: str | None = None) -> ResolveResult:
+        self.calls.append((reference, requester_id))
+        value = self.values[reference]
+        return ResolveResult(
+            success=True,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            ttl_remaining=self.ttl,
+            session_id="wsp71-session",
+            _secret_value=value,
+        )
+
+
+class CapturingResolverFactory:
+    def __init__(self, resolver: FakeResolver) -> None:
+        self.resolver = resolver
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.resolver
+
+
+class CapturingBoundedService:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return IsolatedSignerSocketResidentServiceResult(
+            accepted=True,
+            status=SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
+            rejection_reasons=(),
+            socket_path=str(kwargs["socket_path"]),
+            requests_handled=int(kwargs["max_requests"]),
+            response_digests=("sha256:response",),
+            socket_removed=True,
+        )
+
+
+def _private_key():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return Ed25519PrivateKey.generate()
+
+
+def _private_key_secret(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    raw = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return SIGNING_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _public_text(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return encode_ed25519_public_key(public_bytes)
+
+
+def _audit_secret(raw: bytes = b"0123456789abcdef0123456789abcdef") -> str:
+    return AUDIT_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _config(public_key: str, *, socket_path: Path) -> dict[str, object]:
+    return {
+        "socket_path": str(socket_path),
+        "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+        "allow_test_only_key_material": False,
+        "permission_snapshot_fresh": True,
+        "max_requests": 2,
+        "timeout_s": 2.5,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "key_provider_profile": {
+            "signer_profile_id": "signer-profile-1",
+            "signer_agent_id": "signer:reddog-authority",
+            "signing_key_ref": "op://prod-vault/reddog-signing/private",
+            "audit_mac_key_ref": "op://prod-vault/reddog-audit/mac",
+            "expected_public_key": public_key,
+            "expected_key_fingerprint": public_key_fingerprint(public_key),
+            "expected_key_epoch": "epoch-1",
+            "permission_snapshot_digest": "sha256:permission",
+            "ttl_seconds": 60,
+        },
+        "peer_policy": {
+            "uid_to_principal": {"1001": "github:mjtrout"},
+            "allowed_gids": [1002],
+            "transport": "unix_socket",
+            "credential_source_prefix": "kernel_peer_credential",
+        },
+    }
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def test_cli_runs_signer_bootstrap_with_wsp71_resolver_and_emits_safe_receipt(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    config = _write_json(
+        runtime / "signer-service.json",
+        _config(public_key, socket_path=runtime / "signer.sock"),
+    )
+    resolver = FakeResolver(
+        {
+            "op://prod-vault/reddog-signing/private": _private_key_secret(private_key),
+            "op://prod-vault/reddog-audit/mac": _audit_secret(),
+        }
+    )
+    resolver_factory = CapturingResolverFactory(resolver)
+    service = CapturingBoundedService()
+    emitted: list[str] = []
+
+    code = run_reddog_signer_socket_service_runtime_cli(
+        [
+            "--repo-root",
+            str(repo),
+            "--config",
+            str(config),
+            "--op-executable",
+            "C:/Program Files/1Password/op.exe",
+            "--op-timeout-s",
+            "7",
+            "--ttl-seconds",
+            "61",
+            "--session-id",
+            "session-prod",
+        ],
+        resolver_factory=resolver_factory,
+        serve_bounded=service,
+        emit=emitted.append,
+    )
+
+    assert code == 0
+    payload = json.loads(emitted[0])
+    assert payload["status"] == SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT
+    assert payload["result"]["accepted"] is True
+    assert payload["no_main_runtime_wiring"] is True
+    assert payload["no_holoindex_reindex_performed"] is True
+    assert resolver_factory.calls == [
+        {
+            "op_executable": "C:/Program Files/1Password/op.exe",
+            "timeout_s": 7.0,
+            "ttl_seconds": 61,
+            "session_id": "session-prod",
+        }
+    ]
+    assert resolver.calls == [
+        ("op://prod-vault/reddog-signing/private", "signer:reddog-authority"),
+        ("op://prod-vault/reddog-audit/mac", "signer:reddog-authority"),
+    ]
+    assert len(service.calls) == 1
+    text = emitted[0]
+    assert SIGNING_KEY_PREFIX not in text
+    assert AUDIT_KEY_PREFIX not in text
+    assert "0123456789abcdef" not in text
+
+
+def test_cli_rejects_unsafe_config_before_service_call(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    inside = _write_json(repo / "signer-service.json", {})
+    resolver_factory = CapturingResolverFactory(FakeResolver({}))
+    service = CapturingBoundedService()
+    emitted: list[str] = []
+
+    code = run_reddog_signer_socket_service_runtime_cli(
+        ["--repo-root", str(repo), "--config", str(inside)],
+        resolver_factory=resolver_factory,
+        serve_bounded=service,
+        emit=emitted.append,
+    )
+
+    assert code == 2
+    payload = json.loads(emitted[0])
+    assert payload["status"] == SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT
+    assert payload["result"]["accepted"] is False
+    assert "FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_INSIDE_REPO" in payload["result"]["rejection_reasons"]
+    assert service.calls == []
+
+
+def test_cli_module_has_no_main_openclaw_hermes_or_repo_mutation_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {"os", "subprocess", "holo_index", "git"}
+    banned_import_fragments = {"openclaw", "hermes", "worktree", "github"}
+    banned_name_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {"system", "popen", "remove", "unlink", "rmdir", "replace"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            roots = {alias.name.split(".", 1)[0] for alias in node.names}
+            assert not roots & banned_import_roots
+            assert all(
+                fragment not in alias.name.lower()
+                for alias in node.names
+                for fragment in banned_import_fragments
+            )
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            root = module.split(".", 1)[0]
+            assert root not in banned_import_roots
+            lowered = module.lower()
+            assert all(fragment not in lowered for fragment in banned_import_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- add a signer-owned CLI adapter around the existing signer socket runtime bootstrap
- use OpCliSecretResolver by default while keeping tests dependency-injected
- emit only audit-safe JSON receipts and return nonzero on bootstrap rejection

## Tests
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py modules/infrastructure/secrets_mcp/tests -q
- git diff --check

## Truth Boundary Checklist
- no main.py wiring
- no RedDog model-output invocation
- no OpenClaw enqueue
- no Hermes dispatch
- no PR creation
- no reward settlement
- no HoloIndex re-index
- no secret serialization

Worker-Lane: reddog-signer-authority
Slice: REDDOG_SIGNER_SOCKET_SERVICE_RUNTIME_CLI_PHASE1