### PR TITLE
fix(reddog): gate signed worker claims on signer healthcheck

### DIFF
--- a/main.py
+++ b/main.py
@@ -3948,6 +3948,7 @@ def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> b
         REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional `signed_0102_bounded_code`
         REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED=0  Block startup on reject
         OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS=1             Bounded claims
+        OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK=0          Validate signer before claiming tasks
 
     This preflight does not create tasks, sign authority, create worktrees,
     execute shell commands, publish PRs, dispatch Hermes, write PatternMemory,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK_GATE_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97
+
+- Added an optional OpenClaw signed-worker pre-claim signer healthcheck gate.
+- The gate validates the existing signer service run packet/socket before
+  AgentDB claim, so an unavailable signer leaves signed-worker tasks pending
+  instead of consuming and failing them.
+- Reused the signer service healthcheck module and kept the boundary unchanged:
+  no signer start, no secret resolution, no shell command, no repository
+  mutation, no Hermes dispatch, no PR publication, no reward settlement, and no
+  HoloIndex re-index.
+- Added regressions proving healthcheck rejection blocks before claim while a
+  passing healthcheck allows the existing signed-worker runner to proceed.
+- HoloIndex query-only pre-commit check did not surface the new gate; recorded
+  as HOLOINDEX_REDDOG_OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK_INDEX_GAP.
+
 ## 2026-07-17: REDDOG_SIGNER_SERVICE_HEALTHCHECK_PREFLIGHT_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 71, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -62,6 +62,7 @@ class SignedWorkerOpenClawClaimReason:
     CLAIM_RACE_LOST = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_RACE_LOST"
     MALFORMED_CONTEXT = "REJECT_REDDOG_SIGNED_WORKER_MALFORMED_CONTEXT"
     TASK_EXECUTION_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_TASK_EXECUTION_REJECTED"
+    SIGNER_HEALTHCHECK_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_SIGNER_HEALTHCHECK_REJECTED"
     AGENTDB_FAILURE = "REJECT_REDDOG_SIGNED_WORKER_AGENTDB_FAILURE"
     MAX_CLAIMS_INVALID = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_MAX_CLAIMS_INVALID"
     CLAIM_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_CLAIM_REJECTED"
@@ -279,6 +280,18 @@ def claim_reddog_signed_worker_dispatch_task_once(
             is_0102_readonly_signed_worker_context,
         )
         from modules.infrastructure.database.src.agent_db import AgentDB
+
+        healthcheck = _signed_worker_signer_healthcheck_before_claim(repo_root)
+        if healthcheck is not None and healthcheck.get("accepted") is not True:
+            return _signed_worker_claim_result(
+                accepted=False,
+                status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+                rejection_reasons=(
+                    SignedWorkerOpenClawClaimReason.SIGNER_HEALTHCHECK_REJECTED,
+                    *tuple(healthcheck.get("rejection_reasons", ()) or ()),
+                ),
+                detail=str(healthcheck.get("status") or "")[:300],
+            )
 
         factory = agent_db_factory or AgentDB
         db = factory()
@@ -824,6 +837,76 @@ def _openclaw_queue_stage_tasks_enabled_from_env() -> bool:
         os.environ,
         "OPENCLAW_SIGNED_QUEUE_STAGE_TASKS_ENABLED",
     )
