### PR TITLE
feat(reddog): thread supervisor claim receipt telemetry

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-17: REDDOG_OPENCLAW_SUPERVISOR_CLAIM_RECEIPT_THREADING_PHASE1
+
+**Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 97
+
+- Threaded OpenClaw signed-worker claim-loop `receipt_ids` and
+  `requeued_task_ids` into the supervisor top-level action result and verify
+  summary.
+- Added regression coverage so `OpenClawSupervisor.run_cycle()` exposes claim
+  receipt IDs without requiring callers to inspect nested `claim_loop` payloads.
+- No authority, queue, runner, shell, PR, PatternMemory, reward, or HoloIndex
+  behavior changed.
+- HoloIndex query-only check did not surface the new supervisor receipt-threading
+  surface; recorded as
+  HOLOINDEX_REDDOG_OPENCLAW_SUPERVISOR_CLAIM_RECEIPT_THREADING_INDEX_GAP. No
+  runtime reindex performed.
+
 ## 2026-07-17: REDDOG_RESIDENT_CONTROL_LOOP_RECEIPT_PERSISTENCE_PHASE1
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 15, 22, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -2068,7 +2068,9 @@ class OpenClawSupervisor:
                 "status": result.get("status", "unknown"),
                 "claimed_count": result.get("claimed_count", 0),
                 "completed_task_ids": result.get("completed_task_ids", ()),
+                "requeued_task_ids": result.get("requeued_task_ids", ()),
                 "failed_task_ids": result.get("failed_task_ids", ()),
+                "receipt_ids": result.get("receipt_ids", ()),
                 "rejection_reasons": result.get("rejection_reasons", ()),
                 "claim_loop": result,
             }
@@ -2266,7 +2268,9 @@ class OpenClawSupervisor:
                 "status": action_result,
                 "claimed_count": action_result.get("claimed_count", 0),
                 "completed_task_ids": action_result.get("completed_task_ids", ()),
+                "requeued_task_ids": action_result.get("requeued_task_ids", ()),
                 "failed_task_ids": action_result.get("failed_task_ids", ()),
+                "receipt_ids": action_result.get("receipt_ids", ()),
                 "error": "" if ok else ",".join(str(reason) for reason in reasons),
                 "fidelity": 0.85,
             }

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -233,7 +233,12 @@ def test_run_cycle_claims_signed_worker_tasks_when_enabled(tmp_path):
             "status": "SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT",
             "claimed_count": 2,
             "completed_task_ids": ("task-1", "task-2"),
+            "requeued_task_ids": (),
             "failed_task_ids": (),
+            "receipt_ids": (
+                "signed_worker_task_execution_alpha",
+                "signed_worker_task_execution_beta",
+            ),
             "rejection_reasons": (),
         }
     )
@@ -265,8 +270,16 @@ def test_run_cycle_claims_signed_worker_tasks_when_enabled(tmp_path):
     )
     assert result["action_result"]["ok"] is True
     assert result["action_result"]["claimed_count"] == 2
+    assert result["action_result"]["receipt_ids"] == (
+        "signed_worker_task_execution_alpha",
+        "signed_worker_task_execution_beta",
+    )
     assert result["verify"]["ok"] is True
     assert result["verify"]["completed_task_ids"] == ("task-1", "task-2")
+    assert result["verify"]["receipt_ids"] == (
+        "signed_worker_task_execution_alpha",
+        "signed_worker_task_execution_beta",
+    )
     assert any(event[0] == "supervisor_execute" for event in events)
 
 


### PR DESCRIPTION
## Summary
- thread OpenClaw signed-worker claim `receipt_ids` and `requeued_task_ids` into supervisor top-level action results
- include those IDs in supervisor verification summaries
- add regression coverage for `OpenClawSupervisor.run_cycle()` receipt visibility

## WSP_97 Truth Boundary
- OBSERVED: claim-loop receipt IDs are already produced and persisted by prior slices.
- OBSERVED: this slice only exposes those IDs at the supervisor cycle summary layer.
- OBSERVED: no authority, queue planning, runner execution, shell, PR, PatternMemory, reward, or HoloIndex mutation behavior is changed.
- SPECIFIED_NOT_IMPLEMENTED: higher-level UI/control-plane consumption remains downstream.

## Validation
- `python -m pytest modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 26 passed
- `python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py modules/communication/moltbot_bridge/tests/test_reddog_openclaw_hermes_0102_worker_dispatch_runtime.py modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_worker_dispatch_runtime_handler.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py -q` -> 206 passed, 3 skipped
- `git diff --check` -> clean (line-ending warnings only)
- `python -m py_compile modules/communication/moltbot_bridge/src/openclaw_supervisor.py modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py` -> pass
- added-lines ASCII check -> pass
- HoloIndex query-only check did not surface the new supervisor receipt-threading surface; recorded as `HOLOINDEX_REDDOG_OPENCLAW_SUPERVISOR_CLAIM_RECEIPT_THREADING_INDEX_GAP`; no runtime reindex performed