### PR TITLE
feat(reddog): summarize resident control loop receipts

### DIFF
--- a/main.py
+++ b/main.py
@@ -3854,6 +3854,30 @@ def _reddog_queue_stage_rejected(stage_callable: Any) -> bool:
     return isinstance(raw, Mapping) and raw.get("accepted") is False
 
 
+def _reddog_queue_stage_receipt_ids(stage_callable: Any) -> tuple[str, ...]:
+    """Return receipt IDs recorded by a queue control stage."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return ()
+    values = raw.get("receipt_ids")
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(str(value) for value in values if str(value or "").strip())
+
+
+def _reddog_queue_stage_rejection_reasons(stage_callable: Any) -> tuple[str, ...]:
+    """Return rejection reasons recorded by a queue control stage."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return ()
+    values = raw.get("rejection_reasons")
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(str(value) for value in values if str(value or "").strip())
+
+
 def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
     """
     Drive the resident queue through bounded serial/claim rounds.
@@ -3880,8 +3904,46 @@ def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
     )
     if not requested:
         if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
+            run_reddog_resident_queue_control_loop_preflight.last_result = {
+                "accepted": False,
+                "status": "SERIAL_LOOP_REJECT",
+                "rounds": 0,
+                "serial_progress": _reddog_queue_stage_progress(
+                    run_reddog_resident_queue_serial_loop_preflight,
+                    default_progress=0,
+                ),
+                "claim_progress": 0,
+                "receipt_ids": (),
+                "rejection_reasons": _reddog_queue_stage_rejection_reasons(
+                    run_reddog_resident_queue_serial_loop_preflight
+                ),
+            }
             return False
-        return run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root)
+        claim_ok = run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root)
+        claim_receipts = _reddog_queue_stage_receipt_ids(
+            run_reddog_openclaw_signed_worker_claim_loop_preflight
+        )
+        run_reddog_resident_queue_control_loop_preflight.last_result = {
+            "accepted": bool(claim_ok)
+            and not _reddog_queue_stage_rejected(
+                run_reddog_openclaw_signed_worker_claim_loop_preflight
+            ),
+            "status": "PASS" if claim_ok else "CLAIM_LOOP_REJECT",
+            "rounds": 1,
+            "serial_progress": _reddog_queue_stage_progress(
+                run_reddog_resident_queue_serial_loop_preflight,
+                default_progress=1,
+            ),
+            "claim_progress": _reddog_queue_stage_progress(
+                run_reddog_openclaw_signed_worker_claim_loop_preflight,
+                default_progress=1 if claim_ok else 0,
+            ),
+            "receipt_ids": claim_receipts,
+            "rejection_reasons": _reddog_queue_stage_rejection_reasons(
+                run_reddog_openclaw_signed_worker_claim_loop_preflight
+            ),
+        }
+        return claim_ok
 
     enforced = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED", "0") != "0"
     raw_rounds = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "8").strip()
@@ -3891,11 +3953,21 @@ def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
         max_rounds = 0
     if max_rounds < 1:
         print("[REDDOG-QUEUE-CONTROL] preflight=FAIL error=invalid_max_rounds")
+        run_reddog_resident_queue_control_loop_preflight.last_result = {
+            "accepted": False,
+            "status": "INVALID_MAX_ROUNDS",
+            "rounds": 0,
+            "serial_progress": 0,
+            "claim_progress": 0,
+            "receipt_ids": (),
+            "rejection_reasons": ("invalid_max_rounds",),
+        }
         return not enforced
 
     completed_rounds = 0
     serial_progress_total = 0
     claim_progress_total = 0
+    receipt_ids: list[str] = []
     stopped_reason = "max_rounds"
     for round_index in range(1, max_rounds + 1):
         serial_ok = run_reddog_resident_queue_serial_loop_preflight(repo_root)
@@ -3907,6 +3979,17 @@ def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
         if not serial_ok or _reddog_queue_stage_rejected(
             run_reddog_resident_queue_serial_loop_preflight
         ):
+            run_reddog_resident_queue_control_loop_preflight.last_result = {
+                "accepted": False,
+                "status": "SERIAL_LOOP_REJECT",
+                "rounds": completed_rounds,
+                "serial_progress": serial_progress_total,
+                "claim_progress": claim_progress_total,
+                "receipt_ids": tuple(receipt_ids),
+                "rejection_reasons": _reddog_queue_stage_rejection_reasons(
+                    run_reddog_resident_queue_serial_loop_preflight
+                ),
+            }
             print(
                 f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} "
                 "stage=serial_loop"
@@ -3918,9 +4001,25 @@ def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
             default_progress=1 if claim_ok else 0,
         )
         claim_progress_total += claim_progress
+        receipt_ids.extend(
+            _reddog_queue_stage_receipt_ids(
+                run_reddog_openclaw_signed_worker_claim_loop_preflight
+            )
+        )
         if not claim_ok or _reddog_queue_stage_rejected(
             run_reddog_openclaw_signed_worker_claim_loop_preflight
         ):
+            run_reddog_resident_queue_control_loop_preflight.last_result = {
+                "accepted": False,
+                "status": "CLAIM_LOOP_REJECT",
+                "rounds": completed_rounds,
+                "serial_progress": serial_progress_total,
+                "claim_progress": claim_progress_total,
+                "receipt_ids": tuple(dict.fromkeys(receipt_ids)),
+                "rejection_reasons": _reddog_queue_stage_rejection_reasons(
+                    run_reddog_openclaw_signed_worker_claim_loop_preflight
+                ),
+            }
             print(
                 f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} "
                 "stage=openclaw_claim_loop"
@@ -3931,10 +4030,22 @@ def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
             stopped_reason = "idle"
             break
 
+    receipt_ids_tuple = tuple(dict.fromkeys(receipt_ids))
+    run_reddog_resident_queue_control_loop_preflight.last_result = {
+        "accepted": True,
+        "status": "PASS",
+        "rounds": completed_rounds,
+        "serial_progress": serial_progress_total,
+        "claim_progress": claim_progress_total,
+        "receipt_ids": receipt_ids_tuple,
+        "rejection_reasons": (),
+    }
+    receipts = ",".join(receipt_ids_tuple) or "(none)"
     print(
         f"[REDDOG-QUEUE-CONTROL] preflight=PASS rounds={completed_rounds} "
         f"max_rounds={max_rounds} stopped_reason={stopped_reason} "
-        f"serial_progress={serial_progress_total} claim_progress={claim_progress_total}"
+        f"serial_progress={serial_progress_total} claim_progress={claim_progress_total} "
+        f"receipts={receipts}"
     )
     return True
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_RESIDENT_CONTROL_LOOP_RECEIPT_SUMMARY_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 97
+
+- Surfaced signed-worker execution receipt IDs through the outer resident queue
+  control-loop summary and `run_reddog_resident_queue_control_loop_preflight.last_result`.
+- Added fail-closed control-loop `last_result` summaries for invalid rounds and
+  serial/claim-loop rejection paths.
+- Added regressions proving full resident control-loop runs expose durable
+  signed-worker task receipt IDs without changing authority, queue, runner,
+  shell, PR, PatternMemory, reward, or HoloIndex behavior.
+- HoloIndex query-only check did not surface the new resident control-loop
+  receipt summary surface; recorded as
+  HOLOINDEX_REDDOG_RESIDENT_CONTROL_LOOP_RECEIPT_SUMMARY_INDEX_GAP. No runtime
+  reindex performed.
+
 ## 2026-07-17: REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_RECEIPT_TELEMETRY_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 97

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -1139,6 +1139,12 @@ def test_main_resident_control_loop_profile_runtime_completes_socket_signed_queu
     assert "[REDDOG-QUEUE-LOOP] preflight=PASS" in captured
     assert "[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=PASS" in captured
     assert "claimed_count=7" in captured
+    assert "receipts=signed_worker_task_execution_" in captured
+    assert str(
+        main.run_reddog_resident_queue_control_loop_preflight.last_result[
+            "receipt_ids"
+        ][0]
+    ).startswith("signed_worker_task_execution_")
     assert "REDDOG_WORK_ORDERS_PATH" not in os.environ
 
     pending = [
@@ -1429,6 +1435,12 @@ def test_main_resident_control_loop_consumes_signer_socket_started_by_runtime_cl
     assert "[REDDOG-QUEUE-CONTROL] preflight=PASS" in captured
     assert "[REDDOG-QUEUE-LOOP] preflight=PASS" in captured
     assert "[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=PASS" in captured
+    assert "receipts=signed_worker_task_execution_" in captured
+    assert str(
+        main.run_reddog_resident_queue_control_loop_preflight.last_result[
+            "receipt_ids"
+        ][0]
+    ).startswith("signed_worker_task_execution_")
     assert calls
     stored = json.loads(chain.read_text(encoding="utf-8"))
     assert stored["stage_results"]["worker_dispatch_runtime"]["accepted"] is True


### PR DESCRIPTION
## Summary
- aggregate signed-worker task execution receipt IDs into the outer resident queue control-loop summary
- expose control-loop `last_result` for success and fail-closed paths
- add regressions proving full resident control-loop runs surface durable signed-worker task receipt IDs

## WSP_97 Truth Boundary
- OBSERVED: inner OpenClaw claim-loop receipts are now surfaced by #1278.
- OBSERVED: this slice only aggregates those existing IDs at the resident control-loop layer.
- OBSERVED: no authority, queue planning, runner execution, shell, PR, PatternMemory, reward, or HoloIndex mutation behavior is changed.
- SPECIFIED_NOT_IMPLEMENTED: resident UI/control-plane consumption of these IDs beyond `main.py` preflight output remains downstream.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py -q` -> 14 passed, 2 skipped
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 206 passed, 3 skipped
- `git diff --check` -> clean (line-ending warnings only)
- `python -m py_compile main.py modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py` -> pass
- added-lines ASCII check -> pass
- HoloIndex query-only check did not surface the new control-loop receipt summary surface; recorded as `HOLOINDEX_REDDOG_RESIDENT_CONTROL_LOOP_RECEIPT_SUMMARY_INDEX_GAP`; no runtime reindex performed