+
+
+def _signed_worker_signer_healthcheck_before_claim(repo_root: Path | str) -> Mapping[str, Any] | None:
+    """Run optional signer healthcheck before claiming a signed-worker task."""
+
+    requested = (
+        os.getenv("OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK", "0") == "1"
+        or os.getenv("REDDOG_SIGNER_SERVICE_HEALTHCHECK", "0") == "1"
+    )
+    if not requested:
+        return None
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+            resident_queue_runtime_file_path,
+        )
+        from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_healthcheck import (
+            run_reddog_signer_socket_service_healthcheck,
+        )
+
+        result = run_reddog_signer_socket_service_healthcheck(
+            repo_root=Path(repo_root),
+            run_packet_path=resident_queue_runtime_file_path(
+                os.environ,
+                repo_root,
+                "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH",
+            )
+            or None,
+            requester_principal_id=str(
+                os.getenv("REDDOG_SIGNER_HEALTHCHECK_REQUESTER_PRINCIPAL_ID") or ""
+            )
+            or None,
+            signer_profile_id=str(
+                os.getenv("REDDOG_SIGNER_HEALTHCHECK_PROFILE_ID")
+                or "reddog-work-authority"
+            ),
+            timeout_s=_float_env("REDDOG_SIGNER_HEALTHCHECK_TIMEOUT_S", 5.0),
+            max_response_bytes=_positive_int_env(
+                "REDDOG_SIGNER_HEALTHCHECK_MAX_RESPONSE_BYTES",
+                16384,
+            ),
+        )
+        return result.to_dict()
+    except Exception as exc:
+        return {
+            "accepted": False,
+            "status": "SIGNER_HEALTHCHECK_EXCEPTION",
+            "rejection_reasons": (type(exc).__name__,),
+        }
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.getenv(name, "")
+    if not raw:
+        return float(default)
+    try:
+        value = float(raw)
+    except ValueError:
+        return 0.0
+    return value if value > 0 else 0.0
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name, "")
+    if not raw:
+        return int(default)
+    try:
+        value = int(raw)
+    except ValueError:
+        return 0
+    return value if value > 0 else 0
 
 
 def _signed_0102_bounded_code_stage_ready_from_env(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -763,6 +764,79 @@ def test_openclaw_claim_ignores_0102_readonly_task_until_env_enabled(
     assert result["accepted"] is False
     assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
     assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
+
+
+def test_openclaw_signed_worker_healthcheck_blocks_before_agentdb_claim(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK", "1")
+    from modules.communication.moltbot_bridge.src import (
+        reddog_signer_socket_service_healthcheck as healthcheck_module,
+    )
+
+    monkeypatch.setattr(
+        healthcheck_module,
+        "run_reddog_signer_socket_service_healthcheck",
+        lambda **_: SimpleNamespace(
+            to_dict=lambda: {
+                "accepted": False,
+                "status": "SIGNER_SERVICE_HEALTHCHECK_REJECT",
+                "rejection_reasons": ("signer_healthcheck_client_rejected",),
+            }
+        ),
+    )
+    runner = _FakeRunner()
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=runner,
+    )
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REJECT
+    assert SignedWorkerOpenClawClaimReason.SIGNER_HEALTHCHECK_REJECTED in result[
+        "rejection_reasons"
+    ]
+    assert "signer_healthcheck_client_rejected" in result["rejection_reasons"]
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
+    assert runner.calls == []
+
+
+def test_openclaw_signed_worker_healthcheck_accept_allows_claim(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    task_id = _publish_agentdb_task()
+    monkeypatch.setenv("OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK", "1")
+    from modules.communication.moltbot_bridge.src import (
+        reddog_signer_socket_service_healthcheck as healthcheck_module,
+    )
+
+    monkeypatch.setattr(
+        healthcheck_module,
+        "run_reddog_signer_socket_service_healthcheck",
+        lambda **_: SimpleNamespace(
+            to_dict=lambda: {
+                "accepted": True,
+                "status": "SIGNER_SERVICE_HEALTHCHECK_READY",
+                "rejection_reasons": (),
+            }
+        ),
+    )
+    runner = _FakeRunner()
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=runner,
+    )
+
+    assert result["accepted"] is True
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    assert result["task_id"] == task_id
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
+    assert runner.calls[0]["task_id"] == task_id
 
 
 def test_openclaw_claim_executes_0102_readonly_task_when_env_enabled(


### PR DESCRIPTION
## Summary
- add optional OpenClaw signed-worker signer healthcheck gate before AgentDB claim
- leave signed-worker tasks pending when signer service healthcheck rejects
- document the opt-in preflight env and record HoloIndex discoverability gap

## WSP_97 Truth Boundary
- OBSERVED: gate is opt-in through OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK or REDDOG_SIGNER_SERVICE_HEALTHCHECK
- OBSERVED: rejection happens before AgentDB claim and before worker runner invocation
- OBSERVED: accepted healthcheck preserves existing signed-worker claim path
- OBSERVED: no signer service start, no secret resolution, no shell, no repo mutation, no Hermes dispatch, no PR publication, no reward settlement, no HoloIndex re-index
- SPECIFIED_NOT_IMPLEMENTED: mandatory production signer healthcheck policy and resident-loop default enablement remain future policy slices

## Validation
- python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q
- 228 passed, 3 skipped
- git diff --check
- py_compile for changed Python files
- added-lines ASCII check
- HoloIndex query-only: new gate not surfaced; recorded HOLOINDEX_REDDOG_OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK_INDEX_GAP