### PR TITLE
feat(reddog): prove signer cli main control loop

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_SIGNER_MULTI_PROFILE_MAIN_CLI_PROOF_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added explicit multi-profile signer socket runtime wiring so one bounded
+  signer service can route principal-identity and RedDog work-authority signing
+  requests by requested public key.
+- Preserved the legacy single-profile config and receipt fields while adding
+  profile-count/profile-receipt telemetry and duplicate-public-key rejection.
+- Extended the outside-repo signer bootstrap to accept either one
+  `key_provider_profile` or a bounded `key_provider_profiles` list.
+- Added a main-level proof that the resident queue control loop can consume a
+  signer socket started by the signer-owned CLI with two WSP71 profiles.
+- Boundary remains constrained: no `main.py` signer spawn, no model-output
+  invocation, no OpenClaw/Hermes authorization expansion, no PR publication, no
+  reward settlement, and no HoloIndex re-index.
+
 ## 2026-07-17: REDDOG_SIGNER_SOCKET_SERVICE_RUNTIME_CLI_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
@@ -154,15 +154,28 @@ def _runtime_config(
     payload: dict[str, Any],
 ) -> Optional[SignerSocketServiceRuntimeWiringConfig]:
     try:
-        key_profile = payload["key_provider_profile"]
         peer_policy = payload["peer_policy"]
-        if not isinstance(key_profile, dict) or not isinstance(peer_policy, dict):
+        key_profile = payload.get("key_provider_profile")
+        key_profiles = payload.get("key_provider_profiles") or ()
+        if not isinstance(peer_policy, dict):
+            return None
+        if key_profile is not None and key_profiles:
+            return None
+        if key_profile is not None and not isinstance(key_profile, dict):
+            return None
+        if key_profiles:
+            if not isinstance(key_profiles, list) or not all(
+                isinstance(item, dict) for item in key_profiles
+            ):
+                return None
+            key_profiles = tuple(key_profiles)
+        if key_profile is None and not key_profiles:
             return None
         return SignerSocketServiceRuntimeWiringConfig(
             repo_root=repo_root,
             socket_path=payload.get("socket_path"),
-            key_provider_profile=key_profile,
             peer_policy=peer_policy,
+            key_provider_profile=key_profile,
             provider_mode=str(payload.get("provider_mode") or ""),
             allow_test_only_key_material=payload.get("allow_test_only_key_material") is True,
             permission_snapshot_fresh=payload.get("permission_snapshot_fresh") is True,
@@ -170,6 +183,7 @@ def _runtime_config(
             timeout_s=float(payload.get("timeout_s") or 0),
             max_request_bytes=int(payload.get("max_request_bytes") or 0),
             max_response_bytes=int(payload.get("max_response_bytes") or 0),
+            key_provider_profiles=key_profiles,
         )
     except Exception:
         return None

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -15,6 +15,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
 
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    IsolatedSignerBackend,
+    SignerPeerAttestation,
+)
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
     DEFAULT_SIGNER_SOCKET_RESIDENT_MAX_REQUESTS,
     SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
@@ -34,6 +38,11 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     SignerKeyResolver,
     build_signer_backend_from_provider,
 )
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    RuntimeRejectCode,
+    SigningRequest,
+    SigningResponse,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     KernelPeerCredentialAttestor,
     PeerCredentialPolicy,
@@ -47,6 +56,8 @@ FAIL_SIGNER_RUNTIME_CONFIG_INVALID = "FAIL_SIGNER_RUNTIME_CONFIG_INVALID"
 FAIL_SIGNER_RUNTIME_PROFILE_INVALID = "FAIL_SIGNER_RUNTIME_PROFILE_INVALID"
 FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID = "FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID"
 FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED = "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED"
+FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE = "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE"
+FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID = "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID"
 FAIL_SIGNER_RUNTIME_SERVICE_REJECTED = "FAIL_SIGNER_RUNTIME_SERVICE_REJECTED"
 FAIL_SIGNER_RUNTIME_SERVICE_INVALID = "FAIL_SIGNER_RUNTIME_SERVICE_INVALID"
 
