### PR TITLE
feat(reddog): add signer service healthcheck preflight

### DIFF
--- a/main.py
+++ b/main.py
@@ -3268,6 +3268,12 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
         REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY=0            Materialize signer-owned CLI argv packet
         REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED=0   Block startup if run-packet supply fails
         REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH                Outside-repo signer CLI run-packet JSON
+        REDDOG_SIGNER_SERVICE_HEALTHCHECK=0                  Validate signer run packet and probe existing socket
+        REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED=0         Block startup if signer healthcheck fails
+        REDDOG_SIGNER_HEALTHCHECK_REQUESTER_PRINCIPAL_ID     Optional requester principal for healthcheck request
+        REDDOG_SIGNER_HEALTHCHECK_PROFILE_ID                 Optional signer profile id for healthcheck request
+        REDDOG_SIGNER_HEALTHCHECK_TIMEOUT_S                  Optional signer healthcheck timeout
+        REDDOG_SIGNER_HEALTHCHECK_MAX_RESPONSE_BYTES         Optional signer healthcheck response cap
         REDDOG_SIGNER_SOCKET_PROFILE_BINDING=0              Derive signer socket path/backend when authority runtime is configured
         REDDOG_SIGNER_SOCKET_PATH                            Optional outside-repo isolated signer socket
         REDDOG_SIGNATURE_VERIFIER_BACKEND                    Optional verifier backend (`ed25519`)
@@ -3586,6 +3592,64 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
                 print(
                     "[REDDOG-SIGNER-RUN-PACKET] Startup blocked by "
                     "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED=1"
+                )
+                return False
+
+        signer_healthcheck_requested = str(
+            os.getenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK") or ""
+        ).strip() == "1"
+        signer_healthcheck_enforced = (
+            os.getenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED", "0") != "0"
+        )
+        if signer_healthcheck_requested:
+            from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_healthcheck import (
+                run_reddog_signer_socket_service_healthcheck,
+            )
+
+            signer_healthcheck = run_reddog_signer_socket_service_healthcheck(
+                repo_root=repo_root,
+                run_packet_path=resident_queue_runtime_file_path(
+                    os.environ,
+                    repo_root,
+                    "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
+                )
+                or None,
+                requester_principal_id=str(
+                    os.getenv("REDDOG_SIGNER_HEALTHCHECK_REQUESTER_PRINCIPAL_ID") or ""
+                )
+                or None,
+                signer_profile_id=str(
+                    os.getenv("REDDOG_SIGNER_HEALTHCHECK_PROFILE_ID")
+                    or "reddog-work-authority"
+                ),
+                timeout_s=_reddog_float_env("REDDOG_SIGNER_HEALTHCHECK_TIMEOUT_S", 5.0),
+                max_response_bytes=_reddog_positive_int_env(
+                    "REDDOG_SIGNER_HEALTHCHECK_MAX_RESPONSE_BYTES",
+                    16384,
+                ),
+            )
+            signer_healthcheck_status = "PASS" if signer_healthcheck.accepted else "WARN"
+            signer_healthcheck_reasons = (
+                ",".join(signer_healthcheck.rejection_reasons)
+                if signer_healthcheck.rejection_reasons
+                else "(none)"
+            )
+            print(
+                f"[REDDOG-SIGNER-HEALTHCHECK] preflight={signer_healthcheck_status} "
+                f"status={signer_healthcheck.status} "
+                f"packet={signer_healthcheck.run_packet_id or '(none)'} "
+                f"path={signer_healthcheck.run_packet_path or '(none)'} "
+                f"socket={signer_healthcheck.socket_path or '(none)'} "
+                f"profile={signer_healthcheck.signer_profile_id or '(none)'} "
+                f"requester={signer_healthcheck.requester_principal_id or '(none)'} "
+                f"request={signer_healthcheck.request_digest or '(none)'} "
+                f"response={signer_healthcheck.response_digest or '(none)'} "
+                f"reasons={signer_healthcheck_reasons}"
+            )
+            if not signer_healthcheck.accepted and signer_healthcheck_enforced:
+                print(
+                    "[REDDOG-SIGNER-HEALTHCHECK] Startup blocked by "
+                    "REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED=1"
                 )
                 return False
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_SIGNER_SERVICE_HEALTHCHECK_PREFLIGHT_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added a signer service healthcheck that validates the outside-repo signer
+  run packet, revalidates the bound signer config, and optionally performs a
+  bounded roundtrip against an already-running signer socket.
+- Added an explicit main preflight switch for signer healthcheck; it can block
+  startup when enforced but does not start the signer, bind sockets, resolve
+  secrets, enqueue OpenClaw, dispatch Hermes, publish PRs, settle rewards, or
+  re-index HoloIndex.
+- Hardened packet validation with run-packet self-digest, no-shell/no-spawn
+  invariants, outside-repo config/socket checks, and audit-safe request/response
+  digests only.
+- Added focused tests for accepted healthcheck receipts, malformed/tampered
+  packet rejection, missing profile rejection, unavailable socket rejection,
+  main enforced blocking, and no spawn/secret/runtime-authority surface.
+
 ## 2026-07-17: REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_healthcheck.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_healthcheck.py
@@ -1,0 +1,410 @@
+"""Healthcheck for an already-running RedDog signer socket service.
+
+Slice: REDDOG_SIGNER_SERVICE_HEALTHCHECK_PREFLIGHT_PHASE1
+
+This module validates a signer service run packet and performs an optional
+bounded healthcheck roundtrip against an already-running signer socket. It does
+not start the signer, resolve secrets, bind sockets, parse environment
+variables, mutate the repository, enqueue OpenClaw, dispatch Hermes, publish
+PRs, settle rewards, or re-index HoloIndex.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_client import (
+    DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    SignerSocketConnector,
+    build_reddog_isolated_signer_socket_client,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_run_packet_supply import (
+    SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION,
+)
+
+
+SIGNER_SERVICE_HEALTHCHECK_READY = "SIGNER_SERVICE_HEALTHCHECK_READY"
+SIGNER_SERVICE_HEALTHCHECK_REJECT = "SIGNER_SERVICE_HEALTHCHECK_REJECT"
+
+FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_PATH_INVALID = "signer_healthcheck_run_packet_path_invalid"
+FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED = "signer_healthcheck_run_packet_malformed"
+FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH = "signer_healthcheck_config_mismatch"
+FAIL_SIGNER_HEALTHCHECK_PROFILE_MISSING = "signer_healthcheck_profile_missing"
+FAIL_SIGNER_HEALTHCHECK_REQUESTER_INVALID = "signer_healthcheck_requester_invalid"
+FAIL_SIGNER_HEALTHCHECK_CLIENT_REJECTED = "signer_healthcheck_client_rejected"
+FAIL_SIGNER_HEALTHCHECK_SIGNER_REJECTED = "signer_healthcheck_signer_rejected"
+
+
+@dataclass(frozen=True)
+class SignerServiceHealthcheckResult:
+    """Audit-safe result for signer socket service healthcheck."""
+
+    accepted: bool
+    status: str
+    run_packet_path: str | None
+    run_packet_id: str | None
+    config_path: str | None
+    config_digest: str | None
+    socket_path: str | None
+    signer_profile_id: str | None
+    signer_public_key: str | None
+    requester_principal_id: str | None
+    request_digest: str | None
+    response_digest: str | None
+    rejection_reasons: tuple[str, ...]
+    no_signature_value_returned: bool = True
+    no_secret_values_resolved: bool = True
+    no_signer_started: bool = True
+    no_socket_bound: bool = True
+    no_process_spawned: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_openclaw_enqueue_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_pr_created: bool = True
+    no_reward_settlement_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_reddog_signer_socket_service_healthcheck(
+    *,
+    repo_root: Path | str,
+    run_packet_path: Path | str | None,
+    requester_principal_id: str | None = None,
+    signer_profile_id: str = "reddog-work-authority",
+    timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    connector: Optional[SignerSocketConnector] = None,
+) -> SignerServiceHealthcheckResult:
+    """Validate run packet/config and probe an already-running signer socket."""
+
+    root = Path(repo_root).resolve()
+    packet, packet_path, packet_reasons = _read_run_packet(root, run_packet_path)
+    if packet_reasons:
+        return _reject(packet_reasons)
+    assert packet is not None
+    assert packet_path is not None
+    config, config_digest, config_reasons = _read_bound_config(root, packet)
+    if config_reasons:
+        return _reject(config_reasons, packet_path=str(packet_path), packet=packet)
+    assert config is not None
+    assert config_digest is not None
+    profile = _select_profile(config, signer_profile_id)
+    if profile is None:
+        return _reject(
+            (FAIL_SIGNER_HEALTHCHECK_PROFILE_MISSING,),
+            packet_path=str(packet_path),
+            packet=packet,
+            config_digest=config_digest,
+        )
+    requester = requester_principal_id or _default_requester(config)
+    if not _ascii_string(requester):
+        return _reject(
+            (FAIL_SIGNER_HEALTHCHECK_REQUESTER_INVALID,),
+            packet_path=str(packet_path),
+            packet=packet,
+            config_digest=config_digest,
+        )
+    socket_path = Path(str(packet["socket_path"])).resolve()
+    built = build_reddog_isolated_signer_socket_client(
+        repo_root=root,
+        socket_path=socket_path,
+        timeout_s=timeout_s,
+        max_response_bytes=max_response_bytes,
+        connector=connector,
+    )
+    if not built.accepted or built.client is None:
+        return _reject(
+            (FAIL_SIGNER_HEALTHCHECK_CLIENT_REJECTED, *built.rejection_reasons),
+            packet_path=str(packet_path),
+            packet=packet,
+            config_digest=config_digest,
+            profile=profile,
+            requester=requester,
+        )
+    request = _health_request(packet=packet, profile=profile, requester=requester)
+    response = built.client.sign(request)
+    if not response.accepted or response.signer_public_key != profile["expected_public_key"]:
+        return _reject(
+            (
+                FAIL_SIGNER_HEALTHCHECK_SIGNER_REJECTED,
+                str(response.rejection_code or ""),
+            ),
+            packet_path=str(packet_path),
+            packet=packet,
+            config_digest=config_digest,
+            profile=profile,
+            requester=requester,
+            request_digest=_digest(request.to_dict()),
+        )
+    return SignerServiceHealthcheckResult(
+        accepted=True,
+        status=SIGNER_SERVICE_HEALTHCHECK_READY,
+        run_packet_path=str(packet_path),
+        run_packet_id=str(packet["run_packet_id"]),
+        config_path=str(packet["config_path"]),
+        config_digest=config_digest,
+        socket_path=str(socket_path),
+        signer_profile_id=str(profile["signer_profile_id"]),
+        signer_public_key=str(profile["expected_public_key"]),
+        requester_principal_id=str(requester),
+        request_digest=_digest(request.to_dict()),
+        response_digest=_digest(response.to_dict()),
+        rejection_reasons=(),
+    )
+
+
+def _read_run_packet(
+    repo_root: Path,
+    value: Path | str | None,
+) -> tuple[dict[str, Any] | None, Path | None, tuple[str, ...]]:
+    path, reasons = _resolve_existing_outside_file(
+        repo_root,
+        value,
+        FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_PATH_INVALID,
+    )
+    if reasons:
+        return None, None, reasons
+    assert path is not None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, None, (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if not isinstance(payload, dict) or _packet_reasons(repo_root, payload):
+        return None, None, (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    return payload, path, ()
+
+
+def _packet_reasons(repo_root: Path, payload: Mapping[str, Any]) -> tuple[str, ...]:
+    if payload.get("schema_version") != SIGNER_SERVICE_RUN_PACKET_SCHEMA_VERSION:
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if not _ascii_deep(payload):
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    packet_id = str(payload.get("run_packet_id") or "")
+    if not packet_id.startswith("sha256:"):
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    without_id = {key: value for key, value in payload.items() if key != "run_packet_id"}
+    if packet_id != _digest(without_id):
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if payload.get("run_mode") != "signer_owned_cli_sidecar":
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if payload.get("redDog_must_not_spawn") is not True:
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if payload.get("main_py_must_not_spawn") is not True:
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if payload.get("shell_required") is not False or payload.get("shell_command") is not None:
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if payload.get("no_secret_values_in_packet") is not True:
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    if not str(payload.get("config_digest") or "").startswith("sha256:"):
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    argv = payload.get("argv")
+    if (
+        not isinstance(argv, list)
+        or len(argv) < 3
+        or not all(isinstance(item, str) and item for item in argv)
+    ):
+        return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    for key in ("repo_root", "working_directory"):
+        if not _ascii_string(payload.get(key)):
+            return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+        if Path(str(payload[key])).resolve() != repo_root:
+            return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    for key in ("config_path", "socket_path"):
+        path_text = str(payload.get(key) or "")
+        if "\x00" in path_text or path_text.startswith("\\\\?\\") or path_text.startswith("//?/"):
+            return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+        path = Path(path_text)
+        if not path.is_absolute() or _is_inside(path.resolve(), repo_root):
+            return (FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,)
+    return ()
+
+
+def _read_bound_config(
+    repo_root: Path,
+    packet: Mapping[str, Any],
+) -> tuple[dict[str, Any] | None, str | None, tuple[str, ...]]:
+    config_path, reasons = _resolve_existing_outside_file(
+        repo_root,
+        packet.get("config_path"),
+        FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH,
+    )
+    if reasons:
+        return None, None, reasons
+    assert config_path is not None
+    try:
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None, None, (FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH,)
+    if not isinstance(payload, dict) or not _ascii_deep(payload):
+        return None, None, (FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH,)
+    digest = _digest(payload)
+    if digest != str(packet.get("config_digest") or ""):
+        return None, None, (FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH,)
+    if str(payload.get("socket_path") or "") != str(packet.get("socket_path") or ""):
+        return None, None, (FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH,)
+    return payload, digest, ()
+
+
+def _select_profile(config: Mapping[str, Any], signer_profile_id: str) -> Mapping[str, Any] | None:
+    profiles = config.get("key_provider_profiles")
+    if not isinstance(profiles, list):
+        return None
+    for item in profiles:
+        if isinstance(item, Mapping) and item.get("signer_profile_id") == signer_profile_id:
+            return item
+    for item in profiles:
+        if isinstance(item, Mapping) and item.get("signer_profile_id") == "reddog-profile":
+            return item
+    return None
+
+
+def _default_requester(config: Mapping[str, Any]) -> str | None:
+    peer_policy = config.get("peer_policy")
+    if not isinstance(peer_policy, Mapping):
+        return None
+    uid_map = peer_policy.get("uid_to_principal")
+    if not isinstance(uid_map, Mapping) or not uid_map:
+        return None
+    first_key = sorted(str(key) for key in uid_map.keys())[0]
+    return str(uid_map.get(first_key) or "")
+
+
+def _health_request(
+    *,
+    packet: Mapping[str, Any],
+    profile: Mapping[str, Any],
+    requester: str,
+) -> SigningRequest:
+    payload = {
+        "run_packet_id": str(packet["run_packet_id"]),
+        "config_digest": str(packet["config_digest"]),
+        "socket_path": str(packet["socket_path"]),
+        "signer_profile_id": str(profile["signer_profile_id"]),
+    }
+    signing_input = "reddog-signer-health.v1." + json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return SigningRequest(
+        signing_input=signing_input,
+        payload_digest=_digest(payload),
+        signer_role="healthcheck",
+        signer_public_key=str(profile["expected_public_key"]),
+        requester_principal_id=requester,
+        nonce="signer-healthcheck:" + str(packet["run_packet_id"]).removeprefix("sha256:")[:16],
+        key_epoch=str(profile["expected_key_epoch"]),
+        requested_operation="signer_socket_healthcheck",
+        authority_tier="LOW",
+        consensus_receipt_digest=None,
+    )
+
+
+def _resolve_existing_outside_file(
+    repo_root: Path,
+    value: object,
+    reason: str,
+) -> tuple[Path | None, tuple[str, ...]]:
+    if not value:
+        return None, (reason,)
+    text = str(value)
+    if "\x00" in text or text.startswith("\\\\?\\") or text.startswith("//?/"):
+        return None, (reason,)
+    path = Path(text)
+    if not path.is_absolute():
+        return None, (reason,)
+    resolved = path.resolve()
+    if _is_inside(resolved, repo_root) or not resolved.is_file():
+        return None, (reason,)
+    return resolved, ()
+
+
+def _reject(
+    reasons: tuple[str, ...],
+    *,
+    packet_path: str | None = None,
+    packet: Mapping[str, Any] | None = None,
+    config_digest: str | None = None,
+    profile: Mapping[str, Any] | None = None,
+    requester: str | None = None,
+    request_digest: str | None = None,
+) -> SignerServiceHealthcheckResult:
+    return SignerServiceHealthcheckResult(
+        accepted=False,
+        status=SIGNER_SERVICE_HEALTHCHECK_REJECT,
+        run_packet_path=packet_path,
+        run_packet_id=str(packet.get("run_packet_id") or "") if packet else None,
+        config_path=str(packet.get("config_path") or "") if packet else None,
+        config_digest=config_digest,
+        socket_path=str(packet.get("socket_path") or "") if packet else None,
+        signer_profile_id=str(profile.get("signer_profile_id") or "") if profile else None,
+        signer_public_key=str(profile.get("expected_public_key") or "") if profile else None,
+        requester_principal_id=requester,
+        request_digest=request_digest,
+        response_digest=None,
+        rejection_reasons=_dedupe(reasons),
+    )
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _dedupe(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(value) for value in values if str(value)))
+
+
+def _is_inside(child: Path, parent: Path) -> bool:
+    child_r = child.resolve()
+    parent_r = parent.resolve()
+    return child_r == parent_r or parent_r in child_r.parents
+
+
+def _ascii_string(value: object) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value) and bool(value)
+
+
+def _ascii_deep(value: object) -> bool:
+    if isinstance(value, str):
+        return all(ord(char) < 128 for char in value)
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str)
+            and all(ord(char) < 128 for char in key)
+            and _ascii_deep(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return all(_ascii_deep(item) for item in value)
+    if value is None or isinstance(value, (bool, int, float)):
+        return True
+    return False
+
+
+__all__ = [
+    "FAIL_SIGNER_HEALTHCHECK_CLIENT_REJECTED",
+    "FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH",
+    "FAIL_SIGNER_HEALTHCHECK_PROFILE_MISSING",
+    "FAIL_SIGNER_HEALTHCHECK_REQUESTER_INVALID",
+    "FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED",
+    "FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_PATH_INVALID",
+    "FAIL_SIGNER_HEALTHCHECK_SIGNER_REJECTED",
+    "SIGNER_SERVICE_HEALTHCHECK_READY",
+    "SIGNER_SERVICE_HEALTHCHECK_REJECT",
+    "SignerServiceHealthcheckResult",
+    "run_reddog_signer_socket_service_healthcheck",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
@@ -36,6 +36,12 @@ def clean_signer_supply_env(monkeypatch) -> None:
         "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
         "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY",
         "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED",
+        "REDDOG_SIGNER_SERVICE_HEALTHCHECK",
+        "REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED",
+        "REDDOG_SIGNER_HEALTHCHECK_REQUESTER_PRINCIPAL_ID",
+        "REDDOG_SIGNER_HEALTHCHECK_PROFILE_ID",
+        "REDDOG_SIGNER_HEALTHCHECK_TIMEOUT_S",
+        "REDDOG_SIGNER_HEALTHCHECK_MAX_RESPONSE_BYTES",
         "REDDOG_SIGNER_PRINCIPAL_SIGNING_KEY_REF",
         "REDDOG_SIGNER_PRINCIPAL_AUDIT_MAC_KEY_REF",
         "REDDOG_SIGNER_REDDOG_SIGNING_KEY_REF",
@@ -427,3 +433,94 @@ def test_main_signer_run_packet_supply_enforced_failure_blocks_before_serial_boo
     assert "[REDDOG-SIGNER-RUN-PACKET] preflight=WARN" in captured
     assert "signer_run_packet_config_path_invalid" in captured
     assert "Startup blocked by REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY_ENFORCED=1" in captured
+
+
+def test_main_signer_healthcheck_enforced_failure_blocks_before_serial_bootstrap(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED", "1")
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        side_effect=AssertionError("serial bootstrap must not run after healthcheck reject"),
+    ):
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is False
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-HEALTHCHECK] preflight=WARN" in captured
+    assert "signer_healthcheck_run_packet_path_invalid" in captured
+    assert "Startup blocked by REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED=1" in captured
+
+
+def test_main_signer_healthcheck_passes_without_implicit_socket_consumption(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    import main
+    from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_healthcheck import (
+        SIGNER_SERVICE_HEALTHCHECK_READY,
+        SignerServiceHealthcheckResult,
+    )
+
+    repo = _repo(tmp_path)
+    runtime_root = tmp_path / "runtime"
+    run_packet_path = runtime_root / "signer_service_run_packet.json"
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", PROFILE_SIGNED_0102_BOUNDED_CODE)
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED", "1")
+    monkeypatch.setenv("REDDOG_SIGNER_HEALTHCHECK_REQUESTER_PRINCIPAL_ID", "github:mjtrout")
+    monkeypatch.setenv("REDDOG_SIGNER_HEALTHCHECK_PROFILE_ID", "reddog-work-authority")
+
+    accepted = SignerServiceHealthcheckResult(
+        accepted=True,
+        status=SIGNER_SERVICE_HEALTHCHECK_READY,
+        run_packet_path=str(run_packet_path),
+        run_packet_id="sha256:packet",
+        config_path=str(runtime_root / "signer_service_config.json"),
+        config_digest="sha256:config",
+        socket_path=str(runtime_root / "reddog_signer.sock"),
+        signer_profile_id="reddog-work-authority",
+        signer_public_key="ed25519-pub-v1:reddog",
+        requester_principal_id="github:mjtrout",
+        request_digest="sha256:request",
+        response_digest="sha256:response",
+        rejection_reasons=(),
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_signer_socket_service_healthcheck."
+        "run_reddog_signer_socket_service_healthcheck",
+        return_value=accepted,
+    ) as mocked_healthcheck, patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_resident_queue_serial_loop_bootstrap."
+        "run_reddog_main_resident_queue_serial_loop_bootstrap",
+        return_value=_serial_loop_result(),
+    ) as mocked_bootstrap:
+        assert main.run_reddog_resident_queue_serial_loop_preflight(repo) is True
+
+    captured = capsys.readouterr().out
+    assert "[REDDOG-SIGNER-HEALTHCHECK] preflight=PASS" in captured
+    assert "response=sha256:response" in captured
+    assert mocked_healthcheck.call_args.kwargs["run_packet_path"] == str(run_packet_path)
+    assert mocked_healthcheck.call_args.kwargs["requester_principal_id"] == "github:mjtrout"
+    assert mocked_healthcheck.call_args.kwargs["signer_profile_id"] == "reddog-work-authority"
+    assert mocked_bootstrap.call_args.kwargs["signer_socket_path"] is None

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py
@@ -1,0 +1,275 @@
+"""Tests for REDDOG_SIGNER_SERVICE_HEALTHCHECK_PREFLIGHT_PHASE1."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_healthcheck import (
+    FAIL_SIGNER_HEALTHCHECK_CLIENT_REJECTED,
+    FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH,
+    FAIL_SIGNER_HEALTHCHECK_PROFILE_MISSING,
+    FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED,
+    FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_PATH_INVALID,
+    FAIL_SIGNER_HEALTHCHECK_SIGNER_REJECTED,
+    SIGNER_SERVICE_HEALTHCHECK_READY,
+    run_reddog_signer_socket_service_healthcheck,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_run_packet_supply import (
+    run_reddog_signer_socket_service_run_packet_supply,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_signer_socket_service_healthcheck.py"
+)
+
+
+def _repo(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "socket_path": str(socket_path),
+        "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+        "allow_test_only_key_material": False,
+        "permission_snapshot_fresh": True,
+        "max_requests": 3,
+        "timeout_s": 2.5,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "key_provider_profiles": [
+            {
+                "signer_profile_id": "principal-identity",
+                "signer_agent_id": "signer:principal",
+                "signing_key_ref": "op://prod-vault/principal/private",
+                "audit_mac_key_ref": "op://prod-vault/principal/audit",
+                "expected_public_key": "pub:principal",
+                "expected_key_fingerprint": "sha256:principal",
+                "expected_key_epoch": "epoch-1",
+                "permission_snapshot_digest": "sha256:permission",
+                "ttl_seconds": 60,
+            },
+            {
+                "signer_profile_id": "reddog-work-authority",
+                "signer_agent_id": "signer:reddog",
+                "signing_key_ref": "op://prod-vault/reddog/private",
+                "audit_mac_key_ref": "op://prod-vault/reddog/audit",
+                "expected_public_key": "pub:reddog",
+                "expected_key_fingerprint": "sha256:reddog",
+                "expected_key_epoch": "epoch-1",
+                "permission_snapshot_digest": "sha256:permission",
+                "ttl_seconds": 60,
+            },
+        ],
+        "peer_policy": {
+            "uid_to_principal": {"1001": "github:mjtrout"},
+            "allowed_gids": [1002],
+            "transport": "unix_socket",
+            "credential_source_prefix": "kernel_peer_credential",
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _packet(repo: Path, runtime: Path, *, config_payload: dict[str, object] | None = None) -> Path:
+    config_path = _write_json(
+        runtime / "signer-service.json",
+        config_payload or _config(runtime / "signer.sock"),
+    )
+    packet_path = runtime / "signer-run-packet.json"
+    result = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=config_path,
+        output_path=packet_path,
+        python_executable="python",
+    )
+    assert result.accepted is True
+    return packet_path
+
+
+def _accepted_connector(_path: Path, request: bytes, _timeout: float, _max_bytes: int) -> bytes:
+    decoded = json.loads(request.decode("utf-8"))
+    public_key = decoded["request"]["signer_public_key"]
+    return (
+        json.dumps(
+            {
+                "accepted": True,
+                "signature": "sig:healthcheck",
+                "signer_public_key": public_key,
+                "key_fingerprint": "sha256:fingerprint",
+                "key_epoch": "epoch-1",
+                "audit_mac": "audit:healthcheck",
+                "boundary_attested": True,
+                "requester_identity_attested": True,
+                "signer_loads_no_untrusted_code": True,
+                "no_secret_material_returned": True,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+
+
+def test_healthcheck_validates_run_packet_config_and_returns_digests_only(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    packet_path = _packet(repo, runtime)
+
+    result = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=packet_path,
+        connector=_accepted_connector,
+    )
+
+    assert result.accepted is True
+    assert result.status == SIGNER_SERVICE_HEALTHCHECK_READY
+    assert result.run_packet_path == str(packet_path.resolve())
+    assert result.run_packet_id and result.run_packet_id.startswith("sha256:")
+    assert result.config_digest and result.config_digest.startswith("sha256:")
+    assert result.socket_path == str((runtime / "signer.sock").resolve())
+    assert result.signer_profile_id == "reddog-work-authority"
+    assert result.signer_public_key == "pub:reddog"
+    assert result.requester_principal_id == "github:mjtrout"
+    assert result.request_digest and result.request_digest.startswith("sha256:")
+    assert result.response_digest and result.response_digest.startswith("sha256:")
+    assert result.no_signature_value_returned is True
+    serialized = json.dumps(result.to_dict(), sort_keys=True)
+    assert "sig:healthcheck" not in serialized
+
+
+def test_healthcheck_rejects_missing_malformed_or_tampered_packets(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    missing = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=runtime / "missing.json",
+        connector=_accepted_connector,
+    )
+    malformed = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=_write_json(runtime / "bad-packet.json", {"schema_version": "wrong"}),
+        connector=_accepted_connector,
+    )
+    packet_path = _packet(repo, runtime)
+    packet_payload = json.loads(packet_path.read_text(encoding="utf-8"))
+    packet_payload["shell_required"] = True
+    tampered_packet_path = _write_json(runtime / "tampered-packet.json", packet_payload)
+    tampered_packet = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=tampered_packet_path,
+        connector=_accepted_connector,
+    )
+    config_path = Path(json.loads(packet_path.read_text(encoding="utf-8"))["config_path"])
+    config_payload = json.loads(config_path.read_text(encoding="utf-8"))
+    config_payload["max_requests"] = 99
+    _write_json(config_path, config_payload)
+    tampered_config = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=packet_path,
+        connector=_accepted_connector,
+    )
+
+    assert FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_PATH_INVALID in missing.rejection_reasons
+    assert FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED in malformed.rejection_reasons
+    assert FAIL_SIGNER_HEALTHCHECK_RUN_PACKET_MALFORMED in tampered_packet.rejection_reasons
+    assert FAIL_SIGNER_HEALTHCHECK_CONFIG_MISMATCH in tampered_config.rejection_reasons
+
+
+def test_healthcheck_rejects_missing_profile_and_signer_rejection(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    no_reddog = _config(runtime / "signer.sock")
+    no_reddog["key_provider_profiles"] = [no_reddog["key_provider_profiles"][0]]
+    missing_profile = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=_packet(repo, runtime, config_payload=no_reddog),
+        connector=_accepted_connector,
+    )
+
+    reject_packet = _packet(repo, tmp_path / "runtime2")
+    signer_reject = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=reject_packet,
+        connector=lambda *_: b'{"accepted":false,"rejection_code":"REJECT_TEST"}\n',
+    )
+
+    assert FAIL_SIGNER_HEALTHCHECK_PROFILE_MISSING in missing_profile.rejection_reasons
+    assert FAIL_SIGNER_HEALTHCHECK_SIGNER_REJECTED in signer_reject.rejection_reasons
+    assert "REJECT_TEST" in signer_reject.rejection_reasons
+
+
+def test_healthcheck_rejects_unavailable_socket_without_connector(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    packet_path = _packet(repo, runtime)
+
+    result = run_reddog_signer_socket_service_healthcheck(
+        repo_root=repo,
+        run_packet_path=packet_path,
+    )
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_HEALTHCHECK_CLIENT_REJECTED in result.rejection_reasons
+
+
+def test_healthcheck_module_has_no_spawn_secret_resolution_or_runtime_authority_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_import_roots = {
+        "subprocess",
+        "requests",
+        "urllib",
+        "http",
+        "git",
+        "holo_index",
+    }
+    banned_name_calls = {"eval", "exec", "compile", "__import__", "open"}
+    banned_attrs = {
+        "getenv",
+        "environ",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "check_call",
+        "check_output",
+        "spawn",
+    }
+    banned_name_fragments = ("openclaw", "hermes", "holoindex")
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert alias.name.split(".", 1)[0] not in banned_import_roots
+        if isinstance(node, ast.ImportFrom) and node.module:
+            assert node.module.split(".", 1)[0] not in banned_import_roots
+            assert not any(fragment in node.module.lower() for fragment in banned_name_fragments)
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_name_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_attrs


### PR DESCRIPTION
## Summary
- Add REDDOG_SIGNER_SERVICE_HEALTHCHECK_PREFLIGHT_PHASE1 as an explicit, receipt-only signer socket readiness check.
- Validate the signer run packet self-digest, no-shell/no-spawn invariants, outside-repo config/socket paths, and bound signer config digest before any probe.
- Add an optional main.py preflight gate that can block startup when enforced, without starting the signer or implicitly consuming the signer socket.

## WSP_97 Truth Boundary
- OBSERVED: healthcheck validates an existing signer run packet and existing signer config before socket probing.
- OBSERVED: accepted result returns request/response digests only; raw signature values are not surfaced.
- OBSERVED: main.py prints audit-safe healthcheck telemetry and fails closed when `REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED=1`.
- SPECIFIED_NOT_IMPLEMENTED: signer process launch, secret resolution, socket binding, OpenClaw enqueue, Hermes dispatch, PR publication, reward settlement, and HoloIndex re-index.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py -q` -> 13 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_run_packet_supply.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_isolated_signer_socket_client.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py -q` -> 169 passed, 3 skipped
- `git diff --check` -> clean
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/reddog_signer_socket_service_healthcheck.py modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py` -> pass
- Added lines ASCII clean
- HoloIndex query-only: new module not surfaced yet; expected freshness/index gap for new code before governed re-index.

## Boundary
No signer spawn, no socket bind, no secret read, no OpenClaw/Hermes runtime expansion, no repo mutation, no merge authority, no reward settlement, no HoloIndex mutation.