### PR TITLE
feat(reddog): add Kimi K3 fusion research

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -307,6 +307,7 @@ Model and context routing:
 - Principal/synthesis default: `z-ai/glm-5.2`.
 - Adversarial critic default: `deepseek/deepseek-v4-pro`.
 - Implementation critic default: `moonshotai/kimi-k2.7-code`.
+- Long-horizon reasoning critic default: `moonshotai/kimi-k3` with mandatory `max` reasoning, no temperature parameter, and a receipt-recorded 4096-token critic budget.
 - REGULAR smoke/simple prompts auto-route to `openrouter_single` with the GLM principal and `wsp_holo` HoloIndex grounding (no Fusion panel, Skillz, or git).
 - Context is not a 012-facing selector; it is resolved from WSP_15 tier.
 - Skillz/Wardrobe/Rolodex/OpenClaw/Hermes discovery is context only. RedDog may recommend a governed handoff, but this extension cannot execute it.

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,14 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-18 - REDDOG_FUSION_KIMI_K3_PHASE1 (OpenRouter critic integration, 0.4.1)
+
+- Added the verified OpenRouter slug `moonshotai/kimi-k3` to the default manual Fusion panel while retaining Kimi K2.7 Code for implementation comparison and capacity fallback.
+- Kimi K3 requests use its published mandatory `max` reasoning contract, omit the unsupported temperature field, and use a receipt-recorded 4096-token critic budget validated by the live compatibility smoke.
+- Review packets continue to bind the exact requested panel model IDs; no mutable `kimi-latest` alias is used.
+- Version 0.4.0 -> 0.4.1 (package.json + EXTENSION_VERSION + README + interface + contract tests).
+- WSP_15: Complexity 3 + Importance 4 + Deferability 4 + Impact 4 = 15 (P1).
+
 ## 2026-07-16 - REDDOG_PRODUCT_IDENTITY_AND_THIN_CLIENT_0_4_0 (product identity migration, 0.4.0)
 
 - Renamed the extension folder and product identity from the legacy Foundups Fusion Worker / Foundups(R)Agent surface to RedDog.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,6 +1,6 @@
 # RedDog
 
-Version: 0.4.0
+Version: 0.4.1
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
 
@@ -13,7 +13,7 @@ Command:
 Default panel:
 
 - Principal/synthesis: `z-ai/glm-5.2`
-- Critics: `deepseek/deepseek-v4-pro` and `moonshotai/kimi-k2.7-code`
+- Critics: `deepseek/deepseek-v4-pro`, `moonshotai/kimi-k2.7-code`, and `moonshotai/kimi-k3`
 
 ## RedDog and the Recursive 0102 DAE Ecosystem
 
