### PR TITLE
feat(reddog): surface signed worker claim receipt telemetry

### DIFF
--- a/main.py
+++ b/main.py
@@ -4021,6 +4021,7 @@ def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> b
     completed = ",".join(str(item) for item in result.get("completed_task_ids", ()) or ()) or "(none)"
     requeued = ",".join(str(item) for item in result.get("requeued_task_ids", ()) or ()) or "(none)"
     failed = ",".join(str(item) for item in result.get("failed_task_ids", ()) or ()) or "(none)"
+    receipts = ",".join(str(item) for item in result.get("receipt_ids", ()) or ()) or "(none)"
     reasons = ",".join(str(reason) for reason in result.get("rejection_reasons", ()) or ()) or "(none)"
     status_label = "PASS" if accepted else "WARN"
     run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
@@ -4030,12 +4031,14 @@ def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> b
         "claimed_count": claimed_count,
         "idle": bool(result.get("idle")),
         "max_claims_reached": bool(result.get("max_claims_reached")),
+        "receipt_ids": tuple(result.get("receipt_ids", ()) or ()),
         "rejection_reasons": tuple(result.get("rejection_reasons", ()) or ()),
     }
     print(
         f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight={status_label} status={status} "
         f"claimed_count={claimed_count} max_claims={max_claims} "
-        f"completed={completed} requeued={requeued} failed={failed} reasons={reasons}"
+        f"completed={completed} requeued={requeued} failed={failed} "
+        f"receipts={receipts} reasons={reasons}"
     )
     if accepted:
         return True

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,20 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_RECEIPT_TELEMETRY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 97
+
+- Surfaced signed-worker execution receipt IDs through the OpenClaw claim-loop
+  aggregate result and `main.py` preflight output.
+- Threaded `receipt_ids` into `run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result`
+  so resident queue control can correlate claimed tasks to durable AgentDB
+  result receipts without direct task-row inspection.
+- Added regressions for completed and requeued signed-worker claims.
+- HoloIndex query-only check did not surface the new claim-loop receipt
+  telemetry surfaces; recorded as
+  HOLOINDEX_REDDOG_OPENCLAW_CLAIM_RECEIPT_TELEMETRY_INDEX_GAP. No runtime
+  reindex performed.
+
 ## 2026-07-17: REDDOG_SIGNED_WORKER_AGENTDB_RESULT_RECEIPT_PERSISTENCE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -963,6 +963,11 @@ def _signed_worker_claim_loop_result(
         key: all(bool(result.get(key, True)) for result in results)
         for key in no_fields
     }
+    receipt_ids = tuple(
+        str(result.get("receipt_id") or "")
+        for result in results
+        if str(result.get("receipt_id") or "").strip()
+    )
     return {
         "accepted": accepted,
         "status": status,
@@ -975,6 +980,7 @@ def _signed_worker_claim_loop_result(
         "idle": idle,
         "max_claims_reached": max_claims_reached,
         "claim_results": results,
+        "receipt_ids": receipt_ids,
         "rejection_reasons": tuple(
             dict.fromkeys(str(reason) for reason in rejection_reasons if str(reason))
         ),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -655,6 +655,12 @@ def test_main_openclaw_signed_worker_claim_loop_runs_real_agentdb_queue_stage(
     assert "status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT" in captured
     assert "claimed_count=1" in captured
     assert f"requeued={task_id}" in captured
+    assert "receipts=signed_worker_task_execution_" in captured
+    assert str(
+        main.run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result[
+            "receipt_ids"
+        ][0]
+    ).startswith("signed_worker_task_execution_")
     assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "pending"
 
     stored = json.loads(chain.read_text(encoding="utf-8"))
@@ -771,6 +777,12 @@ def test_main_openclaw_signed_0102_bounded_code_uses_fusion_artifact_generation(
     assert "claimed_count=1" in captured
     assert f"completed={task_id}" in captured
     assert "requeued=(none)" in captured
+    assert "receipts=signed_worker_task_execution_" in captured
+    assert str(
+        main.run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result[
+            "receipt_ids"
+        ][0]
+    ).startswith("signed_worker_task_execution_")
     assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "completed"
     assert calls
     assert calls[0]["api_key"] == "test-openrouter-key"


### PR DESCRIPTION
## Summary
- surface signed-worker task execution receipt IDs from the OpenClaw signed-worker claim-loop aggregate result
- include receipt IDs in `main.py` preflight output and `.last_result`
- add regressions proving completed and requeued claims expose durable receipt IDs

## WSP_97 Truth Boundary
- OBSERVED: signed-worker task result receipts are already persisted in AgentDB by the previous slice.
- OBSERVED: this slice only surfaces existing receipt IDs through claim-loop telemetry and preflight output.
- OBSERVED: no task status, authorization, runner, shell, Hermes, PR, PatternMemory, or HoloIndex mutation behavior is changed.
- SPECIFIED_NOT_IMPLEMENTED: resident control consumption of these receipt IDs remains downstream.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py -q` -> 62 passed, 2 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 206 passed, 3 skipped
- `git diff --check` -> clean (line-ending warnings only)
- `python -m py_compile main.py modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py` -> pass
- added-lines ASCII check -> pass
- HoloIndex query-only check did not surface the new claim-loop receipt telemetry surfaces; recorded as `HOLOINDEX_REDDOG_OPENCLAW_CLAIM_RECEIPT_TELEMETRY_INDEX_GAP`; no runtime reindex performed