### PR TITLE
fix(reddog): restore semantic HoloIndex preflight

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -45,7 +45,7 @@ Autonomous WRE/DAE agents are NOT 012 work. 012 provides work focus, testing, so
 |---|---|---|
 | Advisory model review | YES | OpenRouter request after Fusion redaction gate passes |
 | Bounded repo context | YES | Extension auto-gathers WSP/HoloIndex/editor/git/Skillz context by WSP_15 tier and sends it through redaction gate |
-| HoloIndex recall | YES | `HOLO_SKIP_MODEL=1 --bundle-json` first; offline lexical fallback only if bundle recall fails |
+| HoloIndex recall | YES | Read-only semantic `--bundle-json` first; actual retrieval mode/backend are receipted; offline lexical fallback only if semantic retrieval fails. Explicit opt-down: `REDDOG_HOLO_RETRIEVAL_MODE=lexical`. |
 | WSP_00/WSP_97/WSP_15 prompting | YES | System prompt requires role lock, truth labels, proposed fixes, and MPS priority |
 | Repo edits | NO | No write tool exposed to model |
 | Shell execution by model | NO | Extension host runs only bounded local context/bridge commands; model cannot execute Skillz/OpenClaw/Hermes |

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,16 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-18 - REDDOG_HOLO_SEMANTIC_FIRST_PHASE1 (semantic retrieval recovery, 0.4.2)
+
+- Proved the local HoloIndex embedding stack healthy (`sentence_transformers`, cached `all-MiniLM-L6-v2`) and measured a real semantic bundle at 15.6 seconds with five code and five WSP hits.
+- Removed RedDog's unconditional `HOLO_SKIP_MODEL=1` production policy. The default read-only bundle clears inherited model-skip state, preserves an operator-set `HOLO_OFFLINE` network boundary, and requires the returned receipt to report `retrieval_mode=semantic`.
+- Added explicit `REDDOG_HOLO_RETRIEVAL_MODE=lexical` opt-down for deterministic tests or emergency compute conservation; lexical results are labelled as lexical and never promoted to semantic evidence.
+- Fixed the emergency fallback's block-scope defect: the fallback previously referenced `env` outside the `try` block where it was declared, so a primary bundle exception could collapse into `HoloIndex unavailable` instead of running lexical recovery.
+- Added requested/actual retrieval mode, embedding backend, and routing state to RedDog HoloIndex metadata, scorecards, and bundle summaries.
+- Version 0.4.1 -> 0.4.2 (package.json + EXTENSION_VERSION + README + interface + roadmap + contract tests).
+- WSP_15: Complexity 3 + Importance 4 + Deferability 4 + Impact 4 = 15 (P1).
+
 ## 2026-07-18 - REDDOG_FUSION_KIMI_K3_PHASE1 (OpenRouter critic integration, 0.4.1)
 
 - Added the verified OpenRouter slug `moonshotai/kimi-k3` to the default manual Fusion panel while retaining Kimi K2.7 Code for implementation comparison and capacity fallback.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,6 +1,6 @@
 # RedDog
 
-Version: 0.4.1
+Version: 0.4.2
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
 
@@ -54,7 +54,7 @@ The extension is a bounded 0102 advisory surface:
 - WSP_97: answers must separate observed evidence, inference, and needs-verification.
 - WSP_15: substantive answers must end with a priority block: Complexity, Importance, Deferability, Impact, MPS total, and P0-P4 class.
 - Findings must include proposed fixes or an explicit defer/block reason.
-- HoloIndex recall uses WSP_00 `HOLO_SKIP_MODEL=1 --bundle-json` first, then falls back to offline lexical search only if bundle recall fails.
+- HoloIndex recall is semantic-first: RedDog clears inherited `HOLO_SKIP_MODEL`, preserves an operator-set `HOLO_OFFLINE` network boundary, runs the read-only `--bundle-json` path, records `retrieval_mode` and `embedding_backend`, and falls back to offline lexical search only when semantic retrieval fails. `REDDOG_HOLO_RETRIEVAL_MODE=lexical` is an explicit compute-saving opt-down for tests or emergency operation; it must not be described as semantic retrieval.
 - Free-form target derivation (v0.3.44): repo-relative paths named with read-intent anywhere in the work focus are promoted to required direct-read targets, not only paths under the exact `Required direct-read targets:` header. Recognized read-intent shapes are: the explicit required-targets header, `Read first:` / `READ BEFORE EDITING` blocks, WSP_99 M2M `READ:` arrays, M2M `CTX.FILES` / `CTX: FILES:` arrays, markdown bullet lists of paths, and inline or backticked paths in prose. When a path is named this way it drives the SAME governed direct-read fetch, so it is retrieved even when HoloIndex semantic recall misses. Command/validation fences (```powershell / ```bash with `git diff --check`, `node --check`, `python holo_index.py ...`) and scope-out / "Do NOT touch" sections are excluded, and derivation prefers precision when read-intent is ambiguous.
 - Flowing-prose read-capture tokenization + tiered strictness (v0.3.45): a `Read first:` prompt that names files in flowing PROSE (e.g. `Read first: a.md, b.json, and c.py. Determine ... the breadcrumb/handoff layer`) is now tokenized with the bounded path-token regex, so a path followed by prose (`c.py. Determine ...`) and an embedded-slash English fragment (`breadcrumb/handoff`) no longer corrupt the derived targets. Confidence tiers: FLOWING-PROSE-derived tokens (Read-first prose, inline prose, backtick prose) become required targets ONLY if they have a lowercase file extension (a file shape); a prose token with a slash but no extension is dropped from the required list and reported in the new `work_focus_targets_dropped_low_confidence` telemetry field, so it can never flip `target_recall_ok` to false. The explicit `Required direct-read targets:` header, M2M `READ:` / `CTX.FILES`, and CLEAN BULLETS keep the broader slash-OR-extension behavior (a named directory path is still accepted) -- only flowing prose is stricter. Trailing prose punctuation (`.` `,` `;` `:` `)` `]` `}`) is trimmed from derived paths. The governed direct-read gate (`bundle_json.py`) is unchanged; derived paths still flow through it.
 - Determine-block target derivation guard (v0.3.59): `Determine:` numbered questions are treated as answer/output obligations, not repo-file target intent. Slash-bearing conceptual phrases inside questions (for example `ledger/runtime`) no longer become `repo_file_targets` or block typed grounding. Explicit `Read first:` / required-target sections still drive direct read normally.