@@ -144,7 +144,7 @@ Output is prefixed with a visible **RedDog Routing** block (tier, effort, mode, 
 | Claim | Status |
 | --- | --- |
 | Principal default `z-ai/glm-5.2` | OBSERVED |
-| Critics default DeepSeek V4 Pro + Kimi K2.7 Code | OBSERVED |
+| Critics default DeepSeek V4 Pro + Kimi K2.7 Code + Kimi K3 | OBSERVED |
 | 012 work focus -> 0102 WSP task prompt | OBSERVED |
 | Review packet work_focus_digest + wsp_prompt_digest | OBSERVED |
 | WORK_FOCUS_NOT_AUTHORITY | OBSERVED |
@@ -191,12 +191,13 @@ The lead is configurable. Use Cursor settings or workspace/user settings:
   "reddog.leadModel": "z-ai/glm-5.2",
   "reddog.panelModels": [
     "deepseek/deepseek-v4-pro",
-    "moonshotai/kimi-k2.7-code"
+    "moonshotai/kimi-k2.7-code",
+    "moonshotai/kimi-k3"
   ]
 }
 ```
 
-The extension uses up to four panel models. RedDog defaults to GLM-5.2 as principal, DeepSeek V4 Pro as adversarial critic, and Kimi K2.7 Code as implementation critic.
+The extension uses up to four panel models. RedDog defaults to GLM-5.2 as principal, DeepSeek V4 Pro as adversarial critic, Kimi K2.7 Code as implementation critic, and Kimi K3 as a long-horizon reasoning critic. Kimi K3 uses OpenRouter's explicit `moonshotai/kimi-k3` slug; its request omits unsupported temperature, records mandatory `max` reasoning, and uses a 4096-token critic budget because lower budgets did not produce quorum-usable final output in the live compatibility smoke. The review packet records the actual per-panel token budgets.
 
 ## Bounded Repo Context
 
@@ -224,6 +225,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.0.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.1.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/ROADMAP.md
+++ b/extensions/reddog/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Phase: RedDog 0.4.0 resident architect thin-client surface.
+Phase: RedDog 0.4.1 resident architect thin-client surface.
 
 Current implementation:
 

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.4.0';
+const EXTENSION_VERSION = '0.4.1';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -3817,7 +3817,7 @@ function appendValidationFailureContent(content, validationState) {
 const DEFAULT_FUSION_WORKER = {
   title: 'RedDog',
   lead: 'z-ai/glm-5.2',
-  panel: ['deepseek/deepseek-v4-pro', 'moonshotai/kimi-k2.7-code']
+  panel: ['deepseek/deepseek-v4-pro', 'moonshotai/kimi-k2.7-code', 'moonshotai/kimi-k3']
 };
 
 const REDDOG_ARCHITECT_SYSTEM_PROMPT = [
@@ -5129,7 +5129,7 @@ function activate(context) {
   const installState = detectRedDogInstallState(context);
   if (installState.stale_install_detected) {
     vscode.window.showWarningMessage(
-      'RedDog 0.4.0 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
+      'RedDog 0.4.1 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
     );
   }
   context.subscriptions.push(

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {
@@ -68,7 +68,8 @@
           "type": "array",
           "default": [
             "deepseek/deepseek-v4-pro",
-            "moonshotai/kimi-k2.7-code"
+            "moonshotai/kimi-k2.7-code",
+            "moonshotai/kimi-k3"
           ],
           "items": {
             "type": "string"
@@ -94,7 +95,8 @@
           "type": "array",
           "default": [
             "deepseek/deepseek-v4-pro",
-            "moonshotai/kimi-k2.7-code"
+            "moonshotai/kimi-k2.7-code",
+            "moonshotai/kimi-k3"
           ],
           "items": {
             "type": "string"

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,12 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-18 - REDDOG_FUSION_KIMI_K3_PHASE1
+
+- Asserted the 0.4.1 package/runtime version lock and default Kimi K3 panel membership.
+- Asserted the bridge emits Kimi K3 requests with mandatory `max` reasoning, without temperature, and with the 4096-token panel budget.
+- Retained Kimi K2.7 Code coverage so the default panel can compare the two Kimi generations.
+- Reconciled the stale resident-session contract assertion with the already-shipped durable AgentDB runtime symbol; production resident code was not changed.
+
 ## 2026-07-09 - REDDOG_EXTENSION_TO_WRE_OPERATIONAL_SPINE_DRYRUN_WIRE_PHASE1 (WRE-DRY-001..WRE-DRY-010)
 
 | ID | Asserts |

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -198,8 +198,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.0', 'package version must be 0.4.0');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.0'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.1', 'package version must be 0.4.1');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.1'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -219,7 +219,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.0', 'README version mismatch');
+includes(readme, 'Version: 0.4.1', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -270,6 +270,10 @@ includes(bridgePy, 'messages = [{"role": "system", "content": _system_prompt(pay
 includes(bridgePy, 'base_system = _system_prompt(payload)', 'manual panel system prompt missing');
 includes(bridgePy, 'GLM_PRINCIPAL_MODEL = "z-ai/glm-5.2"', 'bridge GLM principal missing');
 includes(bridgePy, 'DEEPSEEK_CRITIC_MODEL = "deepseek/deepseek-v4-pro"', 'bridge DeepSeek V4 critic missing');
+includes(bridgePy, 'KIMI_PANEL_MODEL = "moonshotai/kimi-k3"', 'bridge Kimi K3 critic missing');
+includes(bridgePy, 'KIMI_K3_PANEL_MAX_TOKENS = 4096', 'Kimi K3 critic budget missing');
+includes(bridgePy, 'body["reasoning"] = {"effort": "max"}', 'Kimi K3 max-reasoning request contract missing');
+includes(bridgePy, '"panel_max_tokens": panel_max_tokens', 'Kimi K3 actual panel budget receipt missing');
 
 includes(iface, 'SPECIFIED_NOT_IMPLEMENTED', 'interface truth boundary missing');
 includes(iface, 'WSP_15 Priority', 'interface priority contract missing');
@@ -408,6 +412,7 @@ includes(iface, '012 Work Focus to 0102 WSP Task Prompt', 'INTERFACE work focus 
 includes(roadmap, 'REDDOG_BRIDGE_HARDENING_PHASE1', 'bridge hardening roadmap slice missing');
 includes(extensionJs, 'Routing: Auto via WSP_15', 'auto routing label missing');
 includes(extensionJs, 'deepseek/deepseek-v4-pro', 'DeepSeek V4 Pro critic default missing');
+includes(extensionJs, 'moonshotai/kimi-k3', 'Kimi K3 critic default missing');
 includes(extensionJs, 'z-ai/glm-5.2', 'GLM 5.2 principal default missing');
 includes(extensionJs, 'openrouter_fusion_alias', 'OpenRouter Fusion alias path must remain implemented');
 assert(!extensionJs.includes('<select id="mode"'), 'Mode must not be a 012-facing dropdown');
@@ -1087,7 +1092,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.0', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.1', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2579,7 +2584,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.0'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.1'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2593,7 +2598,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.0'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.1'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2605,7 +2610,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.0'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.1'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3484,7 +3489,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.0' } }
+      ? { id, packageJSON: { version: '0.4.1' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({
@@ -3502,7 +3507,7 @@ includes(extensionJs, "reddogConfigValue('enableResidentArchitectSession'", 'RAS
 includes(extensionJs, 'function runResidentArchitectSessionBridge', 'RAS-001: resident session extension bridge missing');
 includes(extensionJs, 'resident_architect_session_result', 'RAS-001: resident session result must attach to review packet');
 includes(extensionJs, 'buildResidentArchitectSessionSection', 'RAS-001: Copy MD resident session section missing');
-includes(residentArchitectBridgePy, 'run_reddog_readonly_audit_research_decision_e2e', 'RAS-002: bridge must delegate to resident E2E runtime');
+includes(residentArchitectBridgePy, 'run_reddog_resident_architect_durable_agentdb_cycle', 'RAS-002: bridge must delegate to resident durable runtime');
 includes(residentArchitectBridgePy, 'explicit_resident_architect_session_requested', 'RAS-002: bridge must require explicit request');
 includes(residentArchitectBridgePy, 'no_holoindex_reindex_performed', 'RAS-002: bridge must surface no-reindex attestation');
 includes(residentArchitectBridgePy, 'no_repo_mutation_performed', 'RAS-002: bridge must surface no-repo-mutation attestation');

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -162,6 +162,13 @@ enabled automatically by `main.py` and does not perform verification, promotion,
 PatternMemory writes, HoloIndex mutation, runtime binding, command execution, or
 repository mutation.
 
+OpenRouter candidates use provider `openrouter` and an exact model ID such as
+`moonshotai/kimi-k3`. The provider is available only through explicit configured
+gateway assignments and allowlisting; it is not inserted into normal fallback
+routing. Kimi K3 remains an AutoResearch candidate until signed benchmark and
+promotion evidence authorizes a production binding. Its configured provider
+records separate input/output token prices for bounded cost-gate estimates.
+
 The campaign execution bootstrap accepts this runner only through the explicit
 `configured_gateway` mode, an outside-repo prompt-record file, an explicit
 provider allowlist, an outside-repo output-evidence JSONL path, and the

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,32 @@
 # AI Gateway Module Change Log
 
+## [2026-07-18] - Kimi K3 OpenRouter AutoResearch Candidate
+
+**Who:** 0102 Codex
+**Type:** Model Candidate / Configured Gateway Wiring
+**Slice:** MODEL_AUTORESEARCH_OPENROUTER_KIMI_K3_PHASE1
+
+**What:** Added Kimi K3 to the static candidate catalog and enabled the existing
+configured AutoResearch gateway to target exact OpenRouter model assignments.
+
+**Why:** The combination harness and campaign loop were already implemented, but
+`AIGatewayConfiguredModelCaller` could not execute an OpenRouter candidate. This
+prevented governed held-out comparison of Kimi K3 with RedDog's existing panel.
+
+**Truth Boundary:**
+- IMPLEMENTED: explicit `openrouter` provider, exact `moonshotai/kimi-k3`
+  candidate metadata, mandatory-max-reasoning request shape, 4096-token default,
+  separate input/output cost accounting, catalog and caller tests.
+- NOT IMPLEMENTED: automatic fallback to OpenRouter, automatic promotion,
+  implicit candidate-pool mutation, or bypass of benchmark/verifier receipts.
+
+**WSP References:** WSP 15, WSP 22, WSP 50, WSP 84, WSP 97.
+
+**WSP_15 Score:** Complexity 3 + Importance 4 + Deferability 4 + Impact 4 =
+15 (P1).
+
+---
+
 ## [2026-07-17] - Model AutoResearch Cycle Feedback Chain Main Preflight
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -102,6 +102,14 @@ answers, promote models, mutate catalogs, write PatternMemory, re-index
 HoloIndex, execute commands, mutate the repository, or bind RedDog runtime
 defaults.
 
+The configured gateway includes an explicit `openrouter` provider for governed
+candidate assignments such as `moonshotai/kimi-k3`. OpenRouter remains absent
+from ordinary AI Gateway fallback routing; an AutoResearch candidate pool and
+provider allowlist must name it explicitly. Kimi K3 is cataloged as a candidate,
+not a champion, until held-out benchmark and promotion receipts prove it.
+Configured-runner cost estimates include its separate input and output token
+rates so the existing per-sample cost gate can reject over-budget results.
+
 `src/model_autoresearch_campaign_execution_artifact_supply_bootstrap.py` can
 use this runner only when `REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_RUNNER_MODE` is
 set to `configured_gateway`, prompt records are supplied from outside the repo,

--- a/modules/ai_intelligence/ai_gateway/src/ai_gateway.py
+++ b/modules/ai_intelligence/ai_gateway/src/ai_gateway.py
@@ -61,6 +61,8 @@ class ProviderConfig:
     cost_per_token: float
     rate_limit: int  # requests per minute
     timeout: int = 30
+    output_cost_per_token: float = 0.0
+    automatic_routing_enabled: bool = True
 
 
 class AIGateway:
@@ -68,7 +70,8 @@ class AIGateway:
     AI Gateway for unified access to multiple AI providers.
 
     Provides intelligent routing, automatic fallback, and cost optimization
-    across OpenAI, Anthropic, Grok, and Google Gemini.
+    across OpenAI, Anthropic, Grok, Google Gemini, and explicitly selected
+    OpenRouter models used by governed AutoResearch campaigns.
     """
 
     def __init__(self, gateway_key: Optional[str] = None):
@@ -211,6 +214,30 @@ class AIGateway:
                 },
                 cost_per_token=0.0005,
                 rate_limit=60
+            ),
+
+            # OpenRouter is intentionally absent from the ordinary fallback
+            # order. It is available for exact provider/model assignments from
+            # the governed AutoResearch configured-gateway runner.
+            'openrouter': ProviderConfig(
+                name='openrouter',
+                api_key=os.getenv('OPENROUTER_API_KEY'),
+                base_url='https://openrouter.ai/api/v1',
+                models={
+                    'coding': 'moonshotai/kimi-k3',
+                    'code_review': 'moonshotai/kimi-k3',
+                    'math': 'moonshotai/kimi-k3',
+                    'reasoning': 'moonshotai/kimi-k3',
+                    'research': 'moonshotai/kimi-k3',
+                    'analysis': 'moonshotai/kimi-k3',
+                    'creative': 'moonshotai/kimi-k3',
+                    'quick': 'moonshotai/kimi-k3',
+                },
+                cost_per_token=0.000003,
+                rate_limit=30,
+                timeout=120,
+                output_cost_per_token=0.000015,
+                automatic_routing_enabled=False,
             )
         }
 
@@ -290,7 +317,7 @@ class AIGateway:
         # Sort providers by cost for this task
         available_providers = [
             (name, config) for name, config in self.providers.items()
-            if config.api_key
+            if config.api_key and config.automatic_routing_enabled
         ]
 
         # Sort by cost_per_token ascending (cheapest first)
@@ -384,7 +411,7 @@ class AIGateway:
 
         model = provider.models.get(task_type, provider.models.get('quick', 'default'))
 
-        if provider.name == 'openai':
+        if provider.name in {'openai', 'openrouter'}:
             return self._call_openai(provider, prompt, model)
         elif provider.name == 'anthropic':
             return self._call_anthropic(provider, prompt, model)
@@ -397,7 +424,8 @@ class AIGateway:
 
     def _call_openai(self, provider: ProviderConfig, prompt: str, model: str) -> str:
         """Call OpenAI API"""
-        max_tokens = self._get_provider_max_tokens(provider.name, 1000)
+        default_max_tokens = 4096 if provider.name == 'openrouter' and model == 'moonshotai/kimi-k3' else 1000
+        max_tokens = self._get_provider_max_tokens(provider.name, default_max_tokens)
         temperature = self._get_provider_temperature(provider.name, 0.7)
         headers = {
             'Authorization': f'Bearer {provider.api_key}',
@@ -408,8 +436,13 @@ class AIGateway:
             'model': model,
             'messages': [{'role': 'user', 'content': prompt}],
             'max_tokens': max_tokens,
-            'temperature': temperature
         }
+        if provider.name == 'openrouter' and model == 'moonshotai/kimi-k3':
+            # OpenRouter lists Kimi K3 with mandatory max reasoning and without
+            # temperature support. Preserve the published request contract.
+            data['reasoning'] = {'effort': 'max'}
+        else:
+            data['temperature'] = temperature
 
         response = requests.post(
             f"{provider.base_url}/chat/completions",

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_configured_gateway_runner.py
@@ -180,15 +180,20 @@ class AIGatewayConfiguredModelCaller:
         started = time.monotonic()
         response = str(call_provider(routed_config, prompt, task_name) or "")
         latency_ms = int(round((time.monotonic() - started) * 1000))
+        input_tokens = _token_count(prompt)
+        output_tokens = _token_count(response)
         return GatewayModelCallResult(
             success=bool(response.strip()),
             provider=provider_name,
             model=model_name,
             response_text=response,
             latency_ms=latency_ms,
-            input_tokens=_token_count(prompt),
-            output_tokens=_token_count(response),
-            cost_estimate_usd=float(_token_count(prompt)) * float(getattr(provider_config, "cost_per_token", 0.0)),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_estimate_usd=(
+                float(input_tokens) * float(getattr(provider_config, "cost_per_token", 0.0))
+                + float(output_tokens) * float(getattr(provider_config, "output_cost_per_token", 0.0))
+            ),
         ).normalized()
 
 

--- a/modules/ai_intelligence/ai_gateway/src/model_registry.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_registry.py
@@ -3,7 +3,7 @@
 UPDATE THIS FILE when providers release new models.
 All other modules should import from here, not hardcode model IDs.
 
-Last Updated: 2026-02-22
+Last Updated: 2026-07-18
 """
 
 from dataclasses import dataclass
@@ -297,6 +297,19 @@ GROK_MODELS: Dict[str, ModelInfo] = {
 }
 
 # =============================================================================
+# OPENROUTER MODELS (explicit AutoResearch / RedDog evaluation)
+# =============================================================================
+OPENROUTER_MODELS: Dict[str, ModelInfo] = {
+    "moonshotai/kimi-k3": ModelInfo(
+        model_id="moonshotai/kimi-k3",
+        provider="openrouter",
+        status=ModelStatus.CURRENT,
+        release_date=date(2026, 7, 16),
+        notes="Kimi K3 multimodal reasoning model; explicit evaluation candidate, not automatic fallback",
+    ),
+}
+
+# =============================================================================
 # LOCAL MODELS (LM Studio / Ollama / llama.cpp)
 # =============================================================================
 LOCAL_MODELS: Dict[str, ModelInfo] = {
@@ -346,6 +359,7 @@ ALL_MODELS: Dict[str, ModelInfo] = {
     **ANTHROPIC_MODELS,
     **GEMINI_MODELS,
     **GROK_MODELS,
+    **OPENROUTER_MODELS,
     **LOCAL_MODELS,
 }
 
@@ -354,14 +368,14 @@ ALL_MODELS: Dict[str, ModelInfo] = {
 # =============================================================================
 RECOMMENDED_MODELS = {
     # 012's activity routing matrix (primary task types) — Feb 2026 current
-    "coding": ["claude-opus-4-6", "gpt-5.2-codex", "grok-code-fast-1", "gemini-2.5-pro"],
+    "coding": ["claude-opus-4-6", "gpt-5.2-codex", "grok-code-fast-1", "gemini-2.5-pro", "moonshotai/kimi-k3"],
     "math": ["o3", "o4-mini", "gemini-2.5-pro", "claude-opus-4-6"],
-    "reasoning": ["o3-pro", "gpt-5.2", "claude-opus-4-6", "gemini-2.5-pro"],
+    "reasoning": ["o3-pro", "gpt-5.2", "claude-opus-4-6", "gemini-2.5-pro", "moonshotai/kimi-k3"],
     "social": ["grok-4", "gpt-5", "claude-sonnet-4-5-20250929"],
-    "research": ["gemini-2.5-pro", "gpt-5.2", "claude-sonnet-4-5-20250929"],
+    "research": ["gemini-2.5-pro", "gpt-5.2", "claude-sonnet-4-5-20250929", "moonshotai/kimi-k3"],
     # Secondary task types
-    "code_review": ["claude-opus-4-6", "gpt-5.2-codex", "gemini-2.5-pro"],
-    "analysis": ["gpt-5.2", "claude-sonnet-4-5-20250929", "o3"],
+    "code_review": ["claude-opus-4-6", "gpt-5.2-codex", "gemini-2.5-pro", "moonshotai/kimi-k3"],
+    "analysis": ["gpt-5.2", "claude-sonnet-4-5-20250929", "o3", "moonshotai/kimi-k3"],
     "creative": ["claude-sonnet-4-5-20250929", "gpt-5", "gemini-2.5-flash"],
     "quick": ["grok-4-fast", "gpt-5", "claude-haiku-4-5-20251001", "gemini-2.5-flash"],
     # Local models

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_configured_gateway_runner.py
@@ -7,7 +7,7 @@ import hashlib
 from dataclasses import replace
 from pathlib import Path
 
-from modules.ai_intelligence.ai_gateway.src.ai_gateway import ProviderConfig
+from modules.ai_intelligence.ai_gateway.src.ai_gateway import AIGateway, ProviderConfig
 from modules.ai_intelligence.ai_gateway.src.model_autoresearch_configured_gateway_runner import (
     AIGatewayConfiguredModelCaller,
     ConfiguredGatewayRunnerPolicy,
@@ -339,6 +339,96 @@ def test_aigateway_adapter_targets_exact_provider_and_model_without_fallback():
     assert result.output_tokens == 2
     assert result.cost_estimate_usd == 0.5
     assert len(gateway.calls) == 1
+
+
+def test_aigateway_adapter_targets_kimi_k3_through_openrouter_for_autoresearch():
+    class FakeGateway:
+        def __init__(self) -> None:
+            self.providers = {
+                "openrouter": ProviderConfig(
+                    name="openrouter",
+                    api_key="test-key",
+                    base_url="https://openrouter.ai/api/v1",
+                    models={"quick": "wrong-default"},
+                    cost_per_token=0.000003,
+                    rate_limit=1,
+                    output_cost_per_token=0.000015,
+                )
+            }
+            self.calls: list[tuple[ProviderConfig, str, str]] = []
+
+        def _call_provider(self, provider: ProviderConfig, prompt: str, task_type: str) -> str:
+            self.calls.append((provider, prompt, task_type))
+            assert provider.models[task_type] == "moonshotai/kimi-k3"
+            return "kimi benchmark response"
+
+    gateway = FakeGateway()
+    result = AIGatewayConfiguredModelCaller(gateway).call_model(
+        provider="openrouter",
+        model="moonshotai/kimi-k3",
+        prompt="held out task",
+        task_type="model_autoresearch",
+    )
+
+    assert result.success is True
+    assert result.provider == "openrouter"
+    assert result.model == "moonshotai/kimi-k3"
+    assert round(result.cost_estimate_usd, 8) == 0.000054
+    assert len(gateway.calls) == 1
+
+
+def test_aigateway_kimi_k3_request_uses_openrouter_supported_parameters(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    requests_seen: list[dict[str, object]] = []
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"choices": [{"message": {"content": "ok"}}]}
+
+    def fake_post(url: str, **kwargs: object) -> FakeResponse:
+        requests_seen.append({"url": url, **kwargs})
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "modules.ai_intelligence.ai_gateway.src.ai_gateway.requests.post",
+        fake_post,
+    )
+    gateway = AIGateway()
+    provider = gateway.providers["openrouter"]
+
+    assert "openrouter" not in gateway._get_provider_priority("coding")
+    assert provider.automatic_routing_enabled is False
+    for name, configured in gateway.providers.items():
+        if name != "openrouter":
+            configured.api_key = None
+    automatic_calls: list[str] = []
+    monkeypatch.setattr(
+        gateway,
+        "_call_provider",
+        lambda *_args, **_kwargs: automatic_calls.append("called") or "unexpected",
+    )
+    assert gateway.call_optimized("must stay explicit", "coding").success is False
+    assert automatic_calls == []
+
+    monkeypatch.undo()
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "modules.ai_intelligence.ai_gateway.src.ai_gateway.requests.post",
+        fake_post,
+    )
+    gateway = AIGateway()
+    provider = gateway.providers["openrouter"]
+    assert gateway._call_provider(provider, "benchmark prompt", "coding") == "ok"
+    assert requests_seen[0]["url"] == "https://openrouter.ai/api/v1/chat/completions"
+    body = requests_seen[0]["json"]
+    assert isinstance(body, dict)
+    assert body["model"] == "moonshotai/kimi-k3"
+    assert body["max_tokens"] == 4096
+    assert body["reasoning"] == {"effort": "max"}
+    assert "temperature" not in body
 
 
 def test_configured_runner_module_has_no_direct_network_command_runtime_or_holoindex_imports():

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_catalog.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_intelligence_catalog.py
@@ -47,11 +47,11 @@ def test_openrouter_catalog_normalizes_capability_and_pricing_evidence():
         {
             "data": [
                 {
-                    "id": "moonshotai/kimi-k2.7-code",
-                    "context_length": 262144,
-                    "pricing": {"prompt": "0.0000006", "completion": "0.0000025"},
+                    "id": "moonshotai/kimi-k3",
+                    "context_length": 1048576,
+                    "pricing": {"prompt": "0.000003", "completion": "0.000015"},
                     "architecture": {
-                        "input_modalities": ["text"],
+                        "input_modalities": ["text", "image"],
                         "output_modalities": ["text"],
                     },
                     "supported_parameters": ["tools", "response_format", "reasoning"],
@@ -64,15 +64,29 @@ def test_openrouter_catalog_normalizes_capability_and_pricing_evidence():
     assert len(cards) == 1
     card = cards[0]
     assert card.provider == "moonshotai"
-    assert card.canonical_model_id == "moonshotai/kimi-k2.7-code"
+    assert card.canonical_model_id == "moonshotai/kimi-k3"
     assert card.availability == Availability.AVAILABLE
     assert card.promotion_state == PromotionState.CANDIDATE
-    assert card.context_window == 262144
-    assert card.input_cost_per_million == 0.6
-    assert card.output_cost_per_million == 2.5
+    assert card.context_window == 1048576
+    assert card.input_cost_per_million == 3.0
+    assert card.output_cost_per_million == 15.0
+    assert card.modalities == ("image", "text")
     assert card.supports_tools is True
     assert card.supports_structured_output is True
     assert card.supports_reasoning is True
+
+
+def test_static_registry_exposes_kimi_k3_as_unpromoted_autoresearch_candidate():
+    cards = normalize_static_registry_cards()
+    by_id = {card.canonical_model_id: card for card in cards}
+
+    kimi = by_id["moonshotai/kimi-k3"]
+    assert kimi.provider == "openrouter"
+    assert kimi.availability == Availability.UNKNOWN
+    assert kimi.promotion_state == PromotionState.CANDIDATE
+    assert {"coding", "code_review", "reasoning", "research", "analysis"}.issubset(
+        set(kimi.task_families)
+    )
 
 
 def test_openrouter_catalog_rejects_malformed_records_fail_closed():

--- a/scripts/advisory_model_once.py
+++ b/scripts/advisory_model_once.py
@@ -33,9 +33,11 @@ OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 ENV_API_KEY = "OPENROUTER_API_KEY"
 GLM_PRINCIPAL_MODEL = "z-ai/glm-5.2"
 DEEPSEEK_CRITIC_MODEL = "deepseek/deepseek-v4-pro"
-KIMI_PANEL_MODEL = "moonshotai/kimi-k2.7-code"
+KIMI_CODE_PANEL_MODEL = "moonshotai/kimi-k2.7-code"
+KIMI_PANEL_MODEL = "moonshotai/kimi-k3"
+KIMI_K3_PANEL_MAX_TOKENS = 4096
 DEFAULT_LEAD_MODEL = GLM_PRINCIPAL_MODEL
-DEFAULT_PANEL_MODELS = (DEEPSEEK_CRITIC_MODEL, KIMI_PANEL_MODEL)
+DEFAULT_PANEL_MODELS = (DEEPSEEK_CRITIC_MODEL, KIMI_CODE_PANEL_MODEL, KIMI_PANEL_MODEL)
 MAX_PANEL_MODELS = 6
 RETRYABLE_HTTP_STATUS = frozenset({429, 502, 503})
 MAX_HTTP_RETRIES = 2
@@ -133,13 +135,19 @@ def _chat_completion(
     temperature: float,
     timeout: int,
 ) -> tuple[str, dict[str, Any]]:
-    body = {
+    body: dict[str, Any] = {
         "model": model,
         "messages": messages,
         "max_tokens": max_tokens,
-        "temperature": temperature,
         "stream": False,
     }
+    if model == KIMI_PANEL_MODEL:
+        # Kimi K3 exposes mandatory max reasoning through OpenRouter and does
+        # not advertise temperature support. Keep the request inside the
+        # provider's published parameter contract.
+        body["reasoning"] = {"effort": "max"}
+    else:
+        body["temperature"] = temperature
     data, retry_meta = _post_openrouter(api_key, body, timeout)
     content = data["choices"][0]["message"]["content"]
     return str(content), retry_meta
@@ -275,6 +283,7 @@ def _fusion_quorum_packet(
     lead_model: str,
     panel_models: list[str],
     panel_models_truncated: bool,
+    panel_max_tokens: dict[str, int] | None = None,
     missing_required_evidence: list[str] | None = None,
     challenging_critics: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -298,6 +307,7 @@ def _fusion_quorum_packet(
             "lead_model": lead_model,
             "panel_models": panel_models,
             "panel_models_truncated": panel_models_truncated,
+            "panel_max_tokens": dict(panel_max_tokens or {}),
             "fusion_panel_quorum": quorum,
         },
     }
@@ -373,6 +383,10 @@ def _run_foundups_fusion(
     temperature = _bounded_temperature(payload.get("temperature"), 0.2)
     lead_model = _model_slug(payload.get("lead_model"), DEFAULT_LEAD_MODEL)
     panel_models, panel_models_truncated = _panel_models_with_meta(payload.get("panel_models"))
+    panel_max_tokens = {
+        model: (max(max_tokens, KIMI_K3_PANEL_MAX_TOKENS) if model == KIMI_PANEL_MODEL else max_tokens)
+        for model in panel_models
+    }
     base_system = _system_prompt(payload)
     response_contract = str(payload.get("response_contract") or "")
     strict_json_contract = response_contract.startswith("strict_json")
@@ -387,6 +401,7 @@ def _run_foundups_fusion(
             lead_model=lead_model,
             panel_models=panel_models,
             panel_models_truncated=panel_models_truncated,
+            panel_max_tokens=panel_max_tokens,
             missing_required_evidence=missing_evidence,
         )
 
@@ -424,6 +439,7 @@ def _run_foundups_fusion(
             lead_model=lead_model,
             panel_models=panel_models,
             panel_models_truncated=panel_models_truncated,
+            panel_max_tokens=panel_max_tokens,
         )
 
     _progress("lead_done", "Lead response received: " + lead_model)
@@ -445,7 +461,7 @@ def _run_foundups_fusion(
                 api_key,
                 model,
                 critic_messages,
-                max_tokens=max_tokens,
+                max_tokens=panel_max_tokens[model],
                 temperature=temperature,
                 timeout=timeout,
             ): model
@@ -476,6 +492,7 @@ def _run_foundups_fusion(
             lead_model=lead_model,
             panel_models=panel_models,
             panel_models_truncated=panel_models_truncated,
+            panel_max_tokens=panel_max_tokens,
             challenging_critics=[],
         )
 
@@ -521,6 +538,7 @@ def _run_foundups_fusion(
             lead_model=lead_model,
             panel_models=panel_models,
             panel_models_truncated=panel_models_truncated,
+            panel_max_tokens=panel_max_tokens,
             challenging_critics=challenging_critics,
         )
 
@@ -543,6 +561,7 @@ def _run_foundups_fusion(
             "lead_model": lead_model,
             "panel_models": panel_models,
             "panel_models_truncated": panel_models_truncated,
+            "panel_max_tokens": panel_max_tokens,
             "redacted_prompt": redacted_prompt,
             "lead_excerpt": lead_text[:4000],
             "panel_excerpts": {model: text[:3000] for model, text in panel_results.items()},

--- a/scripts/tests/test_advisory_model_once_hardening.py
+++ b/scripts/tests/test_advisory_model_once_hardening.py
@@ -58,6 +58,33 @@ class AdvisoryBridgeHardeningTests(unittest.TestCase):
         self.assertTrue(truncated)
         self.assertEqual(len(models), bridge.MAX_PANEL_MODELS)
 
+    def test_default_panel_keeps_kimi_code_and_adds_kimi_k3(self) -> None:
+        self.assertIn("moonshotai/kimi-k2.7-code", bridge.DEFAULT_PANEL_MODELS)
+        self.assertIn("moonshotai/kimi-k3", bridge.DEFAULT_PANEL_MODELS)
+        self.assertEqual(bridge.KIMI_K3_PANEL_MAX_TOKENS, 4096)
+
+    def test_kimi_k3_completion_uses_mandatory_max_reasoning_without_temperature(self) -> None:
+        post = mock.Mock(
+            return_value=(
+                {"choices": [{"message": {"content": "ok"}}]},
+                {"retry_count": 0, "final_retry_reason": None},
+            )
+        )
+        with mock.patch.object(bridge, "_post_openrouter", post):
+            content, _meta = bridge._chat_completion(
+                "key",
+                "moonshotai/kimi-k3",
+                [{"role": "user", "content": "test"}],
+                max_tokens=256,
+                temperature=0.2,
+                timeout=30,
+            )
+
+        self.assertEqual(content, "ok")
+        body = post.call_args.args[1]
+        self.assertEqual(body["reasoning"], {"effort": "max"})
+        self.assertNotIn("temperature", body)
+
     def test_retry_429_then_success(self) -> None:
         calls: list[dict] = []
         responses = [
@@ -384,6 +411,43 @@ class AdvisoryBridgeHardeningTests(unittest.TestCase):
         quorum = result["review_packet"]["fusion_panel_quorum"]
         self.assertTrue(quorum["passed"])
         self.assertEqual(quorum["challenging_critics"], ["critic-a"])
+
+    def test_fusion_kimi_k3_uses_and_records_4096_token_critic_budget(self) -> None:
+        calls: list[tuple[str, int]] = []
+
+        def fake_chat(api_key, model, messages, **kwargs):  # noqa: ANN001, ARG001
+            calls.append((model, kwargs["max_tokens"]))
+            system = str(messages[0]["content"])
+            if "Lead pass" in system:
+                return "## Decision\nProceed\n\nEvidence docs/present.md:1", {"retry_count": 0}
+            if "Panel critic pass" in system:
+                return (
+                    "Challenge: the evidence claim is unsupported and the WSP_15 "
+                    "priority sequence needs verification.",
+                    {"retry_count": 0},
+                )
+            return "## Decision\nProceed\n\n## WSP_15 Priority\nP1", {"retry_count": 0}
+
+        with mock.patch.object(bridge, "_chat_completion", side_effect=fake_chat):
+            result = bridge._run_foundups_fusion(
+                "key",
+                "prompt\n\n### Required direct-read target: docs/present.md\ncontent",
+                [],
+                {
+                    "lead_model": "lead-model",
+                    "panel_models": ["moonshotai/kimi-k3"],
+                    "max_tokens": 1600,
+                    "required_target_paths": ["docs/present.md"],
+                    "_redacted_evidence_context": "### Required direct-read target: docs/present.md\ncontent",
+                },
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertIn(("moonshotai/kimi-k3", 4096), calls)
+        self.assertEqual(
+            result["review_packet"]["panel_max_tokens"],
+            {"moonshotai/kimi-k3": 4096},
+        )
 
     def test_fusion_strict_json_contract_reaches_lead_and_synthesis_prompts(self) -> None:
         systems: list[str] = []


### PR DESCRIPTION
## What changed

- adds the exact OpenRouter Kimi K3 model (`moonshotai/kimi-k3`) to the RedDog Fusion critic panel while retaining Kimi K2.7 Code for implementation comparison and capacity fallback
- gives Kimi K3 its required 4096-token critic budget, sends mandatory maximum reasoning, omits unsupported temperature, and records the per-panel budget in review receipts
- extends the existing AutoResearch/AI Gateway path with an explicit-only OpenRouter provider, Kimi K3 candidate metadata, capability/pricing data, and separate input/output cost accounting
- prevents explicit research candidates such as OpenRouter from leaking into normal optimized routing or bypassing the established candidate-pool, benchmark, promotion, and feedback-ledger gates
- updates RedDog and AI Gateway interfaces, roadmaps, ModLogs, and extension contract/version metadata

## Why

The existing AutoResearch combination and promotion machinery was already present. The operational gap was that its configured gateway could not invoke OpenRouter, while RedDog Fusion did not know the released Kimi K3 identifier or its request constraints. Low output budgets also let Kimi K3's mandatory reasoning consume the response, causing Fusion to fail closed without a challenging critic.

## Validation

- `283 passed` across AI Gateway, advisory/Fusion hardening, and RedDog architect tests
- complete RedDog extension contract passed
- strict WSP_00 awakening/check passed
- live OpenRouter single-model Kimi K3 smoke passed
- live manual RedDog Fusion passed quorum with Kimi K3 recorded as the challenging critic and a 4096-token panel budget

## Truth boundary

This registers Kimi K3 as an available research candidate and makes it executable through the existing governed path. It does not silently mutate the external candidate pool, auto-promote Kimi K3, or bypass benchmark receipts and promotion gates.