### PR TITLE
feat(reddog): supply signer service config

### DIFF
--- a/main.py
+++ b/main.py
@@ -1622,6 +1622,15 @@ def _reddog_positive_int_env(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def _reddog_float_env(name: str, default: float) -> float:
+    raw = os.getenv(name, str(default))
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 def _reddog_truthy_env_value(value: str | None) -> bool:
     raw = str(value or "").strip().lower()
     return raw not in {"", "0", "false", "off", "no"}
@@ -1637,6 +1646,16 @@ def _reddog_bounded_json_file(path: Path, *, max_bytes: int = 262_144) -> Any | 
         if not path.is_file() or path.stat().st_size > max_bytes:
             return None
         return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _reddog_bounded_json_env(name: str, *, max_chars: int = 16384) -> Any | None:
+    raw = os.getenv(name, "")
+    if not raw.strip() or len(raw) > max_chars:
+        return None
+    try:
+        return json.loads(raw)
     except Exception:
         return None
 
@@ -3243,6 +3262,9 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_AUTHORITY_RUNTIME_STATE_PATH                  Outside-repo authority runtime state JSON
         REDDOG_PERMISSION_SNAPSHOTS_PATH                     Outside-repo permission resolver JSON
         REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH              Outside-repo principal resolver JSON
+        REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY=0                Materialize signer-owned CLI config from authority profile
+        REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED=0       Block startup if signer config supply fails
+        REDDOG_SIGNER_SERVICE_CONFIG_PATH                    Outside-repo signer CLI config JSON
         REDDOG_SIGNER_SOCKET_PROFILE_BINDING=0              Derive signer socket path/backend when authority runtime is configured
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
@@ -3347,6 +3369,11 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         signer_socket_path = explicit_signer_socket_path
         explicit_signature_verifier_backend = str(os.getenv("REDDOG_SIGNATURE_VERIFIER_BACKEND") or "").strip()
         signature_verifier_backend = explicit_signature_verifier_backend
+        authority_profile_path = resident_queue_runtime_file_path(
+            os.environ,
+            repo_root,
+            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+        )
         resolver_permission_snapshots_output_path = resident_queue_runtime_file_path(
             os.environ,
             repo_root,
@@ -3415,6 +3442,89 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
                 print(
                     "[REDDOG-AUTHORITY-RESOLVERS] Startup blocked by "
                     "REDDOG_AUTHORITY_RUNTIME_RESOLVER_ARTIFACT_SUPPLY_ENFORCED=1"
+                )
+                return False
+
+        signer_config_supply_requested = str(
+            os.getenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY") or ""
+        ).strip() == "1"
+        signer_config_supply_enforced = (
+            os.getenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED", "0") != "0"
+        )
+        if signer_config_supply_requested:
+            from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+                run_reddog_signer_socket_service_config_supply,
+            )
+
+            authority_profile_payload = None
+            if authority_profile_path:
+                authority_profile_payload = _reddog_bounded_json_file(Path(authority_profile_path))
+            peer_uid_to_principal = _reddog_bounded_json_env("REDDOG_SIGNER_PEER_UID_TO_PRINCIPAL")
+            config_output_path = resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_SIGNER_SERVICE_CONFIG_PATH",
+            )
+            config_socket_path = signer_socket_path or resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_SIGNER_SOCKET_PATH",
+            )
+            signer_config = run_reddog_signer_socket_service_config_supply(
+                repo_root=repo_root,
+                authority_profile=(
+                    authority_profile_payload
+                    if isinstance(authority_profile_payload, Mapping)
+                    else None
+                ),
+                output_path=config_output_path or None,
+                socket_path=config_socket_path or None,
+                principal_signing_key_ref=str(
+                    os.getenv("REDDOG_SIGNER_PRINCIPAL_SIGNING_KEY_REF") or ""
+                ),
+                principal_audit_mac_key_ref=str(
+                    os.getenv("REDDOG_SIGNER_PRINCIPAL_AUDIT_MAC_KEY_REF") or ""
+                ),
+                reddog_signing_key_ref=str(os.getenv("REDDOG_SIGNER_REDDOG_SIGNING_KEY_REF") or ""),
+                reddog_audit_mac_key_ref=str(
+                    os.getenv("REDDOG_SIGNER_REDDOG_AUDIT_MAC_KEY_REF") or ""
+                ),
+                peer_uid_to_principal=(
+                    peer_uid_to_principal if isinstance(peer_uid_to_principal, Mapping) else {}
+                ),
+                allowed_gids=_reddog_env_sequence("REDDOG_SIGNER_ALLOWED_GIDS"),
+                max_requests=_reddog_positive_int_env("REDDOG_SIGNER_CONFIG_MAX_REQUESTS", 16),
+                timeout_s=_reddog_float_env("REDDOG_SIGNER_CONFIG_TIMEOUT_S", 5.0),
+                max_request_bytes=_reddog_positive_int_env(
+                    "REDDOG_SIGNER_CONFIG_MAX_REQUEST_BYTES",
+                    16384,
+                ),
+                max_response_bytes=_reddog_positive_int_env(
+                    "REDDOG_SIGNER_CONFIG_MAX_RESPONSE_BYTES",
+                    16384,
+                ),
+            )
+            signer_config_status = "PASS" if signer_config.accepted else "WARN"
+            signer_config_reasons = (
+                ",".join(signer_config.rejection_reasons)
+                if signer_config.rejection_reasons
+                else "(none)"
+            )
+            print(
+                f"[REDDOG-SIGNER-CONFIG] preflight={signer_config_status} "
+                f"status={signer_config.status} "
+                f"receipt={signer_config.config_supply_receipt_id or '(none)'} "
+                f"config={signer_config.config_path or '(none)'} "
+                f"socket={signer_config.socket_path or '(none)'} "
+                f"profiles={signer_config.profile_count} reasons={signer_config_reasons}"
+            )
+            if signer_config.accepted:
+                if signer_config.config_path:
+                    os.environ["REDDOG_SIGNER_SERVICE_CONFIG_PATH"] = signer_config.config_path
+            elif signer_config_supply_enforced:
+                print(
+                    "[REDDOG-SIGNER-CONFIG] Startup blocked by "
+                    "REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED=1"
                 )
                 return False
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added a signer service config supplier that materializes an outside-repo
+  JSON config from an existing promoted authority profile, explicit WSP71
+  `op://` references, and a signer peer policy.
+- Added an explicit main preflight switch for config supply; it prints an
+  audit-safe receipt and never starts the signer, resolves secrets, binds a
+  socket, enqueues OpenClaw, dispatches Hermes, publishes PRs, settles rewards,
+  or re-indexes HoloIndex.
+- Registered the signer service config as a resident runtime artifact path
+  while keeping the supply step explicit rather than profile-defaulted.
+- Added focused tests for config shape, invalid profile/ref/policy/path
+  rejection, main enforced failure, no implicit socket consumption, and no
+  secret-resolution/spawn/runtime-authority surface.
+
 ## 2026-07-17: REDDOG_SIGNER_MULTI_PROFILE_MAIN_CLI_PROOF_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -124,6 +124,7 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": "authority_runtime_state.json",
     "REDDOG_PERMISSION_SNAPSHOTS_PATH": "permission_snapshots.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": "principal_authority_records.json",
+    "REDDOG_SIGNER_SERVICE_CONFIG_PATH": "signer_service_config.json",
     "REDDOG_SIGNER_SOCKET_PATH": "reddog_signer.sock",
     "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": "resident_queue_chain_results.json",
     "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": "authority_profile.json",

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
@@ -1,0 +1,421 @@
+"""Signer socket service config supplier for resident RedDog runtime.
+
+Slice: REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1
+
+This module materializes the outside-repo JSON config consumed by the
+signer-owned CLI. It binds the existing promoted authority profile to explicit
+WSP71 op:// references and a signer-owned peer policy. It does not resolve
+secrets, start the signer service, bind sockets, parse environment variables,
+spawn processes, mutate the repository, enqueue OpenClaw, dispatch Hermes,
+publish PRs, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+)
+from modules.infrastructure.secrets_mcp.src.vault_resolver import parse_op_reference
+
+
+SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT = "SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT"
+SIGNER_SERVICE_CONFIG_SUPPLY_REJECT = "SIGNER_SERVICE_CONFIG_SUPPLY_REJECT"
+SIGNER_SERVICE_CONFIG_SCHEMA_VERSION = "reddog_signer_service_config.v1"
+
+FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID = "signer_config_authority_profile_invalid"
+FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID = "signer_config_output_path_invalid"
+FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID = "signer_config_socket_path_invalid"
+FAIL_SIGNER_CONFIG_OP_REF_INVALID = "signer_config_op_ref_invalid"
+FAIL_SIGNER_CONFIG_OP_REF_REUSED = "signer_config_op_ref_reused"
+FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID = "signer_config_peer_policy_invalid"
+FAIL_SIGNER_CONFIG_LIMITS_INVALID = "signer_config_limits_invalid"
+FAIL_SIGNER_CONFIG_WRITE_FAILED = "signer_config_write_failed"
+
+_REQUIRED_AUTHORITY_FIELDS = (
+    "principal_id",
+    "principal_public_key",
+    "reddog_id",
+    "reddog_public_key",
+    "permission_snapshot_digest",
+    "key_epoch",
+)
+
+
+@dataclass(frozen=True)
+class SignerServiceConfigSupplyResult:
+    """Audit-safe result for signer service config materialization."""
+
+    accepted: bool
+    status: str
+    config_supply_receipt_id: str | None
+    config_path: str | None
+    config_digest: str | None
+    socket_path: str | None
+    principal_id: str | None
+    reddog_id: str | None
+    profile_count: int
+    rejection_reasons: tuple[str, ...]
+    no_secret_values_written: bool = True
+    no_secret_values_resolved: bool = True
+    no_signer_started: bool = True
+    no_socket_bound: bool = True
+    no_process_spawned: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_signer_socket_service_config_supply(
+    *,
+    repo_root: Path | str,
+    authority_profile: Mapping[str, Any] | None,
+    output_path: Path | str | None,
+    socket_path: Path | str | None,
+    principal_signing_key_ref: str,
+    principal_audit_mac_key_ref: str,
+    reddog_signing_key_ref: str,
+    reddog_audit_mac_key_ref: str,
+    peer_uid_to_principal: Mapping[int | str, str],
+    allowed_gids: Sequence[int | str] = (),
+    max_requests: int = 16,
+    timeout_s: float = 5.0,
+    max_request_bytes: int = 16384,
+    max_response_bytes: int = 16384,
+    principal_signer_agent_id: str = "signer:principal",
+    reddog_signer_agent_id: str = "signer:reddog",
+) -> SignerServiceConfigSupplyResult:
+    """Write one signer CLI config from existing authority artifacts."""
+
+    root = Path(repo_root).resolve()
+    profile = _mapping(authority_profile)
+    reasons: list[str] = []
+    reasons.extend(_authority_profile_reasons(profile))
+    out, output_reasons = _resolve_output_path(root, output_path)
+    reasons.extend(output_reasons)
+    sock, socket_reasons = _resolve_socket_path(root, socket_path)
+    reasons.extend(socket_reasons)
+    op_refs = (
+        principal_signing_key_ref,
+        principal_audit_mac_key_ref,
+        reddog_signing_key_ref,
+        reddog_audit_mac_key_ref,
+    )
+    reasons.extend(_op_ref_reasons(op_refs))
+    peer_policy, peer_reasons = _peer_policy(peer_uid_to_principal, allowed_gids)
+    reasons.extend(peer_reasons)
+    reasons.extend(_limit_reasons(max_requests, timeout_s, max_request_bytes, max_response_bytes))
+
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert out is not None
+    assert sock is not None
+    assert peer_policy is not None
+    config = _config(
+        authority_profile=profile,
+        socket_path=sock,
+        principal_signing_key_ref=principal_signing_key_ref,
+        principal_audit_mac_key_ref=principal_audit_mac_key_ref,
+        reddog_signing_key_ref=reddog_signing_key_ref,
+        reddog_audit_mac_key_ref=reddog_audit_mac_key_ref,
+        peer_policy=peer_policy,
+        max_requests=max_requests,
+        timeout_s=timeout_s,
+        max_request_bytes=max_request_bytes,
+        max_response_bytes=max_response_bytes,
+        principal_signer_agent_id=principal_signer_agent_id,
+        reddog_signer_agent_id=reddog_signer_agent_id,
+    )
+    config_digest = _digest(config)
+    receipt = {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "config_digest": config_digest,
+        "config_path": str(out),
+        "socket_path": str(sock),
+        "principal_id": str(profile["principal_id"]),
+        "reddog_id": str(profile["reddog_id"]),
+        "profile_count": 2,
+        "no_secret_values_written": True,
+        "no_secret_values_resolved": True,
+        "no_signer_started": True,
+        "no_socket_bound": True,
+    }
+    receipt["config_supply_receipt_id"] = _digest(receipt)
+    try:
+        _write_json_atomic(out, config)
+    except Exception:
+        return _reject((FAIL_SIGNER_CONFIG_WRITE_FAILED,))
+    return SignerServiceConfigSupplyResult(
+        accepted=True,
+        status=SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT,
+        config_supply_receipt_id=str(receipt["config_supply_receipt_id"]),
+        config_path=str(out),
+        config_digest=config_digest,
+        socket_path=str(sock),
+        principal_id=str(profile["principal_id"]),
+        reddog_id=str(profile["reddog_id"]),
+        profile_count=2,
+        rejection_reasons=(),
+    )
+
+
+def _config(
+    *,
+    authority_profile: Mapping[str, Any],
+    socket_path: Path,
+    principal_signing_key_ref: str,
+    principal_audit_mac_key_ref: str,
+    reddog_signing_key_ref: str,
+    reddog_audit_mac_key_ref: str,
+    peer_policy: Mapping[str, Any],
+    max_requests: int,
+    timeout_s: float,
+    max_request_bytes: int,
+    max_response_bytes: int,
+    principal_signer_agent_id: str,
+    reddog_signer_agent_id: str,
+) -> dict[str, Any]:
+    principal_public = str(authority_profile["principal_public_key"])
+    reddog_public = str(authority_profile["reddog_public_key"])
+    permission_digest = str(authority_profile["permission_snapshot_digest"])
+    key_epoch = str(authority_profile["key_epoch"])
+    return {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "socket_path": str(socket_path),
+        "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+        "allow_test_only_key_material": False,
+        "permission_snapshot_fresh": True,
+        "max_requests": int(max_requests),
+        "timeout_s": float(timeout_s),
+        "max_request_bytes": int(max_request_bytes),
+        "max_response_bytes": int(max_response_bytes),
+        "key_provider_profiles": [
+            {
+                "signer_profile_id": "principal-identity",
+                "signer_agent_id": str(principal_signer_agent_id),
+                "signing_key_ref": str(principal_signing_key_ref),
+                "audit_mac_key_ref": str(principal_audit_mac_key_ref),
+                "expected_public_key": principal_public,
+                "expected_key_fingerprint": public_key_fingerprint(principal_public),
+                "expected_key_epoch": key_epoch,
+                "permission_snapshot_digest": permission_digest,
+                "ttl_seconds": int(authority_profile.get("identity_ttl_seconds") or 300),
+            },
+            {
+                "signer_profile_id": "reddog-work-authority",
+                "signer_agent_id": str(reddog_signer_agent_id),
+                "signing_key_ref": str(reddog_signing_key_ref),
+                "audit_mac_key_ref": str(reddog_audit_mac_key_ref),
+                "expected_public_key": reddog_public,
+                "expected_key_fingerprint": public_key_fingerprint(reddog_public),
+                "expected_key_epoch": key_epoch,
+                "permission_snapshot_digest": permission_digest,
+                "ttl_seconds": int(authority_profile.get("work_authority_ttl_seconds") or 300),
+            },
+        ],
+        "peer_policy": dict(peer_policy),
+    }
+
+
+def _authority_profile_reasons(profile: Mapping[str, Any]) -> list[str]:
+    if not profile or not _ascii_deep(profile):
+        return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID]
+    missing = [field for field in _REQUIRED_AUTHORITY_FIELDS if not str(profile.get(field) or "")]
+    if missing:
+        return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":" + field for field in missing]
+    if str(profile.get("principal_public_key")) == str(profile.get("reddog_public_key")):
+        return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":key_reuse"]
+    return []
+
+
+def _resolve_output_path(repo_root: Path, value: Path | str | None) -> tuple[Path | None, list[str]]:
+    path, reasons = _resolve_outside_repo(repo_root, value, FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID)
+    if reasons:
+        return None, reasons
+    assert path is not None
+    if path.exists() and not path.is_file():
+        return None, [FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID]
+    return path, []
+
+
+def _resolve_socket_path(repo_root: Path, value: Path | str | None) -> tuple[Path | None, list[str]]:
+    path, reasons = _resolve_outside_repo(repo_root, value, FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID)
+    if reasons:
+        return None, reasons
+    assert path is not None
+    if path.exists():
+        return None, [FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID]
+    return path, []
+
+
+def _resolve_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    reason: str,
+) -> tuple[Path | None, list[str]]:
+    if not value:
+        return None, [reason]
+    text = str(value)
+    if "\x00" in text or text.startswith("\\\\?\\") or text.startswith("//?/"):
+        return None, [reason]
+    path = Path(value)
+    if not path.is_absolute():
+        return None, [reason]
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, [reason]
+    return resolved, []
+
+
+def _op_ref_reasons(values: Sequence[str]) -> list[str]:
+    refs = tuple(str(value or "").strip() for value in values)
+    reasons: list[str] = []
+    for ref in refs:
+        if not parse_op_reference(ref):
+            reasons.append(FAIL_SIGNER_CONFIG_OP_REF_INVALID)
+    if len(set(refs)) != len(refs):
+        reasons.append(FAIL_SIGNER_CONFIG_OP_REF_REUSED)
+    return reasons
+
+
+def _peer_policy(
+    uid_to_principal: Mapping[int | str, str],
+    allowed_gids: Sequence[int | str],
+) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        uid_map = {int(uid): str(principal) for uid, principal in uid_to_principal.items()}
+        gids = tuple(int(gid) for gid in allowed_gids)
+    except Exception:
+        return None, [FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID]
+    if not uid_map:
+        return None, [FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID]
+    if any(uid < 0 for uid in uid_map) or any(gid < 0 for gid in gids):
+        return None, [FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID]
+    if any(not principal or not _ascii_string(principal) for principal in uid_map.values()):
+        return None, [FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID]
+    return {
+        "uid_to_principal": {str(uid): principal for uid, principal in sorted(uid_map.items())},
+        "allowed_gids": list(gids),
+        "transport": "unix_socket",
+        "credential_source_prefix": "kernel_peer_credential",
+    }, []
+
+
+def _limit_reasons(
+    max_requests: int,
+    timeout_s: float,
+    max_request_bytes: int,
+    max_response_bytes: int,
+) -> list[str]:
+    if (
+        not isinstance(max_requests, int)
+        or max_requests < 2
+        or max_requests > 128
+        or timeout_s <= 0
+        or timeout_s > 30
+        or max_request_bytes < 1024
+        or max_request_bytes > 262144
+        or max_response_bytes < 1024
+        or max_response_bytes > 262144
+    ):
+        return [FAIL_SIGNER_CONFIG_LIMITS_INVALID]
+    return []
+
+
+def _mapping(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _reject(reasons: Sequence[str]) -> SignerServiceConfigSupplyResult:
+    return SignerServiceConfigSupplyResult(
+        accepted=False,
+        status=SIGNER_SERVICE_CONFIG_SUPPLY_REJECT,
+        config_supply_receipt_id=None,
+        config_path=None,
+        config_digest=None,
+        socket_path=None,
+        principal_id=None,
+        reddog_id=None,
+        profile_count=0,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value)))
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _ascii_string(value: object) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value)
+
+
+def _ascii_deep(value: object) -> bool:
+    if isinstance(value, str):
+        return _ascii_string(value)
+    if isinstance(value, Mapping):
+        return all(_ascii_string(key) and _ascii_deep(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_ascii_deep(item) for item in value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return True
+    return False
+
+
+__all__ = [
+    "FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID",
+    "FAIL_SIGNER_CONFIG_LIMITS_INVALID",
+    "FAIL_SIGNER_CONFIG_OP_REF_INVALID",
+    "FAIL_SIGNER_CONFIG_OP_REF_REUSED",
+    "FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID",
+    "FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID",
+    "FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID",
+    "FAIL_SIGNER_CONFIG_WRITE_FAILED",
+    "SIGNER_SERVICE_CONFIG_SCHEMA_VERSION",
+    "SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT",
+    "SIGNER_SERVICE_CONFIG_SUPPLY_REJECT",
+    "SignerServiceConfigSupplyResult",
+    "run_reddog_signer_socket_service_config_supply",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
@@ -1,0 +1,197 @@
+"""Tests for REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1 main preflight."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+    PROFILE_SIGNED_0102_BOUNDED_CODE,
+    resident_queue_runtime_file_path,
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    return repo
+
+
+def _authority_profile(**overrides: object) -> dict[str, object]:
+    profile: dict[str, object] = {
+        "principal_id": "github:mjtrout",
+        "principal_public_key": "ed25519-pub-v1:principal",
+        "reddog_id": "reddog:foundups-agent",
+        "reddog_public_key": "ed25519-pub-v1:reddog",
+        "permission_snapshot_digest": "sha256:permission",
+        "key_epoch": "epoch-1",
+        "identity_ttl_seconds": 600,
+        "work_authority_ttl_seconds": 300,
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _serial_loop_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        accepted=True,
+        status="SERIAL_LOOP_TEST_ACCEPT",
+        queue_item_id=None,
+        selected_slice=None,
+        steps_run=0,
+        dispatched_stages=(),
+        next_action="STOP_TEST",
+        rejection_reasons=(),
+        chain_results_path=None,
+        store_revision=None,
+    )
+
+
+def test_main_signer_config_supply_writes_outside_repo_config_without_socket_consumption(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    profile_env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": PROFILE_SIGNED_0102_BOUNDED_CODE,
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+    authority_profile_path = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+        )
+    )
+    config_path = Path(
+        resident_queue_runtime_file_path(profile_env, repo, "REDDOG_SIGNER_SERVICE_CONFIG_PATH")
+    )
+    socket_path = Path(
+        resident_queue_runtime_file_path(profile_env, repo, "REDDOG_SIGNER_SOCKET_PATH")
+    )
+    _write_json(authority_profile_path, _authority_profile())
+
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(authority_profile_path))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_PRINCIPAL_SIGNING_KEY_REF", "op://prod-vault/principal/private")
+    monkeypatch.setenv("REDDOG_SIGNER_PRINCIPAL_AUDIT_MAC_KEY_REF", "op://prod-vault/principal/audit")
+    monkeypatch.setenv("REDDOG_SIGNER_REDDOG_SIGNING_KEY_REF", "op://prod-vault/reddog/private")
+    monkeypatch.setenv("REDDOG_SIGNER_REDDOG_AUDIT_MAC_KEY_REF", "op://prod-vault/reddog/audit")
+    monkeypatch.setenv(
+        "REDDOG_SIGNER_PEER_UID_TO_PRINCIPAL",
+        json.dumps({"1001": "github:mjtrout"}, sort_keys=True),
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=_serial_loop_result(),
+    ) as mocked_bootstrap:
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is True
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-CONFIG] preflight=PASS" in captured
+    assert config_path.exists()
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    assert payload["socket_path"] == str(socket_path.resolve())
+    assert payload["key_provider_profiles"][0]["signing_key_ref"] == (
+        "op://prod-vault/principal/private"
+    )
+    assert payload["key_provider_profiles"][1]["signing_key_ref"] == (
+        "op://prod-vault/reddog/private"
+    )
+    assert payload["peer_policy"]["uid_to_principal"] == {"1001": "github:mjtrout"}
+    assert mocked_bootstrap.call_args.kwargs["signer_socket_path"] is None
+
+
+def test_main_signer_config_supply_enforced_failure_blocks_before_serial_bootstrap(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    profile_env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": PROFILE_SIGNED_0102_BOUNDED_CODE,
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+    authority_profile_path = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+        )
+    )
+    _write_json(authority_profile_path, _authority_profile())
+
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(authority_profile_path))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED", "1")
+    monkeypatch.setenv(
+        "REDDOG_SIGNER_PEER_UID_TO_PRINCIPAL",
+        json.dumps({"1001": "github:mjtrout"}, sort_keys=True),
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        side_effect=AssertionError("serial bootstrap must not run after signer config reject"),
+    ):
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is False
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-CONFIG] preflight=WARN" in captured
+    assert "signer_config_op_ref_invalid" in captured
+    assert "Startup blocked by REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED=1" in captured
+
+
+def test_profile_does_not_auto_enable_signer_config_supply(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=_serial_loop_result(),
+    ):
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is True
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-CONFIG]" not in captured
+    assert not (runtime_root / "signer_service_config.json").exists()

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
@@ -1,0 +1,238 @@
+"""Tests for REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID,
+    FAIL_SIGNER_CONFIG_LIMITS_INVALID,
+    FAIL_SIGNER_CONFIG_OP_REF_INVALID,
+    FAIL_SIGNER_CONFIG_OP_REF_REUSED,
+    FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID,
+    FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID,
+    FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID,
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+    SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT,
+    run_reddog_signer_socket_service_config_supply,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signer_socket_service_config_supply.py"
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _authority_profile(**overrides: object) -> dict[str, object]:
+    profile: dict[str, object] = {
+        "principal_id": "github:mjtrout",
+        "principal_public_key": "ed25519-pub-v1:principal",
+        "reddog_id": "reddog:foundups-agent",
+        "reddog_public_key": "ed25519-pub-v1:reddog",
+        "permission_snapshot_digest": "sha256:permission",
+        "key_epoch": "epoch-1",
+        "identity_ttl_seconds": 600,
+        "work_authority_ttl_seconds": 300,
+    }
+    profile.update(overrides)
+    return profile
+
+
+def _kwargs(repo: Path, runtime: Path, **overrides: object) -> dict[str, object]:
+    values: dict[str, object] = {
+        "repo_root": repo,
+        "authority_profile": _authority_profile(),
+        "output_path": runtime / "signer-service.json",
+        "socket_path": runtime / "reddog-signer.sock",
+        "principal_signing_key_ref": "op://prod-vault/principal/private",
+        "principal_audit_mac_key_ref": "op://prod-vault/principal/audit",
+        "reddog_signing_key_ref": "op://prod-vault/reddog/private",
+        "reddog_audit_mac_key_ref": "op://prod-vault/reddog/audit",
+        "peer_uid_to_principal": {1001: "github:mjtrout"},
+        "allowed_gids": (1002,),
+        "max_requests": 2,
+    }
+    values.update(overrides)
+    return values
+
+
+def test_config_supply_writes_multi_profile_signer_cli_config(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    result = run_reddog_signer_socket_service_config_supply(**_kwargs(repo, runtime))
+
+    assert result.accepted is True
+    assert result.status == SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT
+    assert result.profile_count == 2
+    assert result.config_supply_receipt_id and result.config_supply_receipt_id.startswith("sha256:")
+    assert result.config_digest and result.config_digest.startswith("sha256:")
+    assert result.no_secret_values_written is True
+    assert result.no_secret_values_resolved is True
+    assert result.no_signer_started is True
+    assert result.no_holoindex_reindex_performed is True
+    assert not (repo / "signer-service.json").exists()
+
+    payload = json.loads((runtime / "signer-service.json").read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SIGNER_SERVICE_CONFIG_SCHEMA_VERSION
+    assert payload["provider_mode"] == "WSP71_PERMISSIONED"
+    assert payload["allow_test_only_key_material"] is False
+    assert payload["permission_snapshot_fresh"] is True
+    assert payload["socket_path"] == str((runtime / "reddog-signer.sock").resolve())
+    assert payload["peer_policy"] == {
+        "uid_to_principal": {"1001": "github:mjtrout"},
+        "allowed_gids": [1002],
+        "transport": "unix_socket",
+        "credential_source_prefix": "kernel_peer_credential",
+    }
+    profiles = payload["key_provider_profiles"]
+    assert [item["signer_profile_id"] for item in profiles] == [
+        "principal-identity",
+        "reddog-work-authority",
+    ]
+    assert profiles[0]["expected_public_key"] == "ed25519-pub-v1:principal"
+    assert profiles[0]["expected_key_fingerprint"] == public_key_fingerprint(
+        "ed25519-pub-v1:principal"
+    )
+    assert profiles[1]["expected_public_key"] == "ed25519-pub-v1:reddog"
+    assert profiles[1]["expected_key_fingerprint"] == public_key_fingerprint(
+        "ed25519-pub-v1:reddog"
+    )
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "ed25519-private-raw-b64-v1" not in serialized
+    assert "audit-mac-test-key-b64-v1" not in serialized
+
+
+def test_config_supply_rejects_invalid_authority_profile_and_key_reuse(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+
+    missing = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, authority_profile=_authority_profile(principal_public_key=""))
+    )
+    reused = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            authority_profile=_authority_profile(reddog_public_key="ed25519-pub-v1:principal"),
+        )
+    )
+
+    assert missing.accepted is False
+    assert any(
+        reason.startswith(FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID)
+        for reason in missing.rejection_reasons
+    )
+    assert reused.accepted is False
+    assert FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":key_reuse" in reused.rejection_reasons
+
+
+def test_config_supply_rejects_inside_repo_or_existing_socket_paths(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    existing_socket = runtime / "reddog-signer.sock"
+    existing_socket.write_text("", encoding="utf-8")
+
+    inside_output = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, output_path=repo / "signer-service.json")
+    )
+    inside_socket = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, socket_path=repo / "reddog-signer.sock")
+    )
+    existing = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, socket_path=existing_socket)
+    )
+
+    assert FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID in inside_output.rejection_reasons
+    assert FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID in inside_socket.rejection_reasons
+    assert FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID in existing.rejection_reasons
+
+
+def test_config_supply_rejects_bad_or_reused_op_refs(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+
+    bad = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, principal_signing_key_ref="not-op")
+    )
+    reused = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            reddog_audit_mac_key_ref="op://prod-vault/reddog/private",
+        )
+    )
+
+    assert FAIL_SIGNER_CONFIG_OP_REF_INVALID in bad.rejection_reasons
+    assert FAIL_SIGNER_CONFIG_OP_REF_REUSED in reused.rejection_reasons
+
+
+def test_config_supply_rejects_peer_policy_and_limit_errors(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+
+    bad_peer = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, peer_uid_to_principal={})
+    )
+    bad_limit = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, max_requests=1)
+    )
+
+    assert FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID in bad_peer.rejection_reasons
+    assert FAIL_SIGNER_CONFIG_LIMITS_INVALID in bad_limit.rejection_reasons
+
+
+def test_config_supply_module_has_no_secret_resolution_spawn_or_runtime_authority_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "socket",
+        "requests",
+        "urllib",
+        "http",
+        "git",
+        "holo_index",
+    }
+    banned_name_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {
+        "getenv",
+        "environ",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "spawn",
+    }
+    banned_name_fragments = ("openclaw", "hermes", "holoindex")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert not any(fragment in node.module.lower() for fragment in banned_name_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
﻿## Summary
- Add REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1, an explicit config-supply step for the signer-owned socket CLI.
- Materialize an outside-repo signer service JSON config from a promoted authority profile, explicit WSP71 op refs, and signer peer policy.
- Register the signer service config as a resident runtime artifact path and add explicit main.py preflight handling without starting the signer or consuming the socket.

## Truth Boundary
- No secret resolution or secret values written.
- No signer process started and no socket bound.
- No command execution, OpenClaw enqueue, Hermes dispatch, PR publication, reward settlement, or HoloIndex re-index.
- Supply remains explicit via REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY=1; resident profiles do not auto-enable it.

## Validation
- focused config/main tests: 9 passed
- signer/bootstrap/main cluster: 41 passed, 2 skipped
- resident queue regression set: 110 passed, 1 skipped
- git diff --check: clean
- py_compile: pass

## HoloIndex
Query-only bundle search returned WSP 71 and RedDog signing/key-isolation docs. The new module is expected to remain an index gap until post-merge indexing.

Worker-Lane: RedDog signer runtime
Slice: REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1