@@ -225,6 +225,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.1.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.2.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/ROADMAP.md
+++ b/extensions/reddog/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Phase: RedDog 0.4.1 resident architect thin-client surface.
+Phase: RedDog 0.4.2 resident architect thin-client surface.
 
 Current implementation:
 
@@ -10,7 +10,7 @@ Current implementation:
 - Bottom-composer webview with scrollback output.
 - OpenRouter bridge with redaction gate.
 - WSP_00/WSP_97/WSP_15 operating prompt.
-- HoloIndex bundle-json recall with offline fallback.
+- HoloIndex semantic-first bundle-json recall with truthful mode/backend receipts and an operational offline lexical fallback.
 - Manual lead+panel mode for review-packet traceability.
 - REDDOG_FUSION_ORCHESTRATOR_PHASE1: internal task classifier, auto effort, schema validator, one repair pass.
 - REDDOG_UX_PACKET_POLISH_PHASE1 (v0.3.19): Working Tail above controls; 0102 Role label; Copy MD Run Trace; mojibake flag; validation-failure packet semantics.

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 
-const EXTENSION_VERSION = '0.4.1';
+const EXTENSION_VERSION = '0.4.2';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -2016,6 +2016,10 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
   const meta = holoMeta && typeof holoMeta === 'object' ? holoMeta : {};
   return {
     holoindex_status: meta.holoindex_status || 'unknown',
+    requested_retrieval_mode: meta.requested_retrieval_mode || 'unknown',
+    retrieval_mode: meta.retrieval_mode || 'unknown',
+    embedding_backend: meta.embedding_backend || 'unknown',
+    routing_active: meta.routing_active !== undefined ? meta.routing_active : 'unknown',
     code_hits_count: meta.code_hits !== undefined ? meta.code_hits : 'unknown',
     wsp_hits: meta.wsp_hits !== undefined ? meta.wsp_hits : 'unknown',
     code_hits: meta.code_hits !== undefined ? meta.code_hits : 'unknown',
@@ -2094,6 +2098,10 @@ function formatHoloIndexScorecardLines(scorecard) {
   }
   return [
     '- holoindex_status: ' + scorecard.holoindex_status,
+    '- requested_retrieval_mode: ' + scorecard.requested_retrieval_mode,
+    '- retrieval_mode: ' + scorecard.retrieval_mode,
+    '- embedding_backend: ' + scorecard.embedding_backend,
+    '- routing_active: ' + scorecard.routing_active,
     '- code_hits_count: ' + scorecard.code_hits_count,
     '- wsp_hits: ' + scorecard.wsp_hits,
     '- skill_hits: ' + scorecard.skill_hits,
@@ -5129,7 +5137,7 @@ function activate(context) {
   const installState = detectRedDogInstallState(context);
   if (installState.stale_install_detected) {
     vscode.window.showWarningMessage(
-      'RedDog 0.4.1 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
+      'RedDog 0.4.2 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
     );
   }
   context.subscriptions.push(
@@ -6321,7 +6329,7 @@ function buildBoundedRepoContext(mode, taskText) {
     // literal required-target marker embedded in the HoloIndex recall JSON blob so a recall payload
     // whose text echoes "### Required direct-read target: <path>" cannot reach the Python isolation
     // splitter as a real marker section. Dedup in Python is the robust closure; this is belt-and-braces.
-    lowerSections.push('### HoloIndex recall (WSP_00 bundle-json first; offline fallback only if needed)\n```text\n' + neutralizeRequiredTargetMarker(holo.output || '(no HoloIndex output)') + '\n```');
+    lowerSections.push('### HoloIndex recall (WSP_00 semantic bundle first; lexical fallback only if needed)\n```text\n' + neutralizeRequiredTargetMarker(holo.output || '(no HoloIndex output)') + '\n```');
     directReadSection = holo.direct_read_section || null;
     // REDDOG_AUDIT_CONTEXT_BRIDGE_WIRE_PHASE1: preserve audit_context from slice-3
     // direct-read section so the bridge can run audit-mode redaction on egress.
@@ -6903,6 +6911,10 @@ function moduleHintFromActive(root) {
 function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
   const meta = {
     holoindex_status: usedOfflineFallback ? 'offline_fallback' : 'unknown',
+    requested_retrieval_mode: usedOfflineFallback ? 'semantic' : 'unknown',
+    retrieval_mode: usedOfflineFallback ? 'lexical' : 'unknown',
+    embedding_backend: usedOfflineFallback ? 'none' : 'unknown',
+    routing_active: false,
     wsp_hits: 'unknown',
     code_hits: 'unknown',
     skill_hits: 'unknown',
@@ -6946,6 +6958,13 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     const bundleMeta = data.task_retrieval && data.task_retrieval.metadata ? data.task_retrieval.metadata : {};
     const recall = evaluateTargetRecall(taskText, data);
     meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'bundle_json_ok';
+    meta.retrieval_mode = usedOfflineFallback
+      ? 'lexical'
+      : String(bundleMeta.retrieval_mode || bundleMeta.mode || 'unknown');
+    meta.embedding_backend = usedOfflineFallback
+      ? 'none'
+      : String(bundleMeta.embedding_backend || 'unknown');
+    meta.routing_active = usedOfflineFallback ? false : bundleMeta.routing_active === true;
     meta.wsp_hits = Number(bundleMeta.wsp_count || 0);
     meta.code_hits = Number(bundleMeta.code_count || 0);
     meta.skill_hits = bundleMeta.skill_count !== undefined ? Number(bundleMeta.skill_count) : 'unknown';
@@ -6986,6 +7005,30 @@ function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
     meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'parse_error';
   }
   return meta;
+}
+
+// REDDOG_HOLO_SEMANTIC_FIRST_PHASE1: semantic retrieval is the production
+// default. Lexical retrieval remains an explicit compute-saving opt-down for
+// tests/emergency operation, never an implicit claim of semantic coverage.
+function resolveHoloRetrievalMode(envLike) {
+  const source = envLike && typeof envLike === 'object' ? envLike : process.env;
+  const requested = String(source.REDDOG_HOLO_RETRIEVAL_MODE || 'semantic').trim().toLowerCase();
+  return requested === 'lexical' ? 'lexical' : 'semantic';
+}
+
+function buildHoloQueryEnv(envLike, retrievalMode) {
+  const env = Object.assign({}, envLike && typeof envLike === 'object' ? envLike : process.env, {
+    HOLOINDEX_QUERY_READONLY: '1'
+  });
+  if (retrievalMode === 'lexical') {
+    env.HOLO_SKIP_MODEL = '1';
+  } else {
+    // A parent-shell model-skip knob must not silently downgrade a semantic-first
+    // RedDog audit. Preserve HOLO_OFFLINE when the operator set it: cached models
+    // can still run semantically, while a missing cache degrades without network I/O.
+    delete env.HOLO_SKIP_MODEL;
+  }
+  return env;
 }
 
 // REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3): when slice-1's
@@ -7049,18 +7092,25 @@ function classifyDirectReadFetchError(err) {
 function holoIndexOutput(root, taskText, maxChars) {
   const query = String(taskText || '').replace(/\s+/g, ' ').trim().slice(0, 500) || 'FoundUps RedDog WSP_00 WSP_97 WSP_15 current task';
   const moduleHint = moduleHintFromActive(root);
+  const requestedMode = resolveHoloRetrievalMode(process.env);
+  const env = buildHoloQueryEnv(process.env, requestedMode);
   try {
-    const env = Object.assign({}, process.env, { HOLO_SKIP_MODEL: '1', HOLOINDEX_QUERY_READONLY: '1' });
     const baseArgs = ['-B', 'holo_index.py', '--bundle-json', '--search', query, '--bundle-module-hint', moduleHint, '--limit', '5', '--quiet-root-alerts'];
     let output = cp.execFileSync('python', baseArgs, {
       cwd: root,
       env,
       encoding: 'utf8',
-      timeout: 25000,
+      timeout: requestedMode === 'semantic' ? 60000 : 25000,
       maxBuffer: Math.max(maxChars * 4, 65536),
       windowsHide: true
     });
     let meta = holoIndexMetaFromBundle(output, false, taskText);
+    meta.requested_retrieval_mode = requestedMode;
+    if (requestedMode === 'semantic' && meta.retrieval_mode !== 'semantic') {
+      const semanticError = new Error('HoloIndex semantic retrieval unavailable');
+      semanticError.code = 'HOLO_SEMANTIC_UNAVAILABLE';
+      throw semanticError;
+    }
     // Direct-read fallback: if a required-target list was present and any target
     // is missing from the semantic bundle, re-run once asking the Python layer
     // to fetch exactly those paths, then re-evaluate recall on the enriched bundle.
@@ -7100,6 +7150,12 @@ function holoIndexOutput(root, taskText, maxChars) {
           });
           output = enriched;
           meta = holoIndexMetaFromBundle(enriched, false, taskText);
+          meta.requested_retrieval_mode = requestedMode;
+          if (requestedMode === 'semantic' && meta.retrieval_mode !== 'semantic') {
+            const semanticError = new Error('HoloIndex semantic retrieval unavailable after enriched fetch');
+            semanticError.code = 'HOLO_SEMANTIC_UNAVAILABLE';
+            throw semanticError;
+          }
         } catch (fetchErr) {
           // Fetch failure must not abort recall; keep the pre-fetch bundle+meta,
           // but classify + surface the cause so it is never silent again.
@@ -7124,15 +7180,17 @@ function holoIndexOutput(root, taskText, maxChars) {
     };
   } catch (bundleErr) {
     try {
+      const fallbackEnv = buildHoloQueryEnv(process.env, 'lexical');
       const output = cp.execFileSync('python', ['-B', 'holo_index.py', '--offline', '--search', query, '--limit', '5'], {
         cwd: root,
-        env,
+        env: fallbackEnv,
         encoding: 'utf8',
         timeout: 20000,
         maxBuffer: Math.max(maxChars * 4, 65536),
         windowsHide: true
       });
       const meta = holoIndexMetaFromBundle(output, true, query);
+      meta.requested_retrieval_mode = requestedMode;
       return {
         output: String(output || '').slice(0, maxChars),
         quality: 'HoloIndex bundle-json failed; offline lexical fallback used. Treat protocol coverage as NEEDS_VERIFICATION and propose re-index/bundle repair if WSP hits are missing.',
@@ -7214,10 +7272,21 @@ function summarizeHoloBundle(output) {
     const meta = data.task_retrieval && data.task_retrieval.metadata ? data.task_retrieval.metadata : {};
     const wspCount = Number(meta.wsp_count || 0);
     const codeCount = Number(meta.code_count || 0);
+    const retrievalMode = String(meta.retrieval_mode || meta.mode || 'unknown');
+    const embeddingBackend = String(meta.embedding_backend || 'unknown');
     const missing = data.structured_memory && Array.isArray(data.structured_memory.missing_required)
       ? data.structured_memory.missing_required
       : [];
-    const parts = ['HoloIndex bundle-json ok', 'wsp=' + wspCount, 'code=' + codeCount];
+    const parts = [
+      'HoloIndex bundle-json ok',
+      'mode=' + retrievalMode,
+      'backend=' + embeddingBackend,
+      'wsp=' + wspCount,
+      'code=' + codeCount
+    ];
+    if (retrievalMode !== 'semantic') {
+      parts.push('Semantic retrieval was not used; treat intent/role coverage as NEEDS_VERIFICATION.');
+    }
     if (missing.length) {
       parts.push('missing_required=' + missing.join(','));
     }
@@ -7777,6 +7846,9 @@ module.exports = {
   extractTargetTokensFromLine,
   holoIndexMetaFromBundle,
   holoIndexOutput,
+  resolveHoloRetrievalMode,
+  buildHoloQueryEnv,
+  summarizeHoloBundle,
   buildMustIncludeArgs,
   classifyDirectReadFetchError,
   buildDirectReadContentSection,

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,13 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-18 - REDDOG_HOLO_SEMANTIC_FIRST_PHASE1
+
+- Asserted semantic is the production default and lexical retrieval requires explicit `REDDOG_HOLO_RETRIEVAL_MODE=lexical` opt-down.
+- Asserted semantic mode removes inherited `HOLO_SKIP_MODEL`, preserves an operator-set `HOLO_OFFLINE` network boundary, and keeps the read-only query guard.
+- Asserted requested mode, actual retrieval mode, embedding backend, and routing state reach RedDog metadata, scorecards, and summaries.
+- Simulated primary semantic failure and proved exactly one offline lexical fallback receives a valid scoped environment, closing the previous `env` block-scope failure.
+- The exhaustive contract suite opts down to lexical for deterministic runtime; a separate live smoke proves the production semantic path and `sentence_transformers` receipt.
+
 ## 2026-07-18 - REDDOG_FUSION_KIMI_K3_PHASE1
 
 - Asserted the 0.4.1 package/runtime version lock and default Kimi K3 panel membership.

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -4,6 +4,11 @@ const assert = require('assert');
 const cp = require('child_process');
 const Module = require('module');
 
+// Keep the exhaustive contract suite fast and deterministic. Production has
+// no such override and therefore exercises RedDog's semantic-first default;
+// a dedicated live semantic smoke runs separately from this suite.
+process.env.REDDOG_HOLO_RETRIEVAL_MODE = 'lexical';
+
 const fixtures = require('./fixtures');
 
 const root = path.resolve(__dirname, '..', '..', '..');
@@ -198,8 +203,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.1', 'package version must be 0.4.1');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.1'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.2', 'package version must be 0.4.2');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.2'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -219,7 +224,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.1', 'README version mismatch');
+includes(readme, 'Version: 0.4.2', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -259,6 +264,8 @@ includes(extensionJs, 'WSP_15', 'WSP_15 requirement missing');
 includes(extensionJs, 'WSP_97', 'WSP_97 requirement missing');
 includes(extensionJs, 'Every finding must include a proposed fix', 'proposed-fix contract missing');
 includes(extensionJs, 'HOLO_SKIP_MODEL', 'HoloIndex fastpath env missing');
+includes(extensionJs, 'REDDOG_HOLO_RETRIEVAL_MODE', 'HoloIndex explicit lexical opt-down missing');
+includes(extensionJs, "delete env.HOLO_SKIP_MODEL", 'semantic-first path must clear inherited lexical override');
 includes(extensionJs, '--bundle-json', 'bundle-json retrieval missing');
 includes(extensionJs, '--offline', 'offline fallback missing');
 includes(extensionJs, 'Skillz/Wardrobe/Rolodex discovery', 'Skillz/Rolodex discovery context missing');
@@ -449,6 +456,72 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
 const orchestrator = require(path.join(extDir, 'extension.js'));
 Module._resolveFilename = originalResolve;
+
+// REDDOG_HOLO_SEMANTIC_FIRST_PHASE1: mode selection and truth receipts.
+assert.strictEqual(orchestrator.resolveHoloRetrievalMode({}), 'semantic', 'HSF-001: production default must be semantic');
+assert.strictEqual(orchestrator.resolveHoloRetrievalMode({ REDDOG_HOLO_RETRIEVAL_MODE: 'lexical' }), 'lexical', 'HSF-001: lexical mode must require explicit opt-down');
+assert.strictEqual(orchestrator.resolveHoloRetrievalMode({ REDDOG_HOLO_RETRIEVAL_MODE: 'unexpected' }), 'semantic', 'HSF-001: invalid modes must fail to semantic');
+const hsfSemanticEnv = orchestrator.buildHoloQueryEnv({ HOLO_SKIP_MODEL: '1', HOLO_OFFLINE: '1', KEEP_ME: 'yes' }, 'semantic');
+assert.strictEqual(hsfSemanticEnv.HOLO_SKIP_MODEL, undefined, 'HSF-002: semantic mode must clear inherited HOLO_SKIP_MODEL');
+assert.strictEqual(hsfSemanticEnv.HOLO_OFFLINE, '1', 'HSF-002: semantic mode must preserve the operator offline/network boundary');
+assert.strictEqual(hsfSemanticEnv.HOLOINDEX_QUERY_READONLY, '1', 'HSF-002: semantic queries remain read-only');
+assert.strictEqual(hsfSemanticEnv.KEEP_ME, 'yes', 'HSF-002: unrelated environment must survive');
+const hsfLexicalEnv = orchestrator.buildHoloQueryEnv({}, 'lexical');
+assert.strictEqual(hsfLexicalEnv.HOLO_SKIP_MODEL, '1', 'HSF-003: explicit lexical opt-down must set HOLO_SKIP_MODEL');
+assert.strictEqual(hsfLexicalEnv.HOLOINDEX_QUERY_READONLY, '1', 'HSF-003: lexical queries remain read-only');
+
+const hsfSemanticBundle = JSON.stringify({
+  task_retrieval: {
+    code_hits: [],
+    metadata: {
+      retrieval_mode: 'semantic',
+      embedding_backend: 'sentence_transformers',
+      routing_active: false,
+      code_count: 3,
+      wsp_count: 2
+    }
+  }
+});
+const hsfMeta = orchestrator.holoIndexMetaFromBundle(hsfSemanticBundle, false, 'semantic audit');
+assert.strictEqual(hsfMeta.retrieval_mode, 'semantic', 'HSF-004: actual retrieval mode must enter RedDog telemetry');
+assert.strictEqual(hsfMeta.embedding_backend, 'sentence_transformers', 'HSF-004: actual embedding backend must enter RedDog telemetry');
+assert.strictEqual(hsfMeta.routing_active, false, 'HSF-004: routing truth must enter RedDog telemetry');
+const hsfScorecard = orchestrator.extractHoloIndexScorecard('wsp_holo', hsfMeta);
+const hsfLines = orchestrator.formatHoloIndexScorecardLines(hsfScorecard).join('\n');
+includes(hsfLines, '- retrieval_mode: semantic', 'HSF-004: scorecard must expose semantic retrieval truth');
+includes(hsfLines, '- embedding_backend: sentence_transformers', 'HSF-004: scorecard must expose backend truth');
+const hsfSummary = orchestrator.summarizeHoloBundle(hsfSemanticBundle);
+includes(hsfSummary, 'mode=semantic', 'HSF-005: bundle summary must expose semantic mode');
+includes(hsfSummary, 'backend=sentence_transformers', 'HSF-005: bundle summary must expose backend');
+
+// HSF-006: prove the pre-existing block-scope defect is closed. A failed
+// bundle must reach the lexical fallback with a valid read-only environment.
+const hsfOriginalExecFileSync = cp.execFileSync;
+const hsfOriginalMode = process.env.REDDOG_HOLO_RETRIEVAL_MODE;
+let hsfExecCalls = 0;
+try {
+  process.env.REDDOG_HOLO_RETRIEVAL_MODE = 'semantic';
+  cp.execFileSync = function(_exe, args, options) {
+    hsfExecCalls += 1;
+    if (hsfExecCalls === 1) {
+      const err = new Error('simulated semantic bundle failure');
+      err.code = 'SIMULATED';
+      throw err;
+    }
+    assert(args.includes('--offline'), 'HSF-006: second call must be the offline lexical fallback');
+    assert.strictEqual(options.env.HOLO_SKIP_MODEL, '1', 'HSF-006: fallback must receive a valid lexical environment');
+    assert.strictEqual(options.env.HOLOINDEX_QUERY_READONLY, '1', 'HSF-006: fallback must remain read-only');
+    return '[OFFLINE] simulated lexical result';
+  };
+  const hsfFallback = orchestrator.holoIndexOutput(root, 'semantic fallback contract', 18000);
+  assert.strictEqual(hsfExecCalls, 2, 'HSF-006: semantic failure must invoke exactly one lexical fallback');
+  assert.strictEqual(hsfFallback.meta.holoindex_status, 'offline_fallback', 'HSF-006: fallback status must be truthful');
+  assert.strictEqual(hsfFallback.meta.requested_retrieval_mode, 'semantic', 'HSF-006: receipt must retain the requested mode');
+  assert.strictEqual(hsfFallback.meta.retrieval_mode, 'lexical', 'HSF-006: receipt must expose actual lexical behavior');
+} finally {
+  cp.execFileSync = hsfOriginalExecFileSync;
+  process.env.REDDOG_HOLO_RETRIEVAL_MODE = hsfOriginalMode;
+}
 
 const ultra = orchestrator.classifyTaskForRedDog('Audit OAuth auth secrets on live runtime deploy path', 'auto', 'reddog_architect');
 assert.strictEqual(ultra.tier, 'ULTRA', 'security/auth prompts must classify ULTRA');
@@ -1092,7 +1165,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.1', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.2', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2584,7 +2657,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.1'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.2'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2598,7 +2671,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.1'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.2'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2610,7 +2683,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.1'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.2'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3489,7 +3562,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.1' } }
+      ? { id, packageJSON: { version: '0.4.2' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({

--- a/modules/infrastructure/wre_core/INTERFACE.md
+++ b/modules/infrastructure/wre_core/INTERFACE.md
@@ -936,6 +936,11 @@ class MemoryBundle:
     tier0_complete: bool
     preflight_passed: bool
     stubs_created: List[str]
+    requested_retrieval_mode: str
+    retrieval_mode: str
+    embedding_backend: str
+    routing_active: bool
+    semantic_requirement_met: bool
 
 class MemoryPreflightGuard:
     """
@@ -949,6 +954,7 @@ class MemoryPreflightGuard:
         WRE_MEMORY_PREFLIGHT_ENABLED: Enable preflight (default: true)
         WRE_MEMORY_AUTOSTUB_TIER0: Auto-create stubs (default: false)
         WRE_MEMORY_ALLOW_DEGRADED: Allow with warnings (default: false)
+        WRE_HOLO_RETRIEVAL_MODE: semantic (default) or explicit lexical opt-down
     """
 
     def __init__(self, project_root: Optional[Path] = None) -> None:
@@ -971,7 +977,7 @@ class MemoryPreflightGuard:
             MemoryBundle with retrieval results
 
         Raises:
-            MemoryPreflightError: If Tier-0 missing and autostub disabled
+            MemoryPreflightError: If Tier-0 is missing or required semantic retrieval degraded
         """
 
 class MemoryPreflightError(Exception):

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -2,6 +2,21 @@
 
 ## Chronological Change Log
 
+### [2026-07-18] - WRE_HOLO_SEMANTIC_PREFLIGHT_PHASE1
+
+**WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15
+(Priority), WSP 50 (Pre-Action), WSP 87 (HoloIndex), WSP 97 (Truth
+Boundary), WSP 22 (ModLog)
+
+**Deliverable**:
+- Replaced the canonical memory preflight's unconditional `HOLO_SKIP_MODEL=1` policy with semantic-first read-only bundle retrieval; operator-set `HOLO_OFFLINE` remains intact so semantic use of cached models never broadens network authority.
+- Added explicit `WRE_HOLO_RETRIEVAL_MODE=lexical` opt-down for bounded degraded/test operation.
+- Added requested/actual retrieval mode, embedding backend, routing state, and semantic requirement verdict to `MemoryBundle` and serialized telemetry.
+- Preflight now fails closed when semantic retrieval was requested but degraded, unless `WRE_MEMORY_ALLOW_DEGRADED=true` explicitly authorizes the truth-labelled degraded path.
+- No HoloIndex mutation, reindex, worker dispatch, repo write, PR, merge, or PatternMemory promotion is added.
+
+**WSP_15**: 3 + 4 + 4 + 4 = 15 (P1).
+
 ### [2026-07-16] - WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1
 
 **WSP Protocol References**: WSP 00 (Operational Grounding), WSP 15

--- a/modules/infrastructure/wre_core/README.md
+++ b/modules/infrastructure/wre_core/README.md
@@ -38,13 +38,16 @@ wre_core/
 ### Memory Preflight Guard (WSP_CORE Enforcement)
 The `memory_preflight.py` module enforces the WSP_CORE Memory System by:
 - Running tiered retrieval (Tier 0 -> 1 -> 2) before code-changing operations
+- Running HoloIndex semantic retrieval by default, while preserving an operator-set offline/network boundary, and receipting the requested mode, actual mode, embedding backend, routing state, and semantic requirement verdict
 - Blocking if Tier-0 artifacts (README.md, INTERFACE.md) are missing
+- Blocking when semantic retrieval was requested but degraded, unless degraded operation was explicitly authorized
 - Auto-stubbing missing Tier-0 artifacts when `WRE_MEMORY_AUTOSTUB_TIER0=true`
 
 Environment flags:
 - `WRE_MEMORY_PREFLIGHT_ENABLED` (default: true)
 - `WRE_MEMORY_AUTOSTUB_TIER0` (default: false)
 - `WRE_MEMORY_ALLOW_DEGRADED` (default: false)
+- `WRE_HOLO_RETRIEVAL_MODE` (`semantic` by default; explicit `lexical` opt-down)
 
 ### Skills Entry Point (First Principles)
 **Problem (Observed):**

--- a/modules/infrastructure/wre_core/recursive_improvement/src/memory_preflight.py
+++ b/modules/infrastructure/wre_core/recursive_improvement/src/memory_preflight.py
@@ -22,6 +22,7 @@ Environment Variables:
     WRE_MEMORY_PREFLIGHT_ENABLED: Enable preflight checks (default: true)
     WRE_MEMORY_AUTOSTUB_TIER0: Auto-create missing Tier-0 stubs (default: false)
     WRE_MEMORY_ALLOW_DEGRADED: Allow proceed with missing artifacts (default: false)
+    WRE_HOLO_RETRIEVAL_MODE: semantic (default) or explicit lexical opt-down
 """
 
 import os
@@ -112,6 +113,11 @@ class MemoryBundle:
     tier0_complete: bool
     preflight_passed: bool
     stubs_created: List[str] = field(default_factory=list)
+    requested_retrieval_mode: str = "unknown"
+    retrieval_mode: str = "unknown"
+    embedding_backend: str = "unknown"
+    routing_active: bool = False
+    semantic_requirement_met: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -137,7 +143,34 @@ class MemoryBundle:
             "tier0_complete": self.tier0_complete,
             "preflight_passed": self.preflight_passed,
             "stubs_created": self.stubs_created,
+            "requested_retrieval_mode": self.requested_retrieval_mode,
+            "retrieval_mode": self.retrieval_mode,
+            "embedding_backend": self.embedding_backend,
+            "routing_active": self.routing_active,
+            "semantic_requirement_met": self.semantic_requirement_met,
         }
+
+
+def _resolve_holo_retrieval_mode(env: Optional[Dict[str, str]] = None) -> str:
+    """Return the governed WRE retrieval mode (semantic unless explicitly lexical)."""
+    source = env if env is not None else os.environ
+    requested = str(source.get("WRE_HOLO_RETRIEVAL_MODE", "semantic")).strip().lower()
+    return "lexical" if requested == "lexical" else "semantic"
+
+
+def _build_holo_query_env(
+    source_env: Optional[Dict[str, str]] = None,
+    retrieval_mode: str = "semantic",
+) -> Dict[str, str]:
+    """Build a read-only HoloIndex environment without silent mode inheritance."""
+    env = dict(source_env if source_env is not None else os.environ)
+    env["HOLO_SILENT"] = "1"
+    env["HOLOINDEX_QUERY_READONLY"] = "1"
+    if retrieval_mode == "lexical":
+        env["HOLO_SKIP_MODEL"] = "1"
+    else:
+        env.pop("HOLO_SKIP_MODEL", None)
+    return env
 
 
 # =============================================================================
@@ -214,9 +247,15 @@ class MemoryPreflightError(Exception):
         super().__init__(message)
         self.missing_files = missing_files
         self.module_path = module_path
-        self.required_action = (
-            "Create Tier-0 stubs or enable WRE_MEMORY_AUTOSTUB_TIER0=true"
-        )
+        if any(str(item).startswith("Semantic retrieval:") for item in missing_files):
+            self.required_action = (
+                "Restore the cached embedding model/dependencies, or explicitly set "
+                "WRE_MEMORY_ALLOW_DEGRADED=true for a truth-labelled degraded run"
+            )
+        else:
+            self.required_action = (
+                "Create Tier-0 stubs or enable WRE_MEMORY_AUTOSTUB_TIER0=true"
+            )
 
 
 # =============================================================================
@@ -316,12 +355,28 @@ class MemoryPreflightGuard:
                 tier0_complete=tier0_complete,
                 preflight_passed=preflight_passed,
                 stubs_created=stubs_created,
+                requested_retrieval_mode=bundle.requested_retrieval_mode,
+                retrieval_mode=bundle.retrieval_mode,
+                embedding_backend=bundle.embedding_backend,
+                routing_active=bundle.routing_active,
+                semantic_requirement_met=bundle.semantic_requirement_met,
             )
+
+            semantic_ok = bundle.semantic_requirement_met or self.allow_degraded
+            out.preflight_passed = bool(out.preflight_passed and semantic_ok)
 
             self._emit_telemetry(out)
 
-            if not preflight_passed:
+            if not out.preflight_passed:
                 tier0_missing = [m for m in missing_required if "Tier-0" in m]
+                if tier0_complete and not bundle.semantic_requirement_met:
+                    raise MemoryPreflightError(
+                        "HoloIndex semantic retrieval was required but the bundle "
+                        f"reported mode={bundle.retrieval_mode!r}, "
+                        f"backend={bundle.embedding_backend!r}",
+                        missing_files=["Semantic retrieval: unavailable"],
+                        module_path=module_path,
+                    )
                 raise MemoryPreflightError(
                     f"Tier-0 artifacts missing for {module_path}: {tier0_missing}",
                     missing_files=tier0_missing,
@@ -360,6 +415,11 @@ class MemoryPreflightGuard:
             tier0_complete=tier0_complete,
             preflight_passed=preflight_passed,
             stubs_created=stubs_created,
+            requested_retrieval_mode="filesystem",
+            retrieval_mode="filesystem",
+            embedding_backend="none",
+            routing_active=False,
+            semantic_requirement_met=True,
         )
 
         # Log telemetry
@@ -394,11 +454,8 @@ class MemoryPreflightGuard:
             "5",
             "--quiet-root-alerts",
         ]
-        env = os.environ.copy()
-        env.setdefault("HOLO_SILENT", "1")
-        # 0102 speed knob: prefer lexical retrieval for bundle-json preflight.
-        # This avoids heavy Chroma/model imports when Tier-0 enforcement is the primary goal.
-        env.setdefault("HOLO_SKIP_MODEL", "1")
+        requested_mode = _resolve_holo_retrieval_mode(os.environ)
+        env = _build_holo_query_env(os.environ, requested_mode)
 
         try:
             proc = subprocess.run(
@@ -432,6 +489,16 @@ class MemoryPreflightGuard:
                 missing_files=["Tier-0: (unknown)"],
                 module_path=module_path,
             )
+
+        retrieval_meta = (payload.get("task_retrieval") or {}).get("metadata") or {}
+        retrieval_mode = str(
+            retrieval_meta.get("retrieval_mode")
+            or retrieval_meta.get("mode")
+            or "unknown"
+        )
+        embedding_backend = str(retrieval_meta.get("embedding_backend") or "unknown")
+        routing_active = retrieval_meta.get("routing_active") is True
+        semantic_requirement_met = requested_mode != "semantic" or retrieval_mode == "semantic"
 
         # Translate structured_memory.artifacts → ArtifactInfo list.
         artifacts: List[ArtifactInfo] = []
@@ -472,6 +539,11 @@ class MemoryPreflightGuard:
             tier0_complete=True,
             preflight_passed=True,
             stubs_created=[],
+            requested_retrieval_mode=requested_mode,
+            retrieval_mode=retrieval_mode,
+            embedding_backend=embedding_backend,
+            routing_active=routing_active,
+            semantic_requirement_met=semantic_requirement_met,
         )
 
     def _retrieve_tiered_artifacts(
@@ -631,6 +703,11 @@ class MemoryPreflightGuard:
             "missing_optional_count": len(bundle.missing_optional),
             "stubs_created": bundle.stubs_created,
             "duplication_rate_proxy": bundle.duplication_rate_proxy,
+            "requested_retrieval_mode": bundle.requested_retrieval_mode,
+            "retrieval_mode": bundle.retrieval_mode,
+            "embedding_backend": bundle.embedding_backend,
+            "routing_active": bundle.routing_active,
+            "semantic_requirement_met": bundle.semantic_requirement_met,
         }
 
         # Log as JSON for machine parsing
@@ -658,6 +735,11 @@ class MemoryPreflightGuard:
             tier0_complete=True,
             preflight_passed=True,
             stubs_created=[],
+            requested_retrieval_mode="disabled",
+            retrieval_mode="disabled",
+            embedding_backend="none",
+            routing_active=False,
+            semantic_requirement_met=True,
         )
 
 

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,5 +1,13 @@
 # TestModLog - wre_core/tests
 
+## 2026-07-18: WRE_HOLO_SEMANTIC_PREFLIGHT_PHASE1
+
+**New** `test_memory_preflight_semantic_retrieval.py`:
+- Proves semantic is the default, inherited model-skip is removed, and an operator-set offline/network boundary is preserved.
+- Proves explicit lexical opt-down remains read-only and sets `HOLO_SKIP_MODEL=1`.
+- Proves Holo bundle mode/backend truth reaches `MemoryBundle` serialization.
+- Proves a requested semantic retrieval that degrades to lexical fails closed unless `WRE_MEMORY_ALLOW_DEGRADED` is explicitly active.
+
 ## 2026-07-16: WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1
 
 **Slice**: `WRE_INDEPENDENT_EVIDENCE_PRODUCER_RUNTIME_PHASE1`

--- a/modules/infrastructure/wre_core/tests/test_memory_preflight_semantic_retrieval.py
+++ b/modules/infrastructure/wre_core/tests/test_memory_preflight_semantic_retrieval.py
@@ -1,0 +1,135 @@
+"""Semantic-first HoloIndex contract for WRE memory preflight."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from modules.infrastructure.wre_core.recursive_improvement.src import memory_preflight as mp
+
+
+def _bundle_payload(mode: str, backend: str) -> str:
+    return json.dumps(
+        {
+            "ok": True,
+            "task_retrieval": {
+                "metadata": {
+                    "retrieval_mode": mode,
+                    "embedding_backend": backend,
+                    "routing_active": False,
+                }
+            },
+            "structured_memory": {
+                "artifacts": [
+                    {
+                        "relative_path": "README.md",
+                        "path": "modules/demo/README.md",
+                        "tier": 0,
+                        "required": True,
+                        "exists": True,
+                    },
+                    {
+                        "relative_path": "INTERFACE.md",
+                        "path": "modules/demo/INTERFACE.md",
+                        "tier": 0,
+                        "required": True,
+                        "exists": True,
+                    },
+                ]
+            },
+        }
+    )
+
+
+def test_semantic_mode_is_default_and_clears_inherited_lexical_flags():
+    assert mp._resolve_holo_retrieval_mode({}) == "semantic"
+    assert mp._resolve_holo_retrieval_mode({"WRE_HOLO_RETRIEVAL_MODE": "invalid"}) == "semantic"
+
+    env = mp._build_holo_query_env(
+        {"HOLO_SKIP_MODEL": "1", "HOLO_OFFLINE": "1", "KEEP_ME": "yes"},
+        "semantic",
+    )
+
+    assert "HOLO_SKIP_MODEL" not in env
+    assert env["HOLO_OFFLINE"] == "1"
+    assert env["HOLOINDEX_QUERY_READONLY"] == "1"
+    assert env["HOLO_SILENT"] == "1"
+    assert env["KEEP_ME"] == "yes"
+
+
+def test_explicit_lexical_mode_sets_skip_model():
+    assert mp._resolve_holo_retrieval_mode({"WRE_HOLO_RETRIEVAL_MODE": "lexical"}) == "lexical"
+    env = mp._build_holo_query_env({}, "lexical")
+    assert env["HOLO_SKIP_MODEL"] == "1"
+    assert env["HOLOINDEX_QUERY_READONLY"] == "1"
+
+
+def test_holo_bundle_receipts_semantic_backend(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=_bundle_payload("semantic", "sentence_transformers"),
+            stderr="",
+        )
+
+    monkeypatch.delenv("WRE_HOLO_RETRIEVAL_MODE", raising=False)
+    monkeypatch.setenv("HOLO_SKIP_MODEL", "1")
+    monkeypatch.setenv("HOLO_OFFLINE", "1")
+    monkeypatch.setattr(mp.subprocess, "run", fake_run)
+
+    bundle = mp.MemoryPreflightGuard(tmp_path)._retrieve_via_holo_bundle(
+        "modules/demo", "semantic architecture retrieval"
+    )
+
+    assert "--bundle-json" in captured["cmd"]
+    assert "HOLO_SKIP_MODEL" not in captured["env"]
+    assert captured["env"]["HOLO_OFFLINE"] == "1"
+    assert bundle.requested_retrieval_mode == "semantic"
+    assert bundle.retrieval_mode == "semantic"
+    assert bundle.embedding_backend == "sentence_transformers"
+    assert bundle.semantic_requirement_met is True
+    assert bundle.to_dict()["semantic_requirement_met"] is True
+
+
+def test_preflight_fails_closed_when_semantic_request_degrades(monkeypatch, tmp_path):
+    module_dir = tmp_path / "modules" / "demo"
+    module_dir.mkdir(parents=True)
+    (module_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (module_dir / "INTERFACE.md").write_text("# Interface\n", encoding="utf-8")
+
+    degraded = mp.MemoryBundle(
+        module_path="modules/demo",
+        artifacts=[
+            mp.ArtifactInfo(str(module_dir / "README.md"), "modules/demo/README.md", 0, True, True),
+            mp.ArtifactInfo(str(module_dir / "INTERFACE.md"), "modules/demo/INTERFACE.md", 0, True, True),
+        ],
+        missing_required=[],
+        missing_optional=[],
+        duplication_rate_proxy=0.0,
+        ordering_confidence=None,
+        staleness_risk=None,
+        tier0_complete=True,
+        preflight_passed=True,
+        requested_retrieval_mode="semantic",
+        retrieval_mode="lexical",
+        embedding_backend="none",
+        semantic_requirement_met=False,
+    )
+    guard = mp.MemoryPreflightGuard(tmp_path)
+    monkeypatch.setattr(guard, "_retrieve_via_holo_bundle", lambda **_kwargs: degraded)
+
+    with pytest.raises(mp.MemoryPreflightError, match="semantic retrieval was required") as exc_info:
+        guard.run_preflight("modules/demo", "semantic audit")
+    assert "Restore the cached embedding model" in exc_info.value.required_action
+
+    guard.allow_degraded = True
+    receipt = guard.run_preflight("modules/demo", "semantic audit")
+    assert receipt.preflight_passed is True
+    assert receipt.semantic_requirement_met is False
+    assert receipt.retrieval_mode == "lexical"


### PR DESCRIPTION
## What changed

- makes RedDog HoloIndex retrieval semantic-first instead of unconditionally injecting `HOLO_SKIP_MODEL=1`
- makes WRE canonical memory preflight semantic-first so recursive workers use the same governed retrieval contract
- preserves an operator-set `HOLO_OFFLINE=1` network boundary while clearing inherited model-skip state
- records requested mode, actual retrieval mode, embedding backend, routing state, and semantic-requirement verdict in RedDog scorecards and WRE `MemoryBundle` telemetry
- adds explicit `REDDOG_HOLO_RETRIEVAL_MODE=lexical` and `WRE_HOLO_RETRIEVAL_MODE=lexical` opt-downs for deterministic tests/emergency compute conservation
- fails WRE preflight closed when semantic retrieval was required but degraded, unless `WRE_MEMORY_ALLOW_DEGRADED=true` explicitly authorizes a truth-labelled degraded run
- fixes RedDog's lexical recovery path, which previously referenced a block-scoped `env` after the primary bundle call threw
- bumps RedDog 0.4.1 to 0.4.2 and updates module contracts/ModLogs

## Root cause

HoloIndex itself was not broken. The cached `all-MiniLM-L6-v2`, SentenceTransformers, ChromaDB, ONNX Runtime, and Torch stack all loaded successfully. RedDog and WRE memory preflight were forcing lexical mode by policy with `HOLO_SKIP_MODEL=1`; additionally, RedDog's exception fallback could not access the environment object declared inside the failed `try` block.

## Live proof

With the parent shell deliberately set to both `HOLO_SKIP_MODEL=1` and `HOLO_OFFLINE=1`:

- RedDog completed in 12.52s with `requested_retrieval_mode=semantic`, `retrieval_mode=semantic`, `embedding_backend=sentence_transformers`, 5 code hits, and 5 WSP hits
- WRE memory preflight completed in 16.03s with semantic requirement met and Tier-0 complete
- the operator offline/network boundary remained active throughout

## Validation

- 81 relevant HoloIndex/RedDog/WRE regression tests passed
- 4 new WRE semantic-preflight tests passed
- complete RedDog extension contract passed
- Python compile, Node syntax, `git diff --check`, and WSP_00 awakening passed

## Baseline outside this PR

`holo_index/tests/test_phase3_wre_integration.py` has four stale failures against already-removed HoloDAE APIs (`SkillExecutor.check_git_health`, `_check_wre_triggers`, `_monitoring_loop`). This branch does not touch those APIs; they are not included as unrelated repair work.

## Truth boundary

This restores governed semantic retrieval for RedDog and WRE preflight. It does not reindex HoloIndex, mutate PatternMemory, add network authority, dispatch workers, or claim the entire autonomous recursion stack is production-complete.