### PR TITLE
feat(reddog): supply signer service run packet

### DIFF
--- a/main.py
+++ b/main.py
@@ -3265,6 +3265,9 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY=0                Materialize signer-owned CLI config from authority profile
         REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED=0       Block startup if signer config supply fails
         REDDOG_SIGNER_SERVICE_CONFIG_PATH                    Outside-repo signer CLI config JSON
+        REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY=0            Materialize signer-owned CLI argv packet
+        REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED=0   Block startup if run-packet supply fails
+        REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH                Outside-repo signer CLI run-packet JSON
         REDDOG_SIGNER_SOCKET_PROFILE_BINDING=0              Derive signer socket path/backend when authority runtime is configured
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
@@ -3525,6 +3528,64 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
                 print(
                     "[REDDOG-SIGNER-CONFIG] Startup blocked by "
                     "REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED=1"
+                )
+                return False
+
+        signer_run_packet_supply_requested = str(
+            os.getenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY") or ""
+        ).strip() == "1"
+        signer_run_packet_supply_enforced = (
+            os.getenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED", "0") != "0"
+        )
+        if signer_run_packet_supply_requested:
+            from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_run_packet_supply import (
+                run_reddog_signer_socket_service_run_packet_supply,
+            )
+
+            signer_run_packet = run_reddog_signer_socket_service_run_packet_supply(
+                repo_root=repo_root,
+                config_path=resident_queue_runtime_file_path(
+                    os.environ,
+                    repo_root,
+                    "REDDOG_SIGNER_SERVICE_CONFIG_PATH",
+                )
+                or None,
+                output_path=resident_queue_runtime_file_path(
+                    os.environ,
+                    repo_root,
+                    "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
+                )
+                or None,
+                op_executable=str(os.getenv("REDDOG_SIGNER_SERVICE_OP_EXECUTABLE") or "op"),
+                op_timeout_s=_reddog_float_env("REDDOG_SIGNER_SERVICE_OP_TIMEOUT_S", 10.0),
+                ttl_seconds=_reddog_positive_int_env("REDDOG_SIGNER_SERVICE_TTL_SECONDS", 300),
+                session_id=str(os.getenv("REDDOG_SIGNER_SERVICE_SESSION_ID") or "op-cli-session"),
+                python_executable=str(os.getenv("REDDOG_SIGNER_SERVICE_PYTHON_EXECUTABLE") or "") or None,
+            )
+            signer_run_packet_status = "PASS" if signer_run_packet.accepted else "WARN"
+            signer_run_packet_reasons = (
+                ",".join(signer_run_packet.rejection_reasons)
+                if signer_run_packet.rejection_reasons
+                else "(none)"
+            )
+            print(
+                f"[REDDOG-SIGNER-RUN-PACKET] preflight={signer_run_packet_status} "
+                f"status={signer_run_packet.status} "
+                f"packet={signer_run_packet.run_packet_id or '(none)'} "
+                f"path={signer_run_packet.run_packet_path or '(none)'} "
+                f"config={signer_run_packet.config_path or '(none)'} "
+                f"socket={signer_run_packet.socket_path or '(none)'} "
+                f"profiles={signer_run_packet.profile_count} reasons={signer_run_packet_reasons}"
+            )
+            if signer_run_packet.accepted:
+                if signer_run_packet.run_packet_path:
+                    os.environ["REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH"] = (
+                        signer_run_packet.run_packet_path
+                    )
+            elif signer_run_packet_supply_enforced:
+                print(
+                    "[REDDOG-SIGNER-RUN-PACKET] Startup blocked by "
+                    "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED=1"
                 )
                 return False
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added a signer service run-packet supplier that validates the outside-repo
+  signer CLI config and emits a shell-free argv packet for a signer-owned
+  service manager.
+- Added an explicit main preflight switch for run-packet supply; it can run
+  after signer config supply in the same resident preflight and never starts
+  the signer, binds a socket, resolves secrets, enqueues OpenClaw, dispatches
+  Hermes, publishes PRs, settles rewards, or re-indexes HoloIndex.
+- Registered the signer run packet as a resident runtime artifact path while
+  preserving the signer-owned process boundary.
+- Added focused tests for run-packet shape, invalid config/output/op/limit
+  rejection, main enforced failure, config-to-run-packet chaining, and no
+  spawn/shell/runtime-authority surface.
+
 ## 2026-07-17: REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -125,6 +125,7 @@ PROFILE_RUNTIME_PATH_FILENAMES = {
     "REDDOG_PERMISSION_SNAPSHOTS_PATH": "permission_snapshots.json",
     "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": "principal_authority_records.json",
     "REDDOG_SIGNER_SERVICE_CONFIG_PATH": "signer_service_config.json",
+    "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH": "signer_service_run_packet.json",
     "REDDOG_SIGNER_SOCKET_PATH": "reddog_signer.sock",
     "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": "resident_queue_chain_results.json",
     "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": "authority_profile.json",

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
@@ -1,0 +1,373 @@
+"""Signer socket service run-packet supplier for resident RedDog runtime.
+
+Slice: REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_PHASE1
+
+This module materializes an outside-repo run packet for a signer-owned service
+manager to start the signer socket CLI. It validates the signer service config
+and emits a shell-free argv list. It does not start the signer, resolve
+secrets, bind sockets, parse environment variables, mutate the repository,
+enqueue OpenClaw, dispatch Hermes, publish PRs, settle rewards, or re-index
+HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
+
+SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT = "SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT"
+SIGNER_SERVICE_RUN_PACKET_SUPPLY_REJECT = "SIGNER_SERVICE_RUN_PACKET_SUPPLY_REJECT"
+SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION = "reddog_signer_service_run_packet.v1"
+
+FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID = "signer_run_packet_config_path_invalid"
+FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED = "signer_run_packet_config_malformed"
+FAIL_SIGNER_RUN_PACKET_OUTPUT_PATH_INVALID = "signer_run_packet_output_path_invalid"
+FAIL_SIGNER_RUN_PACKET_OP_EXECUTABLE_INVALID = "signer_run_packet_op_executable_invalid"
+FAIL_SIGNER_RUN_PACKET_LIMITS_INVALID = "signer_run_packet_limits_invalid"
+FAIL_SIGNER_RUN_PACKET_SESSION_INVALID = "signer_run_packet_session_invalid"
+FAIL_SIGNER_RUN_PACKET_WRITE_FAILED = "signer_run_packet_write_failed"
+
+_CLI_MODULE = (
+    "modules.communication.moltbot_bridge.src."
+    "reddog_signer_socket_service_runtime_cli"
+)
+
+
+@dataclass(frozen=True)
+class SignerServiceRunPacketSupplyResult:
+    """Audit-safe result for signer service run-packet materialization."""
+
+    accepted: bool
+    status: str
+    run_packet_id: str | None
+    run_packet_path: str | None
+    run_packet_digest: str | None
+    config_path: str | None
+    config_digest: str | None
+    socket_path: str | None
+    profile_count: int
+    rejection_reasons: tuple[str, ...]
+    no_secret_values_written: bool = True
+    no_secret_values_resolved: bool = True
+    no_signer_started: bool = True
+    no_socket_bound: bool = True
+    no_process_spawned: bool = True
+    no_shell_command_emitted: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_signer_socket_service_run_packet_supply(
+    *,
+    repo_root: Path | str,
+    config_path: Path | str | None,
+    output_path: Path | str | None,
+    op_executable: str = "op",
+    op_timeout_s: float = 10.0,
+    ttl_seconds: int = 300,
+    session_id: str = "op-cli-session",
+    python_executable: str | None = None,
+) -> SignerServiceRunPacketSupplyResult:
+    """Write one signer service run packet from an existing signer config."""
+
+    root = Path(repo_root).resolve()
+    config, config_digest, config_resolved, config_reasons = _read_config(root, config_path)
+    output_resolved, output_reasons = _resolve_output_path(root, output_path)
+    reasons: list[str] = []
+    reasons.extend(config_reasons)
+    reasons.extend(output_reasons)
+    reasons.extend(_op_executable_reasons(op_executable))
+    reasons.extend(_limit_reasons(op_timeout_s, ttl_seconds))
+    reasons.extend(_session_reasons(session_id, python_executable or sys.executable))
+    deduped = _dedupe(reasons)
+    if deduped:
+        return _reject(deduped)
+
+    assert config is not None
+    assert config_digest is not None
+    assert config_resolved is not None
+    assert output_resolved is not None
+    socket_path = Path(str(config["socket_path"])).resolve()
+    profiles = tuple(config.get("key_provider_profiles") or ())
+    executable = str(python_executable or sys.executable)
+    argv = (
+        executable,
+        "-m",
+        _CLI_MODULE,
+        "--repo-root",
+        str(root),
+        "--config",
+        str(config_resolved),
+        "--op-executable",
+        str(op_executable),
+        "--op-timeout-s",
+        _number_text(float(op_timeout_s)),
+        "--ttl-seconds",
+        str(int(ttl_seconds)),
+        "--session-id",
+        str(session_id),
+    )
+    packet: dict[str, Any] = {
+        "schema_version": SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION,
+        "run_mode": "signer_owned_cli_sidecar",
+        "repo_root": str(root),
+        "working_directory": str(root),
+        "python_module": _CLI_MODULE,
+        "argv": list(argv),
+        "config_path": str(config_resolved),
+        "config_digest": config_digest,
+        "socket_path": str(socket_path),
+        "profile_count": len(profiles),
+        "provider_mode": str(config.get("provider_mode") or ""),
+        "op_executable": str(op_executable),
+        "op_timeout_s": float(op_timeout_s),
+        "ttl_seconds": int(ttl_seconds),
+        "session_id": str(session_id),
+        "process_owner_requirement": "distinct_signer_os_principal",
+        "redDog_must_not_spawn": True,
+        "main_py_must_not_spawn": True,
+        "shell_required": False,
+        "shell_command": None,
+        "no_secret_values_in_packet": True,
+    }
+    packet["run_packet_id"] = _digest(packet)
+    packet_digest = _digest(packet)
+    try:
+        _write_json_atomic(output_resolved, packet)
+    except Exception:
+        return _reject((FAIL_SIGNER_RUN_PACKET_WRITE_FAILED,))
+    return SignerServiceRunPacketSupplyResult(
+        accepted=True,
+        status=SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT,
+        run_packet_id=str(packet["run_packet_id"]),
+        run_packet_path=str(output_resolved),
+        run_packet_digest=packet_digest,
+        config_path=str(config_resolved),
+        config_digest=config_digest,
+        socket_path=str(socket_path),
+        profile_count=len(profiles),
+        rejection_reasons=(),
+    )
+
+
+def _read_config(
+    repo_root: Path,
+    value: Path | str | None,
+) -> tuple[dict[str, Any] | None, str | None, Path | None, tuple[str, ...]]:
+    path, reasons = _resolve_existing_file(repo_root, value, FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID)
+    if reasons:
+        return None, None, None, reasons
+    assert path is not None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, None, None, (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if not isinstance(payload, dict) or _config_reasons(repo_root, payload):
+        return None, None, None, (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return payload, digest, path, ()
+
+
+def _config_reasons(repo_root: Path, payload: Mapping[str, Any]) -> tuple[str, ...]:
+    if payload.get("schema_version") != SIGNER_SERVICE_CONFIG_SCHEMA_VERSION:
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if payload.get("provider_mode") != PROVIDER_MODE_WSP71_PERMISSIONED:
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if payload.get("allow_test_only_key_material") is not False:
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if payload.get("permission_snapshot_fresh") is not True:
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    socket_path = str(payload.get("socket_path") or "")
+    if "\x00" in socket_path or socket_path.startswith("\\\\?\\") or socket_path.startswith("//?/"):
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    socket_resolved = Path(socket_path)
+    if not socket_resolved.is_absolute() or _is_inside(socket_resolved.resolve(), repo_root):
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    profiles = payload.get("key_provider_profiles")
+    if not isinstance(profiles, list) or len(profiles) < 1 or len(profiles) > 8:
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if not all(isinstance(item, dict) for item in profiles):
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if not _ascii_deep(payload):
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    return ()
+
+
+def _resolve_existing_file(
+    repo_root: Path,
+    value: Path | str | None,
+    reason: str,
+) -> tuple[Path | None, tuple[str, ...]]:
+    path, reasons = _resolve_outside_repo(repo_root, value, reason)
+    if reasons:
+        return None, reasons
+    assert path is not None
+    if not path.is_file():
+        return None, (reason,)
+    return path, ()
+
+
+def _resolve_output_path(repo_root: Path, value: Path | str | None) -> tuple[Path | None, tuple[str, ...]]:
+    path, reasons = _resolve_outside_repo(repo_root, value, FAIL_SIGNER_RUN_PACKET_OUTPUT_PATH_INVALID)
+    if reasons:
+        return None, reasons
+    assert path is not None
+    if path.exists() and not path.is_file():
+        return None, (FAIL_SIGNER_RUN_PACKET_OUTPUT_PATH_INVALID,)
+    return path, ()
+
+
+def _resolve_outside_repo(
+    repo_root: Path,
+    value: Path | str | None,
+    reason: str,
+) -> tuple[Path | None, tuple[str, ...]]:
+    if not value:
+        return None, (reason,)
+    text = str(value)
+    if "\x00" in text or text.startswith("\\\\?\\") or text.startswith("//?/"):
+        return None, (reason,)
+    path = Path(value)
+    if not path.is_absolute():
+        return None, (reason,)
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root):
+        return None, (reason,)
+    return resolved, ()
+
+
+def _op_executable_reasons(value: str) -> tuple[str, ...]:
+    if not _op_executable_allowed(value):
+        return (FAIL_SIGNER_RUN_PACKET_OP_EXECUTABLE_INVALID,)
+    return ()
+
+
+def _op_executable_allowed(value: str) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    stripped = value.strip()
+    if stripped != value:
+        return False
+    basename = stripped.replace("\\", "/").rsplit("/", 1)[-1].lower()
+    return basename in {"op", "op.exe"}
+
+
+def _limit_reasons(op_timeout_s: float, ttl_seconds: int) -> tuple[str, ...]:
+    if (
+        not isinstance(ttl_seconds, int)
+        or ttl_seconds < 30
+        or ttl_seconds > 3600
+        or float(op_timeout_s) <= 0
+        or float(op_timeout_s) > 60
+    ):
+        return (FAIL_SIGNER_RUN_PACKET_LIMITS_INVALID,)
+    return ()
+
+
+def _session_reasons(session_id: str, python_executable: str) -> tuple[str, ...]:
+    if not _ascii_string(session_id) or not session_id or len(session_id) > 128:
+        return (FAIL_SIGNER_RUN_PACKET_SESSION_INVALID,)
+    if not _ascii_string(python_executable) or not python_executable or "\x00" in python_executable:
+        return (FAIL_SIGNER_RUN_PACKET_SESSION_INVALID,)
+    return ()
+
+
+def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, sort_keys=True, indent=2)
+            handle.write("\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def _reject(reasons: tuple[str, ...]) -> SignerServiceRunPacketSupplyResult:
+    return SignerServiceRunPacketSupplyResult(
+        accepted=False,
+        status=SIGNER_SERVICE_RUN_PACKET_SUPPLY_REJECT,
+        run_packet_id=None,
+        run_packet_path=None,
+        run_packet_digest=None,
+        config_path=None,
+        config_digest=None,
+        socket_path=None,
+        profile_count=0,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value)))
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _ascii_string(value: object) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value)
+
+
+def _ascii_deep(value: object) -> bool:
+    if isinstance(value, str):
+        return _ascii_string(value)
+    if isinstance(value, Mapping):
+        return all(_ascii_string(key) and _ascii_deep(item) for key, item in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(_ascii_deep(item) for item in value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return True
+    return False
+
+
+def _number_text(value: float) -> str:
+    return str(int(value)) if value.is_integer() else str(value)
+
+
+__all__ = [
+    "FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED",
+    "FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID",
+    "FAIL_SIGNER_RUN_PACKET_LIMITS_INVALID",
+    "FAIL_SIGNER_RUN_PACKET_OP_EXECUTABLE_INVALID",
+    "FAIL_SIGNER_RUN_PACKET_OUTPUT_PATH_INVALID",
+    "FAIL_SIGNER_RUN_PACKET_SESSION_INVALID",
+    "FAIL_SIGNER_RUN_PACKET_WRITE_FAILED",
+    "SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION",
+    "SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT",
+    "SIGNER_SERVICE_RUN_PACKET_SUPPLY_REJECT",
+    "SignerServiceRunPacketSupplyResult",
+    "run_reddog_signer_socket_service_run_packet_supply",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
@@ -7,6 +7,14 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
     PROFILE_SIGNED_0102_BOUNDED_CODE,
     resident_queue_runtime_file_path,
@@ -17,6 +25,30 @@ def _repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
     return repo
+
+
+@pytest.fixture(autouse=True)
+def clean_signer_supply_env(monkeypatch) -> None:
+    for name in (
+        "REDDOG_SIGNER_SERVICE_CONFIG_PATH",
+        "REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY",
+        "REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED",
+        "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
+        "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY",
+        "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED",
+        "REDDOG_SIGNER_PRINCIPAL_SIGNING_KEY_REF",
+        "REDDOG_SIGNER_PRINCIPAL_AUDIT_MAC_KEY_REF",
+        "REDDOG_SIGNER_REDDOG_SIGNING_KEY_REF",
+        "REDDOG_SIGNER_REDDOG_AUDIT_MAC_KEY_REF",
+        "REDDOG_SIGNER_PEER_UID_TO_PRINCIPAL",
+        "REDDOG_SIGNER_ALLOWED_GIDS",
+        "REDDOG_SIGNER_SERVICE_OP_EXECUTABLE",
+        "REDDOG_SIGNER_SERVICE_OP_TIMEOUT_S",
+        "REDDOG_SIGNER_SERVICE_TTL_SECONDS",
+        "REDDOG_SIGNER_SERVICE_SESSION_ID",
+        "REDDOG_SIGNER_SERVICE_PYTHON_EXECUTABLE",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 def _authority_profile(**overrides: object) -> dict[str, object]:
@@ -38,6 +70,50 @@ def _write_json(path: Path, payload: object) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
     return path
+
+
+def _signer_config(socket_path: Path) -> dict[str, object]:
+    return {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "socket_path": str(socket_path),
+        "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+        "allow_test_only_key_material": False,
+        "permission_snapshot_fresh": True,
+        "max_requests": 3,
+        "timeout_s": 2.5,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "key_provider_profiles": [
+            {
+                "signer_profile_id": "principal-profile",
+                "signer_agent_id": "signer:principal",
+                "signing_key_ref": "op://prod-vault/principal/private",
+                "audit_mac_key_ref": "op://prod-vault/principal/audit",
+                "expected_public_key": "ed25519-pub-v1:principal",
+                "expected_key_fingerprint": "sha256:principal",
+                "expected_key_epoch": "epoch-1",
+                "permission_snapshot_digest": "sha256:permission",
+                "ttl_seconds": 60,
+            },
+            {
+                "signer_profile_id": "reddog-profile",
+                "signer_agent_id": "signer:reddog",
+                "signing_key_ref": "op://prod-vault/reddog/private",
+                "audit_mac_key_ref": "op://prod-vault/reddog/audit",
+                "expected_public_key": "ed25519-pub-v1:reddog",
+                "expected_key_fingerprint": "sha256:reddog",
+                "expected_key_epoch": "epoch-1",
+                "permission_snapshot_digest": "sha256:permission",
+                "ttl_seconds": 60,
+            },
+        ],
+        "peer_policy": {
+            "uid_to_principal": {"1001": "github:mjtrout"},
+            "allowed_gids": [1002],
+            "transport": "unix_socket",
+            "credential_source_prefix": "kernel_peer_credential",
+        },
+    }
 
 
 def _serial_loop_result() -> SimpleNamespace:
@@ -195,3 +271,159 @@ def test_profile_does_not_auto_enable_signer_config_supply(
     captured = capsys.readouterr().out
     assert "[REDDOG-SIGNER-CONFIG]" not in captured
     assert not (runtime_root / "signer_service_config.json").exists()
+
+
+def test_main_signer_run_packet_supply_writes_packet_without_socket_consumption(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    profile_env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": PROFILE_SIGNED_0102_BOUNDED_CODE,
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+    config_path = Path(
+        resident_queue_runtime_file_path(profile_env, repo, "REDDOG_SIGNER_SERVICE_CONFIG_PATH")
+    )
+    run_packet_path = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
+        )
+    )
+    socket_path = Path(
+        resident_queue_runtime_file_path(profile_env, repo, "REDDOG_SIGNER_SOCKET_PATH")
+    )
+    _write_json(config_path, _signer_config(socket_path))
+
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_PYTHON_EXECUTABLE", "python")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_SESSION_ID", "signer-main-run-packet")
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=_serial_loop_result(),
+    ) as mocked_bootstrap:
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is True
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-RUN-PACKET] preflight=PASS" in captured
+    assert run_packet_path.exists()
+    packet = json.loads(run_packet_path.read_text(encoding="utf-8"))
+    assert packet["config_path"] == str(config_path.resolve())
+    assert packet["socket_path"] == str(socket_path.resolve())
+    assert packet["shell_command"] is None
+    assert packet["argv"][:3] == [
+        "python",
+        "-m",
+        "modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_cli",
+    ]
+    assert mocked_bootstrap.call_args.kwargs["signer_socket_path"] is None
+
+
+def test_main_signer_config_supply_can_feed_run_packet_supply_in_same_preflight(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    profile_env = {
+        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": PROFILE_SIGNED_0102_BOUNDED_CODE,
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+    }
+    authority_profile_path = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH",
+        )
+    )
+    config_path = Path(
+        resident_queue_runtime_file_path(profile_env, repo, "REDDOG_SIGNER_SERVICE_CONFIG_PATH")
+    )
+    run_packet_path = Path(
+        resident_queue_runtime_file_path(
+            profile_env,
+            repo,
+            "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
+        )
+    )
+    _write_json(authority_profile_path, _authority_profile())
+
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH", str(authority_profile_path))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_PYTHON_EXECUTABLE", "python")
+    monkeypatch.setenv("REDDOG_SIGNER_PRINCIPAL_SIGNING_KEY_REF", "op://prod-vault/principal/private")
+    monkeypatch.setenv("REDDOG_SIGNER_PRINCIPAL_AUDIT_MAC_KEY_REF", "op://prod-vault/principal/audit")
+    monkeypatch.setenv("REDDOG_SIGNER_REDDOG_SIGNING_KEY_REF", "op://prod-vault/reddog/private")
+    monkeypatch.setenv("REDDOG_SIGNER_REDDOG_AUDIT_MAC_KEY_REF", "op://prod-vault/reddog/audit")
+    monkeypatch.setenv(
+        "REDDOG_SIGNER_PEER_UID_TO_PRINCIPAL",
+        json.dumps({"1001": "github:mjtrout"}, sort_keys=True),
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=_serial_loop_result(),
+    ):
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is True
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-CONFIG] preflight=PASS" in captured
+    assert "[REDDOG-SIGNER-RUN-PACKET] preflight=PASS" in captured
+    assert config_path.exists()
+    assert run_packet_path.exists()
+
+
+def test_main_signer_run_packet_supply_enforced_failure_blocks_before_serial_bootstrap(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED", "1")
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        side_effect=AssertionError("serial bootstrap must not run after run-packet reject"),
+    ):
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is False
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-RUN-PACKET] preflight=WARN" in captured
+    assert "signer_run_packet_config_path_invalid" in captured
+    assert "Startup blocked by REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED=1" in captured

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_run_packet_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_run_packet_supply.py
@@ -1,0 +1,243 @@
+"""Tests for REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_run_packet_supply import (
+    FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,
+    FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID,
+    FAIL_SIGNER_RUN_PACKET_LIMITS_INVALID,
+    FAIL_SIGNER_RUN_PACKET_OP_EXECUTABLE_INVALID,
+    FAIL_SIGNER_RUN_PACKET_OUTPUT_PATH_INVALID,
+    SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION,
+    SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT,
+    run_reddog_signer_socket_service_run_packet_supply,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signer_socket_service_run_packet_supply.py"
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "socket_path": str(socket_path),
+        "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+        "allow_test_only_key_material": False,
+        "permission_snapshot_fresh": True,
+        "max_requests": 3,
+        "timeout_s": 2.5,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "key_provider_profiles": [
+            {
+                "signer_profile_id": "principal-profile",
+                "signer_agent_id": "signer:principal",
+                "signing_key_ref": "op://prod-vault/principal/private",
+                "audit_mac_key_ref": "op://prod-vault/principal/audit",
+                "expected_public_key": "ed25519-pub-v1:principal",
+                "expected_key_fingerprint": "sha256:principal",
+                "expected_key_epoch": "epoch-1",
+                "permission_snapshot_digest": "sha256:permission",
+                "ttl_seconds": 60,
+            },
+            {
+                "signer_profile_id": "reddog-profile",
+                "signer_agent_id": "signer:reddog",
+                "signing_key_ref": "op://prod-vault/reddog/private",
+                "audit_mac_key_ref": "op://prod-vault/reddog/audit",
+                "expected_public_key": "ed25519-pub-v1:reddog",
+                "expected_key_fingerprint": "sha256:reddog",
+                "expected_key_epoch": "epoch-1",
+                "permission_snapshot_digest": "sha256:permission",
+                "ttl_seconds": 60,
+            },
+        ],
+        "peer_policy": {
+            "uid_to_principal": {"1001": "github:mjtrout"},
+            "allowed_gids": [1002],
+            "transport": "unix_socket",
+            "credential_source_prefix": "kernel_peer_credential",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_run_packet_supply_writes_shell_free_signer_cli_argv(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    socket_path = runtime / "reddog-signer.sock"
+    config_path = _write_json(runtime / "signer-service.json", _config(socket_path))
+    packet_path = runtime / "signer-run-packet.json"
+
+    result = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=config_path,
+        output_path=packet_path,
+        op_executable="op",
+        op_timeout_s=11.5,
+        ttl_seconds=300,
+        session_id="signer-run-test",
+        python_executable="python",
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT
+    assert result.run_packet_id and result.run_packet_id.startswith("sha256:")
+    assert result.run_packet_digest and result.run_packet_digest.startswith("sha256:")
+    assert result.config_digest and result.config_digest.startswith("sha256:")
+    assert result.profile_count == 2
+    assert result.no_process_spawned is True
+    assert result.no_shell_command_emitted is True
+    assert result.no_holoindex_reindex_performed is True
+    assert packet_path.exists()
+
+    packet = json.loads(packet_path.read_text(encoding="utf-8"))
+    assert packet["schema_version"] == SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION
+    assert packet["run_mode"] == "signer_owned_cli_sidecar"
+    assert packet["config_path"] == str(config_path.resolve())
+    assert packet["socket_path"] == str(socket_path.resolve())
+    assert packet["profile_count"] == 2
+    assert packet["shell_required"] is False
+    assert packet["shell_command"] is None
+    assert packet["redDog_must_not_spawn"] is True
+    assert packet["main_py_must_not_spawn"] is True
+    argv = packet["argv"]
+    assert isinstance(argv, list)
+    assert argv[:3] == [
+        "python",
+        "-m",
+        "modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_cli",
+    ]
+    assert "--config" in argv
+    assert argv[argv.index("--config") + 1] == str(config_path.resolve())
+    assert "--op-executable" in argv
+    assert argv[argv.index("--op-executable") + 1] == "op"
+    assert "--op-timeout-s" in argv
+    assert argv[argv.index("--op-timeout-s") + 1] == "11.5"
+    serialized = json.dumps(packet, sort_keys=True)
+    assert "ed25519-private-raw-b64-v1" not in serialized
+    assert "audit-mac-test-key-b64-v1" not in serialized
+
+
+def test_run_packet_supply_rejects_config_inside_repo_missing_or_malformed(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+    missing = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=runtime / "missing.json",
+        output_path=output,
+    )
+    inside = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=_write_json(repo / "signer-service.json", _config(runtime / "socket.sock")),
+        output_path=output,
+    )
+    wrong_schema = _config(runtime / "socket.sock", schema_version="wrong")
+    malformed = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=_write_json(runtime / "bad-config.json", wrong_schema),
+        output_path=output,
+    )
+
+    assert FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID in missing.rejection_reasons
+    assert FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID in inside.rejection_reasons
+    assert FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED in malformed.rejection_reasons
+
+
+def test_run_packet_supply_rejects_bad_output_op_and_limits(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    config_path = _write_json(runtime / "signer-service.json", _config(runtime / "socket.sock"))
+
+    inside_output = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=config_path,
+        output_path=repo / "run-packet.json",
+    )
+    bad_op = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=config_path,
+        output_path=runtime / "run-packet.json",
+        op_executable="powershell",
+    )
+    bad_limits = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=config_path,
+        output_path=runtime / "run-packet.json",
+        ttl_seconds=0,
+    )
+
+    assert FAIL_SIGNER_RUN_PACKET_OUTPUT_PATH_INVALID in inside_output.rejection_reasons
+    assert FAIL_SIGNER_RUN_PACKET_OP_EXECUTABLE_INVALID in bad_op.rejection_reasons
+    assert FAIL_SIGNER_RUN_PACKET_LIMITS_INVALID in bad_limits.rejection_reasons
+
+
+def test_run_packet_supply_module_has_no_spawn_shell_or_runtime_authority_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "socket",
+        "requests",
+        "urllib",
+        "http",
+        "git",
+        "holo_index",
+    }
+    banned_name_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {
+        "getenv",
+        "environ",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "spawn",
+    }
+    banned_name_fragments = ("openclaw", "hermes", "holoindex")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert not any(fragment in node.module.lower() for fragment in banned_name_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
﻿## Summary
- Add REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_PHASE1.
- Validate an existing outside-repo signer service config and emit a shell-free argv packet for a signer-owned service manager.
- Add explicit main.py preflight support for producing the run packet without starting the signer or consuming the socket.

## Truth Boundary
- No process spawned and no shell command emitted.
- No secret resolution or secret values written.
- No signer socket bound and no runtime authority expanded.
- No OpenClaw enqueue, Hermes dispatch, PR publication, reward settlement, or HoloIndex re-index.
- Run-packet supply remains explicit via REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY=1.

## Validation
- run-packet/main focused tests: 10 passed
- signer/config/run-packet + resident queue regression set: 155 passed, 3 skipped
- git diff --check: clean
- py_compile: pass

## HoloIndex
Query-only bundle search returned adjacent signing/worker docs and WSP 46/97/77. The new module is expected to remain an index gap until post-merge indexing.

Worker-Lane: RedDog signer runtime
Slice: REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_PHASE1