@@ -60,8 +71,8 @@ class SignerSocketServiceRuntimeWiringConfig:
 
     repo_root: Path | str
     socket_path: Path | str | None
-    key_provider_profile: SignerKeyProviderProfile | Mapping[str, Any]
     peer_policy: PeerCredentialPolicy | Mapping[str, Any]
+    key_provider_profile: SignerKeyProviderProfile | Mapping[str, Any] | None = None
     provider_mode: str = PROVIDER_MODE_TEST_ONLY_DRYRUN
     allow_test_only_key_material: bool = False
     permission_snapshot_fresh: bool = False
@@ -69,6 +80,7 @@ class SignerSocketServiceRuntimeWiringConfig:
     timeout_s: float = DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S
     max_request_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES
     max_response_bytes: int = DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES
+    key_provider_profiles: tuple[SignerKeyProviderProfile | Mapping[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -107,33 +119,28 @@ def run_reddog_signer_socket_service_runtime_wiring(
 
     if not isinstance(config, SignerSocketServiceRuntimeWiringConfig):
         return _reject(FAIL_SIGNER_RUNTIME_CONFIG_INVALID)
-    profile = _profile(config.key_provider_profile)
-    if profile is None:
-        return _reject(FAIL_SIGNER_RUNTIME_PROFILE_INVALID)
+    profiles, profile_reasons = _profiles(config)
+    if profile_reasons:
+        return _reject(*profile_reasons)
     policy = _peer_policy(config.peer_policy)
     if policy is None or not _peer_policy_valid(policy):
         return _reject(FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID)
 
-    key_result = build_signer_backend_from_provider(
-        profile,
+    backend, key_receipt, key_reasons = _build_backend(
+        profiles,
         resolver,
         provider_mode=config.provider_mode,
         allow_test_only_key_material=config.allow_test_only_key_material,
         permission_snapshot_fresh=config.permission_snapshot_fresh,
     )
-    key_receipt = key_result.to_receipt()
-    if not key_result.ok or key_result.backend is None:
-        return _reject(
-            FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
-            key_provider_receipt=key_receipt,
-            max_requests=config.max_requests,
-        )
+    if key_reasons:
+        return _reject(*key_reasons, key_provider_receipt=key_receipt, max_requests=config.max_requests)
 
     try:
         service = serve_bounded(
             repo_root=config.repo_root,
             socket_path=config.socket_path,
-            backend=key_result.backend,
+            backend=backend,
             peer_attestor=KernelPeerCredentialAttestor(policy),
             max_requests=config.max_requests,
             timeout_s=config.timeout_s,
@@ -170,6 +177,97 @@ def run_reddog_signer_socket_service_runtime_wiring(
         service_result=service_receipt,
         max_requests=config.max_requests,
     )
+
+
+@dataclass(frozen=True)
+class _RoutingSignerBackend(IsolatedSignerBackend):
+    backends: Mapping[str, IsolatedSignerBackend]
+
+    def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
+        backend = self.backends.get(request.signer_public_key)
+        if backend is None:
+            return SigningResponse(
+                accepted=False,
+                rejection_code=RuntimeRejectCode.SIGNER_NOT_CONFIGURED,
+                no_secret_material_returned=True,
+            )
+        return backend.sign(request, peer)
+
+
+def _profiles(
+    config: SignerSocketServiceRuntimeWiringConfig,
+) -> tuple[list[SignerKeyProviderProfile], tuple[str, ...]]:
+    if config.key_provider_profile is not None and config.key_provider_profiles:
+        return [], (FAIL_SIGNER_RUNTIME_PROFILE_INVALID,)
+    raw_profiles: tuple[SignerKeyProviderProfile | Mapping[str, Any], ...]
+    if config.key_provider_profiles:
+        raw_profiles = tuple(config.key_provider_profiles)
+    elif config.key_provider_profile is not None:
+        raw_profiles = (config.key_provider_profile,)
+    else:
+        return [], (FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID,)
+    if len(raw_profiles) < 1 or len(raw_profiles) > 8:
+        return [], (FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID,)
+
+    profiles: list[SignerKeyProviderProfile] = []
+    for raw in raw_profiles:
+        profile = _profile(raw)
+        if profile is None:
+            return [], (FAIL_SIGNER_RUNTIME_PROFILE_INVALID,)
+        profiles.append(profile)
+    return profiles, ()
+
+
+def _build_backend(
+    profiles: list[SignerKeyProviderProfile],
+    resolver: SignerKeyResolver,
+    *,
+    provider_mode: str,
+    allow_test_only_key_material: bool,
+    permission_snapshot_fresh: bool,
+) -> tuple[Optional[IsolatedSignerBackend], dict[str, Any], tuple[str, ...]]:
+    receipts: list[dict[str, Any]] = []
+    backends: dict[str, IsolatedSignerBackend] = {}
+    for profile in profiles:
+        key_result = build_signer_backend_from_provider(
+            profile,
+            resolver,
+            provider_mode=provider_mode,
+            allow_test_only_key_material=allow_test_only_key_material,
+            permission_snapshot_fresh=permission_snapshot_fresh,
+        )
+        receipt = key_result.to_receipt()
+        receipts.append(receipt)
+        if not key_result.ok or key_result.backend is None:
+            return None, _key_provider_receipt(False, receipts), (
+                FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
+            )
+        public_key = str(key_result.public_key or "")
+        if public_key in backends:
+            return None, _key_provider_receipt(False, receipts), (
+                FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE,
+            )
+        backends[public_key] = key_result.backend
+
+    if len(backends) == 1:
+        backend = next(iter(backends.values()))
+    else:
+        backend = _RoutingSignerBackend(backends)
+    return backend, _key_provider_receipt(True, receipts), ()
+
+
+def _key_provider_receipt(ok: bool, receipts: list[dict[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = dict(receipts[0]) if len(receipts) == 1 else {"ok": ok}
+    payload["ok"] = ok
+    payload["profile_count"] = len(receipts)
+    payload["profile_receipts"] = receipts
+    payload["public_keys"] = [
+        str(receipt.get("public_key") or "")
+        for receipt in receipts
+        if receipt.get("public_key")
+    ]
+    payload["secret_values_returned"] = False
+    return payload
 
 
 def _profile(value: SignerKeyProviderProfile | Mapping[str, Any]) -> SignerKeyProviderProfile | None:
@@ -241,6 +339,8 @@ def _reject(
 
 __all__ = [
     "FAIL_SIGNER_RUNTIME_CONFIG_INVALID",
+    "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID",
+    "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE",
     "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED",
     "FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID",
     "FAIL_SIGNER_RUNTIME_PROFILE_INVALID",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import socket
 import sqlite3
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -46,6 +48,20 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resi
     SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
     serve_reddog_isolated_signer_socket_bounded,
 )
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    AUDIT_KEY_PREFIX,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+    SIGNING_KEY_PREFIX,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_cli import (
+    run_reddog_signer_socket_service_runtime_cli,
+)
 from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
     build_reddog_signed_worker_queue_loop_runner_from_env,
 )
@@ -63,6 +79,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
 )
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
+from modules.infrastructure.secrets_mcp.src.vault_resolver import ResolveResult, hash_reference
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -152,6 +169,100 @@ def _write_json(path: Path, payload: object) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
     return path
+
+
+def _cli_private_key_material() -> tuple[object, str, str]:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private_key = Ed25519PrivateKey.generate()
+    public_bytes = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    private_bytes = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public_key = encode_ed25519_public_key(public_bytes)
+    secret = SIGNING_KEY_PREFIX + base64.b64encode(private_bytes).decode("ascii")
+    return private_key, public_key, secret
+
+
+def _cli_audit_secret(raw: bytes) -> str:
+    return AUDIT_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+class _FakeCliResolver:
+    def __init__(self, values: dict[str, str]) -> None:
+        self.values = values
+        self.calls: list[tuple[str, str | None]] = []
+
+    def resolve(self, reference: str, requester_id: str | None = None) -> ResolveResult:
+        self.calls.append((reference, requester_id))
+        return ResolveResult(
+            success=True,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            ttl_remaining=60,
+            session_id="cli-test-session",
+            _secret_value=self.values[reference],
+        )
+
+
+class _FakeCliResolverFactory:
+    def __init__(self, values: dict[str, str]) -> None:
+        self.resolver = _FakeCliResolver(values)
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(
+        self,
+        *,
+        op_executable: str,
+        timeout_s: float,
+        ttl_seconds: int,
+        session_id: str,
+    ) -> _FakeCliResolver:
+        self.calls.append(
+            {
+                "op_executable": op_executable,
+                "timeout_s": timeout_s,
+                "ttl_seconds": ttl_seconds,
+                "session_id": session_id,
+            }
+        )
+        return self.resolver
+
+
+def _cli_key_profile(
+    *,
+    public_key: str,
+    signer_profile_id: str,
+    signer_agent_id: str,
+    signing_key_ref: str,
+    audit_mac_key_ref: str,
+) -> dict[str, object]:
+    return {
+        "signer_profile_id": signer_profile_id,
+        "signer_agent_id": signer_agent_id,
+        "signing_key_ref": signing_key_ref,
+        "audit_mac_key_ref": audit_mac_key_ref,
+        "expected_public_key": public_key,
+        "expected_key_fingerprint": public_key_fingerprint(public_key),
+        "expected_key_epoch": "epoch-1",
+        "permission_snapshot_digest": "sha256:permission",
+        "ttl_seconds": 60,
+    }
+
+
+def _wait_for_socket(path: Path, *, timeout_s: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.025)
+    return path.exists()
 
 
 def _patch_fusion_artifact_generator(monkeypatch) -> list[dict[str, object]]:
@@ -1073,3 +1184,241 @@ def test_main_resident_control_loop_profile_runtime_completes_socket_signed_queu
         count = conn.execute("SELECT COUNT(*) FROM skill_outcomes").fetchone()[0]
     assert count == 1
     assert not (repo / "runtime" / "pattern_memory.db").exists()
+
+
+@pytest.mark.skipif(
+    not hasattr(socket, "AF_UNIX")
+    or not hasattr(socket, "SO_PEERCRED")
+    or not hasattr(os, "getuid")
+    or not hasattr(os, "getgid"),
+    reason="AF_UNIX SO_PEERCRED signer CLI proof requires kernel peer credentials",
+)
+def test_main_resident_control_loop_consumes_signer_socket_started_by_runtime_cli(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+    from modules.foundups.agent.src import worktree_pr_runner
+
+    _FakeProfileWorktreeRunner.instances.clear()
+    monkeypatch.setattr(worktree_pr_runner, "RealWorktreeRunner", _FakeProfileWorktreeRunner)
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "resident-runtime"
+    runtime_root.mkdir(parents=True)
+    profile_env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": (
+            PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY
+        ),
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+    _principal_key, principal_public, principal_secret = _cli_private_key_material()
+    _reddog_key, reddog_public, reddog_secret = _cli_private_key_material()
+    resolver_factory = _FakeCliResolverFactory(
+        {
+            "op://prod-vault/principal/private": principal_secret,
+            "op://prod-vault/principal/audit": _cli_audit_secret(
+                b"principal-audit-key-000000000"
+            ),
+            "op://prod-vault/reddog/private": reddog_secret,
+            "op://prod-vault/reddog/audit": _cli_audit_secret(
+                b"reddog-audit-key-000000000000"
+            ),
+        }
+    )
+    pilot_overrides = _pilot_path_overrides()
+    state = _write_json(
+        Path(resident_queue_runtime_file_path(profile_env, repo, "REDDOG_AUTHORITATIVE_WORK_STATE_PATH")),
+        _bootstrap_snapshot(),
+    )
+    profile = _write_json(
+        Path(
+            resident_queue_runtime_file_path(
+                profile_env,
+                repo,
+                "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+            )
+        ),
+        _bootstrap_profile(
+            principal_public_key=principal_public,
+            reddog_public_key=reddog_public,
+            requested_operation=PILOT_OPERATION,
+            allowed_paths=_pilot_allowed_paths(),
+            denied_paths=pilot_overrides["denied_paths"],
+            bounded_worker_plan=_pilot_bounded_worker_plan(),
+        ),
+    )
+    snapshots = _write_json(
+        Path(resident_queue_runtime_file_path(profile_env, repo, "REDDOG_PERMISSION_SNAPSHOTS_PATH")),
+        _snapshots(),
+    )
+    principals = _write_json(
+        Path(
+            resident_queue_runtime_file_path(
+                profile_env,
+                repo,
+                "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH",
+            )
+        ),
+        _principals(principal_public),
+    )
+    valve_env = _write_json(
+        Path(resident_queue_runtime_file_path(profile_env, repo, "REDDOG_EXECUTION_VALVE_ENV_PATH")),
+        _valve_environment(),
+    )
+    chain = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH",
+        )
+    )
+    authority_state = Path(
+        resident_queue_runtime_file_path(profile_env, repo, "REDDOG_AUTHORITY_RUNTIME_STATE_PATH")
+    )
+    socket_path = Path(resident_queue_runtime_file_path(profile_env, repo, "REDDOG_SIGNER_SOCKET_PATH"))
+    materialized_work_order = _work_order(
+        **pilot_overrides,
+        bounded_worker_plan=_pilot_bounded_worker_plan(),
+        nonce="work-order:workauth-nonce-0001",
+    )
+    worktree = _pilot_worktree_path(repo, materialized_work_order)
+    verifier_request = _write_json(
+        runtime_root / "slice_verifier_request.json",
+        _slice_verifier_request(),
+    )
+    publish_request = _write_json(
+        runtime_root / "draft_pr_publish_request.json",
+        _draft_pr_publish_request(worktree),
+    )
+    outcome_store = runtime_root / "outcomes" / "signed-worker-ratchet.jsonl"
+    pattern_memory_db = runtime_root / "pattern_memory.db"
+    signer_config = _write_json(
+        runtime_root / "signer-service.json",
+        {
+            "socket_path": str(socket_path),
+            "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+            "allow_test_only_key_material": False,
+            "permission_snapshot_fresh": True,
+            "max_requests": 2,
+            "timeout_s": 5,
+            "max_request_bytes": 16384,
+            "max_response_bytes": 16384,
+            "key_provider_profiles": [
+                _cli_key_profile(
+                    public_key=principal_public,
+                    signer_profile_id="principal-profile",
+                    signer_agent_id="signer:principal",
+                    signing_key_ref="op://prod-vault/principal/private",
+                    audit_mac_key_ref="op://prod-vault/principal/audit",
+                ),
+                _cli_key_profile(
+                    public_key=reddog_public,
+                    signer_profile_id="reddog-profile",
+                    signer_agent_id="signer:reddog",
+                    signing_key_ref="op://prod-vault/reddog/private",
+                    audit_mac_key_ref="op://prod-vault/reddog/audit",
+                ),
+            ],
+            "peer_policy": {
+                "uid_to_principal": {str(os.getuid()): "github:mjtrout"},
+                "allowed_gids": [os.getgid()],
+                "transport": "unix_socket",
+                "credential_source_prefix": "kernel_peer_credential",
+            },
+        },
+    )
+    assert not socket_path.exists()
+
+    signer_exit: dict[str, int] = {}
+    emitted: list[str] = []
+
+    def _serve_signer_cli() -> None:
+        signer_exit["code"] = run_reddog_signer_socket_service_runtime_cli(
+            [
+                "--repo-root",
+                str(repo),
+                "--config",
+                str(signer_config),
+                "--op-executable",
+                "op",
+                "--op-timeout-s",
+                "2",
+                "--ttl-seconds",
+                "60",
+                "--session-id",
+                "cli-main-loop-proof",
+            ],
+            resolver_factory=resolver_factory,
+            emit=emitted.append,
+        )
+
+    signer_thread = threading.Thread(target=_serve_signer_cli, daemon=True)
+    signer_thread.start()
+    assert _wait_for_socket(socket_path)
+
+    calls = _patch_fusion_artifact_generator(monkeypatch)
+    monkeypatch.setenv(
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE",
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY,
+    )
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS", "9")
+    monkeypatch.setenv("REDDOG_SIGNED_WORKER_QUEUE_LOOP_MAX_STEPS", "1")
+    monkeypatch.setenv("OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS", "7")
+    monkeypatch.setenv("WRE_MOCK_SKILLS", runtime.SIGNED_WORKER_DISPATCH_TASK_SKILL)
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_ISO", BOOTSTRAP_NOW)
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_NOW_EPOCH", "1000")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S", "77")
+    monkeypatch.setenv("REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S", "88")
+    monkeypatch.setenv("REDDOG_AUTHORITY_RUNTIME_RESOLVER_ARTIFACT_SUPPLY", "0")
+    monkeypatch.setenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", str(state))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(profile))
+    monkeypatch.setenv("REDDOG_PERMISSION_SNAPSHOTS_PATH", str(snapshots))
+    monkeypatch.setenv("REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH", str(principals))
+    monkeypatch.setenv("REDDOG_EXECUTION_VALVE_ENV_PATH", str(valve_env))
+    monkeypatch.setenv("REDDOG_AUTHORITY_RUNTIME_STATE_PATH", str(authority_state))
+    monkeypatch.setenv("REDDOG_SLICE_VERIFIER_REQUEST_PATH", str(verifier_request))
+    monkeypatch.setenv("REDDOG_DRAFT_PR_PUBLISH_REQUEST_PATH", str(publish_request))
+    monkeypatch.setenv("REDDOG_OUTCOME_RATCHET_STORE_PATH", str(outcome_store))
+    monkeypatch.setenv("REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH", str(pattern_memory_db))
+    monkeypatch.delenv("REDDOG_WORK_ORDERS_PATH", raising=False)
+
+    try:
+        assert main.run_reddog_resident_queue_control_loop_preflight(repo) is True
+    finally:
+        signer_thread.join(5)
+
+    assert signer_exit["code"] == 0
+    assert emitted
+    signer_receipt = json.loads(emitted[0])
+    assert signer_receipt["status"] == "SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT"
+    assert signer_receipt["result"]["accepted"] is True
+    assert signer_receipt["result"]["runtime_result"]["key_provider_receipt"]["profile_count"] == 2
+    assert resolver_factory.calls == [
+        {
+            "op_executable": "op",
+            "timeout_s": 2.0,
+            "ttl_seconds": 60,
+            "session_id": "cli-main-loop-proof",
+        }
+    ]
+    assert resolver_factory.resolver.calls == [
+        ("op://prod-vault/principal/private", "signer:principal"),
+        ("op://prod-vault/principal/audit", "signer:principal"),
+        ("op://prod-vault/reddog/private", "signer:reddog"),
+        ("op://prod-vault/reddog/audit", "signer:reddog"),
+    ]
+    assert not socket_path.exists()
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-QUEUE-CONTROL] preflight=PASS" in captured
+    assert "[REDDOG-QUEUE-LOOP] preflight=PASS" in captured
+    assert "[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=PASS" in captured
+    assert calls
+    stored = json.loads(chain.read_text(encoding="utf-8"))
+    assert stored["stage_results"]["worker_dispatch_runtime"]["accepted"] is True
+    assert stored["stage_results"]["bounded_worker_pilot"]["artifact_generation_result"]["accepted"] is True
+    assert stored["receipts"][-1]["next_action"] == "STOP_QUEUE_CHAIN_COMPLETE"

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py
@@ -206,6 +206,72 @@ def test_bootstrap_reads_outside_repo_config_and_runs_runtime_wiring(tmp_path: P
     assert result.no_holoindex_reindex_performed is True
 
 
+def test_bootstrap_accepts_multi_profile_config_without_secret_return(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    principal_key = _private_key()
+    reddog_key = _private_key()
+    principal_public = _public_text(principal_key)
+    reddog_public = _public_text(reddog_key)
+    payload = _config(principal_public, socket_path=runtime / "signer.sock")
+    principal_profile = dict(payload["key_provider_profile"])
+    principal_profile.update(
+        {
+            "signer_profile_id": "principal-profile",
+            "signer_agent_id": "signer:principal",
+            "signing_key_ref": "op://prod-vault/principal/private",
+            "audit_mac_key_ref": "op://prod-vault/principal/audit",
+            "expected_public_key": principal_public,
+            "expected_key_fingerprint": public_key_fingerprint(principal_public),
+        }
+    )
+    reddog_profile = dict(payload["key_provider_profile"])
+    reddog_profile.update(
+        {
+            "signer_profile_id": "reddog-profile",
+            "signer_agent_id": "signer:reddog",
+            "signing_key_ref": "op://prod-vault/reddog/private",
+            "audit_mac_key_ref": "op://prod-vault/reddog/audit",
+            "expected_public_key": reddog_public,
+            "expected_key_fingerprint": public_key_fingerprint(reddog_public),
+        }
+    )
+    payload.pop("key_provider_profile")
+    payload["key_provider_profiles"] = [principal_profile, reddog_profile]
+    config_path = _write_json(runtime / "signer-service.json", payload)
+    resolver = FakeResolver(
+        {
+            "op://prod-vault/principal/private": _private_key_secret(principal_key),
+            "op://prod-vault/principal/audit": _audit_secret(b"principal-audit-key-000000000"),
+            "op://prod-vault/reddog/private": _private_key_secret(reddog_key),
+            "op://prod-vault/reddog/audit": _audit_secret(b"reddog-audit-key-000000000000"),
+        }
+    )
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=config_path,
+        resolver=resolver,
+        serve_bounded=service,
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_SOCKET_RUNTIME_BOOTSTRAP_SERVED
+    assert result.runtime_result is not None
+    receipt = result.runtime_result["key_provider_receipt"]
+    assert receipt["ok"] is True
+    assert receipt["profile_count"] == 2
+    assert receipt["secret_values_returned"] is False
+    assert sorted(receipt["public_keys"]) == sorted([principal_public, reddog_public])
+    assert resolver.calls == [
+        ("op://prod-vault/principal/private", "signer:principal"),
+        ("op://prod-vault/principal/audit", "signer:principal"),
+        ("op://prod-vault/reddog/private", "signer:reddog"),
+        ("op://prod-vault/reddog/audit", "signer:reddog"),
+    ]
+
+
 def test_bootstrap_rejects_missing_relative_inside_and_unreadable_config(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     inside = _write_json(repo / "signer-service.json", {})

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
@@ -37,6 +37,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credenti
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     FAIL_SIGNER_RUNTIME_CONFIG_INVALID,
+    FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE,
     FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
     FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID,
     FAIL_SIGNER_RUNTIME_PROFILE_INVALID,
@@ -269,6 +270,89 @@ def test_runtime_wiring_accepts_wsp71_permissioned_provider_mode_without_test_ov
         ("op://test-vault/reddog-signing/private", "signer:reddog-authority"),
         ("op://test-vault/reddog-audit/mac", "signer:reddog-authority"),
     ]
+
+
+def test_runtime_wiring_routes_multiple_wsp71_permissioned_profiles() -> None:
+    principal_key = _private_key()
+    reddog_key = _private_key()
+    principal_public = _public_text(principal_key)
+    reddog_public = _public_text(reddog_key)
+    resolver = FakeResolver(
+        {
+            "op://test-vault/principal/private": _private_key_secret(principal_key),
+            "op://test-vault/principal/audit": _audit_secret(b"principal-audit-key-000000000"),
+            "op://test-vault/reddog/private": _private_key_secret(reddog_key),
+            "op://test-vault/reddog/audit": _audit_secret(b"reddog-audit-key-000000000000"),
+        }
+    )
+    service = CapturingBoundedService()
+    principal_profile = _profile(
+        principal_public,
+        signer_profile_id="principal-profile",
+        signer_agent_id="signer:principal",
+        signing_key_ref="op://test-vault/principal/private",
+        audit_mac_key_ref="op://test-vault/principal/audit",
+    )
+    reddog_profile = _profile(
+        reddog_public,
+        signer_profile_id="reddog-profile",
+        signer_agent_id="signer:reddog",
+        signing_key_ref="op://test-vault/reddog/private",
+        audit_mac_key_ref="op://test-vault/reddog/audit",
+    )
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            principal_public,
+            key_provider_profile=None,
+            key_provider_profiles=(principal_profile, reddog_profile),
+            provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+            allow_test_only_key_material=False,
+            permission_snapshot_fresh=True,
+        ),
+        resolver,
+        serve_bounded=service,
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_SOCKET_RUNTIME_WIRING_SERVED
+    assert result.key_provider_receipt["ok"] is True
+    assert result.key_provider_receipt["profile_count"] == 2
+    backend = service.calls[0]["backend"]
+    for public_key in (principal_public, reddog_public):
+        request = _request(public_key)
+        response = backend.sign(request, _peer())
+        assert response.accepted is True
+        assert Ed25519SignatureVerifier().verify(public_key, request.signing_input, response.signature) is True
+    unknown = _request(_public_text(_private_key()))
+    assert backend.sign(unknown, _peer()).accepted is False
+    assert resolver.calls == [
+        ("op://test-vault/principal/private", "signer:principal"),
+        ("op://test-vault/principal/audit", "signer:principal"),
+        ("op://test-vault/reddog/private", "signer:reddog"),
+        ("op://test-vault/reddog/audit", "signer:reddog"),
+    ]
+
+
+def test_runtime_wiring_rejects_duplicate_multi_profile_public_key() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingBoundedService()
+    profile = _profile(public_key)
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            key_provider_profile=None,
+            key_provider_profiles=(profile, profile),
+        ),
+        _resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE in result.rejection_reasons
+    assert service.calls == []
 
 
 def test_mapping_config_normalizes_profile_and_peer_policy() -> None:


### PR DESCRIPTION
## Summary

- Add explicit multi-profile signer socket runtime wiring so one bounded signer service can route the principal identity signature and the RedDog work-authority signature by requested public key.
- Extend the outside-repo signer runtime bootstrap to accept either legacy `key_provider_profile` or bounded `key_provider_profiles`.
- Preserve single-profile receipt compatibility while adding profile-count/profile-receipt telemetry and duplicate-public-key rejection.
- Add a main-level proof that the resident queue control loop can consume a signer socket started by the signer-owned CLI with two WSP71 profiles.

## Boundaries

- No `main.py` signer spawn.
- No model-output invocation.
- No OpenClaw/Hermes authority expansion.
- No PR publication, reward settlement, source mutation, or HoloIndex re-index.

## Validation

- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 29 passed, 2 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_resident_service.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_service.py modules/communication/moltbot_bridge/tests/test_reddog_signer_key_provider_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 54 passed, 6 skipped
- `git diff --check` -> clean
- Added-line ASCII check -> clean