### PR TITLE
fix(reddog): authenticate resident control receipts

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,34 @@
 # FoundUps Agent - Development Log
 
+## [2026-07-18] RedDog Resident Control Receipt Truth/Auth Phase 1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 62, 71, 91, 97
+
+- Replaced self-issued resident control summaries with full-digest v2 receipts
+  that derive execution effects, bind child receipt IDs, chain predecessors,
+  reject replay, and require isolated Ed25519 attestation in production.
+- Bound live proof to the exact authority profile, signer key epoch, and
+  consensus receipt; legacy v1 rows remain display-only migration evidence.
+- Serialized chain-store compare-and-swap across processes and retained exact
+  OpenClaw completion, requeue, and failure counts in the control result.
+- Authenticated every v2 predecessor against the pinned authority profile,
+  signed the signer audit attestation separately, and bound exact child
+  execution receipt/evidence cardinality into each control receipt.
+- Unified direct OpenClaw claims and resident-main cycles under the same
+  cross-process operation lock; distinct concurrent cycles now serialize
+  without losing either signed append.
+- Required the isolated signer to match every control receipt against its own
+  configured principal, key epoch, consensus, promoted-profile, and source-
+  receipt policy before signing; a signer-owned monotonic anchor rejects
+  resident-state rollback and cross-cycle child-evidence reuse.
+- Made retention, append, head, and chain-result persistence fail closed, and
+  split the modified resident/OpenClaw paths into WSP 62-bounded helpers.
+- Derived parent process/shell totals exclusively from digest-bound child
+  evidence, recorded runner exceptions as effects-unverified, required durable
+  AgentDB state transitions, and fsynced authority-store directory renames.
+- No authority policy, worker permission, merge authority, reward settlement,
+  HoloIndex write, or extension runtime surface was expanded.
+
 ## [2026-07-18] HoloIndex / RedDog Operational Truth Boundary POC Phase 1
 
 **WSP Protocol**: WSP 00, 05, 06, 15, 22, 34, 50, 62, 64, 81, 84, 87, 96, 97

--- a/main.py
+++ b/main.py
@@ -3017,6 +3017,9 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         if authority_supply.accepted and authority_supply.output_path:
             authority_profile_source_path = authority_supply.output_path
             os.environ["REDDOG_AUTHORITY_PROFILE_SOURCE_PATH"] = authority_profile_source_path
+            os.environ["REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID"] = str(
+                authority_supply.authority_profile_source_receipt_id or ""
+            )
         elif authority_supply_enforced:
             print(
                 "[REDDOG-AUTHORITY-SOURCE] Startup blocked by "
@@ -3537,6 +3540,9 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
                     "REDDOG_SIGNER_CONFIG_MAX_RESPONSE_BYTES",
                     16384,
                 ),
+                control_loop_anchor_path=(
+                    os.getenv("REDDOG_SIGNER_CONTROL_LOOP_ANCHOR_PATH") or None
+                ),
             )
             signer_config_status = "PASS" if signer_config.accepted else "WARN"
             signer_config_reasons = (
@@ -3891,6 +3897,72 @@ def _reddog_queue_stage_receipt_ids(stage_callable: Any) -> tuple[str, ...]:
     return tuple(str(value) for value in values if str(value or "").strip())
 
 
+def _reddog_queue_stage_child_evidence_digests(
+    stage_callable: Any,
+) -> tuple[str, ...]:
+    """Return execution-evidence digests emitted by a queue claim stage."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return ()
+    values = raw.get("child_execution_evidence_digests")
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(str(value) for value in values if str(value or "").strip())
+
+
+def _reddog_queue_stage_child_execution_outcomes(
+    stage_callable: Any,
+) -> tuple[Mapping[str, Any], ...]:
+    """Return exact child outcome bindings emitted by a queue claim stage."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return ()
+    values = raw.get("child_execution_outcomes")
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(dict(value) for value in values if isinstance(value, Mapping))
+
+
+def _reddog_queue_stage_child_execution_evidence(
+    stage_callable: Any,
+) -> tuple[Mapping[str, Any], ...]:
+    """Return complete child claim results for digest revalidation."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return ()
+    values = raw.get("child_execution_evidence")
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(dict(value) for value in values if isinstance(value, Mapping))
+
+
+def _reddog_queue_stage_dispatched_stages(stage_callable: Any) -> tuple[str, ...]:
+    """Return bounded stage keys recorded by a queue serial-loop result."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return ()
+    values = raw.get("dispatched_stages")
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(str(value)[:80] for value in values if str(value or "").strip())
+
+
+def _reddog_queue_stage_count(stage_callable: Any, key: str) -> int:
+    """Return one nonnegative integer from a queue stage result."""
+
+    raw = getattr(stage_callable, "last_result", None)
+    if not isinstance(raw, Mapping):
+        return 0
+    value = raw.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(value, 0)
+
+
 def _reddog_queue_stage_rejection_reasons(stage_callable: Any) -> tuple[str, ...]:
     """Return rejection reasons recorded by a queue control stage."""
 
@@ -3922,18 +3994,9 @@ def _reddog_record_queue_control_result(repo_root: Path, result: Mapping[str, An
                 "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPTS_PATH",
             )
             if receipt_path:
-                from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
-                    append_resident_control_loop_receipt,
+                _reddog_persist_queue_control_receipt(
+                    repo_root, recorded, receipt_path, resident_queue_runtime_file_path
                 )
-
-                receipt = append_resident_control_loop_receipt(
-                    path=receipt_path,
-                    result=recorded,
-                    repo_root=repo_root,
-                    created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                )
-                recorded["receipt_id"] = receipt.receipt_id
-                recorded["receipt_path"] = str(receipt_path)
     except Exception as exc:
         recorded["accepted"] = False
         recorded["status"] = "CONTROL_LOOP_RECEIPT_PERSISTENCE_REJECT"
@@ -3953,6 +4016,72 @@ def _reddog_record_queue_control_result(repo_root: Path, result: Mapping[str, An
         )
     run_reddog_resident_queue_control_loop_preflight.last_result = recorded
     return recorded
+
+
+def _reddog_control_rejection_allows_startup(
+    recorded: Mapping[str, Any], *, enforced: bool
+) -> bool:
+    """Allow advisory rejection only when its authenticated receipt persisted."""
+
+    if recorded.get("status") == "CONTROL_LOOP_RECEIPT_PERSISTENCE_REJECT":
+        return False
+    return not enforced
+
+
+def _reddog_persist_queue_control_receipt(
+    repo_root: Path,
+    recorded: Dict[str, Any],
+    receipt_path: Path,
+    runtime_file_path: Any,
+) -> None:
+    from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+        append_resident_control_loop_receipt,
+    )
+    from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_signing_context import (
+        build_control_loop_receipt_signing_context,
+    )
+
+    timeout_s, max_response_bytes = _reddog_control_receipt_signer_limits()
+    signing_context = build_control_loop_receipt_signing_context(
+        repo_root=repo_root,
+        authority_profile_path=runtime_file_path(
+            os.environ, repo_root, "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH"
+        ),
+        authority_profile_source_path=runtime_file_path(
+            os.environ, repo_root, "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH"
+        ),
+        signer_socket_path=runtime_file_path(
+            os.environ, repo_root, "REDDOG_SIGNER_SOCKET_PATH"
+        ),
+        expected_authority_profile_source_receipt_id=os.getenv(
+            "REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID", ""
+        ),
+        signer_socket_timeout_s=timeout_s,
+        signer_socket_max_response_bytes=max_response_bytes,
+    )
+    receipt = append_resident_control_loop_receipt(
+        path=receipt_path,
+        result=recorded,
+        repo_root=repo_root,
+        created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        signing_context=signing_context,
+        require_authentication=True,
+        head_state_path=runtime_file_path(
+            os.environ, repo_root, "REDDOG_AUTHORITY_RUNTIME_STATE_PATH"
+        ),
+    )
+    recorded["receipt_id"] = receipt.receipt_id
+    recorded["receipt_path"] = str(receipt_path)
+
+
+def _reddog_control_receipt_signer_limits() -> tuple[float, int]:
+    try:
+        return (
+            float(os.getenv("REDDOG_SIGNER_SOCKET_TIMEOUT_S", "5") or "5"),
+            int(os.getenv("REDDOG_SIGNER_SOCKET_MAX_RESPONSE_BYTES", "16384") or "16384"),
+        )
+    except ValueError as exc:
+        raise ValueError("control_receipt_signer_limits_invalid") from exc
 
 
 def _reddog_control_lock_annotated_result(result: Mapping[str, Any]) -> Dict[str, Any]:
@@ -3997,242 +4126,317 @@ def _reddog_locked_control_result(reason: str, lock_path: Path) -> Dict[str, Any
     }
 
 
+def _reddog_control_state() -> Dict[str, Any]:
+    return {
+        "rounds": 0, "serial_progress": 0, "claim_progress": 0,
+        "worker_claim_count": 0, "worker_completion_count": 0,
+        "worker_requeue_count": 0, "worker_failure_count": 0,
+        "worker_process_spawn_count": 0, "shell_command_count": 0,
+        "dispatched_stages": [], "receipt_ids": [],
+        "child_execution_evidence_digests": [],
+        "child_execution_outcomes": [], "child_execution_evidence": [],
+    }
+
+
+def _reddog_control_add_serial(state: Dict[str, Any], serial_ok: bool) -> int:
+    progress = _reddog_queue_stage_progress(
+        run_reddog_resident_queue_serial_loop_preflight,
+        default_progress=1 if serial_ok else 0,
+    )
+    state["serial_progress"] += progress
+    state["dispatched_stages"].extend(
+        _reddog_queue_stage_dispatched_stages(
+            run_reddog_resident_queue_serial_loop_preflight
+        )
+    )
+    return progress
+
+
+def _reddog_control_add_claim(state: Dict[str, Any], claim_ok: bool) -> int:
+    stage = run_reddog_openclaw_signed_worker_claim_loop_preflight
+    progress = _reddog_queue_stage_progress(stage, default_progress=1 if claim_ok else 0)
+    state["claim_progress"] += progress
+    state["worker_claim_count"] += progress
+    for target, source in (
+        ("worker_completion_count", "completed_count"),
+        ("worker_requeue_count", "requeued_count"),
+        ("worker_failure_count", "failed_count"),
+        ("worker_process_spawn_count", "worker_process_spawn_count"),
+        ("shell_command_count", "shell_command_count"),
+    ):
+        state[target] += _reddog_queue_stage_count(stage, source)
+    state["receipt_ids"].extend(_reddog_queue_stage_receipt_ids(stage))
+    state["child_execution_evidence_digests"].extend(
+        _reddog_queue_stage_child_evidence_digests(stage)
+    )
+    state["child_execution_outcomes"].extend(
+        _reddog_queue_stage_child_execution_outcomes(stage)
+    )
+    state["child_execution_evidence"].extend(
+        _reddog_queue_stage_child_execution_evidence(stage)
+    )
+    return progress
+
+
+def _reddog_control_result(
+    state: Mapping[str, Any], *, accepted: bool, status: str,
+    rejection_reasons: tuple[str, ...] = (),
+) -> Dict[str, Any]:
+    receipt_ids = tuple(state.get("receipt_ids", ()))
+    return {
+        "accepted": accepted, "status": status, "rounds": state.get("rounds", 0),
+        "serial_progress": state.get("serial_progress", 0),
+        "claim_progress": state.get("claim_progress", 0),
+        "worker_claim_count": state.get("worker_claim_count", 0),
+        "worker_completion_count": state.get("worker_completion_count", 0),
+        "worker_requeue_count": state.get("worker_requeue_count", 0),
+        "worker_failure_count": state.get("worker_failure_count", 0),
+        "worker_process_spawn_count": state.get("worker_process_spawn_count", 0),
+        "shell_command_count": state.get("shell_command_count", 0),
+        "dispatched_stages": tuple(state.get("dispatched_stages", ())),
+        "receipt_ids": receipt_ids, "child_execution_receipt_ids": receipt_ids,
+        "child_execution_evidence_digests": tuple(
+            state.get("child_execution_evidence_digests", ())
+        ),
+        "child_execution_outcomes": tuple(state.get("child_execution_outcomes", ())),
+        "child_execution_evidence": tuple(state.get("child_execution_evidence", ())),
+        "rejection_reasons": rejection_reasons,
+    }
+
+
+def _reddog_run_control_round(
+    repo_root: Path, state: Dict[str, Any]
+) -> tuple[bool, int, int, Callable[..., Any]]:
+    serial_ok = run_reddog_resident_queue_serial_loop_preflight(repo_root)
+    serial_progress = _reddog_control_add_serial(state, serial_ok)
+    if not serial_ok or _reddog_queue_stage_rejected(
+        run_reddog_resident_queue_serial_loop_preflight
+    ):
+        return False, serial_progress, 0, run_reddog_resident_queue_serial_loop_preflight
+    claim_ok = run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root)
+    claim_progress = _reddog_control_add_claim(state, claim_ok)
+    if not claim_ok or _reddog_queue_stage_rejected(
+        run_reddog_openclaw_signed_worker_claim_loop_preflight
+    ):
+        return (
+            False, serial_progress, claim_progress,
+            run_reddog_openclaw_signed_worker_claim_loop_preflight,
+        )
+    return (
+        True, serial_progress, claim_progress,
+        run_reddog_openclaw_signed_worker_claim_loop_preflight,
+    )
+
+
+def _reddog_record_control_failure(
+    repo_root: Path, state: Mapping[str, Any], *, status: str,
+    stage: Callable[..., Any], enforced: bool,
+) -> bool:
+    recorded = _reddog_record_queue_control_result(
+        repo_root,
+        _reddog_control_result(
+            state, accepted=False, status=status,
+            rejection_reasons=_reddog_queue_stage_rejection_reasons(stage),
+        ),
+    )
+    return _reddog_control_rejection_allows_startup(recorded, enforced=enforced)
+
+
+def _reddog_run_single_control_round(repo_root: Path) -> bool:
+    state = _reddog_control_state()
+    ok, _, _, stage = _reddog_run_control_round(repo_root, state)
+    if ok:
+        state["rounds"] = 1
+    status = "PASS" if ok else (
+        "CLAIM_LOOP_REJECT"
+        if stage is run_reddog_openclaw_signed_worker_claim_loop_preflight
+        else "SERIAL_LOOP_REJECT"
+    )
+    recorded = _reddog_record_queue_control_result(
+        repo_root,
+        _reddog_control_result(
+            state, accepted=ok, status=status,
+            rejection_reasons=() if ok else _reddog_queue_stage_rejection_reasons(stage),
+        ),
+    )
+    return bool(recorded.get("accepted")) and ok
+
+
+def _reddog_control_max_rounds() -> int:
+    raw = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "8").strip()
+    try:
+        return int(raw or "8")
+    except ValueError:
+        return 0
+
+
+def _reddog_run_bounded_control_rounds(
+    repo_root: Path, *, max_rounds: int, enforced: bool,
+) -> bool:
+    state = _reddog_control_state()
+    stopped_reason = "max_rounds"
+    for round_index in range(1, max_rounds + 1):
+        ok, serial_progress, claim_progress, stage = _reddog_run_control_round(
+            repo_root, state
+        )
+        if not ok:
+            status = "CLAIM_LOOP_REJECT" if stage is run_reddog_openclaw_signed_worker_claim_loop_preflight else "SERIAL_LOOP_REJECT"
+            print(f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} stage={status.lower()}")
+            return _reddog_record_control_failure(
+                repo_root, state, status=status, stage=stage, enforced=enforced
+            )
+        state["rounds"] = round_index
+        if serial_progress == 0 and claim_progress == 0:
+            stopped_reason = "idle"
+            break
+    recorded = _reddog_record_queue_control_result(
+        repo_root, _reddog_control_result(state, accepted=True, status="PASS")
+    )
+    receipts = ",".join(state["receipt_ids"]) or "(none)"
+    print(
+        f"[REDDOG-QUEUE-CONTROL] preflight=PASS rounds={state['rounds']} "
+        f"max_rounds={max_rounds} stopped_reason={stopped_reason} "
+        f"serial_progress={state['serial_progress']} claim_progress={state['claim_progress']} "
+        f"receipts={receipts} control_receipt={recorded.get('receipt_id') or '(none)'}"
+    )
+    return bool(recorded.get("accepted"))
+
+
 @_with_reddog_queue_control_lock
 def run_reddog_resident_queue_control_loop_preflight(repo_root: Path) -> bool:
-    """
-    Drive the resident queue through bounded serial/claim rounds.
-
-    Env:
-        REDDOG_RESIDENT_QUEUE_CONTROL_LOOP                 Enable bounded alternation (profile may default ON)
-        REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS=8    Max serial/claim rounds
-        REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED=0      Block startup if a round fails
-
-    This function creates no authority, tasks, worktrees, shell commands,
-    source mutations, PRs, PatternMemory writes, rewards, or HoloIndex re-index.
-    It only repeats the already-governed serial-loop and OpenClaw signed-worker
-    claim-loop preflights so one resident startup can advance more than one
-    queue stage without requiring 012 to restart the host.
-    """
+    """Drive the resident queue through bounded serial/claim rounds."""
 
     from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
         resident_queue_runtime_flag_enabled,
     )
 
     requested = resident_queue_runtime_flag_enabled(
-        os.environ,
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP",
+        os.environ, "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP"
     )
     if not requested:
-        if not run_reddog_resident_queue_serial_loop_preflight(repo_root):
-            _reddog_record_queue_control_result(repo_root, {
-                "accepted": False,
-                "status": "SERIAL_LOOP_REJECT",
-                "rounds": 0,
-                "serial_progress": _reddog_queue_stage_progress(
-                    run_reddog_resident_queue_serial_loop_preflight,
-                    default_progress=0,
-                ),
-                "claim_progress": 0,
-                "receipt_ids": (),
-                "rejection_reasons": _reddog_queue_stage_rejection_reasons(
-                    run_reddog_resident_queue_serial_loop_preflight
-                ),
-            })
-            return False
-        claim_ok = run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root)
-        claim_receipts = _reddog_queue_stage_receipt_ids(
-            run_reddog_openclaw_signed_worker_claim_loop_preflight
-        )
-        recorded = _reddog_record_queue_control_result(repo_root, {
-            "accepted": bool(claim_ok)
-            and not _reddog_queue_stage_rejected(
-                run_reddog_openclaw_signed_worker_claim_loop_preflight
-            ),
-            "status": "PASS" if claim_ok else "CLAIM_LOOP_REJECT",
-            "rounds": 1,
-            "serial_progress": _reddog_queue_stage_progress(
-                run_reddog_resident_queue_serial_loop_preflight,
-                default_progress=1,
-            ),
-            "claim_progress": _reddog_queue_stage_progress(
-                run_reddog_openclaw_signed_worker_claim_loop_preflight,
-                default_progress=1 if claim_ok else 0,
-            ),
-            "receipt_ids": claim_receipts,
-            "rejection_reasons": _reddog_queue_stage_rejection_reasons(
-                run_reddog_openclaw_signed_worker_claim_loop_preflight
-            ),
-        })
-        return bool(recorded.get("accepted")) and claim_ok
-
+        return _reddog_run_single_control_round(repo_root)
     enforced = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED", "0") != "0"
-    raw_rounds = os.getenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "8").strip()
-    try:
-        max_rounds = int(raw_rounds or "8")
-    except ValueError:
-        max_rounds = 0
+    max_rounds = _reddog_control_max_rounds()
     if max_rounds < 1:
         print("[REDDOG-QUEUE-CONTROL] preflight=FAIL error=invalid_max_rounds")
-        _reddog_record_queue_control_result(repo_root, {
-            "accepted": False,
-            "status": "INVALID_MAX_ROUNDS",
-            "rounds": 0,
-            "serial_progress": 0,
-            "claim_progress": 0,
-            "receipt_ids": (),
-            "rejection_reasons": ("invalid_max_rounds",),
-        })
-        return not enforced
-
-    completed_rounds = 0
-    serial_progress_total = 0
-    claim_progress_total = 0
-    receipt_ids: list[str] = []
-    stopped_reason = "max_rounds"
-    for round_index in range(1, max_rounds + 1):
-        serial_ok = run_reddog_resident_queue_serial_loop_preflight(repo_root)
-        serial_progress = _reddog_queue_stage_progress(
-            run_reddog_resident_queue_serial_loop_preflight,
-            default_progress=1 if serial_ok else 0,
+        recorded = _reddog_record_queue_control_result(
+            repo_root,
+            _reddog_control_result(
+                _reddog_control_state(), accepted=False, status="INVALID_MAX_ROUNDS",
+                rejection_reasons=("invalid_max_rounds",),
+            ),
         )
-        serial_progress_total += serial_progress
-        if not serial_ok or _reddog_queue_stage_rejected(
-            run_reddog_resident_queue_serial_loop_preflight
-        ):
-            _reddog_record_queue_control_result(repo_root, {
-                "accepted": False,
-                "status": "SERIAL_LOOP_REJECT",
-                "rounds": completed_rounds,
-                "serial_progress": serial_progress_total,
-                "claim_progress": claim_progress_total,
-                "receipt_ids": tuple(receipt_ids),
-                "rejection_reasons": _reddog_queue_stage_rejection_reasons(
-                    run_reddog_resident_queue_serial_loop_preflight
-                ),
-            })
-            print(
-                f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} "
-                "stage=serial_loop"
-            )
-            return not enforced
-        claim_ok = run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root)
-        claim_progress = _reddog_queue_stage_progress(
-            run_reddog_openclaw_signed_worker_claim_loop_preflight,
-            default_progress=1 if claim_ok else 0,
-        )
-        claim_progress_total += claim_progress
-        receipt_ids.extend(
-            _reddog_queue_stage_receipt_ids(
-                run_reddog_openclaw_signed_worker_claim_loop_preflight
-            )
-        )
-        if not claim_ok or _reddog_queue_stage_rejected(
-            run_reddog_openclaw_signed_worker_claim_loop_preflight
-        ):
-            _reddog_record_queue_control_result(repo_root, {
-                "accepted": False,
-                "status": "CLAIM_LOOP_REJECT",
-                "rounds": completed_rounds,
-                "serial_progress": serial_progress_total,
-                "claim_progress": claim_progress_total,
-                "receipt_ids": tuple(dict.fromkeys(receipt_ids)),
-                "rejection_reasons": _reddog_queue_stage_rejection_reasons(
-                    run_reddog_openclaw_signed_worker_claim_loop_preflight
-                ),
-            })
-            print(
-                f"[REDDOG-QUEUE-CONTROL] preflight=FAIL round={round_index} "
-                "stage=openclaw_claim_loop"
-            )
-            return not enforced
-        completed_rounds = round_index
-        if serial_progress == 0 and claim_progress == 0:
-            stopped_reason = "idle"
-            break
-
-    receipt_ids_tuple = tuple(dict.fromkeys(receipt_ids))
-    recorded = _reddog_record_queue_control_result(repo_root, {
-        "accepted": True,
-        "status": "PASS",
-        "rounds": completed_rounds,
-        "serial_progress": serial_progress_total,
-        "claim_progress": claim_progress_total,
-        "receipt_ids": receipt_ids_tuple,
-        "rejection_reasons": (),
-    })
-    receipts = ",".join(receipt_ids_tuple) or "(none)"
-    control_receipt = str(recorded.get("receipt_id") or "(none)")
-    print(
-        f"[REDDOG-QUEUE-CONTROL] preflight=PASS rounds={completed_rounds} "
-        f"max_rounds={max_rounds} stopped_reason={stopped_reason} "
-        f"serial_progress={serial_progress_total} claim_progress={claim_progress_total} "
-        f"receipts={receipts} control_receipt={control_receipt}"
+        return _reddog_control_rejection_allows_startup(recorded, enforced=enforced)
+    return _reddog_run_bounded_control_rounds(
+        repo_root, max_rounds=max_rounds, enforced=enforced
     )
-    return bool(recorded.get("accepted"))
 
 
-def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> bool:
-    """
-    Optionally let OpenClaw claim signed RedDog worker-dispatch AgentDB tasks.
-
-    Env:
-        REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP=0           Enable loop (default OFF)
-        REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional `signed_0102_bounded_code`
-        REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED=0  Block startup on reject
-        OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS=1             Bounded claims
-        OPENCLAW_SIGNED_WORKER_SIGNER_HEALTHCHECK=0          Validate signer before claiming tasks
-
-    This preflight does not create tasks, sign authority, create worktrees,
-    execute shell commands, publish PRs, dispatch Hermes, write PatternMemory,
-    settle rewards, or re-index HoloIndex. It only invokes the existing
-    OpenClaw signed-worker claim loop, whose per-task gates decide what can run.
-    """
-
+def _reddog_signed_worker_claim_loop_enabled() -> bool:
     from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
         resident_queue_runtime_flag_enabled,
     )
-
-    if not resident_queue_runtime_flag_enabled(
+    return resident_queue_runtime_flag_enabled(
         os.environ,
         "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP",
-    ):
-        logger.info("[REDDOG-OPENCLAW-CLAIM-LOOP] Startup claim loop disabled")
-        run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
-            "accepted": True,
-            "status": "DISABLED",
-            "progress_count": 0,
-            "claimed_count": 0,
-            "rejection_reasons": (),
-        }
-        return True
+    )
 
-    enforced = os.getenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED", "0") != "0"
-    max_claims_raw = os.getenv("OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS", "1").strip()
+
+def _reddog_signed_worker_claim_state(
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    claimed = int(result.get("claimed_count") or 0)
+    return {
+        "accepted": result.get("accepted") is True,
+        "status": str(result.get("status") or "(unknown)"),
+        "progress_count": claimed,
+        "claimed_count": claimed,
+        "completed_count": len(tuple(result.get("completed_task_ids", ()) or ())),
+        "requeued_count": len(tuple(result.get("requeued_task_ids", ()) or ())),
+        "failed_count": len(tuple(result.get("failed_task_ids", ()) or ())),
+        "worker_execution_count": int(result.get("worker_execution_count") or 0),
+        "worker_process_spawn_count": int(result.get("worker_process_spawn_count") or 0),
+        "shell_command_count": int(result.get("shell_command_count") or 0),
+        "idle": result.get("idle") is True,
+        "max_claims_reached": result.get("max_claims_reached") is True,
+        "receipt_ids": tuple(result.get("receipt_ids", ()) or ()),
+        "child_execution_evidence_digests": tuple(result.get("child_execution_evidence_digests", ()) or ()),
+        "child_execution_outcomes": tuple(result.get("child_execution_outcomes", ()) or ()),
+        "child_execution_evidence": tuple(result.get("claim_results", ()) or ()),
+        "rejection_reasons": tuple(result.get("rejection_reasons", ()) or ()),
+    }
+
+
+def _reddog_print_signed_worker_claim_result(
+    result: Mapping[str, Any], max_claims: int
+) -> None:
+    accepted = result.get("accepted") is True
+    values = {
+        "completed": result.get("completed_task_ids", ()),
+        "requeued": result.get("requeued_task_ids", ()),
+        "failed": result.get("failed_task_ids", ()),
+        "receipts": result.get("receipt_ids", ()),
+        "reasons": result.get("rejection_reasons", ()),
+    }
+    rendered = {
+        key: ",".join(str(item) for item in tuple(value or ())) or "(none)"
+        for key, value in values.items()
+    }
+    print(
+        f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight={'PASS' if accepted else 'WARN'} "
+        f"status={result.get('status') or '(unknown)'} "
+        f"claimed_count={int(result.get('claimed_count') or 0)} max_claims={max_claims} "
+        f"completed={rendered['completed']} requeued={rendered['requeued']} "
+        f"failed={rendered['failed']} receipts={rendered['receipts']} "
+        f"reasons={rendered['reasons']}"
+    )
+
+
+def _reddog_signed_worker_max_claims() -> int:
     try:
-        max_claims = int(max_claims_raw)
+        return int(os.getenv("OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS", "1").strip())
     except ValueError:
-        max_claims = 0
-    if max_claims < 1:
-        print("[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=FAIL error=invalid_max_claims")
-        run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
-            "accepted": False,
-            "status": "INVALID_MAX_CLAIMS",
-            "progress_count": 0,
-            "claimed_count": 0,
-            "rejection_reasons": ("invalid_max_claims",),
-        }
-        return not enforced
+        return 0
 
+
+def _reddog_claim_signed_worker_tasks(
+    repo_root: Path, max_claims: int
+) -> tuple[Mapping[str, Any] | None, Exception | None]:
     try:
         from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
             claim_reddog_signed_worker_dispatch_tasks_until_idle,
         )
-
-        result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
-            repo_root=repo_root,
-            max_claims=max_claims,
-        )
+        return claim_reddog_signed_worker_dispatch_tasks_until_idle(
+            repo_root=repo_root, max_claims=max_claims
+        ), None
     except Exception as exc:
+        return None, exc
+
+
+def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> bool:
+    """Run the optional bounded OpenClaw signed-worker claim loop."""
+    if not _reddog_signed_worker_claim_loop_enabled():
+        logger.info("[REDDOG-OPENCLAW-CLAIM-LOOP] Startup claim loop disabled")
+        run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
+            "accepted": True, "status": "DISABLED", "progress_count": 0,
+            "claimed_count": 0, "rejection_reasons": (),
+        }
+        return True
+
+    enforced = os.getenv("REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED", "0") != "0"
+    max_claims = _reddog_signed_worker_max_claims()
+    if max_claims < 1:
+        print("[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=FAIL error=invalid_max_claims")
+        run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
+            "accepted": False, "status": "INVALID_MAX_CLAIMS",
+            "progress_count": 0, "claimed_count": 0,
+            "rejection_reasons": ("invalid_max_claims",),
+        }
+        return not enforced
+
+    result, exc = _reddog_claim_signed_worker_tasks(repo_root, max_claims)
+    if exc is not None or result is None:
+        exc = exc or RuntimeError("empty_claim_result")
         logger.error(f"[REDDOG-OPENCLAW-CLAIM-LOOP] Startup claim loop failed: {exc}")
         run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
             "accepted": False,
@@ -4247,32 +4451,11 @@ def run_reddog_openclaw_signed_worker_claim_loop_preflight(repo_root: Path) -> b
         print(f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight=WARN error={type(exc).__name__}")
         return True
 
-    accepted = bool(result.get("accepted"))
-    status = str(result.get("status") or "(unknown)")
-    claimed_count = int(result.get("claimed_count") or 0)
-    completed = ",".join(str(item) for item in result.get("completed_task_ids", ()) or ()) or "(none)"
-    requeued = ",".join(str(item) for item in result.get("requeued_task_ids", ()) or ()) or "(none)"
-    failed = ",".join(str(item) for item in result.get("failed_task_ids", ()) or ()) or "(none)"
-    receipts = ",".join(str(item) for item in result.get("receipt_ids", ()) or ()) or "(none)"
-    reasons = ",".join(str(reason) for reason in result.get("rejection_reasons", ()) or ()) or "(none)"
-    status_label = "PASS" if accepted else "WARN"
-    run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = {
-        "accepted": accepted,
-        "status": status,
-        "progress_count": claimed_count,
-        "claimed_count": claimed_count,
-        "idle": bool(result.get("idle")),
-        "max_claims_reached": bool(result.get("max_claims_reached")),
-        "receipt_ids": tuple(result.get("receipt_ids", ()) or ()),
-        "rejection_reasons": tuple(result.get("rejection_reasons", ()) or ()),
-    }
-    print(
-        f"[REDDOG-OPENCLAW-CLAIM-LOOP] preflight={status_label} status={status} "
-        f"claimed_count={claimed_count} max_claims={max_claims} "
-        f"completed={completed} requeued={requeued} failed={failed} "
-        f"receipts={receipts} reasons={reasons}"
+    run_reddog_openclaw_signed_worker_claim_loop_preflight.last_result = (
+        _reddog_signed_worker_claim_state(result)
     )
-    if accepted:
+    _reddog_print_signed_worker_claim_result(result, max_claims)
+    if result.get("accepted") is True:
         return True
 
     if enforced:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,57 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-18: REDDOG_RESIDENT_CONTROL_RECEIPT_TRUTH_AUTH_CONCURRENCY_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 62, 71, 91, 97
+**Phase**: Runtime truth/auth/concurrency hardening
+**Agent**: 0102 architect with independent adversarial review
+
+- Added signer-domain-validated, predecessor-linked v2 control receipts with
+  cycle/nonce replay rejection and validated legacy-prefix migration.
+- Derived authority, claim, execution, worktree, bounded-edit, verification,
+  draft-PR, PatternMemory, process-spawn, and shell observations from runtime
+  evidence; caller-supplied contradictory claims reject.
+- Required live-canary proof to verify the signature, signer/key epoch,
+  authority-profile digest, consensus digest, repository binding, and complete
+  JSONL stream before accepting a new cycle.
+- Added a cross-process lock around chain-result compare-and-swap and preserved
+  exact OpenClaw outcome counts in `main.py`.
+- Added a second Ed25519 signer attestation over the audit MAC and signing
+  response, then required every v2 predecessor to verify against the same
+  principal, key epoch, authority profile, and consensus receipt.
+- Bound unique child execution receipt IDs and evidence digests to exact
+  completion/requeue/failure cardinality, and made standalone OpenClaw claims
+  contend on the same resident control-loop lock as `main.py`.
+- Reconciled the serial-loop tests with the landed runtime-artifact confinement
+  invariant by placing all positive fixture artifacts under an isolated runtime
+  root outside the synthetic repository.
+- Added signer-owned `ControlLoopAuthorityPolicy` enforcement and a monotonic
+  control-loop anchor outside resident state; self-hashed profile content alone
+  can no longer authorize a control signature or roll the chain backward.
+- Rehydrated complete child claim evidence before parent signing, retained
+  truthful execution/process/shell counts for rejected runners, and rejected
+  retention or durable-head failures before reporting acceptance.
+- Made child evidence the exclusive source for parent process/shell totals;
+  runner exceptions now carry `effect_evidence_complete=false` with no invented
+  negative attestations, and failed AgentDB complete/requeue transitions reject.
+- Extracted authority persistence behind a compatible boundary and fsynced the
+  parent directory after atomic rename on platforms that support it.
+- Decomposed modified `main.py`, OpenClaw claim, receipt, canary, and task-
+  executor paths into focused WSP 62-bounded helpers without changing the
+  configured runtime stages.
+
+**Truth boundary**: v1 and unsigned v2 receipts may be inspected but cannot
+satisfy live proof. The configured isolated signer authenticates the exact
+control authority policy; this does not claim that the profile source JSON is
+independently principal-signed. The v2 receipt records positive observations
+and does not convert an unobserved merge, reward, re-index, process, or shell
+action into a hardcoded negative proof. Detailed stage receipts remain
+authoritative.
+
+**HoloIndex**: read-only retrieval found the new receipt modules by path but no
+focused tests and weak governing-WSP relevance. This is an INDEX_GAP for the
+governed freshness lane; no runtime re-index was performed in this slice.
+
 ## 2026-07-18: REDDOG_VALVE_HIGH_AUTHORITY_CLASSIFICATION_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 71, 97

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -70,6 +70,9 @@ class SignedWorkerOpenClawClaimReason:
     TASK_EXECUTION_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_TASK_EXECUTION_REJECTED"
     SIGNER_HEALTHCHECK_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_SIGNER_HEALTHCHECK_REJECTED"
     RESULT_PERSISTENCE_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_RESULT_PERSISTENCE_REJECTED"
+    TASK_STATE_TRANSITION_REJECTED = (
+        "REJECT_REDDOG_SIGNED_WORKER_TASK_STATE_TRANSITION_REJECTED"
+    )
     AGENTDB_FAILURE = "REJECT_REDDOG_SIGNED_WORKER_AGENTDB_FAILURE"
     MAX_CLAIMS_INVALID = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_MAX_CLAIMS_INVALID"
     CLAIM_REJECTED = "REJECT_REDDOG_SIGNED_WORKER_CLAIM_LOOP_CLAIM_REJECTED"
@@ -264,226 +267,222 @@ def claim_reddog_signed_worker_dispatch_task_once(
     agent_db_factory: Optional[Callable[[], Any]] = None,
     signed_worker_runner: Any | None = None,
 ) -> Dict[str, Any]:
-    """Claim and execute one signed RedDog worker-dispatch AgentDB task.
+    """Claim one signed task only while holding the shared resident lock."""
 
-    This is the OpenClaw-owned consumer for tasks published by the signed
-    worker-dispatch runtime. The task is claimed atomically from AgentDB and
-    then validated by the signed-worker task executor. A real worker runner
-    must be injected; no default runner is created here.
-    """
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_control_lock import (
+        acquire_resident_queue_control_lock,
+    )
 
-    try:
-        from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import (
-            SIGNED_WORKER_DISPATCH_TASK_SOURCE,
-        )
-        from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
-            execute_reddog_signed_worker_dispatch_task,
-        )
-        from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import (
-            build_reddog_signed_worker_queue_loop_runner_from_env,
-        )
-        from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
-            Signed0102ReadOnlyReviewRunner,
-            is_0102_readonly_signed_worker_context,
-        )
-        from modules.infrastructure.database.src.agent_db import AgentDB
-
-        healthcheck = _signed_worker_signer_healthcheck_before_claim(repo_root)
-        if healthcheck is not None and healthcheck.get("accepted") is not True:
+    with acquire_resident_queue_control_lock(repo_root, allow_reentrant=True) as lock:
+        if not lock.acquired:
             return _signed_worker_claim_result(
                 accepted=False,
                 status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-                rejection_reasons=(
-                    SignedWorkerOpenClawClaimReason.SIGNER_HEALTHCHECK_REJECTED,
-                    *tuple(healthcheck.get("rejection_reasons", ()) or ()),
-                ),
-                detail=str(healthcheck.get("status") or "")[:300],
+                rejection_reasons=(lock.reason,),
             )
-
-        factory = agent_db_factory or AgentDB
-        db = factory()
-        task = _claim_pending_reddog_signed_worker_dispatch_task(
-            db=db,
-            agent_id=agent_id,
-            source=SIGNED_WORKER_DISPATCH_TASK_SOURCE,
-            include_0102_readonly=(
-                signed_worker_runner is not None
-                or _signed_0102_readonly_tasks_enabled_from_env()
-            ),
-            include_0102_bounded_code=_signed_0102_bounded_code_tasks_enabled_from_env(),
-            include_queue_stage_progress=_openclaw_queue_stage_tasks_enabled_from_env(),
-            env=os.environ,
+        return _claim_reddog_signed_worker_dispatch_task_once_under_control_lock(
             repo_root=repo_root,
+            agent_id=agent_id,
+            agent_db_factory=agent_db_factory,
+            signed_worker_runner=signed_worker_runner,
         )
-    except Exception as exc:
+
+
+def _claim_reddog_signed_worker_dispatch_task_once_under_control_lock(
+    *,
+    repo_root: Path,
+    agent_id: str = "openclaw_supervisor",
+    agent_db_factory: Optional[Callable[[], Any]] = None,
+    signed_worker_runner: Any | None = None,
+) -> Dict[str, Any]:
+    """Claim and execute one signed task under the resident lock."""
+
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_control_lock import (
+        resident_queue_control_lock_held,
+    )
+
+    if not resident_queue_control_lock_held(repo_root):
         return _signed_worker_claim_result(
             accepted=False,
             status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            rejection_reasons=(SignedWorkerOpenClawClaimReason.AGENTDB_FAILURE,),
-            detail=str(exc)[:300],
+            rejection_reasons=("resident_queue_control_lock_required",),
         )
 
-    if task is None:
-        return _signed_worker_claim_result(
-            accepted=False,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_IDLE,
-            rejection_reasons=(SignedWorkerOpenClawClaimReason.NO_PENDING_TASK,),
-        )
-    if task.get("claim_race_lost"):
-        return _signed_worker_claim_result(
-            accepted=False,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            task_id=str(task.get("task_id") or ""),
-            rejection_reasons=(SignedWorkerOpenClawClaimReason.CLAIM_RACE_LOST,),
-        )
-
-    task_id = str(task.get("task_id") or "")
-    context = task.get("context")
-    if not isinstance(context, dict):
-        _persist_reddog_signed_worker_dispatch_task_result(
-            db,
-            task_id,
-            context={},
-            claim_status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            rejection_reasons=(SignedWorkerOpenClawClaimReason.MALFORMED_CONTEXT,),
-        )
-        _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
-        return _signed_worker_claim_result(
-            accepted=False,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            task_id=task_id,
-            rejection_reasons=(SignedWorkerOpenClawClaimReason.MALFORMED_CONTEXT,),
-        )
-
-    effective_runner = signed_worker_runner
-    if effective_runner is None:
-        if is_0102_readonly_signed_worker_context(context) and _signed_0102_readonly_tasks_enabled_from_env():
-            effective_runner = Signed0102ReadOnlyReviewRunner()
-        else:
-            binding_result = build_reddog_signed_worker_queue_loop_runner_from_env(
-                repo_root=repo_root,
-                env=os.environ,
-            )
-            if binding_result.accepted:
-                effective_runner = binding_result.runner
-            elif binding_result.requested:
-                _persist_reddog_signed_worker_dispatch_task_result(
-                    db,
-                    task_id,
-                    context=context,
-                    claim_status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-                    rejection_reasons=(
-                        SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
-                        *binding_result.rejection_reasons,
-                    ),
-                    runner_result=binding_result.to_dict(),
-                )
-                _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
-                return _signed_worker_claim_result(
-                    accepted=False,
-                    status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-                    task_id=task_id,
-                    rejection_reasons=(
-                        SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
-                        *binding_result.rejection_reasons,
-                    ),
-                )
-
+    db, task, rejected = _signed_worker_claim_pending_task(
+        repo_root=repo_root, agent_id=agent_id,
+        agent_db_factory=agent_db_factory, signed_worker_runner=signed_worker_runner,
+    )
+    if rejected is not None:
+        return rejected
+    assert db is not None
+    task_id, context, task_reject = _signed_worker_claimed_task_context(db, task)
+    if task_reject is not None:
+        return task_reject
+    effective_runner, runner_reject = _signed_worker_effective_runner(
+        repo_root=repo_root, db=db, task_id=task_id, context=context,
+        signed_worker_runner=signed_worker_runner,
+    )
+    if runner_reject is not None:
+        return runner_reject
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_dispatch_task_executor import (
+        execute_reddog_signed_worker_dispatch_task,
+    )
     run_result = execute_reddog_signed_worker_dispatch_task(
         task_context=context,
         task_id=task_id,
         repo_root=repo_root,
         runner=effective_runner,
     )
-    if not run_result.accepted:
-        _persist_reddog_signed_worker_dispatch_task_result(
-            db,
-            task_id,
-            context=context,
-            claim_status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            run_result=run_result.to_dict(),
-            rejection_reasons=(
-                SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
-                *run_result.rejection_reasons,
-            ),
-        )
-        _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
-        return _signed_worker_claim_result(
-            accepted=False,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            task_id=task_id,
-            worker_role=run_result.worker_role,
-            worker_runtime=run_result.worker_runtime,
-            capability=run_result.capability,
-            rejection_reasons=(
-                SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
-                *run_result.rejection_reasons,
-            ),
-        )
-
-    runner_result = (
-        run_result.runner_result if isinstance(run_result.runner_result, Mapping) else {}
+    return _signed_worker_finalize_claimed_task(
+        db=db, task_id=task_id, context=context, run_result=run_result
     )
-    if runner_result.get("queue_chain_requeue_required") is True:
-        if not _persist_reddog_signed_worker_dispatch_task_result(
-            db,
-            task_id,
-            context=context,
-            claim_status=SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
-            run_result=run_result.to_dict(),
-        ):
-            _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
-            return _signed_worker_claim_result(
-                accepted=False,
-                status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-                task_id=task_id,
-                worker_role=run_result.worker_role,
-                worker_runtime=run_result.worker_runtime,
-                capability=run_result.capability,
-                rejection_reasons=(
-                    SignedWorkerOpenClawClaimReason.RESULT_PERSISTENCE_REJECTED,
-                ),
+
+
+def _signed_worker_claimed_task_context(
+    db: Any, task: Optional[Dict[str, Any]]
+) -> tuple[str, Mapping[str, Any], Optional[Dict[str, Any]]]:
+    if task is None:
+        return "", {}, _signed_worker_claim_result(
+            accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_IDLE,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.NO_PENDING_TASK,),
+        )
+    task_id = str(task.get("task_id") or "")
+    if task.get("claim_race_lost"):
+        return task_id, {}, _signed_worker_claim_result(
+            accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            task_id=task_id,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.CLAIM_RACE_LOST,),
+        )
+    context = task.get("context")
+    if not isinstance(context, dict):
+        return task_id, {}, _signed_worker_reject_claimed_task(
+            db=db, task_id=task_id, context={},
+            reasons=(SignedWorkerOpenClawClaimReason.MALFORMED_CONTEXT,),
+        )
+    return task_id, context, None
+
+
+def _signed_worker_claim_pending_task(
+    *, repo_root: Path, agent_id: str,
+    agent_db_factory: Optional[Callable[[], Any]], signed_worker_runner: Any | None,
+) -> tuple[Any | None, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    try:
+        from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker_dispatch_runtime import SIGNED_WORKER_DISPATCH_TASK_SOURCE
+        from modules.infrastructure.database.src.agent_db import AgentDB
+        healthcheck = _signed_worker_signer_healthcheck_before_claim(repo_root)
+        if healthcheck is not None and healthcheck.get("accepted") is not True:
+            return None, None, _signed_worker_claim_result(
+                accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+                rejection_reasons=(SignedWorkerOpenClawClaimReason.SIGNER_HEALTHCHECK_REJECTED,
+                    *tuple(healthcheck.get("rejection_reasons", ()) or ())),
+                detail=str(healthcheck.get("status") or "")[:300],
             )
-        _requeue_reddog_signed_worker_dispatch_task(db, task_id)
-        return _signed_worker_claim_result(
-            accepted=True,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
-            task_id=task_id,
-            worker_role=run_result.worker_role,
-            worker_runtime=run_result.worker_runtime,
-            capability=run_result.capability,
-            receipt_id=run_result.receipt_id,
+        db = (agent_db_factory or AgentDB)()
+        task = _claim_pending_reddog_signed_worker_dispatch_task(
+            db=db, agent_id=agent_id, source=SIGNED_WORKER_DISPATCH_TASK_SOURCE,
+            include_0102_readonly=(signed_worker_runner is not None or _signed_0102_readonly_tasks_enabled_from_env()),
+            include_0102_bounded_code=_signed_0102_bounded_code_tasks_enabled_from_env(),
+            include_queue_stage_progress=_openclaw_queue_stage_tasks_enabled_from_env(),
+            env=os.environ, repo_root=repo_root,
+        )
+        return db, task, None
+    except Exception as exc:
+        return None, None, _signed_worker_claim_result(
+            accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.AGENTDB_FAILURE,),
+            detail=str(exc)[:300],
         )
 
-    if not _persist_reddog_signed_worker_dispatch_task_result(
-        db,
-        task_id,
-        context=context,
-        claim_status=SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
-        run_result=run_result.to_dict(),
-    ):
-        _mark_reddog_signed_worker_dispatch_task_failed(db, task_id)
-        return _signed_worker_claim_result(
-            accepted=False,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
-            task_id=task_id,
-            worker_role=run_result.worker_role,
-            worker_runtime=run_result.worker_runtime,
-            capability=run_result.capability,
-            rejection_reasons=(
-                SignedWorkerOpenClawClaimReason.RESULT_PERSISTENCE_REJECTED,
-            ),
-        )
 
-    db.complete_autonomous_task(task_id)
+def _signed_worker_effective_runner(
+    *, repo_root: Path, db: Any, task_id: str, context: Mapping[str, Any],
+    signed_worker_runner: Any | None,
+) -> tuple[Any | None, Optional[Dict[str, Any]]]:
+    if signed_worker_runner is not None:
+        return signed_worker_runner, None
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_0102_readonly_review_binding import (
+        Signed0102ReadOnlyReviewRunner, is_0102_readonly_signed_worker_context,
+    )
+    if is_0102_readonly_signed_worker_context(context) and _signed_0102_readonly_tasks_enabled_from_env():
+        return Signed0102ReadOnlyReviewRunner(), None
+    from modules.communication.moltbot_bridge.src.reddog_signed_worker_openclaw_queue_loop_runtime_binding import build_reddog_signed_worker_queue_loop_runner_from_env
+    binding = build_reddog_signed_worker_queue_loop_runner_from_env(
+        repo_root=repo_root, env=os.environ
+    )
+    if binding.accepted:
+        return binding.runner, None
+    if not binding.requested:
+        return None, None
+    reasons = (
+        SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
+        *binding.rejection_reasons,
+    )
+    return None, _signed_worker_reject_claimed_task(
+        db=db, task_id=task_id, context=context, reasons=reasons,
+        runner_result=binding.to_dict(),
+    )
+
+
+def _signed_worker_reject_claimed_task(
+    *, db: Any, task_id: str, context: Mapping[str, Any], reasons: Sequence[str],
+    effect_source: Mapping[str, Any] | None = None,
+    runner_result: Mapping[str, Any] | None = None, persist: bool = True,
+) -> Dict[str, Any]:
+    source = effect_source if isinstance(effect_source, Mapping) else {}
+    final_reasons = list(reasons)
+    if persist:
+        if not _persist_reddog_signed_worker_dispatch_task_result(
+            db, task_id, context=context,
+            claim_status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+            run_result=source or None, runner_result=runner_result,
+            rejection_reasons=tuple(final_reasons),
+            task_status="failed",
+        ):
+            final_reasons.append(
+                SignedWorkerOpenClawClaimReason.RESULT_PERSISTENCE_REJECTED
+            )
+            final_reasons.append(
+                SignedWorkerOpenClawClaimReason.TASK_STATE_TRANSITION_REJECTED
+            )
     return _signed_worker_claim_result(
-        accepted=True,
-        status=SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
-        task_id=task_id,
-        worker_role=run_result.worker_role,
-        worker_runtime=run_result.worker_runtime,
-        capability=run_result.capability,
-        receipt_id=run_result.receipt_id,
+        accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+        task_id=task_id, worker_role=str(source.get("worker_role") or ""),
+        worker_runtime=str(source.get("worker_runtime") or ""),
+        capability=str(source.get("capability") or ""),
+        rejection_reasons=tuple(final_reasons), effect_source=source or None,
+    )
+
+
+def _signed_worker_finalize_claimed_task(
+    *, db: Any, task_id: str, context: Mapping[str, Any], run_result: Any,
+) -> Dict[str, Any]:
+    source = run_result.to_dict()
+    if not run_result.accepted:
+        return _signed_worker_reject_claimed_task(
+            db=db, task_id=task_id, context=context, effect_source=source,
+            reasons=(SignedWorkerOpenClawClaimReason.TASK_EXECUTION_REJECTED,
+                *run_result.rejection_reasons),
+        )
+    runner_result = run_result.runner_result if isinstance(run_result.runner_result, Mapping) else {}
+    requeue = runner_result.get("queue_chain_requeue_required") is True
+    status = SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED if requeue else SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT
+    if not _persist_reddog_signed_worker_dispatch_task_result(
+        db, task_id, context=context, claim_status=status, run_result=source,
+        task_status="pending" if requeue else "completed",
+    ):
+        return _signed_worker_reject_claimed_task(
+            db=db, task_id=task_id, context=context, effect_source=source,
+            reasons=(
+                SignedWorkerOpenClawClaimReason.RESULT_PERSISTENCE_REJECTED,
+                SignedWorkerOpenClawClaimReason.TASK_STATE_TRANSITION_REJECTED,
+            ),
+            persist=False,
+        )
+    return _signed_worker_claim_result(
+        accepted=True, status=status, task_id=task_id,
+        worker_role=run_result.worker_role, worker_runtime=run_result.worker_runtime,
+        capability=run_result.capability, receipt_id=run_result.receipt_id,
+        effect_source=source,
     )
 
 
@@ -495,27 +494,44 @@ def claim_reddog_signed_worker_dispatch_tasks_until_idle(
     signed_worker_runner: Any | None = None,
     max_claims: int = 1,
 ) -> Dict[str, Any]:
-    """Claim signed RedDog worker-dispatch tasks until idle or max_claims.
+    """Claim a bounded task batch only while holding the shared resident lock."""
 
-    This bounded resident-loop wrapper widens no authority: each task is still
-    claimed by the existing OpenClaw one-shot primitive and validated by the
-    signed-worker task executor.
-    """
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_control_lock import (
+        acquire_resident_queue_control_lock,
+    )
 
-    if not isinstance(max_claims, int) or isinstance(max_claims, bool) or max_claims < 1:
-        return _signed_worker_claim_loop_result(
-            accepted=False,
-            status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
-            rejection_reasons=(SignedWorkerOpenClawClaimReason.MAX_CLAIMS_INVALID,),
+    with acquire_resident_queue_control_lock(repo_root, allow_reentrant=True) as lock:
+        if not lock.acquired:
+            return _signed_worker_claim_loop_result(
+                accepted=False,
+                status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
+                max_claims=max_claims,
+                rejection_reasons=(lock.reason,),
+            )
+        return _claim_reddog_signed_worker_dispatch_tasks_until_idle_under_control_lock(
+            repo_root=repo_root,
+            agent_id=agent_id,
+            agent_db_factory=agent_db_factory,
+            signed_worker_runner=signed_worker_runner,
             max_claims=max_claims,
         )
 
-    claim_results: list[Dict[str, Any]] = []
-    completed_task_ids: list[str] = []
-    requeued_task_ids: list[str] = []
-    failed_task_ids: list[str] = []
-    idle = False
 
+def _claim_reddog_signed_worker_dispatch_tasks_until_idle_under_control_lock(
+    *,
+    repo_root: Path,
+    agent_id: str = "openclaw_supervisor",
+    agent_db_factory: Optional[Callable[[], Any]] = None,
+    signed_worker_runner: Any | None = None,
+    max_claims: int = 1,
+) -> Dict[str, Any]:
+    """Claim signed tasks until idle or max_claims under the resident lock."""
+
+    guard_reject = _signed_worker_claim_loop_guard(repo_root, max_claims)
+    if guard_reject is not None:
+        return guard_reject
+
+    state = _signed_worker_claim_batch_state()
     for _ in range(max_claims):
         claim = claim_reddog_signed_worker_dispatch_task_once(
             repo_root=repo_root,
@@ -523,68 +539,95 @@ def claim_reddog_signed_worker_dispatch_tasks_until_idle(
             agent_db_factory=agent_db_factory,
             signed_worker_runner=signed_worker_runner,
         )
-        claim_results.append(claim)
-
-        task_id = str(claim.get("task_id") or "")
-        status = str(claim.get("status") or "")
-        if claim.get("accepted") is True and status == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT:
-            if task_id:
-                completed_task_ids.append(task_id)
+        outcome = _signed_worker_record_batch_claim(state, claim)
+        if outcome == "continue":
             continue
-
-        if (
-            claim.get("accepted") is True
-            and status == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED
-        ):
-            if task_id:
-                requeued_task_ids.append(task_id)
-            continue
-
-        if status == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE:
-            idle = True
+        if outcome == "idle":
             break
-
-        if task_id:
-            failed_task_ids.append(task_id)
-        return _signed_worker_claim_loop_result(
-            accepted=False,
+        return _signed_worker_claim_batch_result(
+            state, max_claims=max_claims, accepted=False,
             status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
-            rejection_reasons=(
-                SignedWorkerOpenClawClaimReason.CLAIM_REJECTED,
-                *tuple(claim.get("rejection_reasons") or ()),
-            ),
-            max_claims=max_claims,
-            claim_results=tuple(claim_results),
-            completed_task_ids=tuple(completed_task_ids),
-            requeued_task_ids=tuple(requeued_task_ids),
-            failed_task_ids=tuple(failed_task_ids),
-            idle=idle,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.CLAIM_REJECTED,
+                *tuple(claim.get("rejection_reasons") or ())),
         )
-
-    if completed_task_ids or requeued_task_ids:
-        return _signed_worker_claim_loop_result(
-            accepted=True,
+    if state["completed_task_ids"] or state["requeued_task_ids"]:
+        return _signed_worker_claim_batch_result(
+            state, max_claims=max_claims, accepted=True,
             status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT,
-            max_claims=max_claims,
-            claim_results=tuple(claim_results),
-            completed_task_ids=tuple(completed_task_ids),
-            requeued_task_ids=tuple(requeued_task_ids),
-            failed_task_ids=tuple(failed_task_ids),
-            idle=idle,
-            max_claims_reached=not idle
-            and (len(completed_task_ids) + len(requeued_task_ids)) >= max_claims,
+            max_claims_reached=not state["idle"] and (
+                len(state["completed_task_ids"]) + len(state["requeued_task_ids"])
+            ) >= max_claims,
         )
-
-    return _signed_worker_claim_loop_result(
-        accepted=True,
+    return _signed_worker_claim_batch_result(
+        state, max_claims=max_claims, accepted=True,
         status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_IDLE,
         rejection_reasons=(SignedWorkerOpenClawClaimReason.NO_PENDING_TASK,),
-        max_claims=max_claims,
-        claim_results=tuple(claim_results),
-        completed_task_ids=tuple(completed_task_ids),
-        requeued_task_ids=tuple(requeued_task_ids),
-        failed_task_ids=tuple(failed_task_ids),
-        idle=True,
+    )
+
+
+def _signed_worker_claim_loop_guard(
+    repo_root: Path, max_claims: int
+) -> Optional[Dict[str, Any]]:
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_control_lock import (
+        resident_queue_control_lock_held,
+    )
+
+    if not resident_queue_control_lock_held(repo_root):
+        return _signed_worker_claim_loop_result(
+            accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
+            max_claims=max_claims,
+            rejection_reasons=("resident_queue_control_lock_required",),
+        )
+    if not isinstance(max_claims, int) or isinstance(max_claims, bool) or max_claims < 1:
+        return _signed_worker_claim_loop_result(
+            accepted=False, status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
+            rejection_reasons=(SignedWorkerOpenClawClaimReason.MAX_CLAIMS_INVALID,),
+            max_claims=max_claims,
+        )
+    return None
+
+
+def _signed_worker_claim_batch_state() -> Dict[str, Any]:
+    return {
+        "claim_results": [], "completed_task_ids": [],
+        "requeued_task_ids": [], "failed_task_ids": [], "idle": False,
+    }
+
+
+def _signed_worker_record_batch_claim(
+    state: Dict[str, Any], claim: Mapping[str, Any]
+) -> str:
+    state["claim_results"].append(dict(claim))
+    task_id = str(claim.get("task_id") or "")
+    status = str(claim.get("status") or "")
+    if claim.get("accepted") is True and status == SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT:
+        if task_id:
+            state["completed_task_ids"].append(task_id)
+        return "continue"
+    if claim.get("accepted") is True and status == SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED:
+        if task_id:
+            state["requeued_task_ids"].append(task_id)
+        return "continue"
+    if status == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE:
+        state["idle"] = True
+        return "idle"
+    if task_id:
+        state["failed_task_ids"].append(task_id)
+    return "reject"
+
+
+def _signed_worker_claim_batch_result(
+    state: Mapping[str, Any], *, max_claims: int, accepted: bool, status: str,
+    rejection_reasons: Sequence[str] = (), max_claims_reached: bool = False,
+) -> Dict[str, Any]:
+    return _signed_worker_claim_loop_result(
+        accepted=accepted, status=status,
+        rejection_reasons=tuple(rejection_reasons), max_claims=max_claims,
+        claim_results=tuple(state["claim_results"]),
+        completed_task_ids=tuple(state["completed_task_ids"]),
+        requeued_task_ids=tuple(state["requeued_task_ids"]),
+        failed_task_ids=tuple(state["failed_task_ids"]),
+        idle=bool(state["idle"]), max_claims_reached=max_claims_reached,
     )
 
 
@@ -732,74 +775,25 @@ def _persist_reddog_signed_worker_dispatch_task_result(
     run_result: Mapping[str, Any] | None = None,
     runner_result: Mapping[str, Any] | None = None,
     rejection_reasons: Sequence[str] = (),
+    task_status: str | None = None,
 ) -> bool:
     """Attach a compact signed-worker result receipt to the AgentDB task context."""
-
     if not task_id:
         return False
     try:
         base_context = dict(context) if isinstance(context, Mapping) else {}
         result = dict(run_result) if isinstance(run_result, Mapping) else {}
-        runner_payload = (
-            dict(runner_result)
-            if isinstance(runner_result, Mapping)
-            else dict(result.get("runner_result"))
-            if isinstance(result.get("runner_result"), Mapping)
-            else {}
+        runner_payload = _signed_worker_runner_payload(result, runner_result)
+        receipt = _signed_worker_task_result_receipt(
+            base_context=base_context,
+            claim_status=claim_status,
+            result=result,
+            runner_payload=runner_payload,
+            rejection_reasons=rejection_reasons,
         )
-        receipt = {
-            "schema_version": "reddog_signed_worker_task_result.v1",
-            "claim_status": str(claim_status or ""),
-            "accepted": bool(result.get("accepted")) if result else False,
-            "decision": str(result.get("decision") or ""),
-            "receipt_id": str(result.get("receipt_id") or ""),
-            "worker_role": str(result.get("worker_role") or base_context.get("worker_role") or ""),
-            "worker_runtime": str(result.get("worker_runtime") or base_context.get("worker_runtime") or ""),
-            "capability": str(result.get("capability") or base_context.get("capability") or ""),
-            "rejection_reasons": _signed_worker_receipt_reasons(
-                tuple(rejection_reasons) or tuple(result.get("rejection_reasons") or ())
-            ),
-            "runner_result_digest": _stable_digest(runner_payload) if runner_payload else "",
-            "run_result_digest": _stable_digest(result) if result else "",
-            "runner_result_summary": _signed_worker_runner_result_summary(runner_payload),
-            "no_shell_command_executed": bool(result.get("no_shell_command_executed", True)),
-            "no_source_repo_mutation_performed": bool(
-                result.get("no_source_repo_mutation_performed", True)
-            ),
-            "no_holoindex_reindex_performed": bool(
-                result.get("no_holoindex_reindex_performed", True)
-            ),
-            "no_pr_created": bool(result.get("no_pr_created", True)),
-            "no_pattern_memory_write_performed": bool(
-                result.get("no_pattern_memory_write_performed", True)
-            ),
-            "no_reward_settlement_performed": bool(
-                result.get("no_reward_settlement_performed", True)
-            ),
-        }
-        receipt["receipt_digest"] = _stable_digest(receipt)
-        history = base_context.get("signed_worker_task_result_receipts")
-        if not isinstance(history, list):
-            history = []
-        history = [
-            item
-            for item in history
-            if isinstance(item, Mapping)
-        ][-9:]
-        history.append(
-            {
-                "claim_status": receipt["claim_status"],
-                "receipt_id": receipt["receipt_id"],
-                "receipt_digest": receipt["receipt_digest"],
-            }
+        return _commit_signed_worker_task_result(
+            db, task_id, base_context, receipt, task_status=task_status
         )
-        base_context["signed_worker_task_last_result"] = receipt
-        base_context["signed_worker_task_result_receipts"] = history
-        db.db.execute_write(
-            "UPDATE agents_autonomous_tasks SET context = ? WHERE task_id = ?",
-            (json.dumps(base_context, sort_keys=True), task_id),
-        )
-        return True
     except Exception:
         logger.debug(
             "[SUPERVISOR] Failed to persist RedDog signed-worker task result",
@@ -819,15 +813,13 @@ def _signed_worker_runner_result_summary(payload: Mapping[str, Any]) -> dict[str
     if not isinstance(bootstrap, Mapping):
         bootstrap = {}
     return {
-        "accepted": bool(payload.get("accepted")),
+        "accepted": payload.get("accepted") is True,
         "decision": str(payload.get("decision") or ""),
         "receipt_id": str(payload.get("receipt_id") or ""),
         "queue_item_id": str(payload.get("queue_item_id") or ""),
-        "queue_chain_complete": bool(payload.get("queue_chain_complete", False)),
-        "assigned_stage_complete": bool(payload.get("assigned_stage_complete", False)),
-        "queue_chain_requeue_required": bool(
-            payload.get("queue_chain_requeue_required", False)
-        ),
+        "queue_chain_complete": payload.get("queue_chain_complete") is True,
+        "assigned_stage_complete": payload.get("assigned_stage_complete") is True,
+        "queue_chain_requeue_required": payload.get("queue_chain_requeue_required") is True,
         "rejection_reasons": _signed_worker_receipt_reasons(
             tuple(payload.get("rejection_reasons") or ())
         ),
@@ -844,32 +836,89 @@ def _stable_digest(payload: Any) -> str:
     return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
-def _mark_reddog_signed_worker_dispatch_task_failed(db: Any, task_id: str) -> None:
-    if not task_id:
-        return
-    try:
-        db.db.execute_write(
-            "UPDATE agents_autonomous_tasks SET status = 'failed', completed_at = CURRENT_TIMESTAMP WHERE task_id = ?",
-            (task_id,),
-        )
-    except Exception:
-        logger.debug("[SUPERVISOR] Failed to mark RedDog signed-worker task failed", exc_info=True)
+def _signed_worker_runner_payload(
+    result: Mapping[str, Any], runner_result: Mapping[str, Any] | None
+) -> Dict[str, Any]:
+    if isinstance(runner_result, Mapping):
+        return dict(runner_result)
+    nested = result.get("runner_result")
+    return dict(nested) if isinstance(nested, Mapping) else {}
 
 
-def _requeue_reddog_signed_worker_dispatch_task(db: Any, task_id: str) -> None:
-    if not task_id:
-        return
-    try:
-        db.db.execute_write(
-            """
-            UPDATE agents_autonomous_tasks
-            SET assigned_to = NULL, assigned_at = NULL, status = 'pending'
-            WHERE task_id = ?
-            """,
-            (task_id,),
+def _signed_worker_task_result_receipt(
+    *, base_context: Mapping[str, Any], claim_status: str,
+    result: Mapping[str, Any], runner_payload: Mapping[str, Any],
+    rejection_reasons: Sequence[str],
+) -> Dict[str, Any]:
+    supplied = bool(result)
+    receipt = {
+        "schema_version": "reddog_signed_worker_task_result.v1",
+        "claim_status": str(claim_status or ""),
+        "accepted": result.get("accepted") is True if supplied else False,
+        "decision": str(result.get("decision") or ""),
+        "receipt_id": str(result.get("receipt_id") or ""),
+        "worker_role": str(result.get("worker_role") or base_context.get("worker_role") or ""),
+        "worker_runtime": str(result.get("worker_runtime") or base_context.get("worker_runtime") or ""),
+        "capability": str(result.get("capability") or base_context.get("capability") or ""),
+        "rejection_reasons": _signed_worker_receipt_reasons(
+            tuple(rejection_reasons) or tuple(result.get("rejection_reasons") or ())
+        ),
+        "runner_result_digest": _stable_digest(runner_payload) if runner_payload else "",
+        "run_result_digest": _stable_digest(result) if supplied else "",
+        "runner_result_summary": _signed_worker_runner_result_summary(runner_payload),
+        **_signed_worker_result_effect_fields(result, supplied=supplied),
+    }
+    receipt["receipt_digest"] = _stable_digest(receipt)
+    return receipt
+
+
+def _signed_worker_result_effect_fields(
+    result: Mapping[str, Any], *, supplied: bool
+) -> Dict[str, bool]:
+    source_fields = (
+        "no_shell_command_executed", "no_source_repo_mutation_performed",
+        "no_holoindex_reindex_performed", "no_hermes_dispatch_performed",
+        "no_worktree_operation_performed", "no_pr_created",
+        "no_live_foundup_enqueue_performed", "no_pattern_memory_write_performed",
+        "no_reward_settlement_performed",
+    )
+    return {
+        field: result.get(field) is True if supplied else True
+        for field in source_fields
+    }
+
+
+def _commit_signed_worker_task_result(
+    db: Any, task_id: str, base_context: Dict[str, Any],
+    receipt: Mapping[str, Any], *, task_status: str | None,
+) -> bool:
+    history = base_context.get("signed_worker_task_result_receipts")
+    bounded = [item for item in history or [] if isinstance(item, Mapping)][-9:]
+    bounded.append({
+        "claim_status": receipt["claim_status"],
+        "receipt_id": receipt["receipt_id"],
+        "receipt_digest": receipt["receipt_digest"],
+    })
+    base_context["signed_worker_task_last_result"] = dict(receipt)
+    base_context["signed_worker_task_result_receipts"] = bounded
+    context_json = json.dumps(base_context, sort_keys=True)
+    if task_status == "pending":
+        query = (
+            "UPDATE agents_autonomous_tasks SET context = ?, status = 'pending', "
+            "assigned_to = NULL, assigned_at = NULL WHERE task_id = ? "
+            "AND status = 'assigned'"
         )
-    except Exception:
-        logger.debug("[SUPERVISOR] Failed to requeue RedDog signed-worker task", exc_info=True)
+    elif task_status in {"completed", "failed"}:
+        query = (
+            "UPDATE agents_autonomous_tasks SET context = ?, status = ?, "
+            "completed_at = CURRENT_TIMESTAMP WHERE task_id = ? AND status = 'assigned'"
+        )
+        updated = db.db.execute_write(query, (context_json, task_status, task_id))
+        return updated == 1
+    else:
+        query = "UPDATE agents_autonomous_tasks SET context = ? WHERE task_id = ?"
+    updated = db.db.execute_write(query, (context_json, task_id))
+    return updated == 1
 
 
 def _readonly_assignment_id(context: Dict[str, Any]) -> str:
@@ -916,8 +965,9 @@ def _signed_worker_claim_result(
     receipt_id: str | None = None,
     rejection_reasons=(),
     detail: str = "",
+    effect_source: Mapping[str, Any] | None = None,
 ) -> Dict[str, Any]:
-    return {
+    result = {
         "accepted": accepted,
         "status": status,
         "task_id": task_id,
@@ -927,16 +977,80 @@ def _signed_worker_claim_result(
         "receipt_id": receipt_id,
         "rejection_reasons": tuple(dict.fromkeys(str(reason) for reason in rejection_reasons if str(reason))),
         "detail": detail,
-        "no_shell_command_executed": True,
-        "no_repo_mutation_performed": True,
-        "no_holoindex_reindex_performed": True,
-        "no_hermes_dispatch_performed": True,
-        "no_worktree_operation_performed": True,
-        "no_pr_created": True,
-        "no_live_foundup_enqueue_performed": True,
-        "no_pattern_memory_write_performed": True,
-        "no_reward_settlement_performed": True,
+        "execution_result_digest": "",
+        "worker_execution_performed": False,
+        "effect_evidence_complete": True,
+        "worker_process_spawn_count": 0,
+        "shell_command_count": 0,
     }
+    result.update(_signed_worker_effect_attestations(effect_source))
+    if str(task_id or "").strip():
+        result["execution_result_digest"] = "sha256:" + _stable_mapping_digest(
+            result
+        )
+    return result
+
+
+def _signed_worker_effect_attestations(
+    effect_source: Mapping[str, Any] | None,
+) -> Dict[str, Any]:
+    if effect_source is None:
+        return {
+            **{key: True for key in _SIGNED_WORKER_NO_EFFECT_FIELDS},
+            "worker_execution_performed": False,
+            "effect_evidence_complete": True,
+            "worker_process_spawn_count": 0,
+            "shell_command_count": 0,
+        }
+    source = dict(effect_source)
+    source_fields = {
+        "no_shell_command_executed": "no_shell_command_executed",
+        "no_repo_mutation_performed": "no_source_repo_mutation_performed",
+        "no_holoindex_reindex_performed": "no_holoindex_reindex_performed",
+        "no_hermes_dispatch_performed": "no_hermes_dispatch_performed",
+        "no_worktree_operation_performed": "no_worktree_operation_performed",
+        "no_pr_created": "no_pr_created",
+        "no_live_foundup_enqueue_performed": "no_live_foundup_enqueue_performed",
+        "no_pattern_memory_write_performed": "no_pattern_memory_write_performed",
+        "no_reward_settlement_performed": "no_reward_settlement_performed",
+    }
+    return {
+        **{
+            target: source.get(origin) is True
+            for target, origin in source_fields.items()
+        },
+        "worker_execution_performed": (
+            source.get("worker_execution_performed") is True
+        ),
+        "effect_evidence_complete": (
+            source.get("effect_evidence_complete") is True
+        ),
+        "worker_process_spawn_count": _strict_effect_count(
+            source.get("worker_process_spawn_count")
+        ),
+        "shell_command_count": _strict_effect_count(
+            source.get("shell_command_count")
+        ),
+    }
+
+
+def _strict_effect_count(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(value, 0)
+
+
+_SIGNED_WORKER_NO_EFFECT_FIELDS = (
+    "no_shell_command_executed",
+    "no_repo_mutation_performed",
+    "no_holoindex_reindex_performed",
+    "no_hermes_dispatch_performed",
+    "no_worktree_operation_performed",
+    "no_pr_created",
+    "no_live_foundup_enqueue_performed",
+    "no_pattern_memory_write_performed",
+    "no_reward_settlement_performed",
+)
 
 
 def _signed_worker_claim_loop_result(
@@ -953,44 +1067,152 @@ def _signed_worker_claim_loop_result(
     max_claims_reached: bool = False,
 ) -> Dict[str, Any]:
     results = tuple(claim_results or ())
-    no_fields = (
-        "no_shell_command_executed",
-        "no_repo_mutation_performed",
-        "no_holoindex_reindex_performed",
-        "no_hermes_dispatch_performed",
-        "no_worktree_operation_performed",
-        "no_pr_created",
-        "no_live_foundup_enqueue_performed",
-        "no_pattern_memory_write_performed",
-        "no_reward_settlement_performed",
+    (
+        receipt_ids,
+        child_evidence_digests,
+        aggregate_no,
+        worker_execution_count,
+        worker_process_spawn_count,
+        shell_command_count,
+    ) = _signed_worker_loop_evidence(results)
+    child_execution_outcomes = _signed_worker_child_execution_outcomes(
+        results=results,
+        completed_task_ids=completed_task_ids,
+        requeued_task_ids=requeued_task_ids,
+        failed_task_ids=failed_task_ids,
     )
+    return _signed_worker_claim_loop_payload(
+        accepted=accepted,
+        status=status,
+        max_claims=max_claims,
+        completed_task_ids=completed_task_ids,
+        requeued_task_ids=requeued_task_ids,
+        failed_task_ids=failed_task_ids,
+        idle=idle,
+        max_claims_reached=max_claims_reached,
+        results=results,
+        receipt_ids=receipt_ids,
+        child_evidence_digests=child_evidence_digests,
+        child_execution_outcomes=child_execution_outcomes,
+        aggregate_no=aggregate_no,
+        worker_execution_count=worker_execution_count,
+        worker_process_spawn_count=worker_process_spawn_count,
+        shell_command_count=shell_command_count,
+        rejection_reasons=rejection_reasons,
+    )
+
+
+def _signed_worker_claim_loop_payload(**values: Any) -> Dict[str, Any]:
+    completed_task_ids = values["completed_task_ids"]
+    requeued_task_ids = values["requeued_task_ids"]
+    failed_task_ids = values["failed_task_ids"]
+    return {
+        "accepted": values["accepted"],
+        "status": values["status"],
+        "max_claims": values["max_claims"],
+        "claimed_count": len(tuple(completed_task_ids or ()))
+        + len(tuple(requeued_task_ids or ()))
+        + len(tuple(failed_task_ids or ())),
+        "completed_task_ids": tuple(completed_task_ids or ()),
+        "requeued_task_ids": tuple(requeued_task_ids or ()),
+        "failed_task_ids": tuple(failed_task_ids or ()),
+        "idle": values["idle"],
+        "max_claims_reached": values["max_claims_reached"],
+        "claim_results": values["results"],
+        "receipt_ids": values["receipt_ids"],
+        "child_execution_evidence_digests": values["child_evidence_digests"],
+        "child_execution_outcomes": values["child_execution_outcomes"],
+        "worker_execution_count": values["worker_execution_count"],
+        "worker_process_spawn_count": values["worker_process_spawn_count"],
+        "shell_command_count": values["shell_command_count"],
+        "rejection_reasons": tuple(
+            dict.fromkeys(
+                str(reason)
+                for reason in values["rejection_reasons"]
+                if str(reason)
+            )
+        ),
+        **values["aggregate_no"],
+    }
+
+
+def _signed_worker_loop_evidence(
+    results,
+) -> tuple[
+    tuple[str, ...], tuple[str, ...], Dict[str, bool], int, int, int
+]:
     aggregate_no = {
-        key: all(bool(result.get(key, True)) for result in results)
-        for key in no_fields
+        key: all(result.get(key) is True for result in results)
+        for key in _SIGNED_WORKER_NO_EFFECT_FIELDS
     }
     receipt_ids = tuple(
         str(result.get("receipt_id") or "")
         for result in results
         if str(result.get("receipt_id") or "").strip()
     )
-    return {
-        "accepted": accepted,
-        "status": status,
-        "max_claims": max_claims,
-        "claimed_count": len(tuple(completed_task_ids or ()))
-        + len(tuple(requeued_task_ids or ())),
-        "completed_task_ids": tuple(completed_task_ids or ()),
-        "requeued_task_ids": tuple(requeued_task_ids or ()),
-        "failed_task_ids": tuple(failed_task_ids or ()),
-        "idle": idle,
-        "max_claims_reached": max_claims_reached,
-        "claim_results": results,
-        "receipt_ids": receipt_ids,
-        "rejection_reasons": tuple(
-            dict.fromkeys(str(reason) for reason in rejection_reasons if str(reason))
-        ),
-        **aggregate_no,
-    }
+    evidence = tuple(
+        str(result.get("execution_result_digest") or "")
+        for result in results
+        if str(result.get("task_id") or "").strip()
+        and str(result.get("execution_result_digest") or "").strip()
+    )
+    return (
+        receipt_ids,
+        evidence,
+        aggregate_no,
+        sum(result.get("worker_execution_performed") is True for result in results),
+        sum(_strict_effect_count(result.get("worker_process_spawn_count")) for result in results),
+        sum(_strict_effect_count(result.get("shell_command_count")) for result in results),
+    )
+
+
+def _signed_worker_child_execution_outcomes(
+    *, results, completed_task_ids, requeued_task_ids, failed_task_ids
+) -> tuple[Dict[str, Any], ...]:
+    completed = frozenset(str(item) for item in (completed_task_ids or ()))
+    requeued = frozenset(str(item) for item in (requeued_task_ids or ()))
+    failed = frozenset(str(item) for item in (failed_task_ids or ()))
+    classified = completed | requeued | failed
+    outcomes = []
+    for result in results:
+        task_id = str(result.get("task_id") or "")
+        if task_id not in classified:
+            continue
+        status = "completed" if task_id in completed else "requeued"
+        if task_id in failed:
+            status = "failed"
+        outcomes.append(
+            {
+                "task_id": task_id,
+                "status": status,
+                "receipt_id": "" if task_id in failed else str(result.get("receipt_id") or ""),
+                "evidence_digest": str(result.get("execution_result_digest") or ""),
+                "worker_execution_performed": (
+                    result.get("worker_execution_performed") is True
+                ),
+                "effect_evidence_complete": (
+                    result.get("effect_evidence_complete") is True
+                ),
+                "worker_process_spawn_count": _strict_effect_count(
+                    result.get("worker_process_spawn_count")
+                ),
+                "shell_command_count": _strict_effect_count(
+                    result.get("shell_command_count")
+                ),
+            }
+        )
+    return tuple(outcomes)
+
+
+def _stable_mapping_digest(value: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def _signed_worker_task_max_claims_from_env() -> tuple[int, str | None]:

--- a/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store.py
@@ -1,0 +1,148 @@
+"""Principal-resolution and durable-state boundaries for RedDog authority."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Protocol, Tuple
+
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    runtime_operation_lock,
+)
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class PrincipalAuthorityRecord:
+    """Token-verified principal basis supplied by an external resolver."""
+
+    principal_id: str
+    principal_provider: str
+    principal_public_key: str
+    repo_scope: Tuple[str, ...]
+    foundup_scope: Tuple[str, ...]
+    verified_subject_digest: str
+    reward_account: Optional[str] = None
+    owner_dae: Optional[str] = None
+    principal_wallet: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class PrincipalAuthorityResolver(Protocol):
+    def resolve(
+        self, principal_id: str, principal_provider: str
+    ) -> Optional[PrincipalAuthorityRecord]: ...
+
+
+class FailClosedPrincipalAuthorityResolver:
+    def resolve(
+        self, principal_id: str, principal_provider: str
+    ) -> Optional[PrincipalAuthorityRecord]:
+        return None
+
+
+class AuthorityRuntimeStore(Protocol):
+    def load(self) -> Dict[str, Any]: ...
+
+    def commit(
+        self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]
+    ) -> str: ...
+
+
+class InMemoryAuthorityRuntimeStore:
+    def __init__(
+        self, initial: Optional[Mapping[str, Any]] = None, *, fail_commit: bool = False
+    ) -> None:
+        self._state: Dict[str, Any] = dict(initial or {})
+        self.fail_commit = fail_commit
+
+    def load(self) -> Dict[str, Any]:
+        return json.loads(json.dumps(self._state, sort_keys=True))
+
+    def commit(
+        self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]
+    ) -> str:
+        if self.fail_commit:
+            raise RuntimeError("commit_failed")
+        if self._state.get("revision") != expected_revision:
+            raise RuntimeError("revision_conflict")
+        committed = json.loads(json.dumps(snapshot, sort_keys=True))
+        revision = _canonical_digest(committed)
+        committed["revision"] = revision
+        self._state = committed
+        return revision
+
+
+class AtomicJsonAuthorityRuntimeStore:
+    """Single-file authority store using durable atomic replace."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def load(self) -> Dict[str, Any]:
+        if not self.path.exists():
+            return {}
+        return json.loads(self.path.read_text(encoding="utf-8"))
+
+    def commit(
+        self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]
+    ) -> str:
+        with runtime_operation_lock(str(self.path.resolve()) + ".authority-state"):
+            current = self.load()
+            if current.get("revision") != expected_revision:
+                raise RuntimeError("revision_conflict")
+            committed = json.loads(json.dumps(snapshot, sort_keys=True))
+            revision = _canonical_digest(committed)
+            committed["revision"] = revision
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self._atomic_write(committed)
+            return revision
+
+    def _atomic_write(self, committed: Mapping[str, Any]) -> None:
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                json.dump(committed, handle, sort_keys=True, indent=2)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_name, self.path)
+            _fsync_parent_directory(self.path.parent)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+
+
+def _fsync_parent_directory(path: Path) -> None:
+    """Persist the rename itself on platforms supporting directory fsync."""
+
+    if os.name == "nt":
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(str(path), flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "AtomicJsonAuthorityRuntimeStore",
+    "AuthorityRuntimeStore",
+    "FailClosedPrincipalAuthorityResolver",
+    "InMemoryAuthorityRuntimeStore",
+    "PrincipalAuthorityRecord",
+    "PrincipalAuthorityResolver",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_ed25519_signer_backend.py
+++ b/modules/communication/moltbot_bridge/src/reddog_ed25519_signer_backend.py
@@ -14,8 +14,14 @@ key binding, key epoch, or audit-MAC boundary is missing, it rejects fail-closed
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Any, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    ControlLoopAnchorStore,
+)
 
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
     encode_ed25519_public_key,
@@ -37,7 +43,52 @@ REJECT_ED25519_SIGNER_KEY_INVALID = "REJECT_ED25519_SIGNER_KEY_INVALID"
 REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH = "REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH"
 REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH = "REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH"
 REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING = "REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING"
+REJECT_ED25519_SIGNER_DOMAIN_MISMATCH = "REJECT_ED25519_SIGNER_DOMAIN_MISMATCH"
 REJECT_ED25519_SIGNER_SIGN_FAILED = "REJECT_ED25519_SIGNER_SIGN_FAILED"
+REJECT_ED25519_SIGNER_CONTROL_ANCHOR_MISSING = (
+    "REJECT_ED25519_SIGNER_CONTROL_ANCHOR_MISSING"
+)
+REJECT_ED25519_SIGNER_CONTROL_ANCHOR_REJECTED = (
+    "REJECT_ED25519_SIGNER_CONTROL_ANCHOR_REJECTED"
+)
+REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING = (
+    "REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING"
+)
+REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH = (
+    "REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH"
+)
+
+CONTROL_LOOP_SIGNING_OPERATION = "attest_control_loop_receipt"
+CONTROL_LOOP_SIGNING_PREFIX = "reddog-control-loop.v2."
+CONTROL_LOOP_AUDIT_ATTESTATION_PREFIX = "reddog-control-loop-audit.v1."
+CONTROL_LOOP_RECEIPT_SCHEMA_VERSION = "reddog_resident_control_loop_receipt.v2"
+_CONTROL_LOOP_SIGNED_FIELDS = frozenset(
+    {
+        "schema_version", "receipt_id", "sequence_number", "cycle_id", "nonce",
+        "previous_receipt_id",
+        "legacy_prefix_digest", "accepted", "status", "rounds", "serial_progress",
+        "claim_progress", "receipt_ids", "source_receipt_ids_digest", "rejection_reasons",
+        "child_execution_receipt_ids",
+        "child_execution_evidence_digests", "child_execution_outcomes",
+        "child_execution_evidence_digest",
+        "child_execution_evidence_count",
+        "created_at", "repo_root_digest", "control_lock_acquired", "dispatched_stages",
+        "authority_issuance_count", "worker_claim_count", "worker_execution_count",
+        "worker_completion_count", "worker_requeue_count", "worker_failure_count",
+        "worktree_creation_count", "bounded_file_edit_count", "slice_verification_count",
+        "draft_pr_publish_count", "pattern_memory_admission_count",
+        "worker_process_spawn_count", "shell_command_count",
+        "worker_effects_unverified_count", "authority_issued",
+        "worker_claim_performed", "worker_execution_performed",
+        "worktree_creation_observed", "bounded_file_edit_observed",
+        "slice_verification_observed", "draft_pr_publish_observed",
+        "pattern_memory_admission_observed", "worker_process_spawn_observed",
+        "shell_command_execution_observed",
+        "issuer_principal_id", "signer_public_key", "signer_key_fingerprint", "key_epoch",
+        "consensus_receipt_digest", "authority_profile_digest",
+        "authority_profile_source_receipt_id", "authentication_status",
+    }
+)
 
 
 class SignerAuditMacBuilder(Protocol):
@@ -48,6 +99,18 @@ class SignerAuditMacBuilder(Protocol):
 
 
 @dataclass(frozen=True)
+class ControlLoopAuthorityPolicy:
+    """Signer-owned authorization bindings for control-loop attestations."""
+
+    issuer_principal_id: str
+    signer_public_key: str
+    key_epoch: str
+    consensus_receipt_digest: str
+    authority_profile_digest: str
+    authority_profile_source_receipt_id: str
+
+
+@dataclass(frozen=True)
 class Ed25519SignerBackend(IsolatedSignerBackend):
     """Sign requests with an already-held Ed25519 private key object."""
 
@@ -55,53 +118,132 @@ class Ed25519SignerBackend(IsolatedSignerBackend):
     public_key: str
     key_epoch: str
     audit_mac_builder: SignerAuditMacBuilder
+    control_loop_anchor_store: ControlLoopAnchorStore | None = None
+    control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None
 
     def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
-        if not isinstance(request, SigningRequest) or not isinstance(peer, SignerPeerAttestation):
-            return _reject(REJECT_ED25519_SIGNER_REQUEST_INVALID)
-        if not _assert_ascii_deep(request.to_dict()) or not _assert_ascii_deep(peer.to_dict()):
-            return _reject(REJECT_ED25519_SIGNER_REQUEST_INVALID)
-        if not _is_ascii(self.public_key) or not _is_ascii(self.key_epoch):
-            return _reject(REJECT_ED25519_SIGNER_KEY_INVALID)
-        if request.signer_public_key != self.public_key:
-            return _reject(REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH)
-        if request.key_epoch != self.key_epoch:
-            return _reject(REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH)
-        if not request.signing_input:
-            return _reject(REJECT_ED25519_SIGNER_REQUEST_INVALID)
-
-        try:
-            derived_public_key = encode_ed25519_public_key(_public_bytes_from_private_key(self.private_key))
-        except Exception:
-            return _reject(REJECT_ED25519_SIGNER_KEY_INVALID)
-        if derived_public_key != self.public_key:
-            return _reject(REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH)
-
-        try:
-            signature = encode_ed25519_signature(
-                self.private_key.sign(request.signing_input.encode("utf-8"))
-            )
-        except Exception:
-            return _reject(REJECT_ED25519_SIGNER_SIGN_FAILED)
-        try:
-            audit_mac = self.audit_mac_builder.build(request, signature, peer)
-        except Exception:
-            return _reject(REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING)
-        if not _is_ascii(audit_mac) or not audit_mac:
-            return _reject(REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING)
-
-        return SigningResponse(
-            accepted=True,
-            signature=signature,
-            signer_public_key=self.public_key,
-            key_fingerprint=public_key_fingerprint(self.public_key),
-            key_epoch=self.key_epoch,
-            audit_mac=audit_mac,
-            boundary_attested=peer.boundary_attested,
-            requester_identity_attested=True,
-            signer_loads_no_untrusted_code=True,
-            no_secret_material_returned=True,
+        reason = _signer_request_rejection(self, request, peer)
+        if reason:
+            return _reject(reason)
+        control_payload, preparation, reason = _prepare_control_signing(
+            self, request
         )
+        if reason:
+            return _reject(reason)
+        response, reason = _sign_response(
+            self, request, peer, control_payload is not None
+        )
+        if reason:
+            return _reject(reason)
+        if control_payload is not None and preparation is not None:
+            try:
+                self.control_loop_anchor_store.commit(
+                    control_payload, response.to_dict(),
+                    expected_revision=preparation.expected_revision,
+                )
+            except Exception:
+                return _reject(REJECT_ED25519_SIGNER_CONTROL_ANCHOR_REJECTED)
+        return response
+
+
+def _signer_request_rejection(
+    backend: Ed25519SignerBackend,
+    request: SigningRequest,
+    peer: SignerPeerAttestation,
+) -> str:
+    if not isinstance(request, SigningRequest) or not isinstance(peer, SignerPeerAttestation):
+        return REJECT_ED25519_SIGNER_REQUEST_INVALID
+    if not _assert_ascii_deep(request.to_dict()) or not _assert_ascii_deep(peer.to_dict()):
+        return REJECT_ED25519_SIGNER_REQUEST_INVALID
+    if not _is_ascii(backend.public_key) or not _is_ascii(backend.key_epoch):
+        return REJECT_ED25519_SIGNER_KEY_INVALID
+    if request.signer_public_key != backend.public_key:
+        return REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH
+    if request.key_epoch != backend.key_epoch:
+        return REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH
+    if not request.signing_input:
+        return REJECT_ED25519_SIGNER_REQUEST_INVALID
+    is_control = request.requested_operation == CONTROL_LOOP_SIGNING_OPERATION
+    if is_control is not request.signing_input.startswith(CONTROL_LOOP_SIGNING_PREFIX):
+        return REJECT_ED25519_SIGNER_DOMAIN_MISMATCH
+    try:
+        derived = encode_ed25519_public_key(_public_bytes_from_private_key(backend.private_key))
+    except Exception:
+        return REJECT_ED25519_SIGNER_KEY_INVALID
+    return "" if derived == backend.public_key else REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH
+
+
+def _prepare_control_signing(
+    backend: Ed25519SignerBackend, request: SigningRequest
+) -> tuple[dict[str, Any] | None, Any, str]:
+    if request.requested_operation != CONTROL_LOOP_SIGNING_OPERATION:
+        return None, None, ""
+    payload = _valid_control_receipt_signing_payload(request)
+    if payload is None:
+        return None, None, REJECT_ED25519_SIGNER_REQUEST_INVALID
+    if backend.control_loop_authority_policy is None:
+        return None, None, REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING
+    if not _control_authority_policy_matches(payload, backend.control_loop_authority_policy):
+        return None, None, REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH
+    if backend.control_loop_anchor_store is None:
+        return None, None, REJECT_ED25519_SIGNER_CONTROL_ANCHOR_MISSING
+    try:
+        preparation = backend.control_loop_anchor_store.prepare(payload)
+    except Exception:
+        return None, None, REJECT_ED25519_SIGNER_CONTROL_ANCHOR_REJECTED
+    return payload, preparation, ""
+
+
+def _sign_response(
+    backend: Ed25519SignerBackend, request: SigningRequest,
+    peer: SignerPeerAttestation, is_control: bool,
+) -> tuple[SigningResponse, str]:
+    try:
+        signature = encode_ed25519_signature(
+            backend.private_key.sign(request.signing_input.encode("utf-8"))
+        )
+    except Exception:
+        return SigningResponse(accepted=False), REJECT_ED25519_SIGNER_SIGN_FAILED
+    try:
+        audit_mac = backend.audit_mac_builder.build(request, signature, peer)
+    except Exception:
+        return SigningResponse(accepted=False), REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING
+    if not _is_ascii(audit_mac) or not audit_mac:
+        return SigningResponse(accepted=False), REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING
+    attestation, reason = _control_audit_attestation(
+        backend, request, signature, audit_mac, is_control
+    )
+    if reason:
+        return SigningResponse(accepted=False), reason
+    return SigningResponse(
+        accepted=True, signature=signature, signer_public_key=backend.public_key,
+        key_fingerprint=public_key_fingerprint(backend.public_key),
+        key_epoch=backend.key_epoch, audit_mac=audit_mac,
+        audit_attestation_signature=attestation,
+        boundary_attested=peer.boundary_attested,
+        requester_identity_attested=True, signer_loads_no_untrusted_code=True,
+        no_secret_material_returned=True,
+    ), ""
+
+
+def _control_audit_attestation(
+    backend: Ed25519SignerBackend, request: SigningRequest,
+    signature: str, audit_mac: str, is_control: bool,
+) -> tuple[str, str]:
+    if not is_control:
+        return "", ""
+    try:
+        value = canonical_control_audit_attestation_input(
+            signing_input=request.signing_input, signature=signature,
+            audit_mac=audit_mac, signer_public_key=backend.public_key,
+            key_epoch=backend.key_epoch,
+            requester_principal_id=request.requester_principal_id,
+        )
+        return encode_ed25519_signature(
+            backend.private_key.sign(value.encode("utf-8"))
+        ), ""
+    except Exception:
+        return "", REJECT_ED25519_SIGNER_SIGN_FAILED
 
 
 def _public_bytes_from_private_key(private_key: Any) -> bytes:
@@ -111,6 +253,111 @@ def _public_bytes_from_private_key(private_key: Any) -> bytes:
         encoding=serialization.Encoding.Raw,
         format=serialization.PublicFormat.Raw,
     )
+
+
+def _valid_control_receipt_signing_payload(
+    request: SigningRequest,
+) -> dict[str, Any] | None:
+    raw = request.signing_input[len(CONTROL_LOOP_SIGNING_PREFIX) :]
+    try:
+        payload = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or set(payload) != _CONTROL_LOOP_SIGNED_FIELDS:
+        return None
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    if raw != canonical:
+        return None
+    unsigned = {key: value for key, value in payload.items() if key != "receipt_id"}
+    expected_id = "reddog_resident_control_loop_v2_" + _sha256_json(unsigned)
+    expected_request_digest = "sha256:" + _sha256_json({"signing_input": request.signing_input})
+    valid = bool(
+        request.signer_role == "reddog_control_loop"
+        and request.authority_tier in {"HIGH", "ULTRA"}
+        and payload.get("schema_version") == CONTROL_LOOP_RECEIPT_SCHEMA_VERSION
+        and payload.get("receipt_id") == expected_id
+        and payload.get("nonce") == request.nonce
+        and payload.get("issuer_principal_id") == request.requester_principal_id
+        and payload.get("signer_public_key") == request.signer_public_key
+        and payload.get("key_epoch") == request.key_epoch
+        and payload.get("consensus_receipt_digest") == request.consensus_receipt_digest
+        and _is_sha256_digest(payload.get("consensus_receipt_digest"))
+        and _is_sha256_digest(payload.get("authority_profile_digest"))
+        and _is_sha256_digest(payload.get("authority_profile_source_receipt_id"))
+        and payload.get("authentication_status") == "AUTHENTICATED"
+        and request.payload_digest == expected_request_digest
+    )
+    return payload if valid else None
+
+
+def _control_authority_policy_matches(
+    payload: dict[str, Any], policy: ControlLoopAuthorityPolicy
+) -> bool:
+    if not isinstance(policy, ControlLoopAuthorityPolicy):
+        return False
+    policy_payload = {
+        "authority_profile_digest": policy.authority_profile_digest,
+        "authority_profile_source_receipt_id": (
+            policy.authority_profile_source_receipt_id
+        ),
+        "consensus_receipt_digest": policy.consensus_receipt_digest,
+        "issuer_principal_id": policy.issuer_principal_id,
+        "key_epoch": policy.key_epoch,
+        "signer_public_key": policy.signer_public_key,
+    }
+    if not _assert_ascii_deep(policy_payload):
+        return False
+    if not all(
+        _is_sha256_digest(policy_payload[field])
+        for field in (
+            "authority_profile_digest",
+            "authority_profile_source_receipt_id",
+            "consensus_receipt_digest",
+        )
+    ):
+        return False
+    return all(payload.get(field) == expected for field, expected in policy_payload.items())
+
+
+def canonical_control_audit_attestation_input(
+    *,
+    signing_input: str,
+    signature: str,
+    audit_mac: str,
+    signer_public_key: str,
+    key_epoch: str,
+    requester_principal_id: str,
+) -> str:
+    """Return the public, deterministic attestation input for a signer audit MAC."""
+
+    payload = {
+        "audit_mac": audit_mac,
+        "key_epoch": key_epoch,
+        "requester_principal_id": requester_principal_id,
+        "signature": signature,
+        "signer_public_key": signer_public_key,
+        "signing_input_digest": "sha256:" + hashlib.sha256(
+            signing_input.encode("utf-8")
+        ).hexdigest(),
+    }
+    return CONTROL_LOOP_AUDIT_ATTESTATION_PREFIX + json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = str(value or "")
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
+
+
+def _sha256_json(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def _reject(code: str) -> SigningResponse:
@@ -138,8 +385,18 @@ def _assert_ascii_deep(value: object) -> bool:
 
 
 __all__ = [
+    "CONTROL_LOOP_AUDIT_ATTESTATION_PREFIX",
+    "CONTROL_LOOP_SIGNING_OPERATION",
+    "CONTROL_LOOP_SIGNING_PREFIX",
+    "ControlLoopAuthorityPolicy",
+    "canonical_control_audit_attestation_input",
     "Ed25519SignerBackend",
     "REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING",
+    "REJECT_ED25519_SIGNER_CONTROL_ANCHOR_MISSING",
+    "REJECT_ED25519_SIGNER_CONTROL_ANCHOR_REJECTED",
+    "REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING",
+    "REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH",
+    "REJECT_ED25519_SIGNER_DOMAIN_MISMATCH",
     "REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH",
     "REJECT_ED25519_SIGNER_KEY_INVALID",
     "REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH",

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_client.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_client.py
@@ -202,6 +202,9 @@ def _response_from_mapping(value: object) -> SigningResponse:
         key_fingerprint=str(value["key_fingerprint"]),
         key_epoch=str(value["key_epoch"]),
         audit_mac=str(value["audit_mac"]),
+        audit_attestation_signature=str(
+            value.get("audit_attestation_signature") or ""
+        ),
         boundary_attested=value.get("boundary_attested") is True,
         requester_identity_attested=value.get("requester_identity_attested") is True,
         signer_loads_no_untrusted_code=value.get("signer_loads_no_untrusted_code") is True,

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_chain_state.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_chain_state.py
@@ -1,0 +1,99 @@
+"""Generic state walker for resident control-loop receipt chains."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_validation import (
+    parse_receipt_line,
+    validated_receipt_identity,
+)
+
+
+def validate_control_receipt_chain_state(
+    existing: str,
+    *,
+    current_schema: str,
+    legacy_schema: str,
+    receipt_id_builder: Callable[[Mapping[str, Any]], str],
+    legacy_digest_builder: Callable[[Any], str],
+    verify_current: Callable[[Mapping[str, Any]], Any],
+) -> dict[str, Any]:
+    state = _new_state(legacy_digest_builder)
+    for line_number, raw in enumerate(existing.splitlines(), start=1):
+        if not raw.strip():
+            continue
+        payload = parse_receipt_line(raw, line_number)
+        schema, receipt_id = validated_receipt_identity(
+            payload, line_number, state["seen_ids"], receipt_id_builder
+        )
+        if schema == legacy_schema:
+            _consume_legacy(payload, line_number, state, legacy_digest_builder)
+        elif schema == current_schema:
+            _consume_current(
+                verify_current(payload), line_number, receipt_id, state
+            )
+        else:
+            raise ValueError(f"resident_control_loop_receipt_schema_invalid:{line_number}")
+        state["seen_ids"].add(receipt_id)
+        state["last_receipt_id"] = receipt_id
+    return _public_state(state)
+
+
+def _new_state(legacy_digest_builder: Callable[[Any], str]) -> dict[str, Any]:
+    return {
+        "seen_ids": set(), "cycle_ids": set(), "nonces": set(),
+        "child_receipt_ids": set(), "child_evidence_digests": set(),
+        "legacy_payloads": [], "legacy_prefix_digest": legacy_digest_builder(()),
+        "last_receipt_id": "", "current_seen": False,
+        "current_receipt_ids": [],
+    }
+
+
+def _consume_legacy(
+    payload: Mapping[str, Any], line_number: int, state: dict[str, Any],
+    legacy_digest_builder: Callable[[Any], str],
+) -> None:
+    if state["current_seen"]:
+        raise ValueError(f"resident_control_loop_receipt_legacy_after_v2:{line_number}")
+    state["legacy_payloads"].append(payload)
+    state["legacy_prefix_digest"] = legacy_digest_builder(state["legacy_payloads"])
+
+
+def _consume_current(
+    receipt: Any, line_number: int, receipt_id: str, state: dict[str, Any]
+) -> None:
+    expected_sequence = len(state["current_receipt_ids"]) + 1
+    if receipt.sequence_number != expected_sequence:
+        raise ValueError(f"resident_control_loop_receipt_sequence_invalid:{line_number}")
+    if receipt.previous_receipt_id != state["last_receipt_id"]:
+        raise ValueError(f"resident_control_loop_receipt_previous_link_invalid:{line_number}")
+    if receipt.legacy_prefix_digest != state["legacy_prefix_digest"]:
+        raise ValueError(f"resident_control_loop_receipt_legacy_digest_invalid:{line_number}")
+    if receipt.cycle_id in state["cycle_ids"] or receipt.nonce in state["nonces"]:
+        raise ValueError(f"resident_control_loop_receipt_replay:{line_number}")
+    if state["child_receipt_ids"].intersection(receipt.child_execution_receipt_ids):
+        raise ValueError(f"resident_control_loop_receipt_child_receipt_replay:{line_number}")
+    if state["child_evidence_digests"].intersection(receipt.child_execution_evidence_digests):
+        raise ValueError(f"resident_control_loop_receipt_child_evidence_replay:{line_number}")
+    state["current_seen"] = True
+    state["cycle_ids"].add(receipt.cycle_id)
+    state["nonces"].add(receipt.nonce)
+    state["child_receipt_ids"].update(receipt.child_execution_receipt_ids)
+    state["child_evidence_digests"].update(receipt.child_execution_evidence_digests)
+    state["current_receipt_ids"].append(receipt_id)
+
+
+def _public_state(state: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "last_receipt_id": state["last_receipt_id"],
+        "legacy_prefix_digest": state["legacy_prefix_digest"],
+        "cycle_ids": frozenset(state["cycle_ids"]),
+        "nonces": frozenset(state["nonces"]),
+        "child_receipt_ids": frozenset(state["child_receipt_ids"]),
+        "child_evidence_digests": frozenset(state["child_evidence_digests"]),
+        "current_receipt_ids": tuple(state["current_receipt_ids"]),
+    }
+
+
+__all__ = ["validate_control_receipt_chain_state"]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_effects.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_effects.py
@@ -1,0 +1,113 @@
+"""Derive resident control-loop effect claims from observed stage evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_outcomes import (
+    strict_child_outcomes,
+)
+
+
+_AUTHORITY_ISSUING_STAGES = frozenset({"authority_runtime"})
+_WORKER_EXECUTION_STAGES = frozenset({"bounded_worker_pilot"})
+_WORKTREE_CREATION_STAGES = frozenset({"worktree_create"})
+_BOUNDED_FILE_EDIT_STAGES = frozenset({"bounded_worker_pilot"})
+_SLICE_VERIFICATION_STAGES = frozenset({"slice_verifier"})
+_DRAFT_PR_PUBLISH_STAGES = frozenset({"verified_draft_pr_publish"})
+_PATTERN_MEMORY_ADMISSION_STAGES = frozenset({"pattern_memory_admission"})
+
+
+def derive_control_loop_effects(
+    dispatched_stages: tuple[str, ...],
+    claim_progress: int,
+    result: Mapping[str, Any],
+) -> dict[str, Any]:
+    authority_count = sum(stage in _AUTHORITY_ISSUING_STAGES for stage in dispatched_stages)
+    bounded_worker_count = sum(stage in _WORKER_EXECUTION_STAGES for stage in dispatched_stages)
+    worktree_count = sum(stage in _WORKTREE_CREATION_STAGES for stage in dispatched_stages)
+    bounded_edit_count = sum(stage in _BOUNDED_FILE_EDIT_STAGES for stage in dispatched_stages)
+    verification_count = sum(stage in _SLICE_VERIFICATION_STAGES for stage in dispatched_stages)
+    draft_pr_count = sum(stage in _DRAFT_PR_PUBLISH_STAGES for stage in dispatched_stages)
+    pattern_memory_count = sum(
+        stage in _PATTERN_MEMORY_ADMISSION_STAGES for stage in dispatched_stages
+    )
+    outcomes = strict_child_outcomes(result.get("child_execution_outcomes", ()))
+    counts = _worker_counts(result, claim_progress, bounded_worker_count, outcomes)
+    process_spawn_count = sum(
+        outcome["worker_process_spawn_count"] for outcome in outcomes
+    )
+    shell_count = sum(outcome["shell_command_count"] for outcome in outcomes)
+    unverified_count = sum(
+        outcome["effect_evidence_complete"] is False for outcome in outcomes
+    )
+    if result.get("accepted") is True and unverified_count:
+        raise ValueError("resident_control_loop_accepted_effects_unverified")
+    return {
+        "authority_issuance_count": authority_count,
+        **counts,
+        "worktree_creation_count": worktree_count,
+        "bounded_file_edit_count": bounded_edit_count,
+        "slice_verification_count": verification_count,
+        "draft_pr_publish_count": draft_pr_count,
+        "pattern_memory_admission_count": pattern_memory_count,
+        "worker_process_spawn_count": process_spawn_count,
+        "shell_command_count": shell_count,
+        "worker_effects_unverified_count": unverified_count,
+        "authority_issued": authority_count > 0,
+        "worker_claim_performed": counts["worker_claim_count"] > 0,
+        "worker_execution_performed": counts["worker_execution_count"] > 0,
+        "worktree_creation_observed": worktree_count > 0,
+        "bounded_file_edit_observed": bounded_edit_count > 0,
+        "slice_verification_observed": verification_count > 0,
+        "draft_pr_publish_observed": draft_pr_count > 0,
+        "pattern_memory_admission_observed": pattern_memory_count > 0,
+        "worker_process_spawn_observed": process_spawn_count > 0,
+        "shell_command_execution_observed": shell_count > 0,
+    }
+
+
+def reject_contradictory_effect_claims(
+    result: Mapping[str, Any], effects: Mapping[str, Any]
+) -> None:
+    for key, expected in effects.items():
+        if key in result and result.get(key) != expected:
+            raise ValueError(f"resident_control_loop_effect_claim_conflict:{key}")
+
+
+def _worker_counts(
+    result: Mapping[str, Any],
+    claim_progress: int,
+    bounded_worker_count: int,
+    outcomes: tuple[dict[str, Any], ...],
+) -> dict[str, int]:
+    claim_count = _integer(result.get("worker_claim_count", claim_progress))
+    if claim_count != claim_progress:
+        raise ValueError("resident_control_loop_worker_claim_count_conflict")
+    completion = _integer(result.get("worker_completion_count"))
+    requeue = _integer(result.get("worker_requeue_count"))
+    failure = _integer(result.get("worker_failure_count"))
+    if completion + requeue + failure != claim_count:
+        raise ValueError("resident_control_loop_worker_outcome_count_invalid")
+    if len(outcomes) != claim_count:
+        raise ValueError("resident_control_loop_worker_outcome_count_invalid")
+    child_execution_count = sum(
+        outcome["worker_execution_performed"] is True for outcome in outcomes
+    )
+    return {
+        "worker_claim_count": claim_count,
+        "worker_execution_count": child_execution_count + bounded_worker_count,
+        "worker_completion_count": completion,
+        "worker_requeue_count": requeue,
+        "worker_failure_count": failure,
+    }
+
+
+def _integer(value: Any) -> int:
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+__all__ = ["derive_control_loop_effects", "reject_contradictory_effect_claims"]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_head_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_head_store.py
@@ -1,0 +1,254 @@
+"""Rollback-resistant high-water state for authenticated control receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AtomicJsonAuthorityRuntimeStore,
+)
+
+
+CONTROL_RECEIPT_HEAD_SCHEMA_VERSION = "reddog_control_receipt_head.v1"
+
+
+def load_control_receipt_head(
+    path: Path | str,
+) -> tuple[AtomicJsonAuthorityRuntimeStore, dict[str, Any], dict[str, Any] | None]:
+    store = AtomicJsonAuthorityRuntimeStore(Path(path).resolve())
+    state = store.load()
+    if not isinstance(state, dict):
+        raise ValueError("resident_control_loop_head_state_invalid")
+    raw = state.get("control_receipt_head")
+    if raw is None:
+        return store, state, None
+    if not isinstance(raw, Mapping):
+        raise ValueError("resident_control_loop_head_invalid")
+    head = dict(raw)
+    _validate_head_shape(head)
+    return store, state, head
+
+
+def build_control_receipt_head(
+    *,
+    receipt: Mapping[str, Any],
+    receipt_ids: tuple[str, ...],
+    consumed_child_receipt_ids: tuple[str, ...],
+    consumed_child_evidence_digests: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "schema_version": CONTROL_RECEIPT_HEAD_SCHEMA_VERSION,
+        "sequence_number": int(receipt["sequence_number"]),
+        "receipt_count": len(receipt_ids),
+        "receipt_id": str(receipt["receipt_id"]),
+        "previous_receipt_id": str(receipt["previous_receipt_id"]),
+        "receipt_ids_digest": _digest(list(receipt_ids)),
+        "signed_receipt": dict(receipt),
+        "consumed_child_receipt_ids": list(consumed_child_receipt_ids),
+        "consumed_child_evidence_digests": list(
+            consumed_child_evidence_digests
+        ),
+    }
+
+
+def commit_control_receipt_head(
+    *,
+    store: AtomicJsonAuthorityRuntimeStore,
+    state: Mapping[str, Any],
+    head: Mapping[str, Any],
+) -> str:
+    next_state = dict(state)
+    expected_revision = next_state.get("revision")
+    next_state.pop("revision", None)
+    next_state["control_receipt_head"] = dict(head)
+    return store.commit(next_state, expected_revision=expected_revision)
+
+
+def commit_next_control_receipt_head(
+    *,
+    store: AtomicJsonAuthorityRuntimeStore,
+    state: Mapping[str, Any],
+    chain: Mapping[str, Any],
+    receipt: Any,
+) -> str:
+    receipt_ids = (*chain["current_receipt_ids"], receipt.receipt_id)
+    child_receipts = tuple(
+        sorted({*chain["child_receipt_ids"], *receipt.child_execution_receipt_ids})
+    )
+    child_digests = tuple(
+        sorted(
+            {
+                *chain["child_evidence_digests"],
+                *receipt.child_execution_evidence_digests,
+            }
+        )
+    )
+    head = build_control_receipt_head(
+        receipt=receipt.to_dict(), receipt_ids=receipt_ids,
+        consumed_child_receipt_ids=child_receipts,
+        consumed_child_evidence_digests=child_digests,
+    )
+    return commit_control_receipt_head(store=store, state=state, head=head)
+
+
+def verify_control_receipt_head(
+    head: Mapping[str, Any], *, receipt_ids: tuple[str, ...]
+) -> None:
+    _validate_head_shape(head)
+    if (
+        int(head["receipt_count"]) != len(receipt_ids)
+        or int(head["sequence_number"]) != len(receipt_ids)
+        or str(head["receipt_id"]) != (receipt_ids[-1] if receipt_ids else "")
+        or str(head["receipt_ids_digest"]) != _digest(list(receipt_ids))
+    ):
+        raise ValueError("resident_control_loop_head_chain_mismatch")
+
+
+def verify_control_receipt_head_against_chain(
+    head: Mapping[str, Any],
+    *,
+    receipt_ids: tuple[str, ...],
+    child_receipt_ids: tuple[str, ...],
+    child_evidence_digests: tuple[str, ...],
+) -> None:
+    """Verify the full high-water witness before any downstream execution."""
+
+    verify_control_receipt_head(head, receipt_ids=receipt_ids)
+    _verify_consumed_evidence(
+        head,
+        {
+            "child_receipt_ids": frozenset(child_receipt_ids),
+            "child_evidence_digests": frozenset(child_evidence_digests),
+        },
+    )
+
+
+def reconcile_control_receipt_head(
+    *,
+    target: Path,
+    chain: Mapping[str, Any],
+    head: Mapping[str, Any] | None,
+    repo_root: Path | str,
+    signing_context: Any,
+    verify_receipt: Callable[..., Any],
+    append_receipt: Callable[..., None],
+    validate_chain: Callable[..., dict[str, Any]],
+    read_chain: Callable[[Path], str],
+) -> dict[str, Any]:
+    current_ids = tuple(chain["current_receipt_ids"])
+    if head is None:
+        if current_ids:
+            raise ValueError("resident_control_loop_head_missing_for_existing_chain")
+        return dict(chain)
+    if int(head["receipt_count"]) == len(current_ids):
+        verify_control_receipt_head_against_chain(
+            head,
+            receipt_ids=current_ids,
+            child_receipt_ids=tuple(chain["child_receipt_ids"]),
+            child_evidence_digests=tuple(chain["child_evidence_digests"]),
+        )
+        return dict(chain)
+    if int(head["receipt_count"]) != len(current_ids) + 1:
+        raise ValueError("resident_control_loop_head_rollback_detected")
+    pending = _verify_pending_receipt(
+        head, chain, repo_root, signing_context, verify_receipt
+    )
+    append_receipt(
+        target, pending, repo_root,
+        signing_context=signing_context, require_authentication=True,
+    )
+    recovered = validate_chain(
+        read_chain(target), signing_context=signing_context,
+        require_authenticated_current=True,
+    )
+    verify_control_receipt_head_against_chain(
+        head,
+        receipt_ids=tuple(recovered["current_receipt_ids"]),
+        child_receipt_ids=tuple(recovered["child_receipt_ids"]),
+        child_evidence_digests=tuple(recovered["child_evidence_digests"]),
+    )
+    return recovered
+
+
+def _verify_pending_receipt(
+    head: Mapping[str, Any],
+    chain: Mapping[str, Any],
+    repo_root: Path | str,
+    context: Any,
+    verify_receipt: Callable[..., Any],
+) -> Any:
+    pending = verify_receipt(
+        dict(head["signed_receipt"]), expected_repo_root=repo_root,
+        expected_signer_public_key=context.signer_public_key,
+        expected_key_epoch=context.key_epoch,
+        expected_consensus_receipt_digest=context.consensus_receipt_digest,
+        expected_authority_profile_digest=context.authority_profile_digest,
+        expected_authority_profile_source_receipt_id=(
+            context.authority_profile_source_receipt_id
+        ),
+        expected_issuer_principal_id=context.issuer_principal_id,
+        require_authenticated=True, signature_verifier=context.signature_verifier,
+    )
+    if (
+        pending.sequence_number != int(head["receipt_count"])
+        or pending.previous_receipt_id != chain["last_receipt_id"]
+        or pending.receipt_id != head["receipt_id"]
+    ):
+        raise ValueError("resident_control_loop_head_pending_receipt_invalid")
+    return pending
+
+
+def _verify_consumed_evidence(
+    head: Mapping[str, Any], chain: Mapping[str, Any]
+) -> None:
+    if set(head["consumed_child_receipt_ids"]) != set(chain["child_receipt_ids"]):
+        raise ValueError("resident_control_loop_head_child_receipts_invalid")
+    if set(head["consumed_child_evidence_digests"]) != set(
+        chain["child_evidence_digests"]
+    ):
+        raise ValueError("resident_control_loop_head_child_evidence_invalid")
+
+
+def _validate_head_shape(head: Mapping[str, Any]) -> None:
+    required = {
+        "schema_version", "sequence_number", "receipt_count", "receipt_id",
+        "previous_receipt_id", "receipt_ids_digest", "signed_receipt",
+        "consumed_child_receipt_ids", "consumed_child_evidence_digests",
+    }
+    if set(head) != required or head.get("schema_version") != CONTROL_RECEIPT_HEAD_SCHEMA_VERSION:
+        raise ValueError("resident_control_loop_head_schema_invalid")
+    sequence = head.get("sequence_number")
+    count = head.get("receipt_count")
+    if (
+        isinstance(sequence, bool)
+        or not isinstance(sequence, int)
+        or sequence < 1
+        or isinstance(count, bool)
+        or not isinstance(count, int)
+        or sequence != count
+        or not isinstance(head.get("signed_receipt"), Mapping)
+    ):
+        raise ValueError("resident_control_loop_head_shape_invalid")
+    for key in ("consumed_child_receipt_ids", "consumed_child_evidence_digests"):
+        values = head.get(key)
+        if not isinstance(values, list) or len(values) > 4096 or len(set(values)) != len(values):
+            raise ValueError("resident_control_loop_head_consumed_evidence_invalid")
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "build_control_receipt_head",
+    "commit_control_receipt_head",
+    "commit_next_control_receipt_head",
+    "load_control_receipt_head",
+    "reconcile_control_receipt_head",
+    "verify_control_receipt_head",
+    "verify_control_receipt_head_against_chain",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_outcomes.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_outcomes.py
@@ -1,0 +1,234 @@
+"""Exact child-outcome bindings for resident control-loop receipts."""
+
+from __future__ import annotations
+
+import re
+import hashlib
+import json
+from typing import Any, Mapping
+
+
+_SHA256_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+_CLAIM_STATUS_TO_OUTCOME = {
+    "SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT": "completed",
+    "SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED": "requeued",
+    "SIGNED_WORKER_OPENCLAW_CLAIM_REJECT": "failed",
+}
+_NO_EFFECT_FIELDS = frozenset(
+    {
+        "no_shell_command_executed",
+        "no_repo_mutation_performed",
+        "no_holoindex_reindex_performed",
+        "no_hermes_dispatch_performed",
+        "no_worktree_operation_performed",
+        "no_pr_created",
+        "no_live_foundup_enqueue_performed",
+        "no_pattern_memory_write_performed",
+        "no_reward_settlement_performed",
+    }
+)
+_CLAIM_EVIDENCE_FIELDS = frozenset(
+    {
+        "accepted",
+        "status",
+        "task_id",
+        "worker_role",
+        "worker_runtime",
+        "capability",
+        "receipt_id",
+        "rejection_reasons",
+        "detail",
+        "execution_result_digest",
+        "worker_execution_performed",
+        "effect_evidence_complete",
+        "worker_process_spawn_count",
+        "shell_command_count",
+        *_NO_EFFECT_FIELDS,
+    }
+)
+
+
+def derive_child_outcome_projections(
+    result: Mapping[str, Any],
+) -> tuple[tuple[dict[str, Any], ...], tuple[str, ...], tuple[str, ...]]:
+    outcomes = strict_child_outcomes(result.get("child_execution_outcomes", ()))
+    verify_child_execution_evidence(
+        result.get("child_execution_evidence", ()), outcomes
+    )
+    receipt_ids = tuple(
+        outcome["receipt_id"]
+        for outcome in outcomes
+        if outcome["status"] in {"completed", "requeued"}
+    )
+    evidence_digests = tuple(outcome["evidence_digest"] for outcome in outcomes)
+    _reject_projection_conflicts(result, receipt_ids, evidence_digests)
+    return outcomes, receipt_ids, evidence_digests
+
+
+def strict_child_outcomes(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, (list, tuple)) or len(value) > 128:
+        raise ValueError("resident_control_loop_receipt_child_outcomes_invalid")
+    outcomes: list[dict[str, Any]] = []
+    for raw in value:
+        if not isinstance(raw, Mapping) or set(raw) != {
+            "task_id",
+            "status",
+            "receipt_id",
+            "evidence_digest",
+            "worker_execution_performed",
+            "effect_evidence_complete",
+            "worker_process_spawn_count",
+            "shell_command_count",
+        }:
+            raise ValueError("resident_control_loop_receipt_child_outcomes_invalid")
+        if not isinstance(raw.get("worker_execution_performed"), bool) or not isinstance(
+            raw.get("effect_evidence_complete"), bool
+        ):
+            raise ValueError("resident_control_loop_receipt_child_outcomes_invalid")
+        outcome = {
+            "task_id": str(raw.get("task_id") or "").strip(),
+            "status": str(raw.get("status") or "").strip(),
+            "receipt_id": str(raw.get("receipt_id") or "").strip(),
+            "evidence_digest": str(raw.get("evidence_digest") or "").strip(),
+            "worker_execution_performed": raw["worker_execution_performed"],
+            "effect_evidence_complete": raw["effect_evidence_complete"],
+            "worker_process_spawn_count": raw["worker_process_spawn_count"],
+            "shell_command_count": raw["shell_command_count"],
+        }
+        _validate_outcome(outcome)
+        outcomes.append(outcome)
+    task_ids = tuple(item["task_id"] for item in outcomes)
+    if len(set(task_ids)) != len(task_ids):
+        raise ValueError("resident_control_loop_receipt_child_task_replay")
+    return tuple(outcomes)
+
+
+def verify_child_execution_evidence(
+    value: Any, outcomes: tuple[dict[str, Any], ...]
+) -> None:
+    """Recompute complete OpenClaw child evidence before parent signing."""
+
+    if not isinstance(value, (list, tuple)) or len(value) > 128:
+        raise ValueError("resident_control_loop_child_evidence_invalid")
+    evidence = tuple(item for item in value if isinstance(item, Mapping))
+    if len(evidence) != len(value):
+        raise ValueError("resident_control_loop_child_evidence_invalid")
+    task_evidence = tuple(item for item in evidence if str(item.get("task_id") or ""))
+    if len(task_evidence) != len(outcomes):
+        raise ValueError("resident_control_loop_child_evidence_count_invalid")
+    for raw, outcome in zip(task_evidence, outcomes):
+        _verify_one_child_evidence(raw, outcome)
+
+
+def _verify_one_child_evidence(
+    raw: Mapping[str, Any], outcome: Mapping[str, Any]
+) -> None:
+    if set(raw) != _CLAIM_EVIDENCE_FIELDS:
+        raise ValueError("resident_control_loop_child_evidence_fields_invalid")
+    evidence = dict(raw)
+    supplied_digest = evidence.get("execution_result_digest")
+    evidence["execution_result_digest"] = ""
+    expected_digest = "sha256:" + hashlib.sha256(
+        json.dumps(
+            evidence,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+    status = str(raw.get("status") or "")
+    receipt_id = str(raw.get("receipt_id") or "")
+    expected_outcome = {
+        "task_id": str(raw.get("task_id") or ""),
+        "status": _CLAIM_STATUS_TO_OUTCOME.get(status, ""),
+        "receipt_id": "" if status.endswith("_REJECT") else receipt_id,
+        "evidence_digest": supplied_digest,
+        "worker_execution_performed": raw.get("worker_execution_performed"),
+        "effect_evidence_complete": raw.get("effect_evidence_complete"),
+        "worker_process_spawn_count": raw.get("worker_process_spawn_count"),
+        "shell_command_count": raw.get("shell_command_count"),
+    }
+    if supplied_digest != expected_digest or dict(outcome) != expected_outcome:
+        raise ValueError("resident_control_loop_child_evidence_digest_invalid")
+    _verify_child_effect_fields(raw)
+
+
+def _verify_child_effect_fields(raw: Mapping[str, Any]) -> None:
+    if (
+        not isinstance(raw.get("accepted"), bool)
+        or not isinstance(raw.get("worker_execution_performed"), bool)
+        or not isinstance(raw.get("effect_evidence_complete"), bool)
+        or any(not isinstance(raw.get(field), bool) for field in _NO_EFFECT_FIELDS)
+    ):
+        raise ValueError("resident_control_loop_child_effects_invalid")
+    process_count = raw.get("worker_process_spawn_count")
+    shell_count = raw.get("shell_command_count")
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+        for value in (process_count, shell_count)
+    ):
+        raise ValueError("resident_control_loop_child_effects_invalid")
+    if (raw.get("no_shell_command_executed") is True) != (shell_count == 0):
+        if raw.get("effect_evidence_complete") is True:
+            raise ValueError("resident_control_loop_child_effects_invalid")
+    if raw.get("effect_evidence_complete") is False and any(
+        raw.get(field) is not False for field in _NO_EFFECT_FIELDS
+    ):
+        raise ValueError("resident_control_loop_child_effects_invalid")
+    if raw.get("worker_execution_performed") is False and (
+        process_count > 0 or shell_count > 0
+    ):
+        raise ValueError("resident_control_loop_child_effects_invalid")
+
+
+def _validate_outcome(outcome: Mapping[str, Any]) -> None:
+    status = outcome["status"]
+    counts = (
+        outcome["worker_process_spawn_count"],
+        outcome["shell_command_count"],
+    )
+    if (
+        not outcome["task_id"]
+        or len(outcome["task_id"]) > 256
+        or status not in {"completed", "requeued", "failed"}
+        or len(outcome["receipt_id"]) > 256
+        or _SHA256_DIGEST.fullmatch(outcome["evidence_digest"]) is None
+        or (status == "failed" and outcome["receipt_id"])
+        or (status in {"completed", "requeued"} and not outcome["receipt_id"])
+        or (
+            status in {"completed", "requeued"}
+            and outcome["effect_evidence_complete"] is False
+        )
+        or any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in counts
+        )
+    ):
+        raise ValueError("resident_control_loop_receipt_child_outcomes_invalid")
+
+
+def _reject_projection_conflicts(
+    result: Mapping[str, Any],
+    receipt_ids: tuple[str, ...],
+    evidence_digests: tuple[str, ...],
+) -> None:
+    supplied_receipts = _strings(result.get("child_execution_receipt_ids"), 256)
+    supplied_digests = _strings(
+        result.get("child_execution_evidence_digests"), 80
+    )
+    if supplied_receipts != receipt_ids or supplied_digests != evidence_digests:
+        raise ValueError("resident_control_loop_receipt_child_projection_conflict")
+
+
+def _strings(value: Any, max_chars: int) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(
+        str(item or "").strip()[:max_chars]
+        for item in value[:128]
+        if str(item or "").strip()
+    )
+
+
+__all__ = ["derive_child_outcome_projections", "strict_child_outcomes"]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_auth.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_auth.py
@@ -1,0 +1,301 @@
+"""Cryptographic boundary for resident RedDog control-loop receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    CONTROL_LOOP_SIGNING_OPERATION,
+    CONTROL_LOOP_SIGNING_PREFIX,
+    canonical_control_audit_attestation_input,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    IsolatedSignerClient,
+    SigningRequest,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+
+CONTROL_LOOP_AUTHENTICATED = "AUTHENTICATED"
+CONTROL_LOOP_DISPLAY_ONLY = "DISPLAY_ONLY"
+
+
+@dataclass(frozen=True)
+class ControlLoopReceiptSigningContext:
+    signer: IsolatedSignerClient
+    signature_verifier: SignatureVerifier
+    issuer_principal_id: str
+    signer_public_key: str
+    key_epoch: str
+    authority_tier: str
+    consensus_receipt_digest: str
+    authority_profile_digest: str
+    authority_profile_source_receipt_id: str
+
+
+def control_receipt_authentication_fields(
+    context: ControlLoopReceiptSigningContext | None,
+) -> dict[str, str]:
+    if context is None:
+        return {
+            "issuer_principal_id": "", "signer_public_key": "",
+            "signer_key_fingerprint": "", "key_epoch": "",
+            "consensus_receipt_digest": "", "authority_profile_digest": "",
+            "authority_profile_source_receipt_id": "",
+            "signature": "", "signer_audit_mac": "",
+            "signer_audit_attestation_signature": "",
+            "authentication_status": CONTROL_LOOP_DISPLAY_ONLY,
+        }
+    return {
+        "issuer_principal_id": _bounded(context.issuer_principal_id, 256),
+        "signer_public_key": _bounded(context.signer_public_key, 512),
+        "signer_key_fingerprint": public_key_fingerprint(context.signer_public_key),
+        "key_epoch": _bounded(context.key_epoch, 160),
+        "consensus_receipt_digest": _bounded(context.consensus_receipt_digest, 256),
+        "authority_profile_digest": _bounded(context.authority_profile_digest, 80),
+        "authority_profile_source_receipt_id": _bounded(
+            context.authority_profile_source_receipt_id, 80
+        ),
+        "signature": "", "signer_audit_mac": "",
+        "signer_audit_attestation_signature": "",
+        "authentication_status": CONTROL_LOOP_AUTHENTICATED,
+    }
+
+
+def canonical_control_receipt_signing_input(payload: Mapping[str, Any]) -> str:
+    canonical = {
+        key: value for key, value in payload.items()
+        if key not in {
+            "signature",
+            "signer_audit_mac",
+            "signer_audit_attestation_signature",
+        }
+    }
+    return CONTROL_LOOP_SIGNING_PREFIX + json.dumps(
+        canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+
+
+def attest_control_receipt(
+    payload: dict[str, Any], context: ControlLoopReceiptSigningContext
+) -> None:
+    signing_input = canonical_control_receipt_signing_input(payload)
+    response = context.signer.sign(
+        SigningRequest(
+            signing_input=signing_input,
+            payload_digest="sha256:" + _digest({"signing_input": signing_input}),
+            signer_role="reddog_control_loop",
+            signer_public_key=context.signer_public_key,
+            requester_principal_id=context.issuer_principal_id,
+            nonce=str(payload["nonce"]), key_epoch=context.key_epoch,
+            requested_operation=CONTROL_LOOP_SIGNING_OPERATION,
+            authority_tier=context.authority_tier,
+            consensus_receipt_digest=context.consensus_receipt_digest,
+        )
+    )
+    valid = bool(
+        response.accepted
+        and response.signer_public_key == context.signer_public_key
+        and response.key_fingerprint == public_key_fingerprint(context.signer_public_key)
+        and response.key_epoch == context.key_epoch
+        and response.signature and response.audit_mac
+        and response.audit_attestation_signature
+        and response.boundary_attested
+        and response.requester_identity_attested and response.signer_loads_no_untrusted_code
+        and response.no_secret_material_returned
+        and context.signature_verifier.verify(
+            context.signer_public_key, signing_input, response.signature
+        )
+        and context.signature_verifier.verify(
+            context.signer_public_key,
+            canonical_control_audit_attestation_input(
+                signing_input=signing_input,
+                signature=response.signature,
+                audit_mac=response.audit_mac,
+                signer_public_key=context.signer_public_key,
+                key_epoch=context.key_epoch,
+                requester_principal_id=context.issuer_principal_id,
+            ),
+            response.audit_attestation_signature,
+        )
+    )
+    if not valid:
+        raise ValueError("resident_control_loop_receipt_signing_rejected")
+    payload["signature"] = response.signature
+    payload["signer_audit_mac"] = response.audit_mac
+    payload["signer_audit_attestation_signature"] = (
+        response.audit_attestation_signature
+    )
+
+
+def verify_control_receipt_authentication(
+    payload: Mapping[str, Any], *, expected_signer_public_key: str | None,
+    expected_key_epoch: str | None, expected_consensus_receipt_digest: str | None,
+    expected_authority_profile_digest: str | None,
+    expected_authority_profile_source_receipt_id: str | None,
+    expected_issuer_principal_id: str | None,
+    require_authenticated: bool,
+    signature_verifier: SignatureVerifier | None,
+) -> None:
+    if payload.get("authentication_status") == CONTROL_LOOP_DISPLAY_ONLY:
+        _verify_display_only(payload, require_authenticated)
+        return
+    if payload.get("authentication_status") != CONTROL_LOOP_AUTHENTICATED:
+        raise ValueError("resident_control_loop_receipt_authentication_status_invalid")
+    _verify_expected_bindings(
+        payload, expected_signer_public_key, expected_key_epoch,
+        expected_consensus_receipt_digest, expected_authority_profile_digest,
+        expected_authority_profile_source_receipt_id,
+        expected_issuer_principal_id,
+    )
+    public_key = str(payload.get("signer_public_key") or "")
+    if payload.get("signer_key_fingerprint") != public_key_fingerprint(public_key):
+        raise ValueError("resident_control_loop_receipt_fingerprint_invalid")
+    verifier = signature_verifier or Ed25519SignatureVerifier()
+    signing_input = canonical_control_receipt_signing_input(payload)
+    signature = str(payload.get("signature") or "")
+    audit_mac = str(payload.get("signer_audit_mac") or "")
+    audit_attestation_signature = str(
+        payload.get("signer_audit_attestation_signature") or ""
+    )
+    if not verifier.verify(
+        public_key, signing_input,
+        signature,
+    ):
+        raise ValueError("resident_control_loop_receipt_signature_invalid")
+    if not audit_mac or not audit_attestation_signature or not verifier.verify(
+        public_key,
+        canonical_control_audit_attestation_input(
+            signing_input=signing_input,
+            signature=signature,
+            audit_mac=audit_mac,
+            signer_public_key=public_key,
+            key_epoch=str(payload.get("key_epoch") or ""),
+            requester_principal_id=str(payload.get("issuer_principal_id") or ""),
+        ),
+        audit_attestation_signature,
+    ):
+        raise ValueError("resident_control_loop_receipt_audit_attestation_invalid")
+
+
+def validate_control_receipt_child_evidence(
+    payload: Mapping[str, Any],
+    source_receipt_ids: tuple[str, ...],
+    receipt_ids: tuple[str, ...],
+    child_digests: tuple[str, ...],
+    outcomes: tuple[dict[str, str], ...],
+) -> None:
+    """Bind each worker outcome to one digest and each success to one receipt."""
+
+    completion = _nonnegative_int(payload.get("worker_completion_count"))
+    requeue = _nonnegative_int(payload.get("worker_requeue_count"))
+    failure = _nonnegative_int(payload.get("worker_failure_count"))
+    statuses = tuple(outcome["status"] for outcome in outcomes)
+    expected_counts = {
+        "completed": completion,
+        "requeued": requeue,
+        "failed": failure,
+    }
+    if any(statuses.count(status) != count for status, count in expected_counts.items()):
+        raise ValueError("resident_control_loop_receipt_child_outcome_count_invalid")
+    projected_receipts = tuple(
+        outcome["receipt_id"]
+        for outcome in outcomes
+        if outcome["status"] in {"completed", "requeued"}
+    )
+    projected_digests = tuple(outcome["evidence_digest"] for outcome in outcomes)
+    if (
+        receipt_ids != projected_receipts
+        or any(receipt_id not in source_receipt_ids for receipt_id in projected_receipts)
+        or len(set(receipt_ids)) != len(receipt_ids)
+    ):
+        raise ValueError("resident_control_loop_receipt_child_receipt_cardinality_invalid")
+    if (
+        child_digests != projected_digests
+        or len(child_digests) != completion + requeue + failure
+        or len(set(child_digests)) != len(child_digests)
+        or any(not _is_sha256_digest(item) for item in child_digests)
+    ):
+        raise ValueError("resident_control_loop_receipt_child_evidence_cardinality_invalid")
+    if payload.get("child_execution_evidence_count") != len(child_digests):
+        raise ValueError("resident_control_loop_receipt_child_evidence_count_invalid")
+    if payload.get("child_execution_evidence_digest") != "sha256:" + _digest(
+        list(child_digests)
+    ):
+        raise ValueError("resident_control_loop_receipt_child_evidence_digest_invalid")
+
+
+def _verify_display_only(payload: Mapping[str, Any], require_authenticated: bool) -> None:
+    if require_authenticated:
+        raise ValueError("resident_control_loop_receipt_authentication_required")
+    fields = (
+        "issuer_principal_id", "signer_public_key", "signer_key_fingerprint", "key_epoch",
+        "consensus_receipt_digest", "authority_profile_digest",
+        "authority_profile_source_receipt_id", "signature", "signer_audit_mac",
+        "signer_audit_attestation_signature",
+    )
+    if any(payload.get(key) for key in fields):
+        raise ValueError("resident_control_loop_receipt_display_auth_fields_invalid")
+
+
+def _verify_expected_bindings(
+    payload: Mapping[str, Any], public_key: str | None, key_epoch: str | None,
+    consensus: str | None, profile_digest: str | None,
+    profile_source_receipt_id: str | None,
+    issuer_principal_id: str | None,
+) -> None:
+    checks = (
+        (public_key, payload.get("signer_public_key"), "signer_invalid"),
+        (key_epoch, payload.get("key_epoch"), "key_epoch_invalid"),
+        (consensus, payload.get("consensus_receipt_digest"), "consensus_invalid"),
+        (profile_digest, payload.get("authority_profile_digest"), "authority_profile_invalid"),
+        (
+            profile_source_receipt_id,
+            payload.get("authority_profile_source_receipt_id"),
+            "authority_profile_source_invalid",
+        ),
+        (issuer_principal_id, payload.get("issuer_principal_id"), "issuer_principal_invalid"),
+    )
+    for expected, observed, reason in checks:
+        if expected is not None and observed != expected:
+            raise ValueError("resident_control_loop_receipt_" + reason)
+
+
+def _bounded(value: Any, limit: int) -> str:
+    return str(value or "").strip()[:limit]
+
+
+def _nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("resident_control_loop_receipt_integer_invalid")
+    return value
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = str(value or "")
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "CONTROL_LOOP_AUTHENTICATED", "CONTROL_LOOP_DISPLAY_ONLY",
+    "ControlLoopReceiptSigningContext", "attest_control_receipt",
+    "canonical_control_receipt_signing_input", "control_receipt_authentication_fields",
+    "validate_control_receipt_child_evidence",
+    "verify_control_receipt_authentication",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_chain.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_chain.py
@@ -1,0 +1,84 @@
+"""Complete-chain verification for authenticated resident control receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+    _validate_existing_receipts,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+
+def verify_resident_control_loop_receipt_chain(
+    receipts: Sequence[Mapping[str, Any]],
+    *,
+    expected_signer_public_key: str,
+    expected_key_epoch: str,
+    expected_consensus_receipt_digest: str,
+    expected_authority_profile_digest: str,
+    expected_authority_profile_source_receipt_id: str,
+    expected_issuer_principal_id: str,
+    signature_verifier: SignatureVerifier | None = None,
+) -> None:
+    """Verify every v2 record and link in a serialized append-only chain."""
+
+    existing = "\n".join(
+        json.dumps(dict(receipt), sort_keys=True, separators=(",", ":"))
+        for receipt in receipts
+    )
+    if existing:
+        existing += "\n"
+    _validate_existing_receipts(
+        existing,
+        require_authenticated_current=True,
+        expected_authentication={
+            "signer_public_key": expected_signer_public_key,
+            "key_epoch": expected_key_epoch,
+            "consensus_receipt_digest": expected_consensus_receipt_digest,
+            "authority_profile_digest": expected_authority_profile_digest,
+            "authority_profile_source_receipt_id": (
+                expected_authority_profile_source_receipt_id
+            ),
+            "issuer_principal_id": expected_issuer_principal_id,
+            "signature_verifier": signature_verifier,
+        },
+    )
+
+
+def verify_control_receipt_chain_against_profile(
+    receipts: Sequence[Mapping[str, Any]],
+    authority_profile: Mapping[str, Any],
+) -> None:
+    """Verify a chain against one confined authority-profile mapping."""
+
+    profile_raw = json.dumps(
+        dict(authority_profile),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    verify_resident_control_loop_receipt_chain(
+        receipts,
+        expected_signer_public_key=str(authority_profile["reddog_public_key"]),
+        expected_key_epoch=str(authority_profile["key_epoch"]),
+        expected_consensus_receipt_digest=str(
+            authority_profile["consensus_receipt_digest"]
+        ),
+        expected_authority_profile_digest="sha256:"
+        + hashlib.sha256(profile_raw.encode("utf-8")).hexdigest(),
+        expected_authority_profile_source_receipt_id=str(
+            authority_profile["authority_profile_source_receipt_id"]
+        ),
+        expected_issuer_principal_id=str(authority_profile["principal_id"]),
+    )
+
+
+__all__ = [
+    "verify_control_receipt_chain_against_profile",
+    "verify_resident_control_loop_receipt_chain",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_store.py
@@ -1,54 +1,142 @@
-"""Append-only receipts for the resident RedDog control loop.
+"""Append-only, signed receipts for the resident RedDog control loop.
 
-Slice: REDDOG_RESIDENT_CONTROL_LOOP_RECEIPT_PERSISTENCE_PHASE1
+Slice: REDDOG_RESIDENT_CONTROL_RECEIPT_TRUTH_AUTH_CONCURRENCY_PHASE1
 
-This module records compact control-loop summaries after the already-governed
-resident queue serial loop and OpenClaw signed-worker claim loop run. It does
-not invoke workers, mutate source, issue authority, reindex HoloIndex, or
-settle rewards.
+Current v2 receipts derive effects from stage and OpenClaw claim evidence, bind
+the preceding receipt, and can be attested by the isolated RedDog signer. Legacy
+v1 receipts remain readable for migration, but cannot satisfy authenticated live
+proof. This module records completed work; it never invokes a worker or command.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import secrets
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_auth import (
+    CONTROL_LOOP_AUTHENTICATED,
+    CONTROL_LOOP_DISPLAY_ONLY,
+    ControlLoopReceiptSigningContext,
+    attest_control_receipt,
+    control_receipt_authentication_fields,
+    validate_control_receipt_child_evidence,
+    verify_control_receipt_authentication,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_validation import (
+    strict_nonnegative_int,
+    strict_string_tuple,
+    validate_current_receipt_fields,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_chain_state import (
+    validate_control_receipt_chain_state,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_outcomes import (
+    derive_child_outcome_projections,
+    strict_child_outcomes,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_effects import (
+    derive_control_loop_effects,
+    reject_contradictory_effect_claims,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_head_store import (
+    commit_next_control_receipt_head,
+    load_control_receipt_head,
+    reconcile_control_receipt_head,
+)
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    runtime_operation_lock,
     secure_append_runtime_text,
+    secure_read_confined_bytes,
+    validate_runtime_artifact_path,
 )
 
 
-CONTROL_LOOP_RECEIPT_SCHEMA_VERSION = "reddog_resident_control_loop_receipt.v1"
-
-
+CONTROL_LOOP_RECEIPT_SCHEMA_VERSION = "reddog_resident_control_loop_receipt.v2"
+LEGACY_CONTROL_LOOP_RECEIPT_SCHEMA_VERSION = "reddog_resident_control_loop_receipt.v1"
+MAX_CONTROL_RECEIPT_CHAIN_BYTES = 1024 * 1024
 @dataclass(frozen=True)
 class ResidentControlLoopReceipt:
     schema_version: str
     receipt_id: str
+    sequence_number: int
+    cycle_id: str
+    nonce: str
+    previous_receipt_id: str
+    legacy_prefix_digest: str
     accepted: bool
     status: str
     rounds: int
     serial_progress: int
     claim_progress: int
     receipt_ids: tuple[str, ...]
+    source_receipt_ids_digest: str
+    child_execution_receipt_ids: tuple[str, ...]
+    child_execution_evidence_digests: tuple[str, ...]
+    child_execution_outcomes: tuple[dict[str, Any], ...]
+    child_execution_evidence_digest: str
+    child_execution_evidence_count: int
     rejection_reasons: tuple[str, ...]
     created_at: str
     repo_root_digest: str
     control_lock_acquired: bool
-    no_authority_issued: bool = True
-    no_worker_spawn_performed: bool = True
-    no_shell_command_executed: bool = True
-    no_holoindex_reindex_performed: bool = True
-    no_merge_performed: bool = True
-    no_reward_settlement_performed: bool = True
+    dispatched_stages: tuple[str, ...]
+    authority_issuance_count: int
+    worker_claim_count: int
+    worker_execution_count: int
+    worker_completion_count: int
+    worker_requeue_count: int
+    worker_failure_count: int
+    worktree_creation_count: int
+    bounded_file_edit_count: int
+    slice_verification_count: int
+    draft_pr_publish_count: int
+    pattern_memory_admission_count: int
+    worker_process_spawn_count: int
+    shell_command_count: int
+    worker_effects_unverified_count: int
+    authority_issued: bool
+    worker_claim_performed: bool
+    worker_execution_performed: bool
+    worktree_creation_observed: bool
+    bounded_file_edit_observed: bool
+    slice_verification_observed: bool
+    draft_pr_publish_observed: bool
+    pattern_memory_admission_observed: bool
+    worker_process_spawn_observed: bool
+    shell_command_execution_observed: bool
+    issuer_principal_id: str
+    signer_public_key: str
+    signer_key_fingerprint: str
+    key_epoch: str
+    consensus_receipt_digest: str
+    authority_profile_digest: str
+    authority_profile_source_receipt_id: str
+    signature: str
+    signer_audit_mac: str
+    signer_audit_attestation_signature: str
+    authentication_status: str
 
     def to_dict(self) -> dict[str, Any]:
         payload = asdict(self)
         payload["receipt_ids"] = list(self.receipt_ids)
+        payload["child_execution_receipt_ids"] = list(
+            self.child_execution_receipt_ids
+        )
+        payload["child_execution_evidence_digests"] = list(
+            self.child_execution_evidence_digests
+        )
+        payload["child_execution_outcomes"] = [
+            dict(outcome) for outcome in self.child_execution_outcomes
+        ]
         payload["rejection_reasons"] = list(self.rejection_reasons)
+        payload["dispatched_stages"] = list(self.dispatched_stages)
         return payload
 
 
@@ -57,32 +145,165 @@ def build_resident_control_loop_receipt(
     result: Mapping[str, Any],
     repo_root: Path | str,
     created_at: str,
+    cycle_id: str | None = None, nonce: str | None = None,
+    previous_receipt_id: str = "",
+    legacy_prefix_digest: str | None = None,
+    sequence_number: int = 1,
+    signing_context: ControlLoopReceiptSigningContext | None = None,
 ) -> ResidentControlLoopReceipt:
-    """Build a deterministic receipt for an already-produced control result."""
-
-    payload = {
+    """Build one effect-derived receipt and optionally attest it."""
+    dispatched_stages = _string_tuple(result.get("dispatched_stages"), max_chars=80)
+    claim_progress = _int(result.get("claim_progress"))
+    effects = derive_control_loop_effects(dispatched_stages, claim_progress, result)
+    reject_contradictory_effect_claims(result, effects)
+    receipt_ids = _string_tuple(result.get("receipt_ids"), max_chars=256)
+    child_outcomes, child_receipt_ids, child_evidence_digests = derive_child_outcome_projections(result)
+    payload: dict[str, Any] = {
         "schema_version": CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
-        "accepted": bool(result.get("accepted")),
+        "sequence_number": sequence_number,
+        "cycle_id": _bounded_text(cycle_id, 160) or _new_cycle_id(),
+        "nonce": _bounded_text(nonce, 192) or _new_nonce(),
+        "previous_receipt_id": _bounded_text(previous_receipt_id, 160),
+        "legacy_prefix_digest": legacy_prefix_digest or _legacy_prefix_digest(()),
+        "accepted": result.get("accepted") is True,
         "status": _bounded_text(result.get("status"), 80),
         "rounds": _int(result.get("rounds")),
         "serial_progress": _int(result.get("serial_progress")),
-        "claim_progress": _int(result.get("claim_progress")),
-        "receipt_ids": _string_tuple(result.get("receipt_ids"), max_chars=256),
-        "rejection_reasons": _string_tuple(
-            result.get("rejection_reasons"), max_chars=512
-        ),
+        "claim_progress": claim_progress,
+        "receipt_ids": receipt_ids,
+        "source_receipt_ids_digest": "sha256:" + _digest(list(receipt_ids)),
+        "child_execution_receipt_ids": child_receipt_ids,
+        "child_execution_evidence_digests": child_evidence_digests,
+        "child_execution_outcomes": child_outcomes,
+        "child_execution_evidence_digest": "sha256:" + _digest(list(child_evidence_digests)),
+        "child_execution_evidence_count": len(child_evidence_digests),
+        "rejection_reasons": _string_tuple(result.get("rejection_reasons"), max_chars=512),
         "created_at": _bounded_text(created_at, 80),
         "repo_root_digest": _digest(str(Path(repo_root).resolve())),
         "control_lock_acquired": result.get("control_lock_acquired") is True,
-        "no_authority_issued": True,
-        "no_worker_spawn_performed": True,
-        "no_shell_command_executed": True,
-        "no_holoindex_reindex_performed": True,
-        "no_merge_performed": True,
-        "no_reward_settlement_performed": True,
+        "dispatched_stages": dispatched_stages,
+        **effects,
+        **control_receipt_authentication_fields(signing_context),
     }
-    payload["receipt_id"] = "reddog_resident_control_loop_" + _digest(payload)[:16]
+    payload["receipt_id"] = _receipt_id(payload)
+    if signing_context is not None:
+        attest_control_receipt(payload, signing_context)
+    return _verify_built_receipt(payload, signing_context)
+
+
+def _verify_built_receipt(
+    payload: Mapping[str, Any],
+    signing_context: ControlLoopReceiptSigningContext | None,
+) -> ResidentControlLoopReceipt:
+    return verify_resident_control_loop_receipt(
+        payload,
+        expected_signer_public_key=(
+            signing_context.signer_public_key if signing_context else None
+        ),
+        expected_key_epoch=signing_context.key_epoch if signing_context else None,
+        expected_consensus_receipt_digest=(
+            signing_context.consensus_receipt_digest if signing_context else None
+        ),
+        expected_authority_profile_digest=(
+            signing_context.authority_profile_digest if signing_context else None
+        ),
+        expected_authority_profile_source_receipt_id=(
+            signing_context.authority_profile_source_receipt_id
+            if signing_context
+            else None
+        ),
+        expected_issuer_principal_id=(
+            signing_context.issuer_principal_id if signing_context else None
+        ),
+        require_authenticated=signing_context is not None,
+        signature_verifier=(
+            signing_context.signature_verifier if signing_context else None
+        ),
+    )
+
+
+def verify_resident_control_loop_receipt(
+    value: Mapping[str, Any],
+    *,
+    expected_repo_root: Path | str | None = None,
+    expected_signer_public_key: str | None = None,
+    expected_key_epoch: str | None = None,
+    expected_consensus_receipt_digest: str | None = None,
+    expected_authority_profile_digest: str | None = None,
+    expected_authority_profile_source_receipt_id: str | None = None,
+    expected_issuer_principal_id: str | None = None,
+    require_authenticated: bool = False,
+    signature_verifier: SignatureVerifier | None = None,
+) -> ResidentControlLoopReceipt:
+    """Rehydrate a current receipt after integrity, truth, and auth checks."""
+
+    payload = dict(value)
+    if payload.get("schema_version") != CONTROL_LOOP_RECEIPT_SCHEMA_VERSION:
+        raise ValueError("resident_control_loop_receipt_schema_invalid")
+    if set(payload) != set(ResidentControlLoopReceipt.__dataclass_fields__):
+        raise ValueError("resident_control_loop_receipt_fields_invalid")
+    if payload.get("receipt_id") != _receipt_id(payload):
+        raise ValueError("resident_control_loop_receipt_digest_invalid")
+    stages, receipt_ids, child_receipt_ids, child_evidence_digests, child_outcomes = (
+        _verify_receipt_evidence(payload)
+    )
+    if expected_repo_root is not None:
+        expected_digest = _digest(str(Path(expected_repo_root).resolve()))
+        if payload.get("repo_root_digest") != expected_digest:
+            raise ValueError("resident_control_loop_receipt_repo_root_invalid")
+    verify_control_receipt_authentication(
+        payload,
+        expected_signer_public_key=expected_signer_public_key,
+        expected_key_epoch=expected_key_epoch,
+        expected_consensus_receipt_digest=expected_consensus_receipt_digest,
+        expected_authority_profile_digest=expected_authority_profile_digest,
+        expected_authority_profile_source_receipt_id=(
+            expected_authority_profile_source_receipt_id
+        ),
+        expected_issuer_principal_id=expected_issuer_principal_id,
+        require_authenticated=require_authenticated,
+        signature_verifier=signature_verifier,
+    )
+    payload["receipt_ids"] = receipt_ids
+    payload["child_execution_receipt_ids"] = child_receipt_ids
+    payload["child_execution_evidence_digests"] = child_evidence_digests
+    payload["child_execution_outcomes"] = child_outcomes
+    payload["rejection_reasons"] = strict_string_tuple(payload.get("rejection_reasons"), 512)
+    payload["dispatched_stages"] = stages
     return ResidentControlLoopReceipt(**payload)
+
+
+def _verify_receipt_evidence(
+    payload: Mapping[str, Any],
+) -> tuple[
+    tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...],
+    tuple[dict[str, str], ...],
+]:
+    validate_current_receipt_fields(payload)
+    stages = strict_string_tuple(payload.get("dispatched_stages"), 80)
+    receipt_ids = strict_string_tuple(payload.get("receipt_ids"), 256)
+    child_receipt_ids = strict_string_tuple(
+        payload.get("child_execution_receipt_ids"), 256
+    )
+    child_digests = strict_string_tuple(
+        payload.get("child_execution_evidence_digests"), 80
+    )
+    child_outcomes = strict_child_outcomes(payload.get("child_execution_outcomes"))
+    effects = derive_control_loop_effects(
+        stages,
+        strict_nonnegative_int(payload.get("claim_progress")),
+        payload,
+    )
+    if any(payload.get(key) != expected for key, expected in effects.items()):
+        raise ValueError("resident_control_loop_receipt_effect_claim_invalid")
+    if payload.get("source_receipt_ids_digest") != "sha256:" + _digest(
+        list(receipt_ids)
+    ):
+        raise ValueError("resident_control_loop_receipt_source_digest_invalid")
+    validate_control_receipt_child_evidence(
+        payload, receipt_ids, child_receipt_ids, child_digests, child_outcomes
+    )
+    return stages, receipt_ids, child_receipt_ids, child_digests, child_outcomes
 
 
 def append_resident_control_loop_receipt(
@@ -91,58 +312,271 @@ def append_resident_control_loop_receipt(
     result: Mapping[str, Any],
     repo_root: Path | str,
     created_at: str,
+    cycle_id: str | None = None,
+    nonce: str | None = None,
+    signing_context: ControlLoopReceiptSigningContext | None = None,
+    require_authentication: bool = False,
+    head_state_path: Path | str | None = None,
 ) -> ResidentControlLoopReceipt:
-    """Append one control-loop receipt as JSONL and return it."""
+    """CAS-append one chain-linked control-loop receipt."""
 
-    receipt = build_resident_control_loop_receipt(
-        result=result,
-        repo_root=repo_root,
-        created_at=created_at,
+    if require_authentication and signing_context is None:
+        raise ValueError("resident_control_loop_receipt_signer_required")
+    target = validate_runtime_artifact_path(path, repo_root=repo_root)
+    resolved_head_path = (
+        head_state_path
+        if head_state_path is not None
+        else target.parent / "authority_runtime_state.json"
+        if require_authentication
+        else None
     )
+    head_target = (
+        validate_runtime_artifact_path(resolved_head_path, repo_root=repo_root)
+        if resolved_head_path
+        else None
+    )
+    resolved_cycle_id = _bounded_text(cycle_id, 160) or _new_cycle_id()
+    resolved_nonce = _bounded_text(nonce, 192) or _new_nonce()
+    operation_identity = str(target) + ".control-chain-operation"
+    with runtime_operation_lock(operation_identity):
+        chain, head_store, head_state = _load_control_chain_for_append(
+            target, head_target, repo_root, signing_context, require_authentication
+        )
+        return _build_commit_append_receipt(
+            target=target, chain=chain, result=result, repo_root=repo_root,
+            created_at=created_at, cycle_id=resolved_cycle_id,
+            nonce=resolved_nonce, signing_context=signing_context,
+            require_authentication=require_authentication,
+            head_store=head_store, head_state=head_state,
+        )
+
+
+def _build_commit_append_receipt(
+    *, target: Path, chain: Mapping[str, Any], result: Mapping[str, Any],
+    repo_root: Path | str, created_at: str, cycle_id: str, nonce: str,
+    signing_context: ControlLoopReceiptSigningContext | None,
+    require_authentication: bool, head_store: Any, head_state: Any,
+) -> ResidentControlLoopReceipt:
+    receipt = build_resident_control_loop_receipt(
+        result=result, repo_root=repo_root, created_at=created_at,
+        cycle_id=cycle_id, nonce=nonce,
+        previous_receipt_id=chain["last_receipt_id"],
+        legacy_prefix_digest=chain["legacy_prefix_digest"],
+        sequence_number=len(chain["current_receipt_ids"]) + 1,
+        signing_context=signing_context,
+    )
+    _ensure_append_capacity(target, receipt)
+    if head_store is not None and head_state is not None:
+        commit_next_control_receipt_head(
+            store=head_store, state=head_state, chain=chain, receipt=receipt
+        )
+    _append_receipt_once(
+        target, receipt, repo_root, signing_context=signing_context,
+        require_authentication=require_authentication,
+    )
+    return receipt
+
+
+def _load_control_chain_for_append(
+    target: Path,
+    head_target: Path | None,
+    repo_root: Path | str,
+    signing_context: ControlLoopReceiptSigningContext | None,
+    require_authentication: bool,
+) -> tuple[dict[str, Any], Any, Any]:
+    chain = _validate_existing_receipts(
+        _read_existing_chain(target),
+        signing_context=signing_context,
+        require_authenticated_current=require_authentication,
+    )
+    if not require_authentication or head_target is None:
+        return chain, None, None
+    store, state, head = load_control_receipt_head(head_target)
+    chain = reconcile_control_receipt_head(
+        target=target, chain=chain, head=head, repo_root=repo_root,
+        signing_context=signing_context,
+        verify_receipt=verify_resident_control_loop_receipt,
+        append_receipt=_append_receipt_once,
+        validate_chain=_validate_existing_receipts,
+        read_chain=_read_existing_chain,
+    )
+    return chain, store, state
+
+
+def _append_receipt_once(
+    target: Path,
+    receipt: ResidentControlLoopReceipt,
+    repo_root: Path | str,
+    *,
+    signing_context: ControlLoopReceiptSigningContext | None,
+    require_authentication: bool,
+) -> None:
     line = json.dumps(receipt.to_dict(), sort_keys=True, separators=(",", ":")) + "\n"
     if len(line.encode("utf-8")) > 64 * 1024:
         raise ValueError("resident_control_loop_receipt_too_large")
+
+    def validate_before_append(current: str) -> None:
+        if len(current.encode("utf-8")) + len(line.encode("utf-8")) > MAX_CONTROL_RECEIPT_CHAIN_BYTES:
+            raise ValueError("runtime_artifact_retention_limit_exceeded")
+        chain = _validate_existing_receipts(
+            current,
+            signing_context=signing_context,
+            require_authenticated_current=require_authentication,
+        )
+        if chain["last_receipt_id"] != receipt.previous_receipt_id:
+            raise ValueError("resident_control_loop_receipt_chain_revision_conflict")
+        if chain["legacy_prefix_digest"] != receipt.legacy_prefix_digest:
+            raise ValueError("resident_control_loop_receipt_legacy_prefix_conflict")
+        if receipt.cycle_id in chain["cycle_ids"]:
+            raise ValueError("resident_control_loop_receipt_cycle_replay")
+        if receipt.nonce in chain["nonces"]:
+            raise ValueError("resident_control_loop_receipt_nonce_replay")
+        if chain["child_receipt_ids"].intersection(
+            receipt.child_execution_receipt_ids
+        ):
+            raise ValueError("resident_control_loop_receipt_child_receipt_replay")
+        if chain["child_evidence_digests"].intersection(
+            receipt.child_execution_evidence_digests
+        ):
+            raise ValueError("resident_control_loop_receipt_child_evidence_replay")
+
     secure_append_runtime_text(
-        path,
+        target,
         line,
         repo_root=repo_root,
-        validate_existing=_validate_existing_receipts,
+        validate_existing=validate_before_append,
+        max_existing_bytes=MAX_CONTROL_RECEIPT_CHAIN_BYTES,
     )
-    return receipt
+
+
+def _read_existing_chain(path: Path) -> str:
+    if not path.exists():
+        return ""
+    if path.stat().st_size > MAX_CONTROL_RECEIPT_CHAIN_BYTES:
+        raise ValueError("runtime_artifact_retention_limit_exceeded")
+    raw, offset = secure_read_confined_bytes(
+        path,
+        allowed_root=path.parent,
+        max_bytes=MAX_CONTROL_RECEIPT_CHAIN_BYTES,
+    )
+    if offset != path.stat().st_size:
+        raise ValueError("resident_control_loop_receipt_chain_read_incomplete")
+    return raw.decode("utf-8")
+
+
+def _validate_existing_receipts(
+    existing: str,
+    *,
+    signing_context: ControlLoopReceiptSigningContext | None = None,
+    require_authenticated_current: bool = False,
+    expected_authentication: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    def verify(payload: Mapping[str, Any]) -> ResidentControlLoopReceipt:
+        return _verify_existing_current_receipt(
+            payload, signing_context=signing_context,
+            require_authenticated=require_authenticated_current,
+            expected_authentication=expected_authentication,
+        )
+
+    return validate_control_receipt_chain_state(
+        existing, current_schema=CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
+        legacy_schema=LEGACY_CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
+        receipt_id_builder=_receipt_id, legacy_digest_builder=_legacy_prefix_digest,
+        verify_current=verify,
+    )
+
+
+def _ensure_append_capacity(target: Path, receipt: ResidentControlLoopReceipt) -> None:
+    line = json.dumps(receipt.to_dict(), sort_keys=True, separators=(",", ":")) + "\n"
+    line_size = len(line.encode("utf-8"))
+    existing_size = target.stat().st_size if target.exists() else 0
+    if line_size > 64 * 1024:
+        raise ValueError("resident_control_loop_receipt_too_large")
+    if existing_size + line_size > MAX_CONTROL_RECEIPT_CHAIN_BYTES:
+        raise ValueError("runtime_artifact_retention_limit_exceeded")
+
+
+def _verify_existing_current_receipt(
+    payload: Mapping[str, Any],
+    *,
+    signing_context: ControlLoopReceiptSigningContext | None,
+    require_authenticated: bool,
+    expected_authentication: Mapping[str, Any] | None,
+) -> ResidentControlLoopReceipt:
+    context = signing_context
+    expected = expected_authentication or {}
+    return verify_resident_control_loop_receipt(
+        payload,
+        expected_signer_public_key=(
+            context.signer_public_key if context else expected.get("signer_public_key")
+        ),
+        expected_key_epoch=context.key_epoch if context else expected.get("key_epoch"),
+        expected_consensus_receipt_digest=(
+            context.consensus_receipt_digest
+            if context
+            else expected.get("consensus_receipt_digest")
+        ),
+        expected_authority_profile_digest=(
+            context.authority_profile_digest
+            if context
+            else expected.get("authority_profile_digest")
+        ),
+        expected_authority_profile_source_receipt_id=(
+            context.authority_profile_source_receipt_id
+            if context
+            else expected.get("authority_profile_source_receipt_id")
+        ),
+        expected_issuer_principal_id=(
+            context.issuer_principal_id
+            if context
+            else expected.get("issuer_principal_id")
+        ),
+        require_authenticated=require_authenticated,
+        signature_verifier=(
+            context.signature_verifier
+            if context
+            else expected.get("signature_verifier")
+        ),
+    )
+
+
+def _receipt_id(payload: Mapping[str, Any]) -> str:
+    excluded = {"receipt_id"}
+    if payload.get("schema_version") == CONTROL_LOOP_RECEIPT_SCHEMA_VERSION:
+        excluded.update(
+            {
+                "signature",
+                "signer_audit_mac",
+                "signer_audit_attestation_signature",
+            }
+        )
+    canonical = {key: value for key, value in payload.items() if key not in excluded}
+    digest = _digest(canonical)
+    if payload.get("schema_version") == LEGACY_CONTROL_LOOP_RECEIPT_SCHEMA_VERSION:
+        return "reddog_resident_control_loop_" + digest[:16]
+    return "reddog_resident_control_loop_v2_" + digest
+
+
+def _legacy_prefix_digest(payloads: Any) -> str:
+    return "sha256:" + _digest(list(payloads))
+
+
+def _new_cycle_id() -> str:
+    return "reddog_control_cycle_" + secrets.token_hex(16)
+
+
+def _new_nonce() -> str:
+    return "reddog-control-loop:" + secrets.token_hex(32)
 
 
 def _string_tuple(value: Any, *, max_chars: int) -> tuple[str, ...]:
     if not isinstance(value, (list, tuple)):
         return ()
-    return tuple(
-        _bounded_text(item, max_chars)
-        for item in value[:128]
-        if str(item or "").strip()
-    )
+    return tuple(_bounded_text(item, max_chars) for item in value[:128] if str(item or "").strip())
 
 
 def _bounded_text(value: Any, max_chars: int) -> str:
     return str(value or "").strip()[:max_chars]
-
-
-def _validate_existing_receipts(existing: str) -> None:
-    for line_number, raw in enumerate(existing.splitlines(), start=1):
-        if not raw.strip():
-            continue
-        if len(raw.encode("utf-8")) > 64 * 1024:
-            raise ValueError(f"resident_control_loop_receipt_line_too_large:{line_number}")
-        try:
-            payload = json.loads(raw)
-        except json.JSONDecodeError as exc:
-            raise ValueError(
-                f"resident_control_loop_receipt_chain_invalid_json:{line_number}"
-            ) from exc
-        if not isinstance(payload, dict):
-            raise ValueError(f"resident_control_loop_receipt_chain_invalid:{line_number}")
-        if payload.get("schema_version") != CONTROL_LOOP_RECEIPT_SCHEMA_VERSION:
-            raise ValueError(f"resident_control_loop_receipt_schema_invalid:{line_number}")
-        if not str(payload.get("receipt_id") or "").strip():
-            raise ValueError(f"resident_control_loop_receipt_id_missing:{line_number}")
 
 
 def _int(value: Any) -> int:
@@ -158,8 +592,13 @@ def _digest(payload: Any) -> str:
 
 
 __all__ = [
+    "CONTROL_LOOP_AUTHENTICATED",
+    "CONTROL_LOOP_DISPLAY_ONLY",
     "CONTROL_LOOP_RECEIPT_SCHEMA_VERSION",
+    "ControlLoopReceiptSigningContext",
+    "LEGACY_CONTROL_LOOP_RECEIPT_SCHEMA_VERSION",
     "ResidentControlLoopReceipt",
     "append_resident_control_loop_receipt",
     "build_resident_control_loop_receipt",
+    "verify_resident_control_loop_receipt",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_validation.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_validation.py
@@ -1,0 +1,127 @@
+"""Strict scalar-field validation for resident control-loop receipts."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Mapping
+
+
+def validate_current_receipt_fields(payload: Mapping[str, Any]) -> None:
+    if not isinstance(payload.get("accepted"), bool):
+        raise ValueError("resident_control_loop_receipt_accepted_invalid")
+    _validate_text_fields(payload)
+    _validate_count_fields(payload)
+    _validate_boolean_fields(payload)
+
+
+def _validate_text_fields(payload: Mapping[str, Any]) -> None:
+    required = (
+        ("receipt_id", 160), ("cycle_id", 160), ("nonce", 192),
+        ("legacy_prefix_digest", 80), ("status", 80), ("created_at", 80),
+        ("repo_root_digest", 64), ("source_receipt_ids_digest", 80),
+        ("child_execution_evidence_digest", 80), ("authentication_status", 32),
+    )
+    for key, limit in required:
+        value = payload.get(key)
+        if not isinstance(value, str) or not value.strip() or len(value) > limit:
+            raise ValueError(f"resident_control_loop_receipt_{key}_invalid")
+    optional = (
+        ("previous_receipt_id", 160), ("issuer_principal_id", 256),
+        ("signer_public_key", 512), ("signer_key_fingerprint", 160),
+        ("key_epoch", 160), ("consensus_receipt_digest", 256),
+        ("authority_profile_digest", 80),
+        ("authority_profile_source_receipt_id", 80), ("signature", 512),
+        ("signer_audit_mac", 512), ("signer_audit_attestation_signature", 512),
+    )
+    if any(
+        not isinstance(payload.get(key), str) or len(payload.get(key)) > limit
+        for key, limit in optional
+    ):
+        raise ValueError("resident_control_loop_receipt_text_invalid")
+
+
+def _validate_count_fields(payload: Mapping[str, Any]) -> None:
+    fields = (
+        "sequence_number", "rounds", "serial_progress", "claim_progress",
+        "authority_issuance_count",
+        "worker_claim_count", "worker_execution_count", "worker_completion_count",
+        "worker_requeue_count", "worker_failure_count", "worktree_creation_count",
+        "bounded_file_edit_count", "slice_verification_count", "draft_pr_publish_count",
+        "pattern_memory_admission_count", "worker_process_spawn_count",
+        "shell_command_count", "worker_effects_unverified_count",
+        "child_execution_evidence_count",
+    )
+    for key in fields:
+        value = payload.get(key)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("resident_control_loop_receipt_integer_invalid")
+
+
+def _validate_boolean_fields(payload: Mapping[str, Any]) -> None:
+    fields = (
+        "control_lock_acquired", "authority_issued", "worker_claim_performed",
+        "worker_execution_performed", "worktree_creation_observed",
+        "bounded_file_edit_observed", "slice_verification_observed",
+        "draft_pr_publish_observed", "pattern_memory_admission_observed",
+        "worker_process_spawn_observed", "shell_command_execution_observed",
+    )
+    if any(not isinstance(payload.get(key), bool) for key in fields):
+        raise ValueError("resident_control_loop_receipt_boolean_invalid")
+
+
+def strict_string_tuple(value: Any, max_chars: int) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ValueError("resident_control_loop_receipt_list_invalid")
+    values = tuple(value)
+    if len(values) > 128 or any(
+        not isinstance(item, str) or not item.strip() or len(item.strip()) > max_chars
+        for item in values
+    ):
+        raise ValueError("resident_control_loop_receipt_list_invalid")
+    return tuple(item.strip() for item in values)
+
+
+def strict_nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError("resident_control_loop_receipt_integer_invalid")
+    return value
+
+
+def parse_receipt_line(raw: str, line_number: int) -> dict[str, Any]:
+    if len(raw.encode("utf-8")) > 64 * 1024:
+        raise ValueError(f"resident_control_loop_receipt_line_too_large:{line_number}")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"resident_control_loop_receipt_chain_invalid_json:{line_number}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"resident_control_loop_receipt_chain_invalid:{line_number}")
+    return payload
+
+
+def validated_receipt_identity(
+    payload: Mapping[str, Any],
+    line_number: int,
+    seen_ids: set[str],
+    receipt_id_builder: Callable[[Mapping[str, Any]], str],
+) -> tuple[Any, str]:
+    schema = payload.get("schema_version")
+    receipt_id = str(payload.get("receipt_id") or "").strip()
+    if not receipt_id:
+        raise ValueError(f"resident_control_loop_receipt_id_missing:{line_number}")
+    if receipt_id in seen_ids:
+        raise ValueError(f"resident_control_loop_receipt_id_duplicate:{line_number}")
+    if receipt_id != receipt_id_builder(payload):
+        raise ValueError(f"resident_control_loop_receipt_digest_invalid:{line_number}")
+    return schema, receipt_id
+
+
+__all__ = [
+    "parse_receipt_line",
+    "strict_nonnegative_int",
+    "strict_string_tuple",
+    "validate_current_receipt_fields",
+    "validated_receipt_identity",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_signing_context.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_signing_context.py
@@ -1,0 +1,232 @@
+"""Resolve the isolated signer context for resident control-loop receipts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+    decode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_client import (
+    DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    build_reddog_isolated_signer_socket_client,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_auth import (
+    ControlLoopReceiptSigningContext,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    HIGH_AUTHORITY_OPERATIONS,
+    HIGH_AUTHORITY_TIER,
+    HIGH_AUTHORITY_VALVE_STATES,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    secure_read_confined_bytes,
+    validate_runtime_artifact_path,
+)
+
+
+MAX_AUTHORITY_PROFILE_BYTES = 256 * 1024
+
+
+def build_control_loop_receipt_signing_context(
+    *,
+    repo_root: Path | str,
+    authority_profile_path: Path | str | None,
+    authority_profile_source_path: Path | str | None,
+    signer_socket_path: Path | str | None,
+    expected_authority_profile_source_receipt_id: str | None,
+    signer_socket_timeout_s: float = DEFAULT_SIGNER_SOCKET_TIMEOUT_S,
+    signer_socket_max_response_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_RESPONSE_BYTES,
+    signer_socket_connector: Any = None,
+) -> ControlLoopReceiptSigningContext:
+    """Resolve public authority bindings and an existing signer client."""
+
+    profile = _load_authority_profile(repo_root, authority_profile_path)
+    source_profile = _load_authority_profile(repo_root, authority_profile_source_path)
+    source_receipt_id = validate_authority_profile_source(
+        source_profile, expected_authority_profile_source_receipt_id
+    )
+    _validate_source_authority_basis(source_profile)
+    validate_promoted_authority_profile_source(profile, source_profile)
+    fields = _validated_authority_profile_fields(profile)
+    built = build_reddog_isolated_signer_socket_client(
+        repo_root=repo_root,
+        socket_path=signer_socket_path,
+        timeout_s=signer_socket_timeout_s,
+        max_response_bytes=signer_socket_max_response_bytes,
+        connector=signer_socket_connector,
+    )
+    if not built.accepted or built.client is None:
+        raise ValueError("resident_control_loop_signer_client_unavailable")
+    return ControlLoopReceiptSigningContext(
+        signer=built.client,
+        signature_verifier=Ed25519SignatureVerifier(),
+        issuer_principal_id=fields["principal_id"],
+        signer_public_key=fields["signer_public_key"],
+        key_epoch=fields["key_epoch"],
+        authority_tier=fields["authority_tier"],
+        consensus_receipt_digest=fields["consensus_receipt_digest"],
+        authority_profile_digest="sha256:" + _digest(profile),
+        authority_profile_source_receipt_id=source_receipt_id,
+    )
+
+
+def _validated_authority_profile_fields(profile: Mapping[str, Any]) -> dict[str, str]:
+    signer_public_key = _required_ascii(profile.get("reddog_public_key"), 512, "public_key")
+    if decode_ed25519_public_key(signer_public_key) is None:
+        raise ValueError("resident_control_loop_authority_public_key_invalid")
+    operation = _required_ascii(
+        profile.get("requested_operation"), 160, "requested_operation"
+    )
+    valve_state = _required_ascii(
+        profile.get("valve_state_required"), 160, "valve_state_required"
+    )
+    if operation not in HIGH_AUTHORITY_OPERATIONS and valve_state not in HIGH_AUTHORITY_VALVE_STATES:
+        raise ValueError("resident_control_loop_authority_tier_invalid")
+    consensus = _required_ascii(
+        profile.get("consensus_receipt_digest"), 256, "consensus_receipt_digest"
+    )
+    if not _is_sha256_digest(consensus):
+        raise ValueError("resident_control_loop_authority_consensus_receipt_digest_invalid")
+    sovereign = _required_ascii(
+        profile.get("sovereign_authorization_digest"),
+        256,
+        "sovereign_authorization_digest",
+    )
+    if not _is_sha256_digest(sovereign):
+        raise ValueError("resident_control_loop_authority_sovereign_authorization_digest_invalid")
+    return {
+        "principal_id": _required_ascii(profile.get("principal_id"), 256, "principal_id"),
+        "signer_public_key": signer_public_key,
+        "key_epoch": _required_ascii(profile.get("key_epoch"), 160, "key_epoch"),
+        "authority_tier": HIGH_AUTHORITY_TIER,
+        "consensus_receipt_digest": consensus,
+    }
+
+
+def _load_authority_profile(
+    repo_root: Path | str,
+    authority_profile_path: Path | str | None,
+) -> Mapping[str, Any]:
+    if not authority_profile_path:
+        raise ValueError("resident_control_loop_authority_profile_required")
+    path = validate_runtime_artifact_path(authority_profile_path, repo_root=repo_root)
+    if not path.exists() or path.stat().st_size > MAX_AUTHORITY_PROFILE_BYTES:
+        raise ValueError("resident_control_loop_authority_profile_invalid")
+    raw, offset = secure_read_confined_bytes(
+        path, allowed_root=path.parent, max_bytes=MAX_AUTHORITY_PROFILE_BYTES
+    )
+    if offset != path.stat().st_size:
+        raise ValueError("resident_control_loop_authority_profile_incomplete")
+    try:
+        profile = json.loads(raw.decode("utf-8"))
+    except Exception as exc:
+        raise ValueError("resident_control_loop_authority_profile_invalid") from exc
+    if not isinstance(profile, Mapping):
+        raise ValueError("resident_control_loop_authority_profile_invalid")
+    return profile
+
+
+def validate_authority_profile_source(
+    profile: Mapping[str, Any], expected_receipt_id: str | None
+) -> str:
+    if profile.get("schema_version") != "reddog_authority_profile_source.v1":
+        raise ValueError("resident_control_loop_authority_profile_schema_invalid")
+    expected = str(expected_receipt_id or "").strip()
+    if not _is_sha256_digest(expected):
+        raise ValueError("resident_control_loop_authority_profile_source_receipt_required")
+    supplied = str(profile.get("authority_profile_source_receipt_id") or "").strip()
+    unsigned = dict(profile)
+    unsigned.pop("authority_profile_source_receipt_id", None)
+    computed = "sha256:" + _digest(unsigned)
+    if supplied != computed or supplied != expected:
+        raise ValueError("resident_control_loop_authority_profile_source_receipt_invalid")
+    return supplied
+
+
+def validate_promoted_authority_profile_source(
+    profile: Mapping[str, Any], source_profile: Mapping[str, Any]
+) -> None:
+    """Require the promoted runtime profile to preserve its source verbatim."""
+
+    if not profile or not source_profile:
+        raise ValueError("resident_control_loop_authority_profile_source_binding_invalid")
+    if any(profile.get(key) != value for key, value in source_profile.items()):
+        raise ValueError("resident_control_loop_authority_profile_source_binding_invalid")
+    binding = profile.get("operational_context_binding")
+    if not isinstance(binding, Mapping):
+        raise ValueError("resident_control_loop_authority_profile_promotion_binding_invalid")
+    for field in (
+        "queue_item_id",
+        "claim_id",
+        "architect_determination_receipt_id",
+        "wsp15_allocation_receipt",
+    ):
+        if binding.get(field) in (None, "", (), [], {}):
+            raise ValueError("resident_control_loop_authority_profile_promotion_binding_invalid")
+
+
+def _validate_source_authority_basis(profile: Mapping[str, Any]) -> None:
+    basis = profile.get("source_authority_basis")
+    if not isinstance(basis, Mapping):
+        raise ValueError("resident_control_loop_authority_profile_source_basis_invalid")
+    principal_public_key = _required_ascii(
+        profile.get("principal_public_key"), 512, "principal_public_key"
+    )
+    if decode_ed25519_public_key(principal_public_key) is None:
+        raise ValueError("resident_control_loop_authority_principal_public_key_invalid")
+    permission_digest = _required_ascii(
+        profile.get("permission_snapshot_digest"),
+        256,
+        "permission_snapshot_digest",
+    )
+    subject_digest = str(basis.get("principal_verified_subject_digest") or "")
+    if not _is_sha256_digest(permission_digest) or not _is_sha256_digest(subject_digest):
+        raise ValueError("resident_control_loop_authority_profile_source_basis_invalid")
+    if str(basis.get("permission_snapshot_digest") or "") != permission_digest:
+        raise ValueError("resident_control_loop_authority_profile_source_basis_invalid")
+    repo_scope = basis.get("principal_repo_scope")
+    foundup_scope = basis.get("principal_foundup_scope")
+    if (
+        not isinstance(repo_scope, list)
+        or str(profile.get("repo_full_name") or "") not in repo_scope
+        or not isinstance(foundup_scope, list)
+        or str(profile.get("foundup_id") or "") not in foundup_scope
+    ):
+        raise ValueError("resident_control_loop_authority_profile_source_basis_invalid")
+    if basis.get("permission_snapshot_can_write") is not True and basis.get(
+        "permission_snapshot_can_admin"
+    ) is not True:
+        raise ValueError("resident_control_loop_authority_profile_source_basis_invalid")
+
+
+def _required_ascii(value: Any, max_chars: int, field: str) -> str:
+    text = str(value or "").strip()
+    if not text or len(text) > max_chars or any(ord(char) >= 128 for char in text):
+        raise ValueError(f"resident_control_loop_authority_{field}_invalid")
+    return text
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = str(value or "")
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
+
+
+def _digest(value: Any) -> str:
+    import hashlib
+
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "build_control_loop_receipt_signing_context",
+    "validate_authority_profile_source",
+    "validate_promoted_authority_profile_source",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_live_canary.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_live_canary.py
@@ -27,6 +27,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping, Optional, Sequence
 
+from modules.communication.moltbot_bridge.src.reddog_resident_live_canary_environment import (
+    build_live_canary_environment,
+)
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
     PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY,
 )
@@ -36,6 +39,9 @@ from modules.communication.moltbot_bridge.src.reddog_resident_live_canary_eviden
     evaluate_live_proof,
     read_control_receipts,
     select_new_control_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_live_canary_control_preflight import (
+    verify_live_canary_control_prestate,
 )
 
 
@@ -50,6 +56,7 @@ LIVE_CANARY_PROOF_COMPLETE = "LIVE_PROOF_COMPLETE"
 REQUIRED_JSON_ARTIFACTS = (
     "authoritative_work_state.json",
     "authority_profile.json",
+    "authority_profile_source.json",
     "execution_valve_env.json",
     "permission_snapshots.json",
     "principal_authority_records.json",
@@ -237,19 +244,20 @@ def _invoke_canary(
     pre_chain_state = _read_json_mapping(chain_path)
     previous_revision = _text(pre_chain_state.get("revision"))
     pre_chain_ids = chain_receipt_ids(pre_chain_state)
-    pre_control_receipts = read_control_receipts(control_path)
+    pre_control_receipts = _read_control_receipt_stream(control_path, blockers)
+    _verify_control_receipts(context, pre_control_receipts, blockers)
     invoked = execute and confirmed and not blockers
-    result: Mapping[str, Any] = {}
-    if invoked:
-        with _temporary_environment(
-            _canary_environment(context.runtime_root, queue_item_id, max_rounds)
-        ):
-            result = _mapping(runner(context.repo_root))
+    result = _invoke_control_runner(
+        context, runner, queue_item_id, max_rounds, invoked
+    )
     chain_state = _read_json_mapping(chain_path)
     control_receipt_id = _text(result.get("receipt_id"))
+    post_control_receipts = _verified_post_control_receipts(
+        context, control_path, pre_control_receipts, blockers
+    )
     control_receipt = select_new_control_receipt(
         pre_control_receipts,
-        read_control_receipts(control_path),
+        post_control_receipts,
         control_receipt_id,
     )
     return CanaryInvocationEvidence(
@@ -265,6 +273,99 @@ def _invoke_canary(
         work_state=_read_json_mapping(context.runtime_root / "authoritative_work_state.json"),
         chain_state=chain_state,
     )
+
+
+def _invoke_control_runner(
+    context: _CanaryContext, runner: ControlLoopRunner,
+    queue_item_id: str, max_rounds: int, invoked: bool,
+) -> Mapping[str, Any]:
+    if not invoked:
+        return {}
+    overlay = build_live_canary_environment(
+        runtime_root=context.runtime_root, environ=context.environ,
+        queue_item_id=queue_item_id, max_rounds=max_rounds,
+    )
+    with _temporary_environment(overlay):
+        return _mapping(runner(context.repo_root))
+
+
+def _verified_post_control_receipts(
+    context: _CanaryContext,
+    path: Path,
+    pre_receipts: tuple[Mapping[str, Any], ...],
+    blockers: list[str],
+) -> tuple[Mapping[str, Any], ...]:
+    post_receipts = _read_control_receipt_stream(path, blockers)
+    if len(post_receipts) < len(pre_receipts) or post_receipts[
+        : len(pre_receipts)
+    ] != pre_receipts:
+        blockers.append("control_receipt_stream_not_append_only")
+    try:
+        profile = _read_json_mapping(context.runtime_root / "authority_profile.json")
+        source = _read_json_mapping(
+            context.runtime_root / "authority_profile_source.json"
+        )
+        verify_live_canary_control_prestate(
+            runtime_root=context.runtime_root,
+            receipts=post_receipts,
+            authority_profile=profile,
+            authority_profile_source=source,
+            expected_source_receipt_id=str(
+                context.environ.get("REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID")
+                or ""
+            ),
+            signer_anchor_path=_signer_anchor_path(context),
+        )
+    except (KeyError, TypeError, ValueError):
+        blockers.append("control_receipt_stream_auth_or_integrity_invalid")
+    return post_receipts
+
+
+def _verify_control_receipts(
+    context: _CanaryContext,
+    receipts: tuple[Mapping[str, Any], ...],
+    blockers: list[str],
+) -> None:
+    try:
+        profile = _read_json_mapping(context.runtime_root / "authority_profile.json")
+        source = _read_json_mapping(
+            context.runtime_root / "authority_profile_source.json"
+        )
+        expected_source = str(
+            context.environ.get("REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID") or ""
+        )
+        verify_live_canary_control_prestate(
+            runtime_root=context.runtime_root,
+            receipts=receipts,
+            authority_profile=profile,
+            authority_profile_source=source,
+            expected_source_receipt_id=expected_source,
+            signer_anchor_path=_signer_anchor_path(context),
+        )
+    except (KeyError, TypeError, ValueError):
+        blockers.append("control_receipt_prestate_auth_or_integrity_invalid")
+
+
+def _signer_anchor_path(context: _CanaryContext) -> Path:
+    config = _read_json_mapping(context.runtime_root / "signer_service_config.json")
+    value = str(config.get("control_loop_anchor_path") or "").strip()
+    if not value:
+        raise ValueError("signer_control_loop_anchor_path_missing")
+    path = Path(value)
+    if not path.is_absolute():
+        raise ValueError("signer_control_loop_anchor_path_invalid")
+    return path.resolve()
+
+
+def _read_control_receipt_stream(
+    path: Path,
+    blockers: list[str],
+) -> tuple[Mapping[str, Any], ...]:
+    try:
+        return read_control_receipts(path)
+    except ValueError:
+        blockers.append("control_receipt_stream_invalid")
+        return ()
 
 
 def _readiness_checks(
@@ -305,85 +406,6 @@ def _readiness_checks(
     socket_path = runtime_root / "reddog_signer.sock"
     checks.append(_check("signer_socket", socket_probe(socket_path), "signer_socket_not_ready"))
     return checks
-
-
-def _canary_environment(runtime_root: Path, queue_item_id: str, max_rounds: int) -> dict[str, str]:
-    env = _canary_runtime_paths(runtime_root)
-    env.update(_canary_runtime_modes())
-    env.update(_canary_runtime_controls(max_rounds))
-    env["REDDOG_WRE_QUEUE_ITEM_ID"] = queue_item_id
-    return env
-
-
-def _canary_runtime_paths(runtime_root: Path) -> dict[str, str]:
-    return {
-        "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY,
-        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(runtime_root / "authoritative_work_state.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(runtime_root / "authority_profile.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(runtime_root / "resident_queue_chain_results.json"),
-        "REDDOG_EXECUTION_VALVE_ENV_PATH": str(runtime_root / "execution_valve_env.json"),
-        "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": str(runtime_root / "authority_runtime_state.json"),
-        "REDDOG_PERMISSION_SNAPSHOTS_PATH": str(runtime_root / "permission_snapshots.json"),
-        "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": str(runtime_root / "principal_authority_records.json"),
-        "REDDOG_SIGNER_SERVICE_CONFIG_PATH": str(runtime_root / "signer_service_config.json"),
-        "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH": str(runtime_root / "signer_service_run_packet.json"),
-        "REDDOG_SIGNER_SOCKET_PATH": str(runtime_root / "reddog_signer.sock"),
-        "REDDOG_OUTCOME_RATCHET_STORE_PATH": str(runtime_root / "verified_outcomes.jsonl"),
-        "REDDOG_MODEL_FEEDBACK_LEDGER_STORE_PATH": str(runtime_root / "model_feedback.jsonl"),
-        "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(runtime_root / "pattern_memory.db"),
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPTS_PATH": str(runtime_root / "resident_queue_control_loop_receipts.jsonl"),
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_LOCK_PATH": str(runtime_root / "resident_queue_control_loop.lock"),
-    }
-
-
-def _canary_runtime_modes() -> dict[str, str]:
-    return {
-        "REDDOG_SIGNATURE_VERIFIER_BACKEND": "ed25519",
-        "REDDOG_WORK_ORDER_MATERIALIZER_MODE": "authority_profile",
-        "REDDOG_ARTIFACT_GENERATOR_MODE": "foundups_fusion",
-        "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE": "real",
-        "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE": "real",
-        "REDDOG_DRAFT_PR_RUNNER_MODE": "real",
-        "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S": "120",
-        "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "120",
-        "REDDOG_WORK_ORDERS_PATH": "",
-        "REDDOG_ARTIFACT_CONTENTS_PATH": "",
-        "REDDOG_ARTIFACT_GENERATION_REQUEST_PATH": "",
-        "REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY": "0",
-        "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY": "0",
-        "REDDOG_AUTHORITY_RUNTIME_RESOLVER_ARTIFACT_SUPPLY": "0",
-        "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "",
-    }
-
-
-def _canary_runtime_controls(max_rounds: int) -> dict[str, str]:
-    return {
-        "REDDOG_SIGNER_SERVICE_HEALTHCHECK": "1",
-        "REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED": "1",
-        "REDDOG_PILOT_DRYRUN_BINDING": "1",
-        "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "1",
-        "REDDOG_SLICE_VERIFIER_REQUEST_BINDING": "1",
-        "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING": "1",
-        "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING": "1",
-        "REDDOG_HELD_OUT_GATE_REQUEST_BINDING": "1",
-        "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING": "1",
-        "REDDOG_WORKER_DISPATCH_AGENTDB_WRITER": "1",
-        "OPENCLAW_SIGNED_WORKER_TASKS_ENABLED": "1",
-        "OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED": "1",
-        "OPENCLAW_SIGNED_QUEUE_STAGE_TASKS_ENABLED": "1",
-        "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
-        "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP": "1",
-        "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED": "1",
-        "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS": "16",
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP": "1",
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED": "1",
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS": str(max_rounds),
-        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPT_PERSISTENCE": "1",
-        "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP": "1",
-        "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED": "1",
-        "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "1",
-    }
 
 
 def _run_existing_control_loop(repo_root: Path) -> Mapping[str, Any]:

--- a/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_control_preflight.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_control_preflight.py
@@ -1,0 +1,113 @@
+"""Read-only authenticated preflight for live-canary control state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_head_store import (
+    load_control_receipt_head,
+    verify_control_receipt_head_against_chain,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_chain import (
+    verify_control_receipt_chain_against_profile,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_signing_context import (
+    validate_authority_profile_source,
+    validate_promoted_authority_profile_source,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    AtomicSignerControlLoopAnchorStore,
+)
+
+
+def verify_live_canary_control_prestate(
+    *,
+    runtime_root: Path,
+    receipts: Sequence[Mapping[str, Any]],
+    authority_profile: Mapping[str, Any],
+    authority_profile_source: Mapping[str, Any],
+    expected_source_receipt_id: str,
+    signer_anchor_path: Path,
+) -> None:
+    validate_authority_profile_source(
+        authority_profile_source, expected_source_receipt_id
+    )
+    validate_promoted_authority_profile_source(
+        authority_profile, authority_profile_source
+    )
+    verify_control_receipt_chain_against_profile(receipts, authority_profile)
+    _, _, head = load_control_receipt_head(
+        runtime_root / "authority_runtime_state.json"
+    )
+    current_ids, child_receipts, child_evidence = _chain_evidence(receipts)
+    if head is None:
+        if current_ids:
+            raise ValueError("resident_control_loop_head_missing_for_existing_chain")
+        if signer_anchor_path.exists():
+            raise ValueError("signer_control_loop_anchor_ahead_of_resident_chain")
+        return
+    verify_control_receipt_head_against_chain(
+        head,
+        receipt_ids=current_ids,
+        child_receipt_ids=child_receipts,
+        child_evidence_digests=child_evidence,
+    )
+    _verify_signer_anchor(
+        signer_anchor_path,
+        receipts=receipts,
+        current_ids=current_ids,
+        child_receipts=child_receipts,
+        child_evidence=child_evidence,
+    )
+
+
+def _chain_evidence(
+    receipts: Sequence[Mapping[str, Any]],
+) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    current = tuple(
+        receipt
+        for receipt in receipts
+        if receipt.get("schema_version") == "reddog_resident_control_loop_receipt.v2"
+    )
+    return (
+        tuple(str(receipt["receipt_id"]) for receipt in current),
+        tuple(
+            str(value)
+            for receipt in current
+            for value in tuple(receipt.get("child_execution_receipt_ids") or ())
+        ),
+        tuple(
+            str(value)
+            for receipt in current
+            for value in tuple(
+                receipt.get("child_execution_evidence_digests") or ()
+            )
+        ),
+    )
+
+
+def _verify_signer_anchor(
+    path: Path,
+    *,
+    receipts: Sequence[Mapping[str, Any]],
+    current_ids: tuple[str, ...],
+    child_receipts: tuple[str, ...],
+    child_evidence: tuple[str, ...],
+) -> None:
+    state = AtomicSignerControlLoopAnchorStore(path).load()
+    if not state:
+        raise ValueError("signer_control_loop_anchor_missing")
+    if (
+        state.get("sequence_number") != len(current_ids)
+        or state.get("receipt_id") != current_ids[-1]
+        or dict(state.get("signed_receipt") or {}) != dict(receipts[-1])
+        or set(state.get("consumed_child_receipt_ids") or ())
+        != set(child_receipts)
+        or set(state.get("consumed_child_evidence_digests") or ())
+        != set(child_evidence)
+    ):
+        raise ValueError("signer_control_loop_anchor_chain_mismatch")
+
+
+__all__ = ["verify_live_canary_control_prestate"]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_environment.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_environment.py
@@ -1,0 +1,105 @@
+"""Environment overlay for one explicitly confirmed RedDog live canary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
+    PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY,
+)
+
+
+def build_live_canary_environment(
+    *, runtime_root: Path, environ: Mapping[str, str],
+    queue_item_id: str, max_rounds: int,
+) -> dict[str, str]:
+    env = _runtime_paths(runtime_root)
+    env.update(_runtime_modes())
+    env.update(_runtime_controls(max_rounds))
+    env["REDDOG_WRE_QUEUE_ITEM_ID"] = queue_item_id
+    env["REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID"] = str(
+        environ.get("REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID") or ""
+    )
+    return env
+
+
+def _runtime_paths(runtime_root: Path) -> dict[str, str]:
+    names = {
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": "authoritative_work_state.json",
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": "authority_profile.json",
+        "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": "authority_profile_source.json",
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": "resident_queue_chain_results.json",
+        "REDDOG_EXECUTION_VALVE_ENV_PATH": "execution_valve_env.json",
+        "REDDOG_AUTHORITY_RUNTIME_STATE_PATH": "authority_runtime_state.json",
+        "REDDOG_PERMISSION_SNAPSHOTS_PATH": "permission_snapshots.json",
+        "REDDOG_PRINCIPAL_AUTHORITY_RECORDS_PATH": "principal_authority_records.json",
+        "REDDOG_SIGNER_SERVICE_CONFIG_PATH": "signer_service_config.json",
+        "REDDOG_SIGNER_SERVICE_RUN_PACKET_PATH": "signer_service_run_packet.json",
+        "REDDOG_SIGNER_SOCKET_PATH": "reddog_signer.sock",
+        "REDDOG_OUTCOME_RATCHET_STORE_PATH": "verified_outcomes.jsonl",
+        "REDDOG_MODEL_FEEDBACK_LEDGER_STORE_PATH": "model_feedback.jsonl",
+        "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": "pattern_memory.db",
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPTS_PATH": (
+            "resident_queue_control_loop_receipts.jsonl"
+        ),
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_LOCK_PATH": "resident_queue_control_loop.lock",
+    }
+    paths = {key: str(runtime_root / name) for key, name in names.items()}
+    paths["REDDOG_SIGNER_CONTROL_LOOP_ANCHOR_PATH"] = str(
+        runtime_root.parent
+        / f"{runtime_root.name}-signer-state"
+        / "signer_control_loop_anchor.json"
+    )
+    paths["REDDOG_RESIDENT_RUNTIME_ROOT"] = str(runtime_root)
+    paths["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] = (
+        PROFILE_SIGNED_0102_BOUNDED_CODE_FUSION_WORKTREE_DRAFT_PR_PATTERN_MEMORY
+    )
+    return paths
+
+
+def _runtime_modes() -> dict[str, str]:
+    return {
+        "REDDOG_SIGNATURE_VERIFIER_BACKEND": "ed25519",
+        "REDDOG_WORK_ORDER_MATERIALIZER_MODE": "authority_profile",
+        "REDDOG_ARTIFACT_GENERATOR_MODE": "foundups_fusion",
+        "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE": "real",
+        "REDDOG_EVIDENCE_COMMAND_RUNNER_MODE": "real",
+        "REDDOG_DRAFT_PR_RUNNER_MODE": "real",
+        "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_TIMEOUT_S": "120",
+        "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "120",
+        "REDDOG_WORK_ORDERS_PATH": "",
+        "REDDOG_ARTIFACT_CONTENTS_PATH": "",
+        "REDDOG_ARTIFACT_GENERATION_REQUEST_PATH": "",
+        "REDDOG_SIGNER_SERVICE_CONFIG_SUPPLY": "0",
+        "REDDOG_SIGNER_SERVICE_RUN_PACKET_SUPPLY": "0",
+        "REDDOG_AUTHORITY_RUNTIME_RESOLVER_ARTIFACT_SUPPLY": "0",
+        "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "",
+    }
+
+
+def _runtime_controls(max_rounds: int) -> dict[str, str]:
+    enabled = {
+        "REDDOG_SIGNER_SERVICE_HEALTHCHECK", "REDDOG_SIGNER_SERVICE_HEALTHCHECK_ENFORCED",
+        "REDDOG_PILOT_DRYRUN_BINDING", "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING",
+        "REDDOG_SLICE_VERIFIER_REQUEST_BINDING", "REDDOG_DRAFT_PR_PUBLISH_REQUEST_BINDING",
+        "REDDOG_OUTCOME_RATCHET_REQUEST_BINDING", "REDDOG_HELD_OUT_GATE_REQUEST_BINDING",
+        "REDDOG_PATTERN_MEMORY_ADMISSION_REQUEST_BINDING", "REDDOG_WORKER_DISPATCH_AGENTDB_WRITER",
+        "OPENCLAW_SIGNED_WORKER_TASKS_ENABLED", "OPENCLAW_SIGNED_0102_BOUNDED_CODE_TASKS_ENABLED",
+        "OPENCLAW_SIGNED_QUEUE_STAGE_TASKS_ENABLED", "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER",
+        "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP", "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_ENFORCED",
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP", "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED",
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPT_PERSISTENCE",
+        "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP",
+        "REDDOG_OPENCLAW_SIGNED_WORKER_CLAIM_LOOP_ENFORCED",
+    }
+    controls = {key: "1" for key in enabled}
+    controls.update({
+        "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS": "16",
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS": str(max_rounds),
+        "OPENCLAW_SIGNED_WORKER_TASK_MAX_CLAIMS": "1",
+    })
+    return controls
+
+
+__all__ = ["build_live_canary_environment"]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_evidence.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_evidence.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping, Optional
 
 from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
     CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
+    verify_resident_control_loop_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_chain_results_store import (
     CHAIN_RESULTS_SCHEMA_VERSION,
@@ -65,22 +66,25 @@ class CanaryInvocationEvidence:
 
 
 def read_control_receipts(path: Path) -> tuple[Mapping[str, Any], ...]:
-    """Parse valid JSON-object receipt rows; malformed rows cannot prove a run."""
+    """Parse the complete JSONL stream or reject it fail-closed."""
 
     if not path.is_file():
         return ()
     receipts: list[Mapping[str, Any]] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return ()
-    for line in lines:
+    except OSError as exc:
+        raise ValueError("control_receipt_stream_unreadable") from exc
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
         try:
             payload = json.loads(line)
-        except (json.JSONDecodeError, TypeError):
-            continue
-        if isinstance(payload, Mapping):
-            receipts.append(payload)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError(f"control_receipt_stream_invalid_json:{line_number}") from exc
+        if not isinstance(payload, Mapping):
+            raise ValueError(f"control_receipt_stream_invalid_record:{line_number}")
+        receipts.append(payload)
     return tuple(receipts)
 
 
@@ -140,7 +144,7 @@ def evaluate_live_proof(
         worktree,
     )
     blockers = [
-        *_fresh_execution_blockers(invocation, repo_root),
+        *_fresh_execution_blockers(invocation, repo_root, runtime_root),
         *chain_blockers,
         *draft["blockers"],
         *pattern["blockers"],
@@ -165,6 +169,7 @@ def evaluate_live_proof(
 def _fresh_execution_blockers(
     invocation: CanaryInvocationEvidence,
     repo_root: Path,
+    runtime_root: Path,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
     if not invocation.invoked:
@@ -179,13 +184,14 @@ def _fresh_execution_blockers(
         or invocation.observed_revision == invocation.previous_revision
     ):
         blockers.append("new_chain_revision_not_observed")
-    blockers.extend(_control_receipt_blockers(invocation, repo_root))
+    blockers.extend(_control_receipt_blockers(invocation, repo_root, runtime_root))
     return tuple(blockers)
 
 
 def _control_receipt_blockers(
     invocation: CanaryInvocationEvidence,
     repo_root: Path,
+    runtime_root: Path,
 ) -> tuple[str, ...]:
     receipt = invocation.control_receipt
     if not receipt:
@@ -204,7 +210,45 @@ def _control_receipt_blockers(
     progress = receipt.get("serial_progress")
     if isinstance(progress, bool) or not isinstance(progress, int) or progress <= 0:
         blockers.append("control_receipt_serial_progress_missing")
+    try:
+        authority_profile = _runtime_authority_profile(runtime_root)
+        authority_profile_digest = "sha256:" + _digest(authority_profile)
+        verify_resident_control_loop_receipt(
+            receipt,
+            expected_repo_root=repo_root,
+            expected_signer_public_key=str(authority_profile["reddog_public_key"]),
+            expected_key_epoch=str(authority_profile["key_epoch"]),
+            expected_consensus_receipt_digest=str(
+                authority_profile["consensus_receipt_digest"]
+            ),
+            expected_authority_profile_digest=authority_profile_digest,
+            require_authenticated=True,
+        )
+    except (KeyError, TypeError, ValueError):
+        blockers.append("control_receipt_auth_or_integrity_invalid")
     return tuple(blockers)
+
+
+def _runtime_authority_profile(runtime_root: Path) -> Mapping[str, Any]:
+    path = runtime_root / "authority_profile.json"
+    if path.is_symlink() or not path.is_file() or path.stat().st_size > 256 * 1024:
+        raise ValueError("authority_profile_invalid")
+    resolved = path.resolve()
+    if not _is_inside(resolved, runtime_root):
+        raise ValueError("authority_profile_outside_runtime_root")
+    payload = json.loads(resolved.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("authority_profile_invalid")
+    for key in (
+        "principal_id",
+        "reddog_public_key",
+        "key_epoch",
+        "consensus_receipt_digest",
+    ):
+        value = payload.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"authority_profile_{key}_missing")
+    return payload
 
 
 def _chain_evidence(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_chain_results_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_chain_results_store.py
@@ -19,6 +19,10 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping, Optional, Protocol, Sequence
 
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    runtime_operation_lock,
+)
+
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
     RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE,
     RESIDENT_QUEUE_ORCHESTRATION_PLAN_READY,
@@ -75,7 +79,7 @@ class AtomicJsonResidentQueueChainResultsStore:
     """Single-file JSON store using atomic replace."""
 
     def __init__(self, path: str | Path) -> None:
-        self.path = Path(path)
+        self.path = Path(path).resolve()
 
     def load(self) -> Mapping[str, Any]:
         if not self.path.exists():
@@ -83,21 +87,26 @@ class AtomicJsonResidentQueueChainResultsStore:
         return json.loads(self.path.read_text(encoding="utf-8"))
 
     def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
-        current = self.load()
-        if current.get("revision") != expected_revision:
-            raise RuntimeError("revision_conflict")
-        committed, revision = _committed_snapshot(snapshot)
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent))
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
-                json.dump(committed, handle, sort_keys=True, indent=2)
-                handle.write("\n")
-            os.replace(tmp_name, self.path)
-        finally:
-            if os.path.exists(tmp_name):
-                os.unlink(tmp_name)
-        return revision
+        with runtime_operation_lock(self.path):
+            current = self.load()
+            if current.get("revision") != expected_revision:
+                raise RuntimeError("revision_conflict")
+            committed, revision = _committed_snapshot(snapshot)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp_name = tempfile.mkstemp(
+                prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent)
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+                    json.dump(committed, handle, sort_keys=True, indent=2)
+                    handle.write("\n")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(tmp_name, self.path)
+            finally:
+                if os.path.exists(tmp_name):
+                    os.unlink(tmp_name)
+            return revision
 
 
 @dataclass(frozen=True)

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_control_lock.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_control_lock.py
@@ -13,7 +13,9 @@ from typing import BinaryIO, Iterator, Mapping, Optional
 
 
 CONTROL_LOOP_LOCK_PATH_ENV = "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_LOCK_PATH"
-_CONTROL_LOCK_HELD: ContextVar[bool] = ContextVar("reddog_control_lock_held", default=False)
+_CONTROL_LOCK_IDENTITY: ContextVar[str] = ContextVar(
+    "reddog_control_lock_identity", default=""
+)
 
 
 @dataclass(frozen=True)
@@ -45,11 +47,17 @@ def resident_queue_control_lock_path(
 def acquire_resident_queue_control_lock(
     repo_root: Path | str,
     environ: Optional[Mapping[str, str]] = None,
+    *,
+    allow_reentrant: bool = False,
 ) -> Iterator[ResidentQueueControlLock]:
     """Acquire a non-blocking OS advisory lock that releases on process exit."""
 
     root = Path(repo_root).resolve()
     path = resident_queue_control_lock_path(root, environ)
+    identity = _lock_identity(path)
+    if allow_reentrant and _CONTROL_LOCK_IDENTITY.get() == identity:
+        yield ResidentQueueControlLock(True, path, "control_lock_already_held_by_context")
+        return
     if _is_inside(path, root):
         yield ResidentQueueControlLock(False, path, "control_lock_path_inside_repo")
         return
@@ -64,18 +72,29 @@ def acquire_resident_queue_control_lock(
         yield ResidentQueueControlLock(False, path, "control_loop_already_running")
         return
     try:
-        token = _CONTROL_LOCK_HELD.set(True)
+        token = _CONTROL_LOCK_IDENTITY.set(identity)
         yield ResidentQueueControlLock(True, path, "ok")
     finally:
-        _CONTROL_LOCK_HELD.reset(token)
+        _CONTROL_LOCK_IDENTITY.reset(token)
         _unlock_file(handle)
         handle.close()
 
 
-def resident_queue_control_lock_held() -> bool:
-    """Return whether this execution context owns the shared control lock."""
+def resident_queue_control_lock_held(
+    repo_root: Path | str | None = None,
+    environ: Optional[Mapping[str, str]] = None,
+) -> bool:
+    """Return whether this context owns the expected shared control lock."""
 
-    return _CONTROL_LOCK_HELD.get()
+    held = _CONTROL_LOCK_IDENTITY.get()
+    if repo_root is None:
+        return bool(held)
+    expected = resident_queue_control_lock_path(repo_root, environ)
+    return held == _lock_identity(expected)
+
+
+def _lock_identity(path: Path) -> str:
+    return os.path.normcase(str(path.resolve()))
 
 
 def _lock_file(handle: BinaryIO) -> None:

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_0102_readonly_review_binding.py
@@ -142,8 +142,11 @@ class Signed0102ReadOnlyReviewRunner:
             "no_hermes_dispatch_performed": True,
             "no_worktree_operation_performed": True,
             "no_pr_created": True,
+            "no_live_foundup_enqueue_performed": True,
             "no_pattern_memory_write_performed": True,
             "no_reward_settlement_performed": True,
+            "worker_process_spawn_count": 0,
+            "shell_command_count": 0,
         }
 
 
@@ -279,8 +282,11 @@ def _runner_reject(
         "no_hermes_dispatch_performed": True,
         "no_worktree_operation_performed": True,
         "no_pr_created": True,
+        "no_live_foundup_enqueue_performed": True,
         "no_pattern_memory_write_performed": True,
         "no_reward_settlement_performed": True,
+        "worker_process_spawn_count": 0,
+        "shell_command_count": 0,
     }
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_dispatch_task_executor.py
@@ -25,6 +25,17 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_hermes_0102_worker
 
 SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT = "SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_ACCEPT"
 SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT = "SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT"
+_RUNNER_NO_EFFECT_FIELDS = (
+    "no_shell_command_executed",
+    "no_source_repo_mutation_performed",
+    "no_holoindex_reindex_performed",
+    "no_hermes_dispatch_performed",
+    "no_worktree_operation_performed",
+    "no_pr_created",
+    "no_live_foundup_enqueue_performed",
+    "no_pattern_memory_write_performed",
+    "no_reward_settlement_performed",
+)
 
 
 class SignedWorkerDispatchTaskExecutorReason:
@@ -42,6 +53,9 @@ class SignedWorkerDispatchTaskExecutorReason:
     RUNNER_MISSING = "REJECT_SIGNED_WORKER_RUNNER_MISSING"
     RUNNER_REJECTED = "REJECT_SIGNED_WORKER_RUNNER_REJECTED"
     RUNNER_UNSAFE = "REJECT_SIGNED_WORKER_RUNNER_UNSAFE"
+    RUNNER_EFFECT_EVIDENCE_INCOMPLETE = (
+        "REJECT_SIGNED_WORKER_RUNNER_EFFECT_EVIDENCE_INCOMPLETE"
+    )
 
 
 class SignedWorkerDispatchTaskRunner(Protocol):
@@ -69,11 +83,18 @@ class SignedWorkerDispatchTaskExecutionResult:
     worker_runtime: str
     capability: str
     runner_result: Optional[Mapping[str, Any]]
+    worker_execution_performed: bool
+    effect_evidence_complete: bool
     rejection_reasons: tuple[str, ...]
+    worker_process_spawn_count: int = 0
+    shell_command_count: int = 0
     no_shell_command_executed: bool = True
     no_source_repo_mutation_performed: bool = True
     no_holoindex_reindex_performed: bool = True
+    no_hermes_dispatch_performed: bool = True
+    no_worktree_operation_performed: bool = True
     no_pr_created: bool = True
+    no_live_foundup_enqueue_performed: bool = True
     no_pattern_memory_write_performed: bool = True
     no_reward_settlement_performed: bool = True
 
@@ -93,15 +114,28 @@ def execute_reddog_signed_worker_dispatch_task(
 ) -> SignedWorkerDispatchTaskExecutionResult:
     """Validate and execute one signed worker-dispatch task via injected runner."""
 
+    context, intent, receipt, reasons = _validated_worker_context(task_context)
+    if reasons:
+        return _reject(task_id, reasons, context=context)
+    if runner is None:
+        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.RUNNER_MISSING], context=context)
+    return _invoke_signed_worker_runner(
+        task_id=task_id, repo_root=repo_root, context=context,
+        intent=intent, receipt=receipt, runner=runner,
+    )
+
+
+def _validated_worker_context(
+    task_context: Mapping[str, Any],
+) -> tuple[Mapping[str, Any], Mapping[str, Any], Mapping[str, Any], list[str]]:
     context = _mapping(task_context)
-    reasons: list[str] = []
     if not context:
-        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.CONTEXT_MALFORMED])
+        return context, {}, {}, [SignedWorkerDispatchTaskExecutorReason.CONTEXT_MALFORMED]
+    reasons: list[str] = []
     if context.get("source") != SIGNED_WORKER_DISPATCH_TASK_SOURCE:
         reasons.append(SignedWorkerDispatchTaskExecutorReason.SOURCE_MISMATCH)
     if context.get("schema_version") != WORKER_DISPATCH_RUNTIME_SCHEMA_VERSION:
         reasons.append(SignedWorkerDispatchTaskExecutorReason.SCHEMA_MISMATCH)
-
     intent = _mapping(context.get("worker_dispatch_intent"))
     receipt = _mapping(context.get("signed_authority_worker_dispatch_receipt"))
     allocation = _mapping(context.get("wsp15_allocation_receipt"))
@@ -111,83 +145,123 @@ def execute_reddog_signed_worker_dispatch_task(
         reasons.append(SignedWorkerDispatchTaskExecutorReason.RECEIPT_MISSING)
     if intent and receipt and not _receipt_contains_intent(receipt, intent):
         reasons.append(SignedWorkerDispatchTaskExecutorReason.INTENT_NOT_IN_RECEIPT)
+    reasons.extend(_intent_binding_reasons(context, intent, allocation))
+    reasons.extend(_model_runtime_binding_reasons(context=context, intent=intent, receipt=receipt))
+    reasons.extend(_report_contract_reasons(context))
+    return context, intent, receipt, reasons
 
-    if intent:
-        for context_key, intent_key in (
-            ("worker_runtime", "worker_runtime"),
-            ("worker_role", "role"),
-            ("capability", "capability"),
-        ):
-            if str(context.get(context_key) or "") != str(intent.get(intent_key) or ""):
-                reasons.append(SignedWorkerDispatchTaskExecutorReason.CONTEXT_INTENT_MISMATCH)
-                break
-        if intent.get("dry_run_only") is not True:
-            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
-        if intent.get("no_worker_spawn_performed") is not True:
-            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
-        if intent.get("no_openclaw_enqueue_performed") is not True:
-            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
-        if intent.get("no_hermes_dispatch_performed") is not True:
-            reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
 
-    if intent and allocation:
-        if str(intent.get("wsp15_allocation_receipt_id") or "") != str(allocation.get("receipt_id") or ""):
-            reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
-        if str(intent.get("wsp15_allocation_digest") or "") != _digest(allocation):
-            reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
+def _intent_binding_reasons(
+    context: Mapping[str, Any], intent: Mapping[str, Any], allocation: Mapping[str, Any]
+) -> list[str]:
+    reasons: list[str] = []
+    for context_key, intent_key in (
+        ("worker_runtime", "worker_runtime"), ("worker_role", "role"),
+        ("capability", "capability"),
+    ):
+        if intent and str(context.get(context_key) or "") != str(intent.get(intent_key) or ""):
+            reasons.append(SignedWorkerDispatchTaskExecutorReason.CONTEXT_INTENT_MISMATCH)
+            break
+    flags = (
+        "dry_run_only", "no_worker_spawn_performed",
+        "no_openclaw_enqueue_performed", "no_hermes_dispatch_performed",
+    )
+    if intent and any(intent.get(flag) is not True for flag in flags):
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
+    if intent and allocation and (
+        str(intent.get("wsp15_allocation_receipt_id") or "")
+        != str(allocation.get("receipt_id") or "")
+        or str(intent.get("wsp15_allocation_digest") or "") != _digest(allocation)
+    ):
+        reasons.append(SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH)
+    return reasons
 
-    model_binding_reasons = _model_runtime_binding_reasons(context=context, intent=intent, receipt=receipt)
-    reasons.extend(model_binding_reasons)
 
+def _report_contract_reasons(context: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
     if context.get("execution_allowed_by_dispatch_runtime") is not False:
         reasons.append(SignedWorkerDispatchTaskExecutorReason.EXECUTION_FLAG_MISMATCH)
     contract = _mapping(context.get("report_contract"))
-    if (
-        contract.get("requires_signed_authority") is not True
-        or contract.get("worker_process_started") is not False
-        or contract.get("repo_mutation_performed") is not False
-        or contract.get("hermes_execution_performed") is not False
-    ):
+    expected = {
+        "requires_signed_authority": True, "worker_process_started": False,
+        "repo_mutation_performed": False, "hermes_execution_performed": False,
+    }
+    if any(contract.get(field) is not value for field, value in expected.items()):
         reasons.append(SignedWorkerDispatchTaskExecutorReason.REPORT_CONTRACT_MISMATCH)
+    return reasons
 
-    if reasons:
-        return _reject(task_id, reasons, context=context)
-    if runner is None:
-        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.RUNNER_MISSING], context=context)
 
+def _invoke_signed_worker_runner(
+    *, task_id: str, repo_root: Path, context: Mapping[str, Any],
+    intent: Mapping[str, Any], receipt: Mapping[str, Any],
+    runner: SignedWorkerDispatchTaskRunner,
+) -> SignedWorkerDispatchTaskExecutionResult:
     try:
-        runner_result = runner.run_signed_worker_dispatch_task(
-            task_id=task_id,
-            task_context=context,
-            worker_dispatch_intent=intent,
-            signed_authority_receipt=receipt,
-            repo_root=Path(repo_root),
+        runner_result = _call_signed_worker_runner(
+            runner, task_id, repo_root, context, intent, receipt
         )
     except Exception:
-        return _reject(task_id, [SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED], context=context)
-
+        return _reject(
+            task_id,
+            [SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED],
+            context=context,
+            worker_execution_performed=True,
+        )
     runner_payload = _mapping(runner_result)
+    effects = _runner_effect_attestations(
+        runner_payload,
+        worker_execution_performed=True,
+    )
     if runner_payload.get("accepted") is not True:
         return _reject(
             task_id,
             [SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED, *_reasons(runner_payload)],
             context=context,
             runner_result=runner_payload,
+            worker_execution_performed=True,
         )
-    if runner_payload.get("no_source_repo_mutation_performed") is not True:
+    if effects["effect_evidence_complete"] is not True:
+        return _reject(
+            task_id,
+            [SignedWorkerDispatchTaskExecutorReason.RUNNER_EFFECT_EVIDENCE_INCOMPLETE],
+            context=context,
+            runner_result=runner_payload,
+            worker_execution_performed=True,
+        )
+    if any(
+        runner_payload.get(field) is not True
+        for field in ("no_source_repo_mutation_performed", "no_shell_command_executed")
+    ):
         return _reject(
             task_id,
             [SignedWorkerDispatchTaskExecutorReason.RUNNER_UNSAFE],
             context=context,
             runner_result=runner_payload,
+            worker_execution_performed=True,
         )
-    if runner_payload.get("no_shell_command_executed") is not True:
-        return _reject(
-            task_id,
-            [SignedWorkerDispatchTaskExecutorReason.RUNNER_UNSAFE],
-            context=context,
-            runner_result=runner_payload,
-        )
+    return _accepted_execution_result(task_id, context, runner_payload)
+
+
+def _call_signed_worker_runner(
+    runner: SignedWorkerDispatchTaskRunner,
+    task_id: str,
+    repo_root: Path,
+    context: Mapping[str, Any],
+    intent: Mapping[str, Any],
+    receipt: Mapping[str, Any],
+) -> Mapping[str, Any]:
+    return runner.run_signed_worker_dispatch_task(
+        task_id=task_id,
+        task_context=context,
+        worker_dispatch_intent=intent,
+        signed_authority_receipt=receipt,
+        repo_root=Path(repo_root),
+    )
+
+
+def _accepted_execution_result(
+    task_id: str, context: Mapping[str, Any], runner_payload: Mapping[str, Any]
+) -> SignedWorkerDispatchTaskExecutionResult:
 
     return SignedWorkerDispatchTaskExecutionResult(
         accepted=True,
@@ -199,7 +273,38 @@ def execute_reddog_signed_worker_dispatch_task(
         worker_runtime=str(context.get("worker_runtime") or ""),
         capability=str(context.get("capability") or ""),
         runner_result=dict(runner_payload),
+        worker_execution_performed=True,
+        effect_evidence_complete=True,
         rejection_reasons=(),
+        worker_process_spawn_count=_nonnegative_count(
+            runner_payload.get("worker_process_spawn_count")
+        ),
+        shell_command_count=_observed_shell_count(runner_payload),
+        no_shell_command_executed=(
+            runner_payload.get("no_shell_command_executed") is True
+        ),
+        no_source_repo_mutation_performed=(
+            runner_payload.get("no_source_repo_mutation_performed") is True
+        ),
+        no_holoindex_reindex_performed=(
+            runner_payload.get("no_holoindex_reindex_performed") is True
+        ),
+        no_hermes_dispatch_performed=(
+            runner_payload.get("no_hermes_dispatch_performed") is True
+        ),
+        no_worktree_operation_performed=(
+            runner_payload.get("no_worktree_operation_performed") is True
+        ),
+        no_pr_created=runner_payload.get("no_pr_created") is True,
+        no_live_foundup_enqueue_performed=(
+            runner_payload.get("no_live_foundup_enqueue_performed") is True
+        ),
+        no_pattern_memory_write_performed=(
+            runner_payload.get("no_pattern_memory_write_performed") is True
+        ),
+        no_reward_settlement_performed=(
+            runner_payload.get("no_reward_settlement_performed") is True
+        ),
     )
 
 
@@ -209,8 +314,13 @@ def _reject(
     *,
     context: Mapping[str, Any] | None = None,
     runner_result: Mapping[str, Any] | None = None,
+    worker_execution_performed: bool = False,
 ) -> SignedWorkerDispatchTaskExecutionResult:
     context = _mapping(context)
+    effects = _runner_effect_attestations(
+        runner_result,
+        worker_execution_performed=worker_execution_performed,
+    )
     return SignedWorkerDispatchTaskExecutionResult(
         accepted=False,
         decision=SIGNED_WORKER_DISPATCH_TASK_EXECUTOR_REJECT,
@@ -221,8 +331,60 @@ def _reject(
         worker_runtime=str(context.get("worker_runtime") or ""),
         capability=str(context.get("capability") or ""),
         runner_result=dict(runner_result) if isinstance(runner_result, Mapping) else None,
+        worker_execution_performed=worker_execution_performed,
         rejection_reasons=tuple(_dedupe(reasons)),
+        **effects,
     )
+
+
+def _runner_effect_attestations(
+    runner_result: Mapping[str, Any] | None,
+    *,
+    worker_execution_performed: bool,
+) -> dict[str, Any]:
+    if not isinstance(runner_result, Mapping):
+        complete = not worker_execution_performed
+        return {
+            "effect_evidence_complete": complete,
+            **{field: complete for field in _RUNNER_NO_EFFECT_FIELDS},
+            "worker_process_spawn_count": 0,
+            "shell_command_count": 0,
+        }
+    count_fields = ("worker_process_spawn_count", "shell_command_count")
+    complete = all(
+        isinstance(runner_result.get(field), bool)
+        for field in _RUNNER_NO_EFFECT_FIELDS
+    ) and all(_is_nonnegative_int(runner_result.get(field)) for field in count_fields)
+    if complete and runner_result.get("no_shell_command_executed") is True:
+        complete = runner_result.get("shell_command_count") == 0
+    return {
+        "effect_evidence_complete": complete,
+        **{
+            field: complete and runner_result.get(field) is True
+            for field in _RUNNER_NO_EFFECT_FIELDS
+        },
+        "worker_process_spawn_count": _nonnegative_count(
+            runner_result.get("worker_process_spawn_count")
+        ),
+        "shell_command_count": _observed_shell_count(runner_result),
+    }
+
+
+def _observed_shell_count(runner_result: Mapping[str, Any]) -> int:
+    supplied = _nonnegative_count(runner_result.get("shell_command_count"))
+    if runner_result.get("no_shell_command_executed") is False:
+        return max(supplied, 1)
+    return supplied
+
+
+def _nonnegative_count(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(value, 0)
+
+
+def _is_nonnegative_int(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int) and value >= 0
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:

--- a/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signed_worker_queue_serial_loop_runner.py
@@ -213,10 +213,27 @@ class RedDogSignedWorkerQueueSerialLoopRunner:
             "rejection_reasons": [],
             "no_source_repo_mutation_performed": True,
             "no_shell_command_executed": True,
-            "no_holoindex_reindex_performed": bool(payload.get("no_holoindex_reindex_performed", True)),
-            "no_pr_created": bool(payload.get("no_pr_created", True)),
-            "no_pattern_memory_write_performed": bool(payload.get("no_pattern_memory_write_performed", True)),
-            "no_reward_settlement_performed": bool(payload.get("no_reward_settlement_performed", True)),
+            "no_holoindex_reindex_performed": (
+                payload.get("no_holoindex_reindex_performed") is True
+            ),
+            "no_hermes_dispatch_performed": (
+                payload.get("no_hermes_dispatch_performed") is True
+            ),
+            "no_worktree_operation_performed": payload.get("no_worktree_created") is True,
+            "no_pr_created": payload.get("no_pr_created") is True,
+            "no_live_foundup_enqueue_performed": True,
+            "no_pattern_memory_write_performed": (
+                payload.get("no_pattern_memory_write_performed") is True
+            ),
+            "no_reward_settlement_performed": (
+                payload.get("no_reward_settlement_performed") is True
+            ),
+            "worker_process_spawn_count": _nonnegative_count(
+                payload.get("worker_process_spawn_count")
+            ),
+            "shell_command_count": _nonnegative_count(
+                payload.get("shell_command_count")
+            ),
         }
 
 
@@ -303,10 +320,21 @@ def _reject(
         "no_source_repo_mutation_performed": True,
         "no_shell_command_executed": True,
         "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
         "no_pr_created": True,
+        "no_live_foundup_enqueue_performed": True,
         "no_pattern_memory_write_performed": True,
         "no_reward_settlement_performed": True,
+        "worker_process_spawn_count": 0,
+        "shell_command_count": 0,
     }
+
+
+def _nonnegative_count(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return 0
+    return max(value, 0)
 
 
 def _target_kind(*, worker_runtime: str, capability: str) -> str | None:

--- a/modules/communication/moltbot_bridge/src/reddog_signer_control_loop_anchor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_control_loop_anchor.py
@@ -1,0 +1,251 @@
+"""Signer-owned monotonic anchor for authenticated control-loop receipts."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    AtomicJsonAuthorityRuntimeStore,
+)
+
+
+SIGNER_CONTROL_LOOP_ANCHOR_SCHEMA_VERSION = "reddog_signer_control_loop_anchor.v1"
+_MAX_HISTORY_ITEMS = 4096
+
+
+@dataclass(frozen=True)
+class ControlLoopAnchorPreparation:
+    expected_revision: str | None
+    replay_response: Mapping[str, Any] | None = None
+
+
+class ControlLoopAnchorStore(Protocol):
+    def prepare(self, payload: Mapping[str, Any]) -> ControlLoopAnchorPreparation: ...
+
+    def commit(
+        self,
+        payload: Mapping[str, Any],
+        response: Mapping[str, Any],
+        *,
+        expected_revision: str | None,
+    ) -> None: ...
+
+
+class AtomicSignerControlLoopAnchorStore:
+    """Persist the signer high-water witness outside resident runtime state."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path).resolve()
+        self._store = AtomicJsonAuthorityRuntimeStore(self.path)
+
+    def prepare(self, payload: Mapping[str, Any]) -> ControlLoopAnchorPreparation:
+        state = self._store.load()
+        return _prepare_candidate(state, payload)
+
+    def commit(
+        self,
+        payload: Mapping[str, Any],
+        response: Mapping[str, Any],
+        *,
+        expected_revision: str | None,
+    ) -> None:
+        current = self._store.load()
+        if current.get("revision") != expected_revision:
+            raise ValueError("signer_control_loop_anchor_revision_conflict")
+        prepared = _prepare_candidate(current, payload)
+        if prepared.replay_response is not None:
+            if dict(prepared.replay_response) != dict(response):
+                raise ValueError("signer_control_loop_anchor_replay_response_conflict")
+            return
+        self._store.commit(
+            _next_anchor_state(current, payload, response),
+            expected_revision=expected_revision,
+        )
+
+    def load(self) -> dict[str, Any]:
+        state = self._store.load()
+        _validate_anchor_state(state, allow_empty=True)
+        return state
+
+
+class InMemorySignerControlLoopAnchorStore:
+    """Deterministic signer-anchor test implementation."""
+
+    def __init__(self) -> None:
+        self._state: dict[str, Any] = {}
+        self._lock = threading.Lock()
+
+    def prepare(self, payload: Mapping[str, Any]) -> ControlLoopAnchorPreparation:
+        with self._lock:
+            return _prepare_candidate(dict(self._state), payload)
+
+    def commit(
+        self,
+        payload: Mapping[str, Any],
+        response: Mapping[str, Any],
+        *,
+        expected_revision: str | None,
+    ) -> None:
+        with self._lock:
+            if self._state.get("revision") != expected_revision:
+                raise ValueError("signer_control_loop_anchor_revision_conflict")
+            prepared = _prepare_candidate(self._state, payload)
+            if prepared.replay_response is not None:
+                if dict(prepared.replay_response) != dict(response):
+                    raise ValueError("signer_control_loop_anchor_replay_response_conflict")
+                return
+            next_state = _next_anchor_state(self._state, payload, response)
+            next_state["revision"] = _canonical(next_state)
+            self._state = next_state
+
+    def load(self) -> dict[str, Any]:
+        with self._lock:
+            return json.loads(json.dumps(self._state, sort_keys=True))
+
+
+def _prepare_candidate(
+    state: Mapping[str, Any], payload: Mapping[str, Any]
+) -> ControlLoopAnchorPreparation:
+    _validate_anchor_state(state, allow_empty=True)
+    candidate = dict(payload)
+    expected_revision = state.get("revision")
+    if not state:
+        if candidate.get("sequence_number") != 1 or candidate.get("previous_receipt_id"):
+            raise ValueError("signer_control_loop_anchor_sequence_invalid")
+        return ControlLoopAnchorPreparation(expected_revision=None)
+
+    signed_receipt = dict(state["signed_receipt"])
+    previous_payload = {
+        key: value
+        for key, value in signed_receipt.items()
+        if key not in {
+            "signature",
+            "signer_audit_mac",
+            "signer_audit_attestation_signature",
+        }
+    }
+    if candidate == previous_payload:
+        return ControlLoopAnchorPreparation(
+            expected_revision=str(expected_revision),
+            replay_response=dict(state["signing_response"]),
+        )
+    if (
+        candidate.get("sequence_number") != int(state["sequence_number"]) + 1
+        or candidate.get("previous_receipt_id") != state["receipt_id"]
+        or candidate.get("cycle_id") in state["cycle_ids"]
+        or candidate.get("nonce") in state["nonces"]
+    ):
+        raise ValueError("signer_control_loop_anchor_rollback_detected")
+    _reject_reused_child_evidence(state, candidate)
+    return ControlLoopAnchorPreparation(expected_revision=str(expected_revision))
+
+
+def _next_anchor_state(
+    state: Mapping[str, Any],
+    payload: Mapping[str, Any],
+    response: Mapping[str, Any],
+) -> dict[str, Any]:
+    cycle_ids = [*state.get("cycle_ids", ()), str(payload["cycle_id"])]
+    nonces = [*state.get("nonces", ()), str(payload["nonce"])]
+    child_receipts = [
+        *state.get("consumed_child_receipt_ids", ()),
+        *payload.get("child_execution_receipt_ids", ()),
+    ]
+    child_digests = [
+        *state.get("consumed_child_evidence_digests", ()),
+        *payload.get("child_execution_evidence_digests", ()),
+    ]
+    if any(
+        len(values) > _MAX_HISTORY_ITEMS
+        for values in (cycle_ids, nonces, child_receipts, child_digests)
+    ):
+        raise ValueError("signer_control_loop_anchor_capacity_exceeded")
+    signed_receipt = {
+        **dict(payload),
+        "signature": response["signature"],
+        "signer_audit_mac": response["audit_mac"],
+        "signer_audit_attestation_signature": response[
+            "audit_attestation_signature"
+        ],
+    }
+    return {
+        "schema_version": SIGNER_CONTROL_LOOP_ANCHOR_SCHEMA_VERSION,
+        "sequence_number": int(payload["sequence_number"]),
+        "receipt_id": str(payload["receipt_id"]),
+        "cycle_ids": cycle_ids,
+        "nonces": nonces,
+        "consumed_child_receipt_ids": child_receipts,
+        "consumed_child_evidence_digests": child_digests,
+        "signed_receipt": signed_receipt,
+        "signing_response": dict(response),
+    }
+
+
+def _reject_reused_child_evidence(
+    state: Mapping[str, Any], candidate: Mapping[str, Any]
+) -> None:
+    prior_receipts = set(state["consumed_child_receipt_ids"])
+    prior_digests = set(state["consumed_child_evidence_digests"])
+    if prior_receipts.intersection(candidate.get("child_execution_receipt_ids", ())):
+        raise ValueError("signer_control_loop_anchor_child_receipt_replay")
+    if prior_digests.intersection(candidate.get("child_execution_evidence_digests", ())):
+        raise ValueError("signer_control_loop_anchor_child_evidence_replay")
+
+
+def _validate_anchor_state(state: Mapping[str, Any], *, allow_empty: bool) -> None:
+    if not state and allow_empty:
+        return
+    required = {
+        "schema_version",
+        "sequence_number",
+        "receipt_id",
+        "cycle_ids",
+        "nonces",
+        "consumed_child_receipt_ids",
+        "consumed_child_evidence_digests",
+        "signed_receipt",
+        "signing_response",
+        "revision",
+    }
+    if set(state) != required or state.get("schema_version") != (
+        SIGNER_CONTROL_LOOP_ANCHOR_SCHEMA_VERSION
+    ):
+        raise ValueError("signer_control_loop_anchor_state_invalid")
+    sequence = state.get("sequence_number")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+        raise ValueError("signer_control_loop_anchor_state_invalid")
+    for key in (
+        "cycle_ids",
+        "nonces",
+        "consumed_child_receipt_ids",
+        "consumed_child_evidence_digests",
+    ):
+        values = state.get(key)
+        if not isinstance(values, list) or len(values) > _MAX_HISTORY_ITEMS:
+            raise ValueError("signer_control_loop_anchor_state_invalid")
+        if len(values) != len(set(values)):
+            raise ValueError("signer_control_loop_anchor_state_invalid")
+    if not isinstance(state.get("signed_receipt"), Mapping) or not isinstance(
+        state.get("signing_response"), Mapping
+    ):
+        raise ValueError("signer_control_loop_anchor_state_invalid")
+
+
+def _canonical(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(dict(value), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+__all__ = [
+    "AtomicSignerControlLoopAnchorStore",
+    "ControlLoopAnchorPreparation",
+    "ControlLoopAnchorStore",
+    "InMemorySignerControlLoopAnchorStore",
+    "SIGNER_CONTROL_LOOP_ANCHOR_SCHEMA_VERSION",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_delegated_authority_runtime.py
@@ -23,10 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import tempfile
 from dataclasses import asdict, dataclass, field
-from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Protocol, Sequence, Tuple
 
 from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
@@ -36,7 +33,14 @@ from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifi
     PREFIX_WORKAUTH,
     canonical_signing_input,
 )
-
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
+    AtomicJsonAuthorityRuntimeStore,
+    AuthorityRuntimeStore,
+    FailClosedPrincipalAuthorityResolver,
+    InMemoryAuthorityRuntimeStore,
+    PrincipalAuthorityRecord,
+    PrincipalAuthorityResolver,
+)
 
 AUTHORITY_ISSUED = "DELEGATED_AUTHORITY_ISSUED"
 AUTHORITY_REJECTED = "DELEGATED_AUTHORITY_REJECTED"
@@ -131,34 +135,6 @@ def _path_within_foundup(path: str, foundup_id: str) -> bool:
 
 
 @dataclass(frozen=True)
-class PrincipalAuthorityRecord:
-    """Token-verified principal basis supplied by an external resolver."""
-
-    principal_id: str
-    principal_provider: str
-    principal_public_key: str
-    repo_scope: Tuple[str, ...]
-    foundup_scope: Tuple[str, ...]
-    verified_subject_digest: str
-    reward_account: Optional[str] = None
-    owner_dae: Optional[str] = None
-    principal_wallet: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
-
-class PrincipalAuthorityResolver(Protocol):
-    def resolve(self, principal_id: str, principal_provider: str) -> Optional[PrincipalAuthorityRecord]:
-        """Return token-verified principal authority, or None to fail closed."""
-
-
-class FailClosedPrincipalAuthorityResolver:
-    def resolve(self, principal_id: str, principal_provider: str) -> Optional[PrincipalAuthorityRecord]:
-        return None
-
-
-@dataclass(frozen=True)
 class SigningRequest:
     """Request sent to an isolated signer. The body id is audit-only."""
 
@@ -187,6 +163,7 @@ class SigningResponse:
     key_fingerprint: str = ""
     key_epoch: str = ""
     audit_mac: str = ""
+    audit_attestation_signature: str = ""
     rejection_code: str = ""
     boundary_attested: bool = False
     requester_identity_attested: bool = False
@@ -209,67 +186,6 @@ class FailClosedSignerClient:
             rejection_code=RuntimeRejectCode.SIGNER_NOT_CONFIGURED,
             no_secret_material_returned=True,
         )
-
-
-class AuthorityRuntimeStore(Protocol):
-    def load(self) -> Dict[str, Any]:
-        """Return the current runtime state snapshot."""
-
-    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
-        """Atomically commit snapshot and return the committed revision."""
-
-
-class InMemoryAuthorityRuntimeStore:
-    """In-memory optimistic store for tests and local dry runtime composition."""
-
-    def __init__(self, initial: Optional[Mapping[str, Any]] = None, *, fail_commit: bool = False) -> None:
-        self._state: Dict[str, Any] = dict(initial or {})
-        self.fail_commit = fail_commit
-
-    def load(self) -> Dict[str, Any]:
-        return json.loads(json.dumps(self._state, sort_keys=True))
-
-    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
-        if self.fail_commit:
-            raise RuntimeError("commit_failed")
-        if self._state.get("revision") != expected_revision:
-            raise RuntimeError("revision_conflict")
-        committed = json.loads(json.dumps(snapshot, sort_keys=True))
-        revision = _canonical_digest(committed)
-        committed["revision"] = revision
-        self._state = committed
-        return revision
-
-
-class AtomicJsonAuthorityRuntimeStore:
-    """Single-file authority store using atomic replace."""
-
-    def __init__(self, path: str | Path) -> None:
-        self.path = Path(path)
-
-    def load(self) -> Dict[str, Any]:
-        if not self.path.exists():
-            return {}
-        return json.loads(self.path.read_text(encoding="utf-8"))
-
-    def commit(self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]) -> str:
-        current = self.load()
-        if current.get("revision") != expected_revision:
-            raise RuntimeError("revision_conflict")
-        committed = json.loads(json.dumps(snapshot, sort_keys=True))
-        revision = _canonical_digest(committed)
-        committed["revision"] = revision
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent))
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
-                json.dump(committed, handle, sort_keys=True, indent=2)
-                handle.write("\n")
-            os.replace(tmp_name, self.path)
-        finally:
-            if os.path.exists(tmp_name):
-                os.unlink(tmp_name)
-        return revision
 
 
 @dataclass(frozen=True)

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -23,8 +23,12 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_
     encode_ed25519_public_key,
 )
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    ControlLoopAuthorityPolicy,
     Ed25519SignerBackend,
     SignerAuditMacBuilder,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    ControlLoopAnchorStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
     SignerPeerAttestation,
@@ -143,6 +147,8 @@ def build_test_only_signer_backend_from_provider(
     provider_mode: str = "",
     allow_test_only_key_material: bool = False,
     permission_snapshot_fresh: bool = False,
+    control_loop_anchor_store: ControlLoopAnchorStore | None = None,
+    control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
 ) -> SignerKeyProviderDryRunResult:
     """Validate a signer profile and build an Ed25519 signer backend.
 
@@ -213,6 +219,8 @@ def build_test_only_signer_backend_from_provider(
             public_key=public_key,
             key_epoch=profile.expected_key_epoch,
             audit_mac_builder=_HmacAuditMacBuilder(audit_key),
+            control_loop_anchor_store=control_loop_anchor_store,
+            control_loop_authority_policy=control_loop_authority_policy,
         ),
     )
 
@@ -224,6 +232,8 @@ def build_signer_backend_from_provider(
     provider_mode: str = "",
     allow_test_only_key_material: bool = False,
     permission_snapshot_fresh: bool = False,
+    control_loop_anchor_store: ControlLoopAnchorStore | None = None,
+    control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
 ) -> SignerKeyProviderDryRunResult:
     """Compatibility wrapper with the production-capable boundary name."""
 
@@ -233,6 +243,8 @@ def build_signer_backend_from_provider(
         provider_mode=provider_mode,
         allow_test_only_key_material=allow_test_only_key_material,
         permission_snapshot_fresh=permission_snapshot_fresh,
+        control_loop_anchor_store=control_loop_anchor_store,
+        control_loop_authority_policy=control_loop_authority_policy,
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
@@ -36,6 +36,9 @@ SIGNER_SERVICE_CONFIG_SCHEMA_VERSION = "reddog_signer_service_config.v1"
 FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID = "signer_config_authority_profile_invalid"
 FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID = "signer_config_output_path_invalid"
 FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID = "signer_config_socket_path_invalid"
+FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID = (
+    "signer_config_control_anchor_path_invalid"
+)
 FAIL_SIGNER_CONFIG_OP_REF_INVALID = "signer_config_op_ref_invalid"
 FAIL_SIGNER_CONFIG_OP_REF_REUSED = "signer_config_op_ref_reused"
 FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID = "signer_config_peer_policy_invalid"
@@ -49,6 +52,8 @@ _REQUIRED_AUTHORITY_FIELDS = (
     "reddog_public_key",
     "permission_snapshot_digest",
     "key_epoch",
+    "consensus_receipt_digest",
+    "authority_profile_source_receipt_id",
 )
 
 
@@ -101,6 +106,7 @@ def run_reddog_signer_socket_service_config_supply(
     max_response_bytes: int = 16384,
     principal_signer_agent_id: str = "signer:principal",
     reddog_signer_agent_id: str = "signer:reddog",
+    control_loop_anchor_path: Path | str | None = None,
 ) -> SignerServiceConfigSupplyResult:
     """Write one signer CLI config from existing authority artifacts."""
 
@@ -112,6 +118,17 @@ def run_reddog_signer_socket_service_config_supply(
     reasons.extend(output_reasons)
     sock, socket_reasons = _resolve_socket_path(root, socket_path)
     reasons.extend(socket_reasons)
+    anchor_value = control_loop_anchor_path
+    if anchor_value is None and out is not None:
+        anchor_value = (
+            out.parent.parent
+            / f"{out.parent.name}-signer-state"
+            / "signer_control_loop_anchor.json"
+        )
+    anchor, anchor_reasons = _resolve_outside_repo(
+        root, anchor_value, FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID
+    )
+    reasons.extend(anchor_reasons)
     op_refs = (
         principal_signing_key_ref,
         principal_audit_mac_key_ref,
@@ -129,6 +146,7 @@ def run_reddog_signer_socket_service_config_supply(
 
     assert out is not None
     assert sock is not None
+    assert anchor is not None
     assert peer_policy is not None
     config = _config(
         authority_profile=profile,
@@ -144,6 +162,7 @@ def run_reddog_signer_socket_service_config_supply(
         max_response_bytes=max_response_bytes,
         principal_signer_agent_id=principal_signer_agent_id,
         reddog_signer_agent_id=reddog_signer_agent_id,
+        control_loop_anchor_path=anchor,
     )
     config_digest = _digest(config)
     receipt = {
@@ -151,6 +170,7 @@ def run_reddog_signer_socket_service_config_supply(
         "config_digest": config_digest,
         "config_path": str(out),
         "socket_path": str(sock),
+        "control_loop_anchor_path": str(anchor),
         "principal_id": str(profile["principal_id"]),
         "reddog_id": str(profile["reddog_id"]),
         "profile_count": 2,
@@ -193,6 +213,7 @@ def _config(
     max_response_bytes: int,
     principal_signer_agent_id: str,
     reddog_signer_agent_id: str,
+    control_loop_anchor_path: Path,
 ) -> dict[str, Any]:
     principal_public = str(authority_profile["principal_public_key"])
     reddog_public = str(authority_profile["reddog_public_key"])
@@ -201,9 +222,22 @@ def _config(
     return {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
         "socket_path": str(socket_path),
+        "control_loop_anchor_path": str(control_loop_anchor_path),
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
         "allow_test_only_key_material": False,
         "permission_snapshot_fresh": True,
+        "control_loop_authority_policy": {
+            "issuer_principal_id": str(authority_profile["principal_id"]),
+            "signer_public_key": reddog_public,
+            "key_epoch": key_epoch,
+            "consensus_receipt_digest": str(
+                authority_profile["consensus_receipt_digest"]
+            ),
+            "authority_profile_digest": _digest(authority_profile),
+            "authority_profile_source_receipt_id": str(
+                authority_profile["authority_profile_source_receipt_id"]
+            ),
+        },
         "max_requests": int(max_requests),
         "timeout_s": float(timeout_s),
         "max_request_bytes": int(max_request_bytes),
@@ -244,7 +278,21 @@ def _authority_profile_reasons(profile: Mapping[str, Any]) -> list[str]:
         return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":" + field for field in missing]
     if str(profile.get("principal_public_key")) == str(profile.get("reddog_public_key")):
         return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":key_reuse"]
+    for field in (
+        "permission_snapshot_digest",
+        "consensus_receipt_digest",
+        "authority_profile_source_receipt_id",
+    ):
+        if not _is_sha256_digest(profile.get(field)):
+            return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":" + field]
     return []
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = str(value or "")
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
 
 
 def _resolve_output_path(repo_root: Path, value: Path | str | None) -> tuple[Path | None, list[str]]:
@@ -410,6 +458,7 @@ __all__ = [
     "FAIL_SIGNER_CONFIG_OP_REF_INVALID",
     "FAIL_SIGNER_CONFIG_OP_REF_REUSED",
     "FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID",
+    "FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID",
     "FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID",
     "FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID",
     "FAIL_SIGNER_CONFIG_WRITE_FAILED",

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
@@ -184,6 +184,10 @@ def _runtime_config(
             max_request_bytes=int(payload.get("max_request_bytes") or 0),
             max_response_bytes=int(payload.get("max_response_bytes") or 0),
             key_provider_profiles=key_profiles,
+            control_loop_anchor_path=payload.get("control_loop_anchor_path"),
+            control_loop_authority_policy=payload.get(
+                "control_loop_authority_policy"
+            ),
         )
     except Exception:
         return None

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -43,6 +43,13 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
     SigningRequest,
     SigningResponse,
 )
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    ControlLoopAuthorityPolicy,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    AtomicSignerControlLoopAnchorStore,
+    ControlLoopAnchorStore,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     KernelPeerCredentialAttestor,
     PeerCredentialPolicy,
@@ -60,6 +67,9 @@ FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE = "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_D
 FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID = "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID"
 FAIL_SIGNER_RUNTIME_SERVICE_REJECTED = "FAIL_SIGNER_RUNTIME_SERVICE_REJECTED"
 FAIL_SIGNER_RUNTIME_SERVICE_INVALID = "FAIL_SIGNER_RUNTIME_SERVICE_INVALID"
+FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID = (
+    "FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID"
+)
 
 
 ServeSignerSocketBounded = Callable[..., IsolatedSignerSocketResidentServiceResult]
@@ -81,6 +91,8 @@ class SignerSocketServiceRuntimeWiringConfig:
     max_request_bytes: int = DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES
     max_response_bytes: int = DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES
     key_provider_profiles: tuple[SignerKeyProviderProfile | Mapping[str, Any], ...] = ()
+    control_loop_anchor_path: Path | str | None = None
+    control_loop_authority_policy: ControlLoopAuthorityPolicy | Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -125,6 +137,14 @@ def run_reddog_signer_socket_service_runtime_wiring(
     policy = _peer_policy(config.peer_policy)
     if policy is None or not _peer_policy_valid(policy):
         return _reject(FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID)
+    anchor_store, anchor_reasons = _control_loop_anchor_store(config)
+    if anchor_reasons:
+        return _reject(*anchor_reasons)
+    control_authority_policy = _control_loop_authority_policy(
+        config.control_loop_authority_policy
+    )
+    if config.control_loop_anchor_path is not None and control_authority_policy is None:
+        return _reject(FAIL_SIGNER_RUNTIME_CONFIG_INVALID)
 
     backend, key_receipt, key_reasons = _build_backend(
         profiles,
@@ -132,6 +152,8 @@ def run_reddog_signer_socket_service_runtime_wiring(
         provider_mode=config.provider_mode,
         allow_test_only_key_material=config.allow_test_only_key_material,
         permission_snapshot_fresh=config.permission_snapshot_fresh,
+        control_loop_anchor_store=anchor_store,
+        control_loop_authority_policy=control_authority_policy,
     )
     if key_reasons:
         return _reject(*key_reasons, key_provider_receipt=key_receipt, max_requests=config.max_requests)
@@ -225,6 +247,8 @@ def _build_backend(
     provider_mode: str,
     allow_test_only_key_material: bool,
     permission_snapshot_fresh: bool,
+    control_loop_anchor_store: ControlLoopAnchorStore | None,
+    control_loop_authority_policy: ControlLoopAuthorityPolicy | None,
 ) -> tuple[Optional[IsolatedSignerBackend], dict[str, Any], tuple[str, ...]]:
     receipts: list[dict[str, Any]] = []
     backends: dict[str, IsolatedSignerBackend] = {}
@@ -235,6 +259,14 @@ def _build_backend(
             provider_mode=provider_mode,
             allow_test_only_key_material=allow_test_only_key_material,
             permission_snapshot_fresh=permission_snapshot_fresh,
+            control_loop_anchor_store=control_loop_anchor_store,
+            control_loop_authority_policy=(
+                control_loop_authority_policy
+                if control_loop_authority_policy is not None
+                and profile.expected_public_key
+                == control_loop_authority_policy.signer_public_key
+                else None
+            ),
         )
         receipt = key_result.to_receipt()
         receipts.append(receipt)
@@ -254,6 +286,62 @@ def _build_backend(
     else:
         backend = _RoutingSignerBackend(backends)
     return backend, _key_provider_receipt(True, receipts), ()
+
+
+def _control_loop_anchor_store(
+    config: SignerSocketServiceRuntimeWiringConfig,
+) -> tuple[ControlLoopAnchorStore | None, tuple[str, ...]]:
+    if config.control_loop_anchor_path is None:
+        return None, ()
+    try:
+        repo_root = Path(config.repo_root).resolve()
+        path = Path(config.control_loop_anchor_path)
+        if not path.is_absolute():
+            return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
+        resolved = path.resolve()
+        if resolved == repo_root or repo_root in resolved.parents:
+            return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
+        return AtomicSignerControlLoopAnchorStore(resolved), ()
+    except Exception:
+        return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
+
+
+def _control_loop_authority_policy(
+    value: ControlLoopAuthorityPolicy | Mapping[str, Any] | None,
+) -> ControlLoopAuthorityPolicy | None:
+    if isinstance(value, ControlLoopAuthorityPolicy):
+        return value
+    if not isinstance(value, Mapping):
+        return None
+    try:
+        policy = ControlLoopAuthorityPolicy(**dict(value))
+    except Exception:
+        return None
+    values = (
+        policy.issuer_principal_id,
+        policy.signer_public_key,
+        policy.key_epoch,
+        policy.consensus_receipt_digest,
+        policy.authority_profile_digest,
+        policy.authority_profile_source_receipt_id,
+    )
+    if any(not item or not _ascii(item) for item in values):
+        return None
+    for digest in (
+        policy.consensus_receipt_digest,
+        policy.authority_profile_digest,
+        policy.authority_profile_source_receipt_id,
+    ):
+        if not _is_sha256_digest(digest):
+            return None
+    return policy
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = str(value or "")
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
 
 
 def _key_provider_receipt(ok: bool, receipts: list[dict[str, Any]]) -> dict[str, Any]:
@@ -339,6 +427,7 @@ def _reject(
 
 __all__ = [
     "FAIL_SIGNER_RUNTIME_CONFIG_INVALID",
+    "FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID",
     "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_COUNT_INVALID",
     "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE",
     "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED",

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,40 @@
+## 2026-07-18: REDDOG_RESIDENT_CONTROL_RECEIPT_TRUTH_AUTH_CONCURRENCY_PHASE1
+
+**Files**: control-receipt auth/context, signer, canary, chain-store, OpenClaw,
+and `main.py` focused suites.
+
+**Coverage**:
+
+- Signed receipt round-trip, field/signature/key/profile tamper rejection,
+  unsigned-live rejection, duplicate cycle/nonce rejection, and v1-prefix to
+  signed-v2 migration.
+- Dedicated signer operation/domain validation rejects malformed payloads and
+  control-domain confusion.
+- Concurrent thread/process appends preserve valid JSONL; concurrent chain CAS
+  produces one commit and one revision conflict.
+- Distinct signed cycles serialize without lost updates while same-cycle races
+  produce exactly one commit; direct supervisor and resident-main contention
+  is rejected before AgentDB claim.
+- Whole-chain verification rejects unsigned/foreign predecessors, reordered or
+  tampered rows, mutable audit MACs, child-cardinality mismatches, duplicate
+  child receipts/evidence, and signer role/tier/profile-policy violations.
+- Malformed receipt streams block before model/worker invocation; live proof
+  revalidates the exact authority profile and signer epoch.
+- Truth counters distinguish worker execution from observed OS-process spawn,
+  and stage observations replace hardcoded no-effect claims.
+- Updated serial-loop fixtures prove the runtime-artifact root remains outside
+  the synthetic repository without weakening the production confinement gate.
+- Signer-policy tests reject missing/mismatched principal, key epoch,
+  consensus, promoted-profile, or source-receipt bindings; anchor tests reject
+  resident rollback, anchor tamper, and reused child evidence.
+- Complete child evidence tests recompute every digest and reject changed body,
+  execution truth, order, projection, or receipt linkage before parent signing.
+- Regression cases reject caller-inflated parent effect counts, preserve unknown
+  runner effects without safe defaults, fail closed on AgentDB transition loss,
+  and prove directory-fsync invocation after atomic authority-state replacement.
+- WSP 62 tests explicitly cover every modified production entrypoint, including
+  `main.py`, OpenClaw claim loops, the signer backend, and task executor.
+
 ## 2026-07-18: REDDOG_VALVE_HIGH_AUTHORITY_CLASSIFICATION_PHASE1
 
 - Added signer, authority-seed, and authority-source regressions proving both

--- a/modules/communication/moltbot_bridge/tests/reddog_resident_live_canary_test_support.py
+++ b/modules/communication/moltbot_bridge/tests/reddog_resident_live_canary_test_support.py
@@ -3,11 +3,27 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import subprocess
 from pathlib import Path
 
 from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+    ControlLoopReceiptSigningContext,
     build_resident_control_loop_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    ControlLoopAuthorityPolicy,
+    Ed25519SignerBackend,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_live_canary import (
     LIVE_CANARY_CONFIRMATION,
@@ -50,6 +66,162 @@ WORK_ORDER_ID = "work-order-1"
 NOW = "2026-07-14T00:00:00+00:00"
 
 
+def _test_private_key():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return Ed25519PrivateKey.generate()
+
+
+def _test_public_key(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    return encode_ed25519_public_key(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+
+class _AuditMacBuilder:
+    def build(self, request: SigningRequest, signature: str, peer: SignerPeerAttestation) -> str:
+        return "audit:" + request.nonce + ":" + peer.peer_principal_id
+
+
+class _LocalSignerClient:
+    def __init__(self, backend: Ed25519SignerBackend) -> None:
+        self.backend = backend
+
+    def sign(self, request: SigningRequest):
+        return self.backend.sign(
+            request,
+            SignerPeerAttestation(
+                peer_principal_id="github:mjtrout",
+                transport="test_in_process",
+                credential_source="test_fixture",
+                boundary_attested=True,
+            ),
+        )
+
+
+_PRIVATE_KEY = _test_private_key()
+_PUBLIC_KEY = _test_public_key(_PRIVATE_KEY)
+_AUTHORITY_PROFILE_SOURCE = {
+    "schema_version": "reddog_authority_profile_source.v1",
+    "principal_id": "github:mjtrout",
+    "principal_provider": "github",
+    "principal_public_key": "ed25519-pub-v1:" + "B" * 43,
+    "reddog_id": "reddog:architect",
+    "reddog_public_key": _PUBLIC_KEY,
+    "repo_full_name": "FOUNDUPS/Foundups-Agent",
+    "foundup_id": "paccess_001",
+    "allowed_paths": ["modules/foundups/paccess_001/src/**"],
+    "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
+    "requested_operation": "worktree_create",
+    "permission_snapshot_digest": "sha256:" + "1" * 64,
+    "identity_nonce": "canary-identity-nonce",
+    "work_authority_nonce": "canary-work-nonce",
+    "issued_at": 1_700_000_000,
+    "identity_expires_at": 1_800_000_000,
+    "work_authority_expires_at": 1_800_000_000,
+    "valve_state_required": "VALVE_OPEN_WORKTREE_CREATE",
+    "key_epoch": "epoch-canary-1",
+    "required_tests": ["pytest live-canary"],
+    "required_policy_gates": ["WSP_97"],
+    "consensus_receipt_digest": "sha256:" + "c" * 64,
+    "sovereign_authorization_digest": "sha256:" + "5" * 64,
+    "source_authority_basis": {
+        "principal_verified_subject_digest": "sha256:" + "2" * 64,
+        "principal_repo_scope": ["FOUNDUPS/Foundups-Agent"],
+        "principal_foundup_scope": ["paccess_001"],
+        "permission_snapshot_digest": "sha256:" + "1" * 64,
+        "permission_snapshot_expires_at": 1_800_000_000,
+        "permission_snapshot_can_write": True,
+        "permission_snapshot_can_admin": False,
+    },
+}
+_AUTHORITY_PROFILE_SOURCE["authority_profile_source_receipt_id"] = (
+    "sha256:"
+    + hashlib.sha256(
+        json.dumps(
+            _AUTHORITY_PROFILE_SOURCE,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+)
+_AUTHORITY_PROFILE = {
+    **_AUTHORITY_PROFILE_SOURCE,
+    "operational_context_binding": {
+        "queue_item_id": QUEUE_ID,
+        "claim_id": "claim-live-canary",
+        "architect_determination_receipt_id": "determination-live-canary",
+        "wsp15_allocation_receipt": {
+            "receipt_id": "sha256:" + "3" * 64
+        },
+    },
+}
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_head_store import (
+    build_control_receipt_head,
+    commit_control_receipt_head,
+    load_control_receipt_head,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    AtomicSignerControlLoopAnchorStore,
+    ControlLoopAnchorPreparation,
+)
+
+
+class _StatelessTestControlLoopAnchorStore:
+    """Test-only anchor used where persistence is not under test."""
+
+    def prepare(self, payload):
+        return ControlLoopAnchorPreparation(expected_revision=None)
+
+    def commit(self, payload, response, *, expected_revision):
+        return None
+_AUTHORITY_PROFILE_DIGEST = "sha256:" + hashlib.sha256(
+    json.dumps(
+        _AUTHORITY_PROFILE,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+).hexdigest()
+_SIGNING_CONTEXT = ControlLoopReceiptSigningContext(
+    signer=_LocalSignerClient(
+        Ed25519SignerBackend(
+            private_key=_PRIVATE_KEY,
+            public_key=_PUBLIC_KEY,
+            key_epoch="epoch-canary-1",
+            audit_mac_builder=_AuditMacBuilder(),
+            control_loop_anchor_store=_StatelessTestControlLoopAnchorStore(),
+            control_loop_authority_policy=ControlLoopAuthorityPolicy(
+                issuer_principal_id="github:mjtrout",
+                signer_public_key=_PUBLIC_KEY,
+                key_epoch="epoch-canary-1",
+                consensus_receipt_digest="sha256:" + "c" * 64,
+                authority_profile_digest=_AUTHORITY_PROFILE_DIGEST,
+                authority_profile_source_receipt_id=str(
+                    _AUTHORITY_PROFILE["authority_profile_source_receipt_id"]
+                ),
+            ),
+        )
+    ),
+    signature_verifier=Ed25519SignatureVerifier(),
+    issuer_principal_id="github:mjtrout",
+    signer_public_key=_PUBLIC_KEY,
+    key_epoch="epoch-canary-1",
+    authority_tier="HIGH",
+    consensus_receipt_digest="sha256:" + "c" * 64,
+    authority_profile_digest=_AUTHORITY_PROFILE_DIGEST,
+    authority_profile_source_receipt_id=str(
+        _AUTHORITY_PROFILE["authority_profile_source_receipt_id"]
+    ),
+)
+
+
 def _git(cwd: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", "-C", str(cwd), *args], capture_output=True, text=True, check=True
@@ -69,7 +241,22 @@ def _roots(tmp_path: Path) -> tuple[Path, Path]:
     runtime = tmp_path / "runtime"
     runtime.mkdir()
     for filename in REQUIRED_JSON_ARTIFACTS:
-        (runtime / filename).write_text(json.dumps({"kind": filename}), encoding="utf-8")
+        payload = {"kind": filename}
+        if filename == "authority_profile.json":
+            payload = dict(_AUTHORITY_PROFILE)
+        (runtime / filename).write_text(json.dumps(payload), encoding="utf-8")
+    anchor_path = (
+        runtime.parent
+        / f"{runtime.name}-signer-state"
+        / "signer_control_loop_anchor.json"
+    )
+    (runtime / "signer_service_config.json").write_text(
+        json.dumps({"control_loop_anchor_path": str(anchor_path)}),
+        encoding="utf-8",
+    )
+    (runtime / "authority_profile_source.json").write_text(
+        json.dumps(_AUTHORITY_PROFILE_SOURCE), encoding="utf-8"
+    )
     return repo, runtime
 
 
@@ -77,7 +264,12 @@ def _kwargs(repo: Path, runtime: Path) -> dict[str, object]:
     return {
         "repo_root": repo,
         "runtime_root": runtime,
-        "environ": {"OPENROUTER_API_KEY": "must-never-be-serialized"},
+        "environ": {
+            "OPENROUTER_API_KEY": "must-never-be-serialized",
+            "REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID": str(
+                _AUTHORITY_PROFILE["authority_profile_source_receipt_id"]
+            ),
+        },
         "platform_name": "linux",
         "command_resolver": lambda command: f"/usr/bin/{command}",
         "command_probe": lambda argv, cwd: True,
@@ -226,9 +418,56 @@ def _control_receipt(repo: Path, **changes: object) -> dict[str, object]:
         },
         repo_root=repo,
         created_at="2026-07-14T00:00:00Z",
+        cycle_id="canary-cycle-1",
+        nonce="canary-nonce-1",
+        signing_context=_SIGNING_CONTEXT,
     ).to_dict()
     receipt.update(changes)
     return receipt
+
+
+def _write_control_receipt_and_head(
+    runtime: Path, control: dict[str, object]
+) -> None:
+    (runtime / "resident_queue_control_loop_receipts.jsonl").write_text(
+        json.dumps(control) + "\n", encoding="utf-8"
+    )
+    store, state, _ = load_control_receipt_head(
+        runtime / "authority_runtime_state.json"
+    )
+    head = build_control_receipt_head(
+        receipt=control,
+        receipt_ids=(str(control["receipt_id"]),),
+        consumed_child_receipt_ids=tuple(
+            str(item) for item in control["child_execution_receipt_ids"]
+        ),
+        consumed_child_evidence_digests=tuple(
+            str(item) for item in control["child_execution_evidence_digests"]
+        ),
+    )
+    commit_control_receipt_head(store=store, state=state, head=head)
+    config = json.loads(
+        (runtime / "signer_service_config.json").read_text(encoding="utf-8")
+    )
+    anchor = AtomicSignerControlLoopAnchorStore(config["control_loop_anchor_path"])
+    unsigned = {
+        key: value
+        for key, value in control.items()
+        if key
+        not in {
+            "signature",
+            "signer_audit_mac",
+            "signer_audit_attestation_signature",
+        }
+    }
+    response = {
+        "signature": control["signature"],
+        "audit_mac": control["signer_audit_mac"],
+        "audit_attestation_signature": control[
+            "signer_audit_attestation_signature"
+        ],
+    }
+    anchor.commit(unsigned, response, expected_revision=None)
 
 
 def _canonicalize_terminal_receipt(chain: dict[str, object]) -> None:
@@ -297,9 +536,7 @@ def _runner(
                     chain["receipts"][-1]["store_revision"] = revision
         (runtime / "resident_queue_chain_results.json").write_text(json.dumps(chain), encoding="utf-8")
         control = _control_receipt(repo, **(receipt_changes or {}))
-        (runtime / "resident_queue_control_loop_receipts.jsonl").write_text(
-            json.dumps(control) + "\n", encoding="utf-8"
-        )
+        _write_control_receipt_and_head(runtime, control)
         return {"accepted": True, "status": "PASS", "receipt_id": result_receipt_id or control["receipt_id"]}
 
     return run

--- a/modules/communication/moltbot_bridge/tests/test_reddog_ed25519_signer_backend.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_ed25519_signer_backend.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -13,10 +15,18 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_
     encode_ed25519_public_key,
 )
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    CONTROL_LOOP_SIGNING_OPERATION,
+    CONTROL_LOOP_SIGNING_PREFIX,
+    ControlLoopAuthorityPolicy,
     Ed25519SignerBackend,
     REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING,
+    REJECT_ED25519_SIGNER_DOMAIN_MISMATCH,
+    REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH,
+    REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING,
+    REJECT_ED25519_SIGNER_CONTROL_ANCHOR_MISSING,
     REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH,
     REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH,
+    canonical_control_audit_attestation_input,
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
     SIGNER_SOCKET_REQUEST_SCHEMA_VERSION,
@@ -25,6 +35,9 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_prot
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     SigningRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    InMemorySignerControlLoopAnchorStore,
 )
 
 
@@ -105,6 +118,29 @@ def _wire_payload(request: SigningRequest) -> bytes:
         )
         + "\n"
     ).encode("utf-8")
+
+
+def _request_digest(signing_input: str) -> str:
+    raw = json.dumps(
+        {"signing_input": signing_input},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _control_policy(
+    public_key: str, *, authority_profile_digest: str = "sha256:" + "a" * 64
+) -> ControlLoopAuthorityPolicy:
+    return ControlLoopAuthorityPolicy(
+        issuer_principal_id="github:mjtrout",
+        signer_public_key=public_key,
+        key_epoch="epoch-1",
+        consensus_receipt_digest="sha256:" + "c" * 64,
+        authority_profile_digest=authority_profile_digest,
+        authority_profile_source_receipt_id="sha256:" + "e" * 64,
+    )
 
 
 def test_ed25519_signer_backend_signs_and_public_verifier_accepts() -> None:
@@ -201,6 +237,360 @@ def test_ed25519_signer_backend_requires_audit_mac() -> None:
 
     assert response.accepted is False
     assert response.rejection_code == REJECT_ED25519_SIGNER_AUDIT_MAC_MISSING
+
+
+@pytest.mark.parametrize(
+    ("requested_operation", "signing_input"),
+    [
+        (CONTROL_LOOP_SIGNING_OPERATION, 'reddog-workauth.v1.{"receipt_id":"r-1"}'),
+        ("create_foundup", CONTROL_LOOP_SIGNING_PREFIX + '{"receipt_id":"r-1"}'),
+    ],
+)
+def test_ed25519_signer_backend_rejects_control_receipt_domain_confusion(
+    requested_operation: str,
+    signing_input: str,
+) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    backend = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+    )
+
+    response = backend.sign(
+        _request(
+            public_key,
+            requested_operation=requested_operation,
+            signing_input=signing_input,
+        ),
+        _peer(),
+    )
+
+    assert response.accepted is False
+    assert response.rejection_code == REJECT_ED25519_SIGNER_DOMAIN_MISMATCH
+
+
+def test_ed25519_signer_backend_signs_control_receipt_only_in_control_domain() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    backend = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+        control_loop_authority_policy=_control_policy(public_key),
+    )
+    from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+        ControlLoopReceiptSigningContext,
+        build_resident_control_loop_receipt,
+    )
+
+    class DirectClient:
+        def sign(self, request: SigningRequest):
+            return backend.sign(request, _peer())
+
+    receipt = build_resident_control_loop_receipt(
+        result={
+            "accepted": True,
+            "status": "PASS",
+            "rounds": 1,
+            "serial_progress": 1,
+            "claim_progress": 0,
+            "receipt_ids": (),
+            "rejection_reasons": (),
+            "control_lock_acquired": True,
+            "dispatched_stages": (),
+        },
+        repo_root=Path.cwd(),
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-1",
+        nonce="nonce-1",
+        signing_context=ControlLoopReceiptSigningContext(
+            signer=DirectClient(),
+            signature_verifier=Ed25519SignatureVerifier(),
+            issuer_principal_id="github:mjtrout",
+            signer_public_key=public_key,
+            key_epoch="epoch-1",
+            authority_tier="HIGH",
+            consensus_receipt_digest="sha256:" + "c" * 64,
+            authority_profile_digest="sha256:" + "a" * 64,
+            authority_profile_source_receipt_id="sha256:" + "e" * 64,
+        ),
+    )
+
+    assert receipt.authentication_status == "AUTHENTICATED"
+    assert receipt.signer_audit_attestation_signature
+    assert Ed25519SignatureVerifier().verify(
+        public_key,
+        CONTROL_LOOP_SIGNING_PREFIX + json.dumps(
+            {
+                key: value
+                for key, value in receipt.to_dict().items()
+                if key not in {
+                    "signature",
+                    "signer_audit_mac",
+                    "signer_audit_attestation_signature",
+                }
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        receipt.signature,
+    ) is True
+    assert Ed25519SignatureVerifier().verify(
+        public_key,
+        canonical_control_audit_attestation_input(
+            signing_input=CONTROL_LOOP_SIGNING_PREFIX
+            + json.dumps(
+                {
+                    key: value
+                    for key, value in receipt.to_dict().items()
+                    if key
+                    not in {
+                        "signature",
+                        "signer_audit_mac",
+                        "signer_audit_attestation_signature",
+                    }
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            signature=receipt.signature,
+            audit_mac=receipt.signer_audit_mac,
+            signer_public_key=public_key,
+            key_epoch="epoch-1",
+            requester_principal_id="github:mjtrout",
+        ),
+        receipt.signer_audit_attestation_signature,
+    ) is True
+
+
+def test_control_receipt_signer_requires_exact_signer_owned_authority_policy() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    trusted = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+        control_loop_authority_policy=_control_policy(public_key),
+    )
+    captured: list[SigningRequest] = []
+
+    class CapturingClient:
+        def sign(self, request: SigningRequest):
+            captured.append(request)
+            return trusted.sign(request, _peer())
+
+    from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+        ControlLoopReceiptSigningContext,
+        build_resident_control_loop_receipt,
+    )
+
+    build_resident_control_loop_receipt(
+        result={
+            "accepted": True,
+            "status": "PASS",
+            "rounds": 1,
+            "serial_progress": 1,
+            "claim_progress": 0,
+            "receipt_ids": (),
+            "rejection_reasons": (),
+            "control_lock_acquired": True,
+            "dispatched_stages": (),
+        },
+        repo_root=Path.cwd(),
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-policy",
+        nonce="nonce-policy",
+        signing_context=ControlLoopReceiptSigningContext(
+            signer=CapturingClient(),
+            signature_verifier=Ed25519SignatureVerifier(),
+            issuer_principal_id="github:mjtrout",
+            signer_public_key=public_key,
+            key_epoch="epoch-1",
+            authority_tier="HIGH",
+            consensus_receipt_digest="sha256:" + "c" * 64,
+            authority_profile_digest="sha256:" + "a" * 64,
+            authority_profile_source_receipt_id="sha256:" + "e" * 64,
+        ),
+    )
+
+    missing_policy = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+    ).sign(captured[0], _peer())
+    mismatched_policy = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+        control_loop_authority_policy=replace(
+            _control_policy(public_key),
+            authority_profile_source_receipt_id="sha256:" + "f" * 64,
+        ),
+    ).sign(captured[0], _peer())
+    missing_anchor = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_authority_policy=_control_policy(public_key),
+    ).sign(captured[0], _peer())
+
+    assert missing_policy.rejection_code == (
+        REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING
+    )
+    assert mismatched_policy.rejection_code == (
+        REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH
+    )
+    assert missing_anchor.rejection_code == REJECT_ED25519_SIGNER_CONTROL_ANCHOR_MISSING
+
+
+@pytest.mark.parametrize(
+    ("authority_tier", "profile_digest"),
+    [
+        ("LOW", "sha256:" + "a" * 64),
+        ("HIGH", "not-a-digest"),
+    ],
+)
+def test_control_receipt_signer_rejects_invalid_tier_or_profile_digest(
+    authority_tier: str, profile_digest: str
+) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    backend = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+        control_loop_authority_policy=_control_policy(
+            public_key, authority_profile_digest=profile_digest
+        ),
+    )
+
+    class DirectClient:
+        def sign(self, request: SigningRequest):
+            return backend.sign(request, _peer())
+
+    from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+        ControlLoopReceiptSigningContext,
+        build_resident_control_loop_receipt,
+    )
+
+    with pytest.raises(ValueError, match="signing_rejected"):
+        build_resident_control_loop_receipt(
+            result={
+                "accepted": True,
+                "status": "PASS",
+                "rounds": 1,
+                "serial_progress": 1,
+                "claim_progress": 0,
+                "receipt_ids": (),
+                "rejection_reasons": (),
+                "control_lock_acquired": True,
+                "dispatched_stages": (),
+            },
+            repo_root=Path.cwd(),
+            created_at="2026-07-18T00:00:00Z",
+            signing_context=ControlLoopReceiptSigningContext(
+                signer=DirectClient(),
+                signature_verifier=Ed25519SignatureVerifier(),
+                issuer_principal_id="github:mjtrout",
+                signer_public_key=public_key,
+                key_epoch="epoch-1",
+                authority_tier=authority_tier,
+                consensus_receipt_digest="sha256:" + "c" * 64,
+                authority_profile_digest=profile_digest,
+                authority_profile_source_receipt_id="sha256:" + "e" * 64,
+            ),
+        )
+
+
+def test_control_receipt_signer_rejects_wrong_signer_role() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    backend = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+        control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+        control_loop_authority_policy=_control_policy(public_key),
+    )
+    captured: list[SigningRequest] = []
+
+    class CapturingClient:
+        def sign(self, request: SigningRequest):
+            captured.append(request)
+            return backend.sign(request, _peer())
+
+    from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+        ControlLoopReceiptSigningContext,
+        build_resident_control_loop_receipt,
+    )
+
+    build_resident_control_loop_receipt(
+        result={
+            "accepted": True,
+            "status": "PASS",
+            "rounds": 1,
+            "serial_progress": 1,
+            "claim_progress": 0,
+            "receipt_ids": (),
+            "rejection_reasons": (),
+            "control_lock_acquired": True,
+            "dispatched_stages": (),
+        },
+        repo_root=Path.cwd(),
+        created_at="2026-07-18T00:00:00Z",
+        signing_context=ControlLoopReceiptSigningContext(
+            signer=CapturingClient(),
+            signature_verifier=Ed25519SignatureVerifier(),
+            issuer_principal_id="github:mjtrout",
+            signer_public_key=public_key,
+            key_epoch="epoch-1",
+            authority_tier="HIGH",
+            consensus_receipt_digest="sha256:" + "c" * 64,
+            authority_profile_digest="sha256:" + "a" * 64,
+            authority_profile_source_receipt_id="sha256:" + "e" * 64,
+        ),
+    )
+    rejected = backend.sign(replace(captured[0], signer_role="reddog"), _peer())
+    assert rejected.accepted is False
+
+
+def test_ed25519_signer_backend_rejects_malformed_control_receipt_payload() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    backend = Ed25519SignerBackend(
+        private_key=private_key,
+        public_key=public_key,
+        key_epoch="epoch-1",
+        audit_mac_builder=AuditMacBuilder(),
+    )
+    signing_input = CONTROL_LOOP_SIGNING_PREFIX + '{"receipt_id":"forged"}'
+
+    response = backend.sign(
+        _request(
+            public_key,
+            requested_operation=CONTROL_LOOP_SIGNING_OPERATION,
+            signing_input=signing_input,
+            payload_digest=_request_digest(signing_input),
+        ),
+        _peer(),
+    )
+
+    assert response.accepted is False
 
 
 def test_signer_backend_module_has_no_key_loading_repo_shell_or_socket_surfaces() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py
@@ -985,6 +985,90 @@ def test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain(
     assert not (repo / "runtime" / "pattern_memory.db").exists()
 
 
+def test_private_openclaw_claim_primitives_reject_without_control_lock(
+    tmp_path: Path,
+) -> None:
+    from modules.communication.moltbot_bridge.src import openclaw_supervisor as supervisor
+
+    def forbidden_factory():
+        raise AssertionError("AgentDB must not be opened without the control lock")
+
+    once = supervisor._claim_reddog_signed_worker_dispatch_task_once_under_control_lock(
+        repo_root=tmp_path, agent_db_factory=forbidden_factory
+    )
+    loop = supervisor._claim_reddog_signed_worker_dispatch_tasks_until_idle_under_control_lock(
+        repo_root=tmp_path, agent_db_factory=forbidden_factory, max_claims=1
+    )
+    assert once["accepted"] is False
+    assert loop["accepted"] is False
+    assert "resident_queue_control_lock_required" in once["rejection_reasons"]
+    assert "resident_queue_control_lock_required" in loop["rejection_reasons"]
+
+
+def test_control_lock_reentry_is_bound_to_exact_repository_identity(
+    tmp_path: Path,
+) -> None:
+    from modules.communication.moltbot_bridge.src import openclaw_supervisor as supervisor
+    from modules.communication.moltbot_bridge.src.reddog_resident_queue_control_lock import (
+        acquire_resident_queue_control_lock,
+        resident_queue_control_lock_held,
+    )
+
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    def forbidden_factory():
+        raise AssertionError("lock A must not authorize AgentDB access for repo B")
+
+    with acquire_resident_queue_control_lock(repo_a) as lock:
+        assert lock.acquired is True
+        assert resident_queue_control_lock_held(repo_a) is True
+        assert resident_queue_control_lock_held(repo_b) is False
+        result = supervisor._claim_reddog_signed_worker_dispatch_task_once_under_control_lock(
+            repo_root=repo_b,
+            agent_db_factory=forbidden_factory,
+        )
+
+    assert result["accepted"] is False
+    assert "resident_queue_control_lock_required" in result["rejection_reasons"]
+
+
+def test_failed_claim_has_digest_bound_exact_child_outcome() -> None:
+    from modules.communication.moltbot_bridge.src import openclaw_supervisor as supervisor
+
+    claim = supervisor._signed_worker_claim_result(
+        accepted=False,
+        status=supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+        task_id="task-failed-1",
+        rejection_reasons=("test_failure",),
+    )
+    result = supervisor._signed_worker_claim_loop_result(
+        accepted=False,
+        status=supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT,
+        max_claims=1,
+        claim_results=(claim,),
+        failed_task_ids=("task-failed-1",),
+    )
+    assert claim["execution_result_digest"].startswith("sha256:")
+    assert result["child_execution_evidence_digests"] == (
+        claim["execution_result_digest"],
+    )
+    assert result["child_execution_outcomes"] == (
+        {
+            "task_id": "task-failed-1",
+            "status": "failed",
+                "receipt_id": "",
+                "evidence_digest": claim["execution_result_digest"],
+                "worker_execution_performed": False,
+                "effect_evidence_complete": True,
+                "worker_process_spawn_count": 0,
+                "shell_command_count": 0,
+            },
+    )
+
+
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="AF_UNIX required")
 def test_main_resident_control_loop_profile_runtime_completes_socket_signed_queue_chain_without_work_orders(
     tmp_path: Path,
@@ -1084,7 +1168,7 @@ def test_main_resident_control_loop_profile_runtime_completes_socket_signed_queu
             socket_path=socket_path,
             backend=signer_backend,
             peer_attestor=_StaticSocketPeerAttestor(),
-            max_requests=2,
+            max_requests=3,
             timeout_s=5,
             ready_callback=ready.set,
         )
@@ -1131,7 +1215,7 @@ def test_main_resident_control_loop_profile_runtime_completes_socket_signed_queu
     result = service_result["result"]
     assert result.accepted is True
     assert result.status == SIGNER_SOCKET_RESIDENT_SERVICE_SERVED
-    assert result.requests_handled == 2
+    assert result.requests_handled == 3
     assert not socket_path.exists()
 
     captured = capsys.readouterr().out
@@ -1159,7 +1243,32 @@ def test_main_resident_control_loop_profile_runtime_completes_socket_signed_queu
         == main.run_reddog_resident_queue_control_loop_preflight.last_result["receipt_id"]
     )
     assert control_receipt["receipt_ids"][0].startswith("signed_worker_task_execution_")
+    assert control_receipt["child_execution_receipt_ids"] == control_receipt["receipt_ids"]
+    assert control_receipt["child_execution_evidence_count"] == (
+        control_receipt["worker_completion_count"]
+        + control_receipt["worker_requeue_count"]
+        + control_receipt["worker_failure_count"]
+    )
     assert control_receipt["control_lock_acquired"] is True
+    assert "authority_runtime" in control_receipt["dispatched_stages"]
+    assert "bounded_worker_pilot" in control_receipt["dispatched_stages"]
+    assert control_receipt["authority_issued"] is True
+    assert control_receipt["worker_claim_performed"] is True
+    assert control_receipt["worker_execution_performed"] is True
+    assert control_receipt["worktree_creation_observed"] is True
+    assert control_receipt["bounded_file_edit_observed"] is True
+    assert control_receipt["slice_verification_observed"] is True
+    assert control_receipt["draft_pr_publish_observed"] is True
+    assert control_receipt["pattern_memory_admission_observed"] is True
+    assert control_receipt["shell_command_execution_observed"] is False
+    assert control_receipt["shell_command_count"] == 0
+    assert control_receipt["worker_process_spawn_observed"] is False
+    assert control_receipt["worker_process_spawn_count"] == 0
+    assert control_receipt["authentication_status"] == "AUTHENTICATED"
+    assert control_receipt["signature"].startswith("ed25519-sig-v1:")
+    assert control_receipt["signer_audit_attestation_signature"].startswith(
+        "ed25519-sig-v1:"
+    )
     assert main.run_reddog_resident_queue_control_loop_preflight.last_result["control_lock_acquired"] is True
     assert "REDDOG_WORK_ORDERS_PATH" not in os.environ
 
@@ -1331,10 +1440,13 @@ def test_main_resident_control_loop_consumes_signer_socket_started_by_runtime_cl
         runtime_root / "signer-service.json",
         {
             "socket_path": str(socket_path),
+            "control_loop_anchor_path": str(
+                tmp_path / "signer-state" / "control-loop-anchor.json"
+            ),
             "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
             "allow_test_only_key_material": False,
             "permission_snapshot_fresh": True,
-            "max_requests": 2,
+            "max_requests": 3,
             "timeout_s": 5,
             "max_request_bytes": 16384,
             "max_response_bytes": 16384,
@@ -1472,6 +1584,8 @@ def test_main_resident_control_loop_consumes_signer_socket_started_by_runtime_cl
     )
     assert control_receipt["receipt_ids"][0].startswith("signed_worker_task_execution_")
     assert control_receipt["control_lock_acquired"] is True
+    assert control_receipt["authentication_status"] == "AUTHENTICATED"
+    assert control_receipt["signature"].startswith("ed25519-sig-v1:")
     assert main.run_reddog_resident_queue_control_loop_preflight.last_result["control_lock_acquired"] is True
     assert calls
     stored = json.loads(chain.read_text(encoding="utf-8"))

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
@@ -63,8 +63,10 @@ def _authority_profile(**overrides: object) -> dict[str, object]:
         "principal_public_key": "ed25519-pub-v1:principal",
         "reddog_id": "reddog:foundups-agent",
         "reddog_public_key": "ed25519-pub-v1:reddog",
-        "permission_snapshot_digest": "sha256:permission",
+        "permission_snapshot_digest": "sha256:" + "1" * 64,
         "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:" + "c" * 64,
+        "authority_profile_source_receipt_id": "sha256:" + "a" * 64,
         "identity_ttl_seconds": 600,
         "work_authority_ttl_seconds": 300,
     }

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_receipt_auth.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_receipt_auth.py
@@ -1,0 +1,928 @@
+"""Authentication, replay, and migration tests for resident control receipts."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_resident_control_loop_receipt_store as receipt_store,
+)
+
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
+    CONTROL_LOOP_AUTHENTICATED,
+    CONTROL_LOOP_DISPLAY_ONLY,
+    ControlLoopReceiptSigningContext,
+    LEGACY_CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
+    _receipt_id,
+    append_resident_control_loop_receipt,
+    build_resident_control_loop_receipt,
+    verify_resident_control_loop_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_chain import (
+    verify_resident_control_loop_receipt_chain,
+)
+from modules.communication.moltbot_bridge.tests.reddog_resident_live_canary_test_support import (
+    _AuditMacBuilder,
+    _LocalSignerClient,
+    _PUBLIC_KEY,
+    _SIGNING_CONTEXT,
+    _test_private_key,
+    _test_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    ControlLoopAuthorityPolicy,
+    Ed25519SignerBackend,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    InMemorySignerControlLoopAnchorStore,
+)
+from modules.communication.moltbot_bridge.src import openclaw_supervisor
+
+
+def _claim_evidence(
+    *, task_id: str, status: str = "completed", receipt_id: str = "child-receipt-1"
+) -> dict[str, object]:
+    claim_status = {
+        "completed": openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
+        "requeued": openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
+        "failed": openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+    }[status]
+    return openclaw_supervisor._signed_worker_claim_result(
+        accepted=status != "failed",
+        status=claim_status,
+        task_id=task_id,
+        receipt_id=None if status == "failed" else receipt_id,
+    )
+
+
+def _result(**overrides: object) -> dict[str, object]:
+    evidence = _claim_evidence(task_id="task-1")
+    evidence_digest = str(evidence["execution_result_digest"])
+    result: dict[str, object] = {
+        "accepted": True,
+        "status": "PASS",
+        "rounds": 1,
+        "serial_progress": 2,
+        "claim_progress": 1,
+        "worker_claim_count": 1,
+        "worker_completion_count": 1,
+        "worker_requeue_count": 0,
+        "worker_failure_count": 0,
+        "receipt_ids": ("child-receipt-1",),
+        "child_execution_receipt_ids": ("child-receipt-1",),
+        "child_execution_evidence_digests": (evidence_digest,),
+        "child_execution_outcomes": (
+            {
+                "task_id": "task-1",
+                "status": "completed",
+                "receipt_id": "child-receipt-1",
+                "evidence_digest": evidence_digest,
+                "worker_execution_performed": False,
+                "effect_evidence_complete": True,
+                "worker_process_spawn_count": 0,
+                "shell_command_count": 0,
+            },
+        ),
+        "child_execution_evidence": (evidence,),
+        "rejection_reasons": (),
+        "control_lock_acquired": True,
+        "dispatched_stages": ("authority_runtime",),
+    }
+    result.update(overrides)
+    if "receipt_ids" in overrides and "child_execution_receipt_ids" not in overrides:
+        result["child_execution_receipt_ids"] = overrides["receipt_ids"]
+    if (
+        "child_execution_outcomes" not in overrides
+        and "child_execution_receipt_ids" not in overrides
+        and "child_execution_evidence_digests" not in overrides
+        and "receipt_ids" in overrides
+    ):
+        receipts = tuple(result["child_execution_receipt_ids"])
+        digests = tuple(
+            "sha256:" + hashlib.sha256(receipt_id.encode("utf-8")).hexdigest()
+            for receipt_id in receipts
+        )
+        result["child_execution_evidence_digests"] = digests
+        result["child_execution_outcomes"] = tuple(
+            {
+                "task_id": f"task-{index}",
+                "status": "completed",
+                "receipt_id": receipt_id,
+                "evidence_digest": digest,
+                "worker_execution_performed": False,
+                "effect_evidence_complete": True,
+                "worker_process_spawn_count": 0,
+                "shell_command_count": 0,
+            }
+            for index, (receipt_id, digest) in enumerate(
+                zip(receipts, digests), start=1
+            )
+        )
+    if (
+        "child_execution_outcomes" not in overrides
+        and "child_execution_evidence_digests" in overrides
+        and "child_execution_receipt_ids" not in overrides
+    ):
+        receipts = tuple(result["child_execution_receipt_ids"])
+        digests = tuple(result["child_execution_evidence_digests"])
+        result["child_execution_outcomes"] = tuple(
+            {
+                "task_id": f"task-{index}",
+                "status": "completed",
+                "receipt_id": receipt_id,
+                "evidence_digest": digest,
+                "worker_execution_performed": False,
+                "effect_evidence_complete": True,
+                "worker_process_spawn_count": 0,
+                "shell_command_count": 0,
+            }
+            for index, (receipt_id, digest) in enumerate(
+                zip(receipts, digests), start=1
+            )
+        )
+    outcomes = tuple(dict(item) for item in result["child_execution_outcomes"])
+    for outcome in outcomes:
+        outcome.setdefault("worker_execution_performed", False)
+        outcome.setdefault("effect_evidence_complete", True)
+        outcome.setdefault("worker_process_spawn_count", 0)
+        outcome.setdefault("shell_command_count", 0)
+    result["child_execution_outcomes"] = outcomes
+    if not any(
+        key in overrides
+        for key in (
+            "child_execution_outcomes",
+            "child_execution_evidence_digests",
+            "child_execution_evidence",
+        )
+    ):
+        generated = tuple(
+            _claim_evidence(
+                task_id=str(outcome["task_id"]),
+                status=str(outcome["status"]),
+                receipt_id=str(outcome["receipt_id"]),
+            )
+            for outcome in outcomes
+        )
+        result["child_execution_evidence"] = generated
+        result["child_execution_evidence_digests"] = tuple(
+            str(item["execution_result_digest"]) for item in generated
+        )
+        for outcome, item in zip(outcomes, generated):
+            outcome["evidence_digest"] = item["execution_result_digest"]
+    return result
+
+
+def test_signed_receipt_requires_valid_signature_and_expected_key(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    receipt = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-1",
+        nonce="nonce-1",
+        signing_context=_SIGNING_CONTEXT,
+    )
+
+    verified = verify_resident_control_loop_receipt(
+        receipt.to_dict(),
+        expected_repo_root=repo,
+        expected_signer_public_key=_PUBLIC_KEY,
+        expected_key_epoch="epoch-canary-1",
+        require_authenticated=True,
+    )
+
+    assert verified.authentication_status == CONTROL_LOOP_AUTHENTICATED
+    assert verified.signature
+    assert verified.worker_claim_count == 1
+    assert verified.worker_completion_count == 1
+    assert verified.worker_requeue_count == 0
+    assert verified.shell_command_execution_observed is False
+    assert verified.shell_command_count == 0
+    with pytest.raises(ValueError, match="signer_invalid"):
+        verify_resident_control_loop_receipt(
+            receipt.to_dict(),
+            expected_signer_public_key="wrong-key",
+            require_authenticated=True,
+        )
+
+
+def test_signature_tamper_and_display_only_receipt_fail_live_auth(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    signed = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-1",
+        nonce="nonce-1",
+        signing_context=_SIGNING_CONTEXT,
+    ).to_dict()
+    signed["signature"] = "ed25519-sig-v1:" + "A" * 86
+    with pytest.raises(ValueError, match="signature_invalid"):
+        verify_resident_control_loop_receipt(signed, require_authenticated=True)
+
+    display = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-display",
+        nonce="nonce-display",
+    )
+    assert display.authentication_status == CONTROL_LOOP_DISPLAY_ONLY
+    with pytest.raises(ValueError, match="authentication_required"):
+        verify_resident_control_loop_receipt(display.to_dict(), require_authenticated=True)
+
+
+def test_signer_audit_mac_tamper_fails_public_attestation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    receipt = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-audit",
+        nonce="nonce-audit",
+        signing_context=_SIGNING_CONTEXT,
+    ).to_dict()
+    receipt["signer_audit_mac"] = "audit:tampered"
+
+    with pytest.raises(ValueError, match="audit_attestation_invalid"):
+        verify_resident_control_loop_receipt(receipt, require_authenticated=True)
+
+
+def test_authority_profile_source_receipt_is_signature_bound(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    receipt = build_resident_control_loop_receipt(
+        result=_result(), repo_root=repo,
+        created_at="2026-07-18T00:00:00Z", cycle_id="cycle-source",
+        nonce="nonce-source", signing_context=_SIGNING_CONTEXT,
+    ).to_dict()
+    receipt["authority_profile_source_receipt_id"] = "sha256:" + "9" * 64
+
+    with pytest.raises(ValueError):
+        verify_resident_control_loop_receipt(receipt, require_authenticated=True)
+
+
+def test_chain_links_receipts_and_rejects_cycle_or_nonce_replay(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    first = append_resident_control_loop_receipt(
+        path=path,
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-1",
+        nonce="nonce-1",
+        signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+    )
+    second = append_resident_control_loop_receipt(
+        path=path,
+        result=_result(receipt_ids=("child-receipt-2",)),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:01Z",
+        cycle_id="cycle-2",
+        nonce="nonce-2",
+        signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+    )
+
+    assert second.previous_receipt_id == first.receipt_id
+    with pytest.raises(ValueError, match="cycle_replay"):
+        append_resident_control_loop_receipt(
+            path=path,
+            result=_result(),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:02Z",
+            cycle_id="cycle-1",
+            nonce="nonce-3",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+
+
+def test_child_receipt_and_evidence_reuse_is_rejected_across_cycles(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    append_resident_control_loop_receipt(
+        path=path, result=_result(), repo_root=repo,
+        created_at="2026-07-18T00:00:00Z", cycle_id="cycle-1",
+        nonce="nonce-1", signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+    )
+
+    with pytest.raises(ValueError, match="child_(receipt|evidence)_replay"):
+        append_resident_control_loop_receipt(
+            path=path, result=_result(), repo_root=repo,
+            created_at="2026-07-18T00:00:01Z", cycle_id="cycle-2",
+            nonce="nonce-2", signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+
+
+def test_head_recovers_exact_signed_receipt_after_append_interruption(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    original_append = receipt_store._append_receipt_once
+    calls = 0
+
+    def fail_once(*args: object, **kwargs: object) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("simulated_append_interruption")
+        original_append(*args, **kwargs)
+
+    monkeypatch.setattr(receipt_store, "_append_receipt_once", fail_once)
+    with pytest.raises(RuntimeError, match="simulated_append_interruption"):
+        append_resident_control_loop_receipt(
+            path=path, result=_result(), repo_root=repo,
+            created_at="2026-07-18T00:00:00Z", cycle_id="cycle-1",
+            nonce="nonce-1", signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+
+    second = append_resident_control_loop_receipt(
+        path=path, result=_result(receipt_ids=("child-receipt-2",)),
+        repo_root=repo, created_at="2026-07-18T00:00:01Z",
+        cycle_id="cycle-2", nonce="nonce-2", signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+    )
+    payloads = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+    assert len(payloads) == 2
+    assert payloads[0]["sequence_number"] == 1
+    assert payloads[1]["sequence_number"] == 2
+    assert second.previous_receipt_id == payloads[0]["receipt_id"]
+
+
+def test_retention_limit_rejects_before_advancing_high_water_head(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    state_path = tmp_path / "runtime" / "authority.json"
+    first = append_resident_control_loop_receipt(
+        path=path,
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-capacity-1",
+        nonce="nonce-capacity-1",
+        signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+        head_state_path=state_path,
+    )
+    before = json.loads(state_path.read_text(encoding="utf-8"))
+    monkeypatch.setattr(
+        receipt_store,
+        "MAX_CONTROL_RECEIPT_CHAIN_BYTES",
+        path.stat().st_size + 1,
+    )
+
+    with pytest.raises(ValueError, match="retention_limit"):
+        append_resident_control_loop_receipt(
+            path=path,
+            result=_result(receipt_ids=("child-receipt-capacity-2",)),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:01Z",
+            cycle_id="cycle-capacity-2",
+            nonce="nonce-capacity-2",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+            head_state_path=state_path,
+        )
+
+    after = json.loads(state_path.read_text(encoding="utf-8"))
+    assert after["control_receipt_head"]["receipt_id"] == first.receipt_id
+    assert after["revision"] == before["revision"]
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_concurrent_same_cycle_allows_exactly_one_signed_append(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+
+    def append() -> str:
+        receipt = append_resident_control_loop_receipt(
+            path=path,
+            result=_result(),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:00Z",
+            cycle_id="same-cycle",
+            nonce="same-nonce",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+        return receipt.receipt_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(append) for _ in range(2)]
+    successes = [future.result() for future in futures if future.exception() is None]
+    failures = [future.exception() for future in futures if future.exception() is not None]
+
+    assert len(successes) == 1
+    assert len(failures) == 1
+    assert "replay" in str(failures[0]) or "revision_conflict" in str(failures[0])
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_concurrent_distinct_signed_appends_are_serialized_without_loss(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+
+    def append(index: int) -> str:
+            return append_resident_control_loop_receipt(
+                path=path,
+                result=_result(receipt_ids=(f"child-receipt-{index}",)),
+            repo_root=repo,
+            created_at=f"2026-07-18T00:00:0{index}Z",
+            cycle_id=f"distinct-cycle-{index}",
+            nonce=f"distinct-nonce-{index}",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        ).receipt_id
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        receipt_ids = list(executor.map(append, (0, 1)))
+
+    payloads = tuple(
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+    )
+    assert len(set(receipt_ids)) == 2
+    assert len(payloads) == 2
+    assert payloads[1]["previous_receipt_id"] == payloads[0]["receipt_id"]
+
+
+def test_string_false_never_becomes_accepted_true(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    receipt = build_resident_control_loop_receipt(
+        result=_result(accepted="false"),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-false",
+        nonce="nonce-false",
+        signing_context=_SIGNING_CONTEXT,
+    )
+
+    assert receipt.accepted is False
+
+
+def test_receipt_records_observed_stage_effects_without_inventing_shell_or_process_use(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    receipt = build_resident_control_loop_receipt(
+        result=_result(
+            dispatched_stages=(
+                "authority_runtime",
+                "worktree_create",
+                "bounded_worker_pilot",
+                "slice_verifier",
+                "verified_draft_pr_publish",
+                "pattern_memory_admission",
+            ),
+        ),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-effects",
+        nonce="nonce-effects",
+        signing_context=_SIGNING_CONTEXT,
+    )
+
+    assert receipt.worktree_creation_count == 1
+    assert receipt.bounded_file_edit_count == 1
+    assert receipt.slice_verification_count == 1
+    assert receipt.draft_pr_publish_count == 1
+    assert receipt.pattern_memory_admission_count == 1
+    assert receipt.worktree_creation_observed is True
+    assert receipt.bounded_file_edit_observed is True
+    assert receipt.shell_command_count == 0
+    assert receipt.shell_command_execution_observed is False
+    assert receipt.worker_process_spawn_count == 0
+    assert receipt.worker_process_spawn_observed is False
+    assert "no_merge_performed" not in receipt.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (("worker_process_spawn_count", 7), ("shell_command_count", 9)),
+)
+def test_parent_effect_counts_must_equal_digest_bound_child_counts(
+    tmp_path: Path, field: str, value: int
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    with pytest.raises(ValueError, match=f"effect_claim_conflict:{field}"):
+        build_resident_control_loop_receipt(
+            result=_result(**{field: value}),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:00Z",
+        )
+
+
+def test_unknown_runner_effects_are_signed_as_unverified_not_no_effect(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    unknown_effects = {
+        "worker_execution_performed": True,
+        "effect_evidence_complete": False,
+        "worker_process_spawn_count": 0,
+        "shell_command_count": 0,
+        **{
+            field: False
+            for field in openclaw_supervisor._SIGNED_WORKER_NO_EFFECT_FIELDS
+        },
+    }
+    evidence = openclaw_supervisor._signed_worker_claim_result(
+        accepted=False,
+        status=openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+        task_id="task-runner-exception",
+        rejection_reasons=("runner_exception",),
+        effect_source=unknown_effects,
+    )
+    digest = str(evidence["execution_result_digest"])
+
+    receipt = build_resident_control_loop_receipt(
+        result=_result(
+            accepted=False,
+            status="REJECT",
+            claim_progress=1,
+            worker_claim_count=1,
+            worker_completion_count=0,
+            worker_failure_count=1,
+            worker_execution_count=1,
+            receipt_ids=(),
+            child_execution_receipt_ids=(),
+            child_execution_evidence_digests=(digest,),
+            child_execution_outcomes=(
+                {
+                    "task_id": "task-runner-exception",
+                    "status": "failed",
+                    "receipt_id": "",
+                    "evidence_digest": digest,
+                    "worker_execution_performed": True,
+                    "effect_evidence_complete": False,
+                    "worker_process_spawn_count": 0,
+                    "shell_command_count": 0,
+                },
+            ),
+            child_execution_evidence=(evidence,),
+        ),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        signing_context=_SIGNING_CONTEXT,
+    )
+
+    assert receipt.worker_effects_unverified_count == 1
+    assert receipt.worker_execution_count == 1
+    assert receipt.shell_command_count == 0
+
+
+def test_failed_claim_counts_execution_only_when_runner_was_invoked(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    effect_source = {
+        "worker_execution_performed": True,
+        "effect_evidence_complete": True,
+        "worker_process_spawn_count": 0,
+        "shell_command_count": 1,
+        "no_shell_command_executed": False,
+        "no_source_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_live_foundup_enqueue_performed": True,
+        "no_pattern_memory_write_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+    evidence = openclaw_supervisor._signed_worker_claim_result(
+        accepted=False,
+        status=openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
+        task_id="task-failed-after-runner",
+        rejection_reasons=("runner_rejected",),
+        effect_source=effect_source,
+    )
+    digest = str(evidence["execution_result_digest"])
+    receipt = build_resident_control_loop_receipt(
+        result=_result(
+            claim_progress=1,
+            worker_claim_count=1,
+            worker_completion_count=0,
+            worker_failure_count=1,
+            worker_execution_count=1,
+            shell_command_count=1,
+            receipt_ids=(),
+            child_execution_receipt_ids=(),
+            child_execution_evidence_digests=(digest,),
+            child_execution_outcomes=(
+                {
+                    "task_id": "task-failed-after-runner",
+                    "status": "failed",
+                    "receipt_id": "",
+                    "evidence_digest": digest,
+                    "worker_execution_performed": True,
+                    "effect_evidence_complete": True,
+                    "worker_process_spawn_count": 0,
+                    "shell_command_count": 1,
+                },
+            ),
+            child_execution_evidence=(evidence,),
+        ),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-failed-after-runner",
+        nonce="nonce-failed-after-runner",
+        signing_context=_SIGNING_CONTEXT,
+    )
+    assert receipt.worker_failure_count == 1
+    assert receipt.worker_execution_count == 1
+    assert receipt.worker_execution_performed is True
+    assert receipt.shell_command_count == 1
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"child_execution_receipt_ids": ()},
+        {"child_execution_evidence_digests": ()},
+    ],
+)
+def test_completed_worker_requires_exact_child_receipt_and_execution_evidence(
+    tmp_path: Path, overrides: dict[str, object]
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(
+        ValueError,
+        match="(child_.*(cardinality|projection)_.*|worker_outcome_count_invalid)",
+    ):
+        build_resident_control_loop_receipt(
+            result=_result(**overrides),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:00Z",
+            cycle_id="cycle-missing-child",
+            nonce="nonce-missing-child",
+            signing_context=_SIGNING_CONTEXT,
+        )
+
+
+def test_child_outcome_order_must_match_receipt_and_evidence_projections(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    evidence_two = _claim_evidence(task_id="task-2", receipt_id="child-receipt-2")
+    evidence_one = _claim_evidence(task_id="task-1", receipt_id="child-receipt-1")
+    digest_one = str(evidence_one["execution_result_digest"])
+    digest_two = str(evidence_two["execution_result_digest"])
+    result = _result(
+        claim_progress=2,
+        worker_claim_count=2,
+        worker_completion_count=2,
+        receipt_ids=("child-receipt-1", "child-receipt-2"),
+        child_execution_receipt_ids=("child-receipt-1", "child-receipt-2"),
+        child_execution_evidence_digests=(digest_one, digest_two),
+        child_execution_outcomes=(
+            {
+                "task_id": "task-2", "status": "completed",
+                "receipt_id": "child-receipt-2", "evidence_digest": digest_two,
+                "worker_execution_performed": False,
+            },
+            {
+                "task_id": "task-1", "status": "completed",
+                "receipt_id": "child-receipt-1", "evidence_digest": digest_one,
+                "worker_execution_performed": False,
+            },
+        ),
+        child_execution_evidence=(evidence_two, evidence_one),
+    )
+    with pytest.raises(ValueError, match="child_projection_conflict"):
+        build_resident_control_loop_receipt(
+            result=result, repo_root=repo, created_at="2026-07-18T00:00:00Z",
+            cycle_id="cycle-order", nonce="nonce-order",
+            signing_context=_SIGNING_CONTEXT,
+        )
+
+
+@pytest.mark.parametrize("field", ["detail", "worker_execution_performed", "execution_result_digest"])
+def test_complete_child_evidence_rejects_body_or_digest_tamper(
+    tmp_path: Path, field: str
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = _result()
+    evidence = dict(result["child_execution_evidence"][0])
+    if field == "worker_execution_performed":
+        evidence[field] = True
+    elif field == "execution_result_digest":
+        evidence[field] = "sha256:" + "f" * 64
+    else:
+        evidence[field] = "tampered after child execution"
+    result["child_execution_evidence"] = (evidence,)
+
+    with pytest.raises(ValueError, match="child_evidence"):
+        build_resident_control_loop_receipt(
+            result=result, repo_root=repo, created_at="2026-07-18T00:00:00Z",
+            cycle_id="cycle-child-tamper", nonce="nonce-child-tamper",
+            signing_context=_SIGNING_CONTEXT,
+        )
+
+
+def test_authenticated_append_rejects_unsigned_v2_predecessor(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    append_resident_control_loop_receipt(
+        path=path,
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="display-cycle",
+        nonce="display-nonce",
+    )
+
+    with pytest.raises(ValueError, match="authentication_required"):
+        append_resident_control_loop_receipt(
+            path=path,
+            result=_result(receipt_ids=("child-receipt-2",)),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:01Z",
+            cycle_id="signed-cycle",
+            nonce="signed-nonce",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+
+
+def test_authenticated_append_rejects_foreign_signed_v2_predecessor(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    private_key = _test_private_key()
+    public_key = _test_public_key(private_key)
+    foreign_context = ControlLoopReceiptSigningContext(
+        signer=_LocalSignerClient(
+            Ed25519SignerBackend(
+                private_key=private_key,
+                    public_key=public_key,
+                    key_epoch="foreign-epoch",
+                    audit_mac_builder=_AuditMacBuilder(),
+                    control_loop_anchor_store=InMemorySignerControlLoopAnchorStore(),
+                    control_loop_authority_policy=ControlLoopAuthorityPolicy(
+                        issuer_principal_id="github:foreign",
+                        signer_public_key=public_key,
+                        key_epoch="foreign-epoch",
+                        consensus_receipt_digest="sha256:" + "d" * 64,
+                        authority_profile_digest="sha256:" + "f" * 64,
+                        authority_profile_source_receipt_id="sha256:" + "e" * 64,
+                    ),
+                )
+        ),
+        signature_verifier=Ed25519SignatureVerifier(),
+        issuer_principal_id="github:foreign",
+        signer_public_key=public_key,
+        key_epoch="foreign-epoch",
+        authority_tier="HIGH",
+        consensus_receipt_digest="sha256:" + "d" * 64,
+        authority_profile_digest="sha256:" + "f" * 64,
+        authority_profile_source_receipt_id="sha256:" + "e" * 64,
+    )
+    append_resident_control_loop_receipt(
+        path=path,
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="foreign-cycle",
+        nonce="foreign-nonce",
+        signing_context=foreign_context,
+        require_authentication=True,
+    )
+
+    with pytest.raises(ValueError, match="signer_invalid"):
+        append_resident_control_loop_receipt(
+            path=path,
+            result=_result(receipt_ids=("child-receipt-2",)),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:01Z",
+            cycle_id="local-cycle",
+            nonce="local-nonce",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+
+
+def test_complete_chain_verifier_rejects_tamper_and_reorder(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    for index in range(2):
+        append_resident_control_loop_receipt(
+            path=path,
+            result=_result(
+                receipt_ids=(f"child-receipt-{index + 1}",),
+            ),
+            repo_root=repo,
+            created_at=f"2026-07-18T00:00:0{index}Z",
+            cycle_id=f"chain-cycle-{index}",
+            nonce=f"chain-nonce-{index}",
+            signing_context=_SIGNING_CONTEXT,
+            require_authentication=True,
+        )
+    payloads = tuple(
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+    )
+    expected = {
+        "expected_signer_public_key": _SIGNING_CONTEXT.signer_public_key,
+        "expected_key_epoch": _SIGNING_CONTEXT.key_epoch,
+        "expected_consensus_receipt_digest": (
+            _SIGNING_CONTEXT.consensus_receipt_digest
+        ),
+        "expected_authority_profile_digest": (
+            _SIGNING_CONTEXT.authority_profile_digest
+        ),
+        "expected_authority_profile_source_receipt_id": (
+            _SIGNING_CONTEXT.authority_profile_source_receipt_id
+        ),
+        "expected_issuer_principal_id": _SIGNING_CONTEXT.issuer_principal_id,
+    }
+    verify_resident_control_loop_receipt_chain(payloads, **expected)
+    tampered = [dict(item) for item in payloads]
+    tampered[0]["status"] = "TAMPERED"
+    with pytest.raises(ValueError):
+        verify_resident_control_loop_receipt_chain(tampered, **expected)
+    with pytest.raises(ValueError, match="(previous_link|sequence)_invalid"):
+        verify_resident_control_loop_receipt_chain(tuple(reversed(payloads)), **expected)
+
+
+def test_first_v2_receipt_binds_validated_legacy_prefix(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    path = tmp_path / "runtime" / "control.jsonl"
+    path.parent.mkdir()
+    legacy = {
+        "schema_version": LEGACY_CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
+        "accepted": True,
+        "status": "PASS",
+        "rounds": 1,
+        "serial_progress": 1,
+        "claim_progress": 0,
+        "receipt_ids": [],
+        "rejection_reasons": [],
+        "created_at": "2026-07-17T00:00:00Z",
+        "repo_root_digest": "legacy-repo",
+        "control_lock_acquired": True,
+        "no_authority_issued": True,
+        "no_worker_spawn_performed": True,
+        "no_shell_command_executed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_merge_performed": True,
+        "no_reward_settlement_performed": True,
+    }
+    legacy["receipt_id"] = _receipt_id(legacy)
+    path.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+
+    current = append_resident_control_loop_receipt(
+        path=path,
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-current",
+        nonce="nonce-current",
+        signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+    )
+
+    assert current.previous_receipt_id == legacy["receipt_id"]
+    assert current.legacy_prefix_digest.startswith("sha256:")

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_signing_context.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_signing_context.py
@@ -1,0 +1,262 @@
+"""Tests for runtime control-loop signer context resolution."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_signing_context import (
+    build_control_loop_receipt_signing_context,
+)
+
+
+def _source_profile(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": "reddog_authority_profile_source.v1",
+        "principal_id": "github:mjtrout",
+        "principal_provider": "github",
+        "principal_public_key": "ed25519-pub-v1:" + "B" * 43,
+        "reddog_id": "reddog:architect",
+        "reddog_public_key": "ed25519-pub-v1:" + "A" * 43,
+        "repo_full_name": "FOUNDUPS/Foundups-Agent",
+        "foundup_id": "paccess_001",
+        "allowed_paths": ["modules/foundups/paccess_001/src/**"],
+        "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
+        "requested_operation": "worktree_create",
+        "permission_snapshot_digest": "sha256:" + "1" * 64,
+        "identity_nonce": "identity-nonce-1",
+        "work_authority_nonce": "work-nonce-1",
+        "issued_at": 1_700_000_000,
+        "identity_expires_at": 1_800_000_000,
+        "work_authority_expires_at": 1_800_000_000,
+        "valve_state_required": "VALVE_OPEN_WORKTREE_CREATE",
+        "key_epoch": "epoch-1",
+        "required_tests": ["pytest focused"],
+        "required_policy_gates": ["WSP_97"],
+        "consensus_receipt_digest": "sha256:" + "c" * 64,
+        "sovereign_authorization_digest": "sha256:" + "5" * 64,
+        "source_authority_basis": {
+            "principal_verified_subject_digest": "sha256:" + "2" * 64,
+            "principal_repo_scope": ["FOUNDUPS/Foundups-Agent"],
+            "principal_foundup_scope": ["paccess_001"],
+            "permission_snapshot_digest": "sha256:" + "1" * 64,
+            "permission_snapshot_expires_at": 1_800_000_000,
+            "permission_snapshot_can_write": True,
+            "permission_snapshot_can_admin": False,
+        },
+    }
+    value.update(overrides)
+    value["authority_profile_source_receipt_id"] = "sha256:" + hashlib.sha256(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+    ).hexdigest()
+    return value
+
+
+def _write_profiles(
+    runtime: Path,
+    *,
+    source_path: Path | None = None,
+    profile_path: Path | None = None,
+    source_overrides: dict[str, object] | None = None,
+    profile_overrides: dict[str, object] | None = None,
+) -> tuple[Path, Path]:
+    source = _source_profile(**(source_overrides or {}))
+    profile = {
+        **source,
+        "operational_context_binding": {
+            "queue_item_id": "queue-1",
+            "claim_id": "claim-1",
+            "architect_determination_receipt_id": "determination-1",
+            "wsp15_allocation_receipt": {
+                "receipt_id": "sha256:" + "3" * 64
+            },
+        },
+    }
+    profile.update(profile_overrides or {})
+    source_file = source_path or runtime / "authority_profile_source.json"
+    profile_file = profile_path or runtime / "authority_profile.json"
+    source_file.parent.mkdir(parents=True, exist_ok=True)
+    profile_file.parent.mkdir(parents=True, exist_ok=True)
+    source_file.write_text(json.dumps(source), encoding="utf-8")
+    profile_file.write_text(json.dumps(profile), encoding="utf-8")
+    return source_file, profile_file
+
+
+def _source_receipt(path: Path) -> str:
+    return str(
+        json.loads(path.read_text(encoding="utf-8"))[
+            "authority_profile_source_receipt_id"
+        ]
+    )
+
+
+def _build(
+    repo: Path,
+    source: Path,
+    profile: Path,
+    *,
+    expected_receipt: str | None = None,
+    signer_socket_connector: object = None,
+):
+    return build_control_loop_receipt_signing_context(
+        repo_root=repo,
+        authority_profile_path=profile,
+        authority_profile_source_path=source,
+        signer_socket_path=source.parent / "reddog.sock",
+        expected_authority_profile_source_receipt_id=(
+            expected_receipt or _source_receipt(source)
+        ),
+        signer_socket_connector=signer_socket_connector,
+    )
+
+
+def test_context_binds_promoted_profile_source_and_existing_signer(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, profile = _write_profiles(tmp_path / "runtime")
+
+    context = _build(
+        repo,
+        source,
+        profile,
+        signer_socket_connector=lambda *_args: b"{}",
+    )
+
+    assert context.issuer_principal_id == "github:mjtrout"
+    assert context.key_epoch == "epoch-1"
+    assert context.authority_tier == "HIGH"
+    assert context.consensus_receipt_digest == "sha256:" + "c" * 64
+    assert context.authority_profile_digest.startswith("sha256:")
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"principal_id": ""}, "principal_id_invalid"),
+        ({"key_epoch": ""}, "key_epoch_invalid"),
+        ({"consensus_receipt_digest": ""}, "consensus_receipt_digest_invalid"),
+        ({"consensus_receipt_digest": "sha256:bad"}, "consensus_receipt_digest_invalid"),
+        (
+            {
+                "requested_operation": "feature_slice",
+                "valve_state_required": "VALVE_CLOSED",
+            },
+            "authority_tier_invalid",
+        ),
+        ({"reddog_public_key": "not-a-key"}, "public_key_invalid"),
+        ({"schema_version": "untrusted.v1"}, "profile_schema_invalid"),
+        (
+            {"sovereign_authorization_digest": "sha256:bad"},
+            "sovereign_authorization_digest_invalid",
+        ),
+    ],
+)
+def test_context_rejects_missing_authority_bindings(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    reason: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, profile = _write_profiles(
+        tmp_path / "runtime", source_overrides=overrides
+    )
+
+    with pytest.raises(ValueError, match=reason):
+        _build(
+            repo,
+            source,
+            profile,
+            signer_socket_connector=lambda *_args: b"{}",
+        )
+
+
+def test_context_rejects_mismatched_profile_source_receipt(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, profile = _write_profiles(tmp_path / "runtime")
+
+    with pytest.raises(ValueError, match="profile_source_receipt_invalid"):
+        _build(
+            repo,
+            source,
+            profile,
+            expected_receipt="sha256:" + "f" * 64,
+            signer_socket_connector=lambda *_args: b"{}",
+        )
+
+
+def test_context_rejects_profile_inside_repo_or_unavailable_signer(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, inside = _write_profiles(
+        tmp_path / "runtime", profile_path=repo / "authority_profile.json"
+    )
+    with pytest.raises(ValueError, match="inside_repo"):
+        _build(
+            repo,
+            source,
+            inside,
+            signer_socket_connector=lambda *_args: b"{}",
+        )
+
+    source, outside = _write_profiles(tmp_path / "runtime")
+    with pytest.raises(ValueError, match="signer_client_unavailable"):
+        _build(repo, source, outside)
+
+
+def test_context_rejects_promoted_profile_that_rewrites_its_source(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, profile = _write_profiles(
+        tmp_path / "runtime",
+        profile_overrides={"principal_id": "github:forged"},
+    )
+
+    with pytest.raises(ValueError, match="profile_source_binding_invalid"):
+        _build(
+            repo,
+            source,
+            profile,
+            signer_socket_connector=lambda *_args: b"{}",
+        )
+
+
+def test_context_rejects_profile_without_promotion_binding(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, profile = _write_profiles(
+        tmp_path / "runtime", profile_overrides={"operational_context_binding": None}
+    )
+
+    with pytest.raises(ValueError, match="profile_promotion_binding_invalid"):
+        _build(
+            repo,
+            source,
+            profile,
+            signer_socket_connector=lambda *_args: b"{}",
+        )
+
+
+def test_context_rejects_self_hashed_source_without_verified_authority_basis(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source, profile = _write_profiles(
+        tmp_path / "runtime",
+        source_overrides={"source_authority_basis": {"untrusted": True}},
+    )
+
+    with pytest.raises(ValueError, match="profile_source_basis_invalid"):
+        _build(
+            repo,
+            source,
+            profile,
+            signer_socket_connector=lambda *_args: b"{}",
+        )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_live_canary.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_live_canary.py
@@ -12,6 +12,7 @@ import pytest
 
 from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
     CONTROL_LOOP_RECEIPT_SCHEMA_VERSION,
+    append_resident_control_loop_receipt,
     build_resident_control_loop_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_live_canary import (
@@ -77,7 +78,17 @@ PRODUCTION_PATHS = (
     SRC_ROOT / "reddog_resident_live_canary.py",
     SRC_ROOT / "reddog_resident_live_canary_evidence.py",
     SRC_ROOT / "reddog_resident_queue_control_lock.py",
+    SRC_ROOT / "reddog_resident_control_loop_receipt_auth.py",
+    SRC_ROOT / "reddog_resident_control_loop_receipt_chain.py",
     SRC_ROOT / "reddog_resident_control_loop_receipt_store.py",
+    SRC_ROOT / "reddog_resident_control_loop_receipt_validation.py",
+    SRC_ROOT / "reddog_resident_control_loop_signing_context.py",
+    SRC_ROOT / "reddog_resident_control_loop_head_store.py",
+    SRC_ROOT / "reddog_resident_control_loop_chain_state.py",
+    SRC_ROOT / "reddog_resident_control_loop_outcomes.py",
+    SRC_ROOT / "reddog_resident_control_loop_effects.py",
+    SRC_ROOT / "reddog_resident_live_canary_environment.py",
+    SRC_ROOT / "reddog_resident_live_canary_control_preflight.py",
 )
 COMMUNICATION_TEST_PATHS = (
     Path(__file__),
@@ -88,6 +99,7 @@ from modules.communication.moltbot_bridge.tests.reddog_resident_live_canary_test
     NOW,
     QUEUE_ID,
     SLICE_NAME,
+    _SIGNING_CONTEXT,
     _canonicalize_terminal_receipt,
     _control_receipt,
     _execute,
@@ -95,6 +107,7 @@ from modules.communication.moltbot_bridge.tests.reddog_resident_live_canary_test
     _roots,
     _runner,
     _write_pre_state,
+    _write_control_receipt_and_head,
 )
 
 
@@ -158,6 +171,7 @@ def test_false_control_receipts_cannot_complete_proof(
 
     assert receipt.status == LIVE_CANARY_PROOF_INCOMPLETE
     assert blocker in receipt.blockers
+    assert "control_receipt_auth_or_integrity_invalid" in receipt.blockers
 
 
 def test_runner_result_must_match_one_new_persisted_control_receipt(tmp_path: Path) -> None:
@@ -166,6 +180,187 @@ def test_runner_result_must_match_one_new_persisted_control_receipt(tmp_path: Pa
 
     assert receipt.live_proof_complete is False
     assert "new_control_receipt_not_observed" in receipt.blockers
+
+
+def test_malformed_control_receipt_stream_blocks_before_runner(tmp_path: Path) -> None:
+    repo, runtime = _roots(tmp_path)
+    (runtime / "resident_queue_control_loop_receipts.jsonl").write_text(
+        "{malformed}\n",
+        encoding="utf-8",
+    )
+    called = False
+
+    def runner(_: Path) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {"accepted": True}
+
+    receipt = run_reddog_resident_live_canary(
+        **_kwargs(repo, runtime),
+        execute=True,
+        confirmation=LIVE_CANARY_CONFIRMATION,
+        control_loop_runner=runner,
+    )
+
+    assert called is False
+    assert receipt.live_proof_complete is False
+    assert "control_receipt_stream_invalid" in receipt.blockers
+
+
+def test_valid_json_signature_tamper_blocks_before_runner(tmp_path: Path) -> None:
+    repo, runtime = _roots(tmp_path)
+    _write_pre_state(repo, runtime)
+    control = _control_receipt(repo)
+    _write_control_receipt_and_head(runtime, control)
+    control["status"] = "TAMPERED"
+    (runtime / "resident_queue_control_loop_receipts.jsonl").write_text(
+        json.dumps(control) + "\n", encoding="utf-8"
+    )
+    called = False
+
+    def runner(_: Path) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {"accepted": True}
+
+    receipt = run_reddog_resident_live_canary(
+        **_kwargs(repo, runtime), execute=True,
+        confirmation=LIVE_CANARY_CONFIRMATION, control_loop_runner=runner,
+    )
+    assert called is False
+    assert receipt.live_proof_complete is False
+
+
+def test_canary_blocks_when_signer_anchor_is_ahead_of_resident_chain(
+    tmp_path: Path,
+) -> None:
+    from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+        AtomicSignerControlLoopAnchorStore,
+    )
+
+    repo, runtime = _roots(tmp_path)
+    first = _control_receipt(repo)
+    _write_control_receipt_and_head(runtime, first)
+    second = build_resident_control_loop_receipt(
+        result={
+            "accepted": True,
+            "status": "PASS",
+            "rounds": 1,
+            "serial_progress": 1,
+            "claim_progress": 0,
+            "control_lock_acquired": True,
+            "receipt_ids": (),
+            "rejection_reasons": (),
+        },
+        repo_root=repo,
+        created_at="2026-07-14T00:00:01Z",
+        sequence_number=2,
+        previous_receipt_id=str(first["receipt_id"]),
+        cycle_id="canary-cycle-2",
+        nonce="canary-nonce-2",
+        signing_context=_SIGNING_CONTEXT,
+    ).to_dict()
+    config = json.loads(
+        (runtime / "signer_service_config.json").read_text(encoding="utf-8")
+    )
+    store = AtomicSignerControlLoopAnchorStore(config["control_loop_anchor_path"])
+    state = store.load()
+    unsigned = {
+        key: value
+        for key, value in second.items()
+        if key
+        not in {
+            "signature",
+            "signer_audit_mac",
+            "signer_audit_attestation_signature",
+        }
+    }
+    response = {
+        "signature": second["signature"],
+        "audit_mac": second["signer_audit_mac"],
+        "audit_attestation_signature": second[
+            "signer_audit_attestation_signature"
+        ],
+    }
+    prepared = store.prepare(unsigned)
+    store.commit(
+        unsigned, response, expected_revision=prepared.expected_revision
+    )
+    assert state["receipt_id"] == first["receipt_id"]
+
+    receipt = run_reddog_resident_live_canary(**_kwargs(repo, runtime))
+    assert receipt.status == LIVE_CANARY_BLOCKED
+    assert "control_receipt_prestate_auth_or_integrity_invalid" in (
+        receipt.blockers
+    )
+    assert "control_receipt_prestate_auth_or_integrity_invalid" in receipt.blockers
+
+
+def test_signed_chain_suffix_truncation_blocks_before_runner(tmp_path: Path) -> None:
+    repo, runtime = _roots(tmp_path)
+    _write_pre_state(repo, runtime)
+    path = runtime / "resident_queue_control_loop_receipts.jsonl"
+    base_result = {
+        "accepted": True, "status": "PASS", "rounds": 1,
+        "serial_progress": 1, "claim_progress": 0, "receipt_ids": (),
+        "child_execution_receipt_ids": (),
+        "child_execution_evidence_digests": (), "child_execution_outcomes": (),
+        "rejection_reasons": (), "control_lock_acquired": True,
+        "dispatched_stages": (),
+    }
+    for index in (1, 2):
+        append_resident_control_loop_receipt(
+            path=path, result=base_result, repo_root=repo,
+            created_at=f"2026-07-14T00:00:0{index}Z",
+            cycle_id=f"truncate-cycle-{index}", nonce=f"truncate-nonce-{index}",
+            signing_context=_SIGNING_CONTEXT, require_authentication=True,
+            head_state_path=runtime / "authority_runtime_state.json",
+        )
+    first_line = path.read_text(encoding="utf-8").splitlines()[0]
+    path.write_text(first_line + "\n", encoding="utf-8")
+    called = False
+
+    def runner(_: Path) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {"accepted": True}
+
+    receipt = run_reddog_resident_live_canary(
+        **_kwargs(repo, runtime), execute=True,
+        confirmation=LIVE_CANARY_CONFIRMATION, control_loop_runner=runner,
+    )
+    assert called is False
+    assert receipt.live_proof_complete is False
+    assert "control_receipt_prestate_auth_or_integrity_invalid" in receipt.blockers
+
+
+def test_head_consumed_evidence_tamper_blocks_before_runner(tmp_path: Path) -> None:
+    repo, runtime = _roots(tmp_path)
+    _write_pre_state(repo, runtime)
+    control = _control_receipt(repo)
+    _write_control_receipt_and_head(runtime, control)
+    state_path = runtime / "authority_runtime_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["control_receipt_head"]["consumed_child_evidence_digests"] = [
+        "sha256:" + "f" * 64
+    ]
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    called = False
+
+    def runner(_: Path) -> dict[str, object]:
+        nonlocal called
+        called = True
+        return {"accepted": True}
+
+    receipt = run_reddog_resident_live_canary(
+        **_kwargs(repo, runtime),
+        execute=True,
+        confirmation=LIVE_CANARY_CONFIRMATION,
+        control_loop_runner=runner,
+    )
+
+    assert called is False
+    assert "control_receipt_prestate_auth_or_integrity_invalid" in receipt.blockers
 
 
 def test_preseeded_complete_chain_cannot_be_relabelled_as_new_live_proof(tmp_path: Path) -> None:
@@ -187,7 +382,55 @@ def test_preseeded_complete_chain_cannot_be_relabelled_as_new_live_proof(tmp_pat
         now=lambda: __import__("datetime").datetime.fromisoformat(NOW),
     )
     assert receipt.live_proof_complete is False
-    assert "new_chain_revision_not_observed" in receipt.blockers
+    assert "control_receipt_prestate_auth_or_integrity_invalid" in receipt.blockers
+
+
+def test_canary_rejects_control_receipt_stream_replacement(tmp_path: Path) -> None:
+    repo, runtime = _roots(tmp_path)
+    _write_pre_state(repo, runtime)
+
+    def control(cycle: str, nonce: str) -> dict[str, object]:
+        return build_resident_control_loop_receipt(
+            result={
+                "accepted": True,
+                "status": "PASS",
+                "rounds": 1,
+                "serial_progress": 1,
+                "claim_progress": 0,
+                "receipt_ids": (),
+                "rejection_reasons": (),
+                "control_lock_acquired": True,
+                "dispatched_stages": (),
+            },
+            repo_root=repo,
+            created_at=NOW,
+            cycle_id=cycle,
+            nonce=nonce,
+            signing_context=_SIGNING_CONTEXT,
+        ).to_dict()
+
+    original = control("canary-prefix-cycle", "canary-prefix-nonce")
+    replacement = control("canary-replacement-cycle", "canary-replacement-nonce")
+    path = runtime / "resident_queue_control_loop_receipts.jsonl"
+    _write_control_receipt_and_head(runtime, original)
+
+    def runner(_: Path) -> dict[str, object]:
+        path.write_text(json.dumps(replacement) + "\n", encoding="utf-8")
+        return {
+            "accepted": True,
+            "status": "PASS",
+            "receipt_id": replacement["receipt_id"],
+        }
+
+    receipt = run_reddog_resident_live_canary(
+        **_kwargs(repo, runtime), execute=True,
+        confirmation=LIVE_CANARY_CONFIRMATION, queue_item_id=QUEUE_ID,
+        control_loop_runner=runner,
+        now=lambda: __import__("datetime").datetime.fromisoformat(NOW),
+    )
+
+    assert "control_receipt_stream_not_append_only" in receipt.blockers
+    assert receipt.status != LIVE_CANARY_PROOF_COMPLETE
 
 
 def test_live_proof_requires_a_pre_invocation_chain_revision(tmp_path: Path) -> None:
@@ -304,6 +547,21 @@ def test_shared_control_lock_excludes_a_competing_process(tmp_path: Path) -> Non
         ) as competing:
             assert competing.acquired is False
             assert competing.reason == "control_loop_already_running"
+        from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
+            claim_reddog_signed_worker_dispatch_tasks_until_idle,
+        )
+
+        with patch.dict(
+            os.environ,
+            {CONTROL_LOOP_LOCK_PATH_ENV: str(lock_path)},
+            clear=False,
+        ):
+            result = claim_reddog_signed_worker_dispatch_tasks_until_idle(
+                repo_root=repo,
+                agent_db_factory=lambda: pytest.fail("AgentDB must not be opened"),
+            )
+        assert result["accepted"] is False
+        assert "control_loop_already_running" in result["rejection_reasons"]
     finally:
         if child.stdin is not None:
             child.stdin.write("\n")
@@ -327,7 +585,7 @@ def test_actual_resident_chain_schema_and_constants_reach_complete_plan() -> Non
         _snapshot(), chain_results=stages, requested_queue_item_id=QUEUE_ID,
         now_iso="2026-07-14T00:00:00+00:00",
     )
-    assert CONTROL_LOOP_RECEIPT_SCHEMA_VERSION == "reddog_resident_control_loop_receipt.v1"
+    assert CONTROL_LOOP_RECEIPT_SCHEMA_VERSION == "reddog_resident_control_loop_receipt.v2"
     assert CHAIN_RESULTS_SCHEMA_VERSION == "reddog_resident_queue_chain_results.v1"
     assert plan.status == RESIDENT_QUEUE_ORCHESTRATION_PLAN_COMPLETE
     assert len(plan.accepted_stages) == len(_CHAIN) + 1
@@ -349,3 +607,57 @@ def test_live_canary_production_files_and_functions_follow_wsp62() -> None:
                     oversized_functions[f"{path.name}:{node.name}"] = lines
     assert oversized_files == {}
     assert oversized_functions == {}
+
+
+def test_modified_control_receipt_helpers_follow_wsp62() -> None:
+    targets = {
+        Path(__file__).resolve().parents[4] / "main.py": {
+            "_reddog_record_queue_control_result",
+            "_reddog_persist_queue_control_receipt",
+            "_reddog_control_receipt_signer_limits",
+            "_reddog_queue_stage_child_execution_outcomes",
+            "run_reddog_resident_queue_control_loop_preflight",
+            "_reddog_run_bounded_control_rounds",
+            "_reddog_run_control_round",
+            "run_reddog_openclaw_signed_worker_claim_loop_preflight",
+        },
+        SRC_ROOT / "openclaw_supervisor.py": {
+            "_claim_reddog_signed_worker_dispatch_task_once_under_control_lock",
+            "_claim_reddog_signed_worker_dispatch_tasks_until_idle_under_control_lock",
+            "_signed_worker_claim_result",
+            "_signed_worker_claim_loop_result",
+            "_signed_worker_effect_attestations",
+            "_signed_worker_loop_evidence",
+            "_signed_worker_child_execution_outcomes",
+            "_persist_reddog_signed_worker_dispatch_task_result",
+        },
+        SRC_ROOT / "reddog_ed25519_signer_backend.py": {
+            "_valid_control_receipt_signing_payload",
+            "_control_authority_policy_matches",
+            "sign",
+        },
+        SRC_ROOT / "reddog_signed_worker_dispatch_task_executor.py": {
+            "execute_reddog_signed_worker_dispatch_task",
+            "_validated_worker_context",
+            "_invoke_signed_worker_runner",
+            "_accepted_execution_result",
+        },
+    }
+    oversized = {}
+    for path, names in targets.items():
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in names:
+                lines = int(node.end_lineno or node.lineno) - node.lineno + 1
+                if lines > 50:
+                    oversized[f"{path.name}:{node.name}"] = lines
+    assert oversized == {}
+    bounded_modules = (
+        SRC_ROOT / "reddog_signer_delegated_authority_runtime.py",
+        SRC_ROOT / "reddog_authority_runtime_store.py",
+    )
+    assert {
+        path.name: len(path.read_text(encoding="utf-8").splitlines())
+        for path in bounded_modules
+        if len(path.read_text(encoding="utf-8").splitlines()) > 675
+    } == {}

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_chain_results_store.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import ast
 import json
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
+
+import pytest
 
 from modules.communication.moltbot_bridge.src.reddog_main_resident_queue_orchestration_plan_bootstrap import (
     run_reddog_main_resident_queue_orchestration_plan_bootstrap,
@@ -41,6 +45,19 @@ MODULE_PATH = (
 )
 NOW = "2026-07-14T00:00:00+00:00"
 EXPIRES = "2026-07-14T01:00:00+00:00"
+
+
+def _concurrent_commit(args: tuple[str, str]) -> str:
+    path, marker = args
+    store = AtomicJsonResidentQueueChainResultsStore(path)
+    try:
+        store.commit(
+            {"schema_version": "test.v1", "marker": marker, "receipts": []},
+            expected_revision=None,
+        )
+    except RuntimeError as exc:
+        return str(exc)
+    return "committed"
 
 
 def _queue_wsp15_allocation_receipt() -> dict[str, object]:
@@ -287,6 +304,37 @@ def test_multi_stage_recording_keeps_serial_order() -> None:
     assert result.next_plan is not None
     assert result.next_plan.next_action == NEXT_QUEUE_WORKTREE_CREATE_INVOKE
     assert result.next_plan.current_stage == "worktree_create"
+
+
+def test_atomic_store_cross_process_compare_and_swap_allows_one_commit(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "runtime" / "chain-results.json"
+    jobs = [(str(path), "first"), (str(path), "second")]
+
+    with ProcessPoolExecutor(
+        max_workers=2,
+        mp_context=multiprocessing.get_context("spawn"),
+    ) as executor:
+        outcomes = list(executor.map(_concurrent_commit, jobs))
+
+    assert sorted(outcomes) == ["committed", "revision_conflict"]
+    stored = json.loads(path.read_text(encoding="utf-8"))
+    assert stored["marker"] in {"first", "second"}
+
+
+def test_relative_and_absolute_store_paths_share_one_canonical_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    relative = AtomicJsonResidentQueueChainResultsStore("runtime/chain-results.json")
+    absolute = AtomicJsonResidentQueueChainResultsStore(
+        tmp_path / "runtime" / "chain-results.json"
+    )
+    assert relative.path == absolute.path
+    relative.commit({"marker": "first"}, expected_revision=None)
+    with pytest.raises(RuntimeError, match="revision_conflict"):
+        absolute.commit({"marker": "stale"}, expected_revision=None)
 
 
 def test_module_has_no_bridge_invocation_or_reindex_imports() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_runtime_artifact_confinement.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_runtime_artifact_confinement.py
@@ -9,8 +9,11 @@ from pathlib import Path
 
 import pytest
 
+from modules.communication.moltbot_bridge.src import openclaw_supervisor
 from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
     append_resident_control_loop_receipt,
+    build_resident_control_loop_receipt,
+    verify_resident_control_loop_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
     PROFILE_SIGNED_0102_BOUNDED_CODE,
@@ -18,22 +21,75 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
 )
 
 
+def _claim_evidence(task_id: str, receipt_id: str) -> dict[str, object]:
+    return openclaw_supervisor._signed_worker_claim_result(
+        accepted=True,
+        status=openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
+        task_id=task_id,
+        receipt_id=receipt_id,
+    )
+
+
 def _result() -> dict[str, object]:
+    evidence = _claim_evidence("task-1", "receipt-1")
+    evidence_digest = str(evidence["execution_result_digest"])
     return {
         "accepted": True,
         "status": "complete",
         "rounds": 1,
         "serial_progress": 1,
         "claim_progress": 1,
+        "worker_claim_count": 1,
+        "worker_completion_count": 1,
+        "worker_requeue_count": 0,
+        "worker_failure_count": 0,
         "receipt_ids": ["receipt-1"],
+        "child_execution_receipt_ids": ["receipt-1"],
+        "child_execution_evidence_digests": [evidence_digest],
+        "child_execution_outcomes": [
+            {
+                "task_id": "task-1", "status": "completed",
+                "receipt_id": "receipt-1", "evidence_digest": evidence_digest,
+                "worker_execution_performed": False,
+                "effect_evidence_complete": True,
+                "worker_process_spawn_count": 0,
+                "shell_command_count": 0,
+            }
+        ],
+        "child_execution_evidence": [evidence],
         "rejection_reasons": [],
     }
+
+
+def _set_child_outcomes(
+    result: dict[str, object], receipts: list[str]
+) -> None:
+    evidence = [
+        _claim_evidence(f"task-{index}", receipt_id)
+        for index, receipt_id in enumerate(receipts, start=1)
+    ]
+    digests = [str(item["execution_result_digest"]) for item in evidence]
+    result["receipt_ids"] = list(receipts)
+    result["child_execution_receipt_ids"] = list(receipts)
+    result["child_execution_evidence_digests"] = list(digests)
+    result["child_execution_outcomes"] = [
+        {
+            "task_id": f"task-{index}", "status": "completed",
+            "receipt_id": receipt_id, "evidence_digest": digest,
+            "worker_execution_performed": False,
+            "effect_evidence_complete": True,
+            "worker_process_spawn_count": 0,
+            "shell_command_count": 0,
+        }
+        for index, (receipt_id, digest) in enumerate(zip(receipts, digests), start=1)
+    ]
+    result["child_execution_evidence"] = evidence
 
 
 def _append_receipt_process(args: tuple[str, str, int]) -> str:
     repo, target, index = args
     result = _result()
-    result["receipt_ids"] = [f"process-receipt-{index}"]
+    _set_child_outcomes(result, [f"process-receipt-{index}"])
     receipt = append_resident_control_loop_receipt(
         path=target,
         result=result,
@@ -133,7 +189,7 @@ def test_receipt_store_serializes_concurrent_appends_as_valid_jsonl(tmp_path: Pa
 
     def append(index: int) -> None:
         result = _result()
-        result["receipt_ids"] = [f"receipt-{index}"]
+        _set_child_outcomes(result, [f"receipt-{index}"])
         append_resident_control_loop_receipt(
             path=target,
             result=result,
@@ -169,3 +225,95 @@ def test_receipt_store_serializes_cross_process_appends(tmp_path: Path) -> None:
     assert {row["receipt_ids"][0] for row in rows} == {
         f"process-receipt-{index}" for index in range(8)
     }
+
+
+def test_receipt_effect_claims_are_derived_from_stages_and_claim_progress(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = _result()
+    _set_child_outcomes(result, ["receipt-1", "receipt-2"])
+    result.update(
+        {
+            "claim_progress": 2,
+            "worker_claim_count": 2,
+            "worker_completion_count": 2,
+            "dispatched_stages": ["authority_runtime", "bounded_worker_pilot"],
+        }
+    )
+
+    receipt = build_resident_control_loop_receipt(
+        result=result,
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00+00:00",
+    )
+
+    assert receipt.authority_issued is True
+    assert receipt.worker_claim_performed is True
+    assert receipt.worker_execution_performed is True
+    assert receipt.bounded_file_edit_observed is True
+    assert receipt.shell_command_execution_observed is False
+    assert receipt.shell_command_count == 0
+    assert receipt.worker_process_spawn_observed is False
+    assert receipt.worker_process_spawn_count == 0
+
+
+def test_receipt_builder_rejects_caller_effect_claim_conflict(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    result = _result()
+    result.update(
+        {
+            "dispatched_stages": ["authority_runtime"],
+            "authority_issued": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="effect_claim_conflict:authority_issued"):
+        build_resident_control_loop_receipt(
+            result=result,
+            repo_root=repo,
+            created_at="2026-07-18T00:00:00+00:00",
+        )
+
+
+def test_receipt_verifier_rejects_tampered_serialized_mapping(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    receipt = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00+00:00",
+    ).to_dict()
+    receipt["status"] = "FORGED_PASS"
+
+    with pytest.raises(ValueError, match="digest_invalid"):
+        verify_resident_control_loop_receipt(receipt, expected_repo_root=repo)
+
+
+def test_receipt_store_rejects_tampered_existing_receipt_unchanged(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = tmp_path / "runtime" / "receipt.jsonl"
+    target.parent.mkdir()
+    receipt = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00+00:00",
+    ).to_dict()
+    receipt["accepted"] = False
+    original = json.dumps(receipt, sort_keys=True) + "\n"
+    target.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="digest_invalid"):
+        append_resident_control_loop_receipt(
+            path=target,
+            result=_result(),
+            repo_root=repo,
+            created_at="2026-07-18T00:00:01+00:00",
+        )
+
+    assert target.read_text(encoding="utf-8") == original

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_dispatch_task_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import subprocess
 import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
@@ -25,6 +26,7 @@ from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
     SIGNED_WORKER_OPENCLAW_CLAIM_REJECT,
     SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
     SignedWorkerOpenClawClaimReason,
+    _signed_worker_claim_loop_result,
     claim_reddog_signed_worker_dispatch_task_once,
     claim_reddog_signed_worker_dispatch_tasks_until_idle,
 )
@@ -117,10 +119,12 @@ class _FakeRunner:
         accepted: bool = True,
         unsafe: bool = False,
         requeue_required: bool = False,
+        result_overrides: dict | None = None,
     ) -> None:
         self.accepted = accepted
         self.unsafe = unsafe
         self.requeue_required = requeue_required
+        self.result_overrides = dict(result_overrides or {})
         self.calls = []
 
     def run_signed_worker_dispatch_task(
@@ -147,14 +151,27 @@ class _FakeRunner:
             "rejection_reasons": [] if self.accepted else ["runner_declined"],
             "no_source_repo_mutation_performed": not self.unsafe,
             "no_shell_command_executed": not self.unsafe,
+            "no_holoindex_reindex_performed": True,
+            "no_hermes_dispatch_performed": True,
+            "no_worktree_operation_performed": True,
+            "no_pr_created": True,
+            "no_live_foundup_enqueue_performed": True,
+            "no_pattern_memory_write_performed": True,
+            "no_reward_settlement_performed": True,
+            "worker_process_spawn_count": 0,
+            "shell_command_count": 0,
         }
         if self.requeue_required:
             result["queue_chain_complete"] = False
             result["queue_chain_requeue_required"] = True
+        result.update(self.result_overrides)
         return result
 
 
 class _FakeQueryAdapter:
+    def __init__(self, repo_head_sha: str = "abc123") -> None:
+        self.repo_head_sha = repo_head_sha
+
     def query(self, *, query: str, allowed_paths, limit: int):
         path = allowed_paths[0] if allowed_paths else "docs/work_ledger.schema.json"
         return {
@@ -174,7 +191,7 @@ class _FakeQueryAdapter:
             "freshness_generation_id": "generation-1",
             "freshness_receipt_digest": "sha256:freshness",
             "freshness_receipt_path": "O:/Foundups-Agent/.holoindex/freshness.json",
-            "repo_head_sha": "abc123",
+            "repo_head_sha": self.repo_head_sha,
         }
 
 
@@ -466,7 +483,29 @@ def _repo_with_readonly_target(tmp_path: Path) -> Path:
     target = root / "docs" / "work_ledger.schema.json"
     target.parent.mkdir(parents=True)
     target.write_text('{"schema": "work-ledger", "version": 1}\n', encoding="utf-8")
+    subprocess.run(["git", "init", str(root)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.email", "test@example.invalid"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.name", "RedDog Test"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(["git", "-C", str(root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(root), "commit", "-m", "test: seed readonly target"],
+        check=True, capture_output=True,
+    )
     return root
+
+
+def _repo_head(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    )
+    return result.stdout.strip()
 
 
 def test_signed_worker_executor_accepts_valid_task_with_injected_runner(tmp_path: Path) -> None:
@@ -485,6 +524,9 @@ def test_signed_worker_executor_accepts_valid_task_with_injected_runner(tmp_path
     assert result.capability == "candidate_queue_review"
     assert result.no_shell_command_executed is True
     assert result.no_source_repo_mutation_performed is True
+    assert result.worker_execution_performed is True
+    assert result.worker_process_spawn_count == 0
+    assert result.shell_command_count == 0
     assert runner.calls[0]["worker_dispatch_intent"]["intent_id"] == "worker_dispatch_intent_openclaw_candidate"
 
 
@@ -554,8 +596,8 @@ def test_signed_0102_readonly_runner_executes_architect_review_with_bound_target
     model_runner = _EchoEvidenceModelRunner()
     runner = Signed0102ReadOnlyReviewRunner(
         model_runner=model_runner,
-        holoindex_adapter=_FakeQueryAdapter(),
-        codeindex_adapter=_FakeQueryAdapter(),
+        holoindex_adapter=_FakeQueryAdapter(_repo_head(repo)),
+        codeindex_adapter=_FakeQueryAdapter(_repo_head(repo)),
     )
 
     result = execute_reddog_signed_worker_dispatch_task(
@@ -577,6 +619,7 @@ def test_signed_0102_readonly_runner_executes_architect_review_with_bound_target
     assert model_runner.calls[0]["binding"]["wsp15_allocation_receipt_id"] == allocation["receipt_id"]
     assert result.no_source_repo_mutation_performed is True
     assert result.no_shell_command_executed is True
+    assert result.no_live_foundup_enqueue_performed is True
 
 
 def test_signed_0102_readonly_runner_receives_model_runtime_binding_receipt(
@@ -613,8 +656,8 @@ def test_signed_0102_readonly_runner_receives_model_runtime_binding_receipt(
         repo_root=repo,
         runner=Signed0102ReadOnlyReviewRunner(
             model_runner=model_runner,
-            holoindex_adapter=_FakeQueryAdapter(),
-            codeindex_adapter=_FakeQueryAdapter(),
+            holoindex_adapter=_FakeQueryAdapter(_repo_head(repo)),
+            codeindex_adapter=_FakeQueryAdapter(_repo_head(repo)),
         ),
     )
 
@@ -686,6 +729,7 @@ def test_signed_worker_executor_rejects_tampered_receipt_and_wsp15(tmp_path: Pat
     assert result.accepted is False
     assert SignedWorkerDispatchTaskExecutorReason.INTENT_NOT_IN_RECEIPT in result.rejection_reasons
     assert SignedWorkerDispatchTaskExecutorReason.WSP15_MISMATCH in result.rejection_reasons
+    assert result.worker_execution_performed is False
 
 
 def test_signed_worker_executor_rejects_unsafe_runner(tmp_path: Path) -> None:
@@ -698,6 +742,66 @@ def test_signed_worker_executor_rejects_unsafe_runner(tmp_path: Path) -> None:
 
     assert result.accepted is False
     assert SignedWorkerDispatchTaskExecutorReason.RUNNER_UNSAFE in result.rejection_reasons
+    assert result.no_source_repo_mutation_performed is False
+    assert result.no_shell_command_executed is False
+    assert result.worker_execution_performed is True
+    assert result.shell_command_count == 1
+
+
+def test_signed_worker_executor_counts_rejected_and_raising_runner_execution(
+    tmp_path: Path,
+) -> None:
+    rejected = execute_reddog_signed_worker_dispatch_task(
+        task_context=_task_context(), task_id="task-rejected",
+        repo_root=tmp_path, runner=_FakeRunner(accepted=False),
+    )
+
+    class RaisingRunner:
+        def run_signed_worker_dispatch_task(self, **kwargs):
+            raise RuntimeError("runner failed after invocation")
+
+    raised = execute_reddog_signed_worker_dispatch_task(
+        task_context=_task_context(), task_id="task-raised",
+        repo_root=tmp_path, runner=RaisingRunner(),
+    )
+
+    assert rejected.worker_execution_performed is True
+    assert raised.worker_execution_performed is True
+    assert raised.effect_evidence_complete is False
+    assert raised.no_shell_command_executed is False
+    assert raised.no_source_repo_mutation_performed is False
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED in rejected.rejection_reasons
+    assert SignedWorkerDispatchTaskExecutorReason.RUNNER_REJECTED in raised.rejection_reasons
+
+
+def test_signed_worker_executor_rejects_incomplete_or_inconsistent_effect_evidence(
+    tmp_path: Path,
+) -> None:
+    context = _task_context()
+    incomplete = _FakeRunner(result_overrides={"shell_command_count": None})
+    inconsistent = _FakeRunner(result_overrides={"shell_command_count": 1})
+
+    incomplete_result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-incomplete-effects",
+        repo_root=tmp_path,
+        runner=incomplete,
+    )
+    inconsistent_result = execute_reddog_signed_worker_dispatch_task(
+        task_context=context,
+        task_id="task-inconsistent-effects",
+        repo_root=tmp_path,
+        runner=inconsistent,
+    )
+
+    for result in (incomplete_result, inconsistent_result):
+        assert result.accepted is False
+        assert result.effect_evidence_complete is False
+        assert result.no_shell_command_executed is False
+        assert (
+            SignedWorkerDispatchTaskExecutorReason.RUNNER_EFFECT_EVIDENCE_INCOMPLETE
+            in result.rejection_reasons
+        )
 
 
 def test_run_task_routes_signed_worker_before_wre_fallback(tmp_path: Path, monkeypatch) -> None:
@@ -928,7 +1032,65 @@ def test_openclaw_signed_worker_claim_rejects_when_result_persistence_fails(
     assert SignedWorkerOpenClawClaimReason.RESULT_PERSISTENCE_REJECTED in result[
         "rejection_reasons"
     ]
-    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "failed"
+    assert AgentDB().get_autonomous_task_by_id(task_id)["status"] == "assigned"
+
+
+@pytest.mark.parametrize(
+    "requeue_required",
+    (False, True),
+)
+def test_openclaw_signed_worker_claim_rejects_when_task_transition_fails(
+    tmp_path: Path,
+    monkeypatch,
+    requeue_required: bool,
+) -> None:
+    _publish_agentdb_task()
+    from modules.communication.moltbot_bridge.src import openclaw_supervisor
+
+    monkeypatch.setattr(
+        openclaw_supervisor,
+        "_commit_signed_worker_task_result",
+        lambda *_, **__: False,
+    )
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=_FakeRunner(requeue_required=requeue_required),
+    )
+
+    assert result["accepted"] is False
+    assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_REJECT
+    assert (
+        SignedWorkerOpenClawClaimReason.TASK_STATE_TRANSITION_REJECTED
+        in result["rejection_reasons"]
+    )
+
+
+def test_openclaw_signed_worker_rejection_surfaces_failed_failure_transition(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _publish_agentdb_task()
+    from modules.communication.moltbot_bridge.src import openclaw_supervisor
+
+    monkeypatch.setattr(
+        openclaw_supervisor,
+        "_persist_reddog_signed_worker_dispatch_task_result",
+        lambda *_, **__: False,
+    )
+
+    result = claim_reddog_signed_worker_dispatch_task_once(
+        repo_root=tmp_path,
+        signed_worker_runner=None,
+    )
+
+    assert result["accepted"] is False
+    assert result["worker_execution_performed"] is False
+    assert result["effect_evidence_complete"] is True
+    assert (
+        SignedWorkerOpenClawClaimReason.TASK_STATE_TRANSITION_REJECTED
+        in result["rejection_reasons"]
+    )
 
 
 def test_openclaw_claim_executes_0102_readonly_task_when_env_enabled(
@@ -1981,6 +2143,12 @@ def test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues(
     assert result["idle"] is True
     assert result["max_claims_reached"] is False
     assert result["claim_results"][-1]["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_IDLE
+    assert len(result["receipt_ids"]) == 7
+    assert len(result["child_execution_evidence_digests"]) == 7
+    assert all(
+        digest.startswith("sha256:")
+        for digest in result["child_execution_evidence_digests"]
+    )
     assert [claim["status"] for claim in result["claim_results"][:-1]] == [
         SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
         SIGNED_WORKER_OPENCLAW_CLAIM_REQUEUED,
@@ -2328,6 +2496,7 @@ def test_openclaw_claim_loop_respects_max_claims(tmp_path: Path) -> None:
     assert result["completed_task_ids"] == (task_id_1,)
     assert result["max_claims_reached"] is True
     assert result["idle"] is False
+    assert len(result["child_execution_evidence_digests"]) == 1
     assert db.get_autonomous_task_by_id(task_id_1)["status"] == "completed"
     assert db.get_autonomous_task_by_id(task_id_2)["status"] == "pending"
 
@@ -2401,7 +2570,7 @@ def test_openclaw_claim_loop_stops_after_first_rejected_claim(tmp_path: Path) ->
 
     assert result["accepted"] is False
     assert result["status"] == SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_REJECT
-    assert result["claimed_count"] == 0
+    assert result["claimed_count"] == 1
     assert len(result["failed_task_ids"]) == 1
     assert SignedWorkerOpenClawClaimReason.CLAIM_REJECTED in result["rejection_reasons"]
     statuses = {
@@ -2409,6 +2578,31 @@ def test_openclaw_claim_loop_stops_after_first_rejected_claim(tmp_path: Path) ->
         task_id_2: db.get_autonomous_task_by_id(task_id_2)["status"],
     }
     assert sorted(statuses.values()) == ["failed", "pending"]
+
+
+def test_claim_loop_no_effect_attestations_are_strict_booleans() -> None:
+    result = _signed_worker_claim_loop_result(
+        accepted=True,
+        status=SIGNED_WORKER_OPENCLAW_CLAIM_LOOP_ACCEPT,
+        max_claims=1,
+        claim_results=(
+            {
+                "no_shell_command_executed": "false",
+                "no_repo_mutation_performed": True,
+                "no_holoindex_reindex_performed": True,
+                "no_hermes_dispatch_performed": True,
+                "no_worktree_operation_performed": True,
+                "no_pr_created": True,
+                "no_live_foundup_enqueue_performed": True,
+                "no_pattern_memory_write_performed": True,
+                "no_reward_settlement_performed": True,
+            },
+        ),
+        completed_task_ids=("task-1",),
+    )
+
+    assert result["no_shell_command_executed"] is False
+    assert result["no_repo_mutation_performed"] is True
 
 
 def test_openclaw_claim_loop_rejects_invalid_max_claims(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_queue_serial_loop_runner.py
@@ -84,6 +84,16 @@ def _digest(value: object) -> str:
     return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
+def _runtime_paths_env(tmp_path: Path) -> dict[str, str]:
+    runtime_root = tmp_path.parent / f"{tmp_path.name}-resident-runtime"
+    return {
+        "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
+        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(runtime_root / "state.json"),
+        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(runtime_root / "chain.json"),
+        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(runtime_root / "profile.json"),
+    }
+
+
 def _allocation():
     return {
         "schema_version": "reddog_wsp15_allocation_receipt.v1",
@@ -357,9 +367,7 @@ def test_runtime_binding_builds_runner_from_explicit_env(tmp_path: Path) -> None
     bootstrap = _FakeBootstrap()
     env = {
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
         "REDDOG_WORK_ORDER_MATERIALIZER_MODE": "authority_profile",
         "REDDOG_RESIDENT_QUEUE_SERIAL_LOOP_MAX_STEPS": "1",
         "REDDOG_RESIDENT_QUEUE_NOW_EPOCH": "1000",
@@ -391,9 +399,7 @@ def test_runtime_binding_builds_runner_from_explicit_env(tmp_path: Path) -> None
 def test_runtime_binding_profile_enables_runner_without_explicit_runner_flag(tmp_path: Path) -> None:
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -411,9 +417,7 @@ def test_runtime_binding_fusion_profile_supplies_artifact_generator_mode(tmp_pat
     bootstrap = _FakeBootstrap()
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -443,9 +447,7 @@ def test_runtime_binding_explicit_artifact_generator_mode_overrides_fusion_profi
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion",
         "REDDOG_ARTIFACT_GENERATOR_MODE": "unsafe",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -471,9 +473,7 @@ def test_runtime_binding_worktree_profile_supplies_worktree_runner_mode(tmp_path
     bootstrap = _FakeBootstrap()
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -506,9 +506,7 @@ def test_runtime_binding_explicit_worktree_mode_overrides_worktree_profile(
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree",
         "REDDOG_RESIDENT_QUEUE_WORKTREE_RUNNER_MODE": "unsafe",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -534,9 +532,7 @@ def test_runtime_binding_explicit_zero_disables_runner_profile(tmp_path: Path) -
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "0",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -574,9 +570,7 @@ def test_runtime_binding_builds_draft_pr_runner_when_requested(
     bootstrap = _FakeBootstrap()
     env = {
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
         "REDDOG_DRAFT_PR_RUNNER_MODE": "real",
         "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "88",
     }
@@ -614,9 +608,7 @@ def test_runtime_binding_draft_pr_profile_supplies_verified_draft_runner(
     bootstrap = _FakeBootstrap()
     env = {
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code_fusion_worktree_draft_pr",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
         "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "89",
     }
 
@@ -673,9 +665,7 @@ def test_runtime_binding_pattern_memory_profile_derives_outside_repo_sink(
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": (
             "signed_0102_bounded_code_fusion_worktree_draft_pr_pattern_memory"
         ),
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
         "REDDOG_DRAFT_PR_RUNNER_TIMEOUT_S": "90",
     }
 
@@ -733,9 +723,7 @@ def test_runtime_binding_rejects_unsupported_draft_pr_runner_mode(tmp_path: Path
         repo_root=tmp_path,
         env={
             "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
-            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+            **_runtime_paths_env(tmp_path),
             "REDDOG_DRAFT_PR_RUNNER_MODE": "unsafe",
         },
         bootstrap=_FakeBootstrap(),
@@ -757,9 +745,7 @@ def test_runtime_binding_builds_pattern_memory_admission_sink_from_outside_repo_
     bootstrap = _FakeBootstrap()
     env = {
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
         "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "1",
         "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(tmp_path / "pattern_memory.db"),
     }
@@ -794,9 +780,7 @@ def test_runtime_binding_profile_defaults_derivation_flags(tmp_path: Path) -> No
     env = {
         "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -934,9 +918,7 @@ def test_runtime_binding_profile_respects_explicit_binding_disable(tmp_path: Pat
         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
         "REDDOG_ARTIFACT_GENERATION_REQUEST_BINDING": "0",
         "REDDOG_WORKER_DISPATCH_AGENTDB_WRITER": "0",
-        "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-        "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-        "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+        **_runtime_paths_env(tmp_path),
     }
 
     binding = build_reddog_signed_worker_queue_loop_runner_from_env(
@@ -968,9 +950,7 @@ def test_runtime_binding_rejects_pattern_memory_admission_db_inside_repo(
         repo_root=repo,
         env={
             "REDDOG_SIGNED_WORKER_QUEUE_LOOP_RUNNER": "1",
-            "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
-            "REDDOG_RESIDENT_QUEUE_CHAIN_RESULTS_PATH": str(tmp_path / "chain.json"),
-            "REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH": str(tmp_path / "profile.json"),
+            **_runtime_paths_env(tmp_path),
             "REDDOG_PATTERN_MEMORY_ADMISSION_DB_PATH": str(repo / "pattern_memory.db"),
         },
         bootstrap=_FakeBootstrap(),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_control_loop_anchor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_control_loop_anchor.py
@@ -1,0 +1,84 @@
+"""Tests for the signer-owned control-loop monotonic anchor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
+    AtomicSignerControlLoopAnchorStore,
+)
+
+
+def _payload(sequence: int, previous: str = "") -> dict[str, object]:
+    return {
+        "sequence_number": sequence,
+        "previous_receipt_id": previous,
+        "receipt_id": f"receipt-{sequence}",
+        "cycle_id": f"cycle-{sequence}",
+        "nonce": f"nonce-{sequence}",
+        "child_execution_receipt_ids": [f"child-{sequence}"],
+        "child_execution_evidence_digests": [f"digest-{sequence}"],
+    }
+
+
+def _response(sequence: int) -> dict[str, str]:
+    return {
+        "signature": f"signature-{sequence}",
+        "audit_mac": f"audit-{sequence}",
+        "audit_attestation_signature": f"attestation-{sequence}",
+    }
+
+
+def _commit(store: AtomicSignerControlLoopAnchorStore, payload: dict[str, object]) -> None:
+    prepared = store.prepare(payload)
+    store.commit(
+        payload,
+        _response(int(payload["sequence_number"])),
+        expected_revision=prepared.expected_revision,
+    )
+
+
+def test_anchor_rejects_resident_rollback_but_allows_exact_recovery(
+    tmp_path: Path,
+) -> None:
+    store = AtomicSignerControlLoopAnchorStore(tmp_path / "signer" / "anchor.json")
+    first = _payload(1)
+    second = _payload(2, "receipt-1")
+    _commit(store, first)
+    _commit(store, second)
+
+    replay = store.prepare(second)
+    assert replay.replay_response == _response(2)
+    store.commit(second, _response(2), expected_revision=replay.expected_revision)
+
+    rolled_back_candidate = {
+        **_payload(2, "receipt-1"),
+        "receipt_id": "different-receipt-2",
+        "cycle_id": "different-cycle-2",
+        "nonce": "different-nonce-2",
+    }
+    with pytest.raises(ValueError, match="rollback_detected"):
+        store.prepare(rolled_back_candidate)
+
+
+def test_anchor_rejects_reused_child_evidence(tmp_path: Path) -> None:
+    store = AtomicSignerControlLoopAnchorStore(tmp_path / "signer" / "anchor.json")
+    first = _payload(1)
+    _commit(store, first)
+    second = _payload(2, "receipt-1")
+    second["child_execution_receipt_ids"] = first[
+        "child_execution_receipt_ids"
+    ]
+    with pytest.raises(ValueError, match="child_receipt_replay"):
+        store.prepare(second)
+
+
+def test_anchor_state_tamper_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "signer" / "anchor.json"
+    store = AtomicSignerControlLoopAnchorStore(path)
+    _commit(store, _payload(1))
+    path.write_text('{"schema_version":"forged"}\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="state_invalid"):
+        store.load()

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ast
 import hashlib
 import hmac
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from modules.communication.moltbot_bridge.src import reddog_signer_delegated_authority_runtime as r
@@ -462,6 +464,51 @@ def test_json_store_commits_authority_receipt(tmp_path) -> None:
     content = path.read_text(encoding="utf-8")
     assert request.work_order_id in content
     assert result.receipt.store_revision
+
+
+def test_json_store_compare_and_swap_is_serialized_across_store_instances(
+    tmp_path,
+) -> None:
+    path = tmp_path / "authority-state.json"
+    barrier = threading.Barrier(2)
+
+    def commit(index: int) -> str:
+        barrier.wait(timeout=5)
+        try:
+            AtomicJsonAuthorityRuntimeStore(path).commit(
+                {"writer": index}, expected_revision=None
+            )
+        except RuntimeError as exc:
+            return str(exc)
+        return "committed"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = list(executor.map(commit, (1, 2)))
+
+    assert sorted(outcomes) == ["committed", "revision_conflict"]
+    assert AtomicJsonAuthorityRuntimeStore(path).load()["writer"] in {1, 2}
+
+
+def test_json_store_fsyncs_parent_directory_after_atomic_replace(
+    tmp_path, monkeypatch
+) -> None:
+    from modules.communication.moltbot_bridge.src import (
+        reddog_authority_runtime_store as store_module,
+    )
+
+    observed = []
+    monkeypatch.setattr(
+        store_module,
+        "_fsync_parent_directory",
+        lambda path: observed.append(path),
+    )
+    target = tmp_path / "authority-state.json"
+
+    AtomicJsonAuthorityRuntimeStore(target).commit(
+        {"writer": 1}, expected_revision=None
+    )
+
+    assert observed == [tmp_path]
 
 
 def test_result_contains_no_secret_or_signing_material_labels() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
 from pathlib import Path
 
@@ -46,8 +47,10 @@ def _authority_profile(**overrides: object) -> dict[str, object]:
         "principal_public_key": "ed25519-pub-v1:principal",
         "reddog_id": "reddog:foundups-agent",
         "reddog_public_key": "ed25519-pub-v1:reddog",
-        "permission_snapshot_digest": "sha256:permission",
+        "permission_snapshot_digest": "sha256:" + "1" * 64,
         "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:" + "2" * 64,
+        "authority_profile_source_receipt_id": "sha256:" + "3" * 64,
         "identity_ttl_seconds": 600,
         "work_authority_ttl_seconds": 300,
     }
@@ -95,6 +98,24 @@ def test_config_supply_writes_multi_profile_signer_cli_config(tmp_path: Path) ->
     assert payload["allow_test_only_key_material"] is False
     assert payload["permission_snapshot_fresh"] is True
     assert payload["socket_path"] == str((runtime / "reddog-signer.sock").resolve())
+    control_policy = payload["control_loop_authority_policy"]
+    assert control_policy == {
+        "issuer_principal_id": "github:mjtrout",
+        "signer_public_key": "ed25519-pub-v1:reddog",
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:" + "2" * 64,
+        "authority_profile_digest": control_policy["authority_profile_digest"],
+        "authority_profile_source_receipt_id": "sha256:" + "3" * 64,
+    }
+    expected_profile_digest = "sha256:" + hashlib.sha256(
+        json.dumps(
+            _authority_profile(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    assert control_policy["authority_profile_digest"] == expected_profile_digest
     assert payload["peer_policy"] == {
         "uid_to_principal": {"1001": "github:mjtrout"},
         "allowed_gids": [1002],

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -258,6 +259,7 @@ def test_reddog_queue_control_loop_profile_repeats_serial_and_claim(monkeypatch)
         "signed_0102_bounded_code_fusion_worktree_draft_pr",
     )
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "3")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPT_PERSISTENCE", "0")
 
     with patch.object(
         main,
@@ -273,6 +275,101 @@ def test_reddog_queue_control_loop_profile_repeats_serial_and_claim(monkeypatch)
     assert calls == ["serial", "claim", "serial", "claim", "serial", "claim"]
 
 
+def test_reddog_queue_control_receipt_reports_observed_authority_and_worker_effects(
+    monkeypatch, tmp_path
+):
+    from modules.communication.moltbot_bridge.tests.reddog_resident_live_canary_test_support import (
+        _SIGNING_CONTEXT,
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime_root = tmp_path / "runtime"
+    receipt_path = runtime_root / "control-receipts.jsonl"
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPT_PERSISTENCE", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_RUNTIME_ROOT", str(runtime_root))
+    monkeypatch.setenv(
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPTS_PATH", str(receipt_path)
+    )
+
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_control_loop_signing_context."
+        "build_control_loop_receipt_signing_context",
+        return_value=_SIGNING_CONTEXT,
+    ), patch.object(
+        main, "run_reddog_resident_queue_serial_loop_preflight"
+    ) as serial, patch.object(
+        main, "run_reddog_openclaw_signed_worker_claim_loop_preflight"
+    ) as claim:
+
+        def serial_side_effect(_repo_root):
+            serial.last_result = {
+                "accepted": True,
+                "progress_count": 2,
+                "dispatched_stages": ("authority_runtime", "bounded_worker_pilot"),
+                "rejection_reasons": (),
+            }
+            return True
+
+        def claim_side_effect(_repo_root):
+            from modules.communication.moltbot_bridge.src import openclaw_supervisor
+
+            evidence = openclaw_supervisor._signed_worker_claim_result(
+                accepted=True,
+                status=openclaw_supervisor.SIGNED_WORKER_OPENCLAW_CLAIM_ACCEPT,
+                task_id="task-1",
+                receipt_id="signed-worker-receipt-1",
+            )
+            claim.last_result = {
+                "accepted": True,
+                "progress_count": 1,
+                "completed_count": 1,
+                "requeued_count": 0,
+                "failed_count": 0,
+                "receipt_ids": ("signed-worker-receipt-1",),
+                    "worker_execution_count": 0,
+                    "worker_process_spawn_count": 0,
+                    "shell_command_count": 0,
+                    "child_execution_evidence_digests": (
+                        evidence["execution_result_digest"],
+                    ),
+                    "child_execution_outcomes": (
+                        {
+                            "task_id": "task-1",
+                            "status": "completed",
+                            "receipt_id": "signed-worker-receipt-1",
+                            "evidence_digest": evidence[
+                                "execution_result_digest"
+                            ],
+                            "worker_execution_performed": False,
+                            "effect_evidence_complete": True,
+                            "worker_process_spawn_count": 0,
+                            "shell_command_count": 0,
+                        },
+                    ),
+                    "child_execution_evidence": (evidence,),
+                "rejection_reasons": (),
+            }
+            return True
+
+        serial.side_effect = serial_side_effect
+        claim.side_effect = claim_side_effect
+        assert main.run_reddog_resident_queue_control_loop_preflight(repo) is True
+
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert receipt["authority_issued"] is True
+    assert receipt["worker_claim_performed"] is True
+    assert receipt["worker_execution_performed"] is True
+    assert receipt["bounded_file_edit_observed"] is True
+    assert receipt["bounded_file_edit_count"] == 1
+    assert receipt["shell_command_execution_observed"] is False
+    assert receipt["shell_command_count"] == 0
+    assert receipt["worker_process_spawn_observed"] is False
+    assert receipt["worker_process_spawn_count"] == 0
+
+
 def test_reddog_queue_control_loop_stops_after_idle_round(monkeypatch):
     calls: list[str] = []
 
@@ -281,6 +378,7 @@ def test_reddog_queue_control_loop_stops_after_idle_round(monkeypatch):
         "signed_0102_bounded_code_fusion_worktree_draft_pr",
     )
     monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "5")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPT_PERSISTENCE", "0")
 
     with patch.object(main, "run_reddog_resident_queue_serial_loop_preflight") as serial, patch.object(
         main,
@@ -338,6 +436,41 @@ def test_reddog_queue_control_loop_invalid_rounds_fail_closed_when_enforced(monk
 
     serial.assert_not_called()
     claim.assert_not_called()
+
+
+def test_control_receipt_persistence_failure_blocks_even_when_not_enforced(
+    monkeypatch, tmp_path
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_MAX_ROUNDS", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_ENFORCED", "0")
+    monkeypatch.setenv(
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPT_PERSISTENCE", "1"
+    )
+    monkeypatch.setenv(
+        "REDDOG_RESIDENT_QUEUE_CONTROL_LOOP_RECEIPTS_PATH",
+        str(tmp_path / "runtime" / "control.jsonl"),
+    )
+
+    with patch.object(
+        main, "run_reddog_resident_queue_serial_loop_preflight"
+    ) as serial, patch.object(
+        main, "_reddog_persist_queue_control_receipt", side_effect=OSError("disk")
+    ):
+        serial.return_value = False
+        serial.last_result = {
+            "accepted": False,
+            "progress_count": 1,
+            "dispatched_stages": ("authority_runtime",),
+            "rejection_reasons": ("serial_reject",),
+        }
+        assert main.run_reddog_resident_queue_control_loop_preflight(repo) is False
+
+    result = main.run_reddog_resident_queue_control_loop_preflight.last_result
+    assert result["status"] == "CONTROL_LOOP_RECEIPT_PERSISTENCE_REJECT"
+    assert result["accepted"] is False
 
 
 def test_reddog_serial_loop_profile_passes_agentdb_worker_dispatch_writer(monkeypatch):


### PR DESCRIPTION
## Summary

- authenticate RedDog resident control receipts with signer-owned Ed25519 policy and monotonic anchors
- rehydrate exact child evidence and derive parent effects from digest-bound outcomes
- make AgentDB result persistence/status transition atomic and serialize control-loop state
- fail closed on replay, rollback, conflicting effects, incomplete evidence, and persistence failures
- split large runtime paths to preserve WSP 62 boundaries

## WSP_97 truth boundary

**OBSERVED**
- v2 receipts are signed and verified before control admission
- parent effects are derived from authenticated child outcomes
- completed/requeued children require complete effect evidence
- runner exceptions cannot claim harmless no-effect outcomes
- AgentDB result receipt and assigned->completed transition use one conditional SQL update
- control receipt/head/anchor persistence fsyncs the parent directory after atomic replace

**SPECIFIED_NOT_IMPLEMENTED / unchanged**
- no broader worker authority
- no extension runtime wiring
- no HoloIndex mutation
- no merge authority expansion

## Verification

- focused control/signing/executor matrix: 118 passed
- WSP_00/bootstrap matrix: 27 passed
- full moltbot_bridge suite: 3705 passed, 8 skipped, 39 known baseline failures
  - baseline clusters are environment/fixture dependent (FoundUp manifests, grant data, FastAPI/model runtime, stale OpenClaw/bootstrap expectations)
  - no new control receipt/signer/effect failures
- compileall: pass
- git diff --check: clean
- new files: ASCII/NUL clean

## Security review

Independent adversarial reviews found and this branch fixed:
- caller-asserted effect counts
- exception paths inventing safe attestations
- swallowed AgentDB transition failures
- same-user signer/runtime trust leakage
- replay/rollback and child-evidence substitution
- missing parent-directory fsync after atomic replacement

