### PR TITLE
fix(reddog): require grounded semantic audit targets

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -312,6 +312,7 @@ Model and context routing:
 - Implementation critic default: `moonshotai/kimi-k2.7-code`.
 - Long-horizon reasoning critic default: `moonshotai/kimi-k3` with mandatory `max` reasoning, no temperature parameter, and a receipt-recorded 4096-token floor for every direct completion call. An explicit direct selection or receipt-backed signed promotion may place K3 in single, principal, or synthesis roles; this bridge does not itself promote a champion, change defaults, open an OpenClaw execution valve, or dispatch Hermes.
 - REGULAR smoke/simple prompts auto-route to `openrouter_single` with the GLM principal and `wsp_holo` HoloIndex grounding (no Fusion panel, Skillz, or git).
+- Substantive audit/research/implementation prompts must produce a non-empty typed target universe. When no explicit path, external source, or semantic header exists, RedDog derives a generic semantic subject and requires content-bearing HoloIndex evidence for it; broad audits require two references across implementation/authority and verification/authority categories. Unparseable work fails before Fusion with `grounding_target_universe_empty`.
 - Context is not a 012-facing selector; it is resolved from WSP_15 tier.
 - Skillz/Wardrobe/Rolodex/OpenClaw/Hermes discovery is context only. RedDog may recommend a governed handoff, but this extension cannot execute it.
 - `openrouter_fusion_alias` remains implemented for future explicit use, but is not the RedDog default because critic traces are not exposed.

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,16 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-19 - REDDOG_BROAD_SEMANTIC_GROUNDING_NONVACUITY_PHASE1 (0.4.3)
+
+- Replaced the hardcoded semantic-domain noun gate with a generic, bounded action-and-subject derivation rule, so short repository audits such as `Audit <FoundUp>` create a semantic target without embedding FoundUp-specific names or paths in the extension.
+- Kept explicit repo paths, external sources, and explicit semantic headers authoritative; generic fallback does not add duplicate `Determine` or prose targets when those stronger channels are present.
+- Added a fail-closed `grounding_target_universe_empty` decision for substantive audit, implementation, verification, and research requests that still produce no actionable target. Fusion is not called after this rejection.
+- Broad audit targets now use one bounded generic query expansion and require two distinct evidence references spanning implementation/authority plus verification/authority categories. Matching filenames without descriptive content no longer count as evidence.
+- Added HoloIndex test, symbol, and knowledge buckets to semantic evidence projection and surfaced original/effective query plus expansion strategy in Run Trace telemetry.
+- Preserved local identity and operational-diagnostic fast paths, per-target content-bearing HoloIndex evidence, query-only runtime behavior, and the existing no-runtime-reindex boundary.
+- Version 0.4.2 -> 0.4.3. WSP_15: Complexity 2 + Importance 5 + Deferability 5 + Impact 5 = 17 (P0).
+
 ## 2026-07-18 - REDDOG_EXPLICIT_EMPTY_FUSION_PANEL_FAIL_CLOSED_PHASE1 (0.4.2 unchanged)
 
 - Made an explicitly supplied Fusion panel list authoritative at both extension ingress and the Python bridge: `[]` and invalid-only lists remain empty instead of silently restoring `DEFAULT_PANEL_MODELS`; omitted/non-list inputs retain compatibility defaults.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,6 +1,6 @@
 # RedDog
 
-Version: 0.4.2
+Version: 0.4.3
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
 
@@ -65,6 +65,7 @@ The extension is a bounded 0102 advisory surface:
 - Operational-output target guard (v0.3.64): browser/DAEmon diagnostic payloads with URLs, timing values, screenshot filenames, and status ratios are routed to local assessment and suppressed from repo/external target extraction so log fragments cannot block typed grounding.
 - Prompt-authoring override (v0.3.65): requests for worker/slice/M2M prompts override the DAEmon/log local diagnostic fast path, so pasted logs can be used as context for governed prompt generation instead of being answered instantly as non-actionable diagnostics.
 - Semantic grounding per-target proof (v0.3.66): semantic targets now require independent content-bearing HoloIndex evidence refs before Fusion or wardrobe selection may proceed. Aggregate `code_hits` / `wsp_hits` no longer satisfy unrelated semantic targets; missing, errored, or ref-less semantic evidence fails closed and is surfaced through `semantic_targets_required`, `semantic_targets_grounded`, `semantic_targets_missing`, and `semantic_target_coverage_digest` telemetry.
+- Broad semantic grounding non-vacuity (v0.4.3): substantive audit/research/implementation verbs derive a generic semantic subject when no stronger repo, external, or explicit semantic target exists. Broad audits use one bounded generic query expansion and require distinct implementation/authority plus verification/authority evidence; path-only hits are insufficient. An empty target universe fails before Fusion with `grounding_target_universe_empty`; local identity and operational diagnostics remain exempt. HoloIndex remains query-only at runtime.
 - OpenClaw live-enqueue runtime binding (v0.3.67): after grounding, fusion quorum, output validation, wardrobe selection, and runtime-consumption gates pass, the extension may call the one-shot explicit live-enqueue invoke bridge for `live_enqueue` authority requests. This slice keeps `enableConcreteWriter=false`, so the editor subprocess can prove the guarded path is reachable but cannot perform a durable OpenClaw queue write.
 - Resident architect session bridge (v0.3.68): when `reddog.enableResidentArchitectSession=true` and local runtime-consumption gates pass, the extension may call the resident read-only RedDog audit -> research -> backend architect determination E2E runtime. The bridge returns snapshot/swarm/task/report/architect decision telemetry plus no-mutation attestations. It does not edit files, re-index HoloIndex, dispatch Hermes, create worktrees, enqueue live FoundUps work, create PRs, merge, or promote PatternMemory.
 
@@ -225,6 +226,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.2.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.3.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/ROADMAP.md
+++ b/extensions/reddog/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Phase: RedDog 0.4.2 resident architect thin-client surface.
+Phase: RedDog 0.4.3 resident architect thin-client surface.
 
 Current implementation:
 

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -3,8 +3,9 @@ const cp = require('child_process');
 const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
+const semanticGroundingPolicy = require('./semantic_grounding_policy');
 
-const EXTENSION_VERSION = '0.4.2';
+const EXTENSION_VERSION = '0.4.3';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -1419,6 +1420,12 @@ function removeQuotedReferenceBlocks(taskText) {
   return kept.join('\n');
 }
 
+function isSubstantiveGroundingRequest(taskText) {
+  const text = removeQuotedReferenceBlocks(taskText);
+  return semanticGroundingPolicy.SEMANTIC_WORK_ACTION_PATTERN.test(text)
+    && !isRunTraceAssessmentRequest(taskText) && !isDaemonOutputAssessmentRequest(taskText);
+}
+
 function extractSemanticTargets(taskText, repoTargets, externalTargets) {
   const text = removeQuotedReferenceBlocks(taskText);
   const repoSet = new Set((repoTargets || []).map((t) => String(t || '').toLowerCase()));
@@ -1439,6 +1446,8 @@ function extractSemanticTargets(taskText, repoTargets, externalTargets) {
     targets.push(value);
   };
   const lines = text.split(/\r?\n/);
+  const hasExplicitSemanticTarget = lines.some((line) => semanticHeaderBody(line.trim()) !== null);
+  const allowBroadActionFallback = repoSet.size === 0 && externalSet.size === 0 && !hasExplicitSemanticTarget;
   for (const line of lines) {
     const stripped = line.trim();
     if (!stripped || stripped.startsWith('- ') || stripped.startsWith('* ')) {
@@ -1454,8 +1463,10 @@ function extractSemanticTargets(taskText, repoTargets, externalTargets) {
       }
       continue;
     }
-    if (lineHasAnyLowerPhrase(stripped, ['audit', 'evaluate', 'assess', 'compare', 'research', 'investigate'])
-        && lineHasAnyLowerPhrase(stripped, ['architecture', 'workflow', 'orchestration', 'grounding', 'authority', 'selection', 'pipeline', 'concept', 'paper', 'repo'])) {
+    const legacyActionTarget = lineHasAnyLowerPhrase(stripped, ['audit', 'evaluate', 'assess', 'compare', 'research', 'investigate'])
+      && lineHasAnyLowerPhrase(stripped, ['architecture', 'workflow', 'orchestration', 'grounding', 'authority', 'selection', 'pipeline', 'concept', 'paper', 'repo']);
+    if ((legacyActionTarget || allowBroadActionFallback) && semanticGroundingPolicy.SEMANTIC_WORK_ACTION_PATTERN.test(stripped)
+        && semanticGroundingPolicy.hasSubstantiveSemanticSubject(stripped)) {
       add(stripped);
     }
   }
@@ -1509,28 +1520,6 @@ function numberFromScorecard(value) {
   return Number.isFinite(n) ? n : 0;
 }
 
-const SEMANTIC_GROUNDING_STOPWORDS = new Set([
-  'about', 'after', 'against', 'agent', 'audit', 'based', 'before', 'build', 'code',
-  'compare', 'concept', 'current', 'does', 'evaluate', 'foundups', 'from', 'governance',
-  'grounding', 'implementation', 'into', 'mapping', 'module', 'need', 'needs', 'paper',
-  'pipeline', 'question', 'read', 'repo', 'research', 'review', 'selection', 'should',
-  'system', 'that', 'the', 'this', 'through', 'topic', 'using', 'whether', 'with',
-  'workflow', 'wsp'
-]);
-
-function normalizeSemanticQuery(value) {
-  return collapseAsciiWhitespace(String(value || '')
-    .toLowerCase()
-    .replace(/[`"'()[\]{}<>]/g, ' ')
-    .replace(/[_./\\:-]+/g, ' '));
-}
-
-function tokenizeSemanticQuery(value) {
-  const normalized = normalizeSemanticQuery(value);
-  const tokens = normalized.match(/[a-z0-9]+/g) || [];
-  return uniqueStrings(tokens.filter((token) => token.length >= 3 && !SEMANTIC_GROUNDING_STOPWORDS.has(token)));
-}
-
 function semanticEvidenceRef(hit) {
   const h = hit && typeof hit === 'object' ? hit : {};
   const raw = h.evidence_ref || h.ref || h.location || h.path || h.file || h.uri || h.id;
@@ -1538,25 +1527,7 @@ function semanticEvidenceRef(hit) {
 }
 
 function semanticHitText(hit) {
-  if (!hit || typeof hit !== 'object') {
-    return String(hit || '');
-  }
-  const fields = [
-    hit.need,
-    hit.title,
-    hit.summary,
-    hit.preview,
-    hit.snippet,
-    hit.content,
-    hit.text,
-    hit.location,
-    hit.path,
-    hit.file,
-    hit.module,
-    hit.kind,
-    hit.type
-  ];
-  return fields.map((field) => String(field || '')).join(' ');
+  return semanticGroundingPolicy.semanticEvidenceText(hit);
 }
 
 function normalizeSemanticEvidenceHit(hit, index, bucket) {
@@ -1593,14 +1564,20 @@ function semanticEvidenceHitsFromBundleData(data) {
     ? data.task_retrieval
     : {};
   appendSemanticEvidenceHits(out, task.code_hits, 'code');
+  appendSemanticEvidenceHits(out, task.test_hits, 'test');
+  appendSemanticEvidenceHits(out, task.symbol_hits, 'symbol');
   appendSemanticEvidenceHits(out, task.wsp_hits, 'wsp');
   appendSemanticEvidenceHits(out, task.doc_hits, 'docs');
   appendSemanticEvidenceHits(out, task.docs_hits, 'docs');
   appendSemanticEvidenceHits(out, task.skill_hits, 'skill');
+  appendSemanticEvidenceHits(out, task.knowledge_hits, 'knowledge');
   appendSemanticEvidenceHits(out, data && data.code_hits, 'code');
+  appendSemanticEvidenceHits(out, data && data.test_hits, 'test');
+  appendSemanticEvidenceHits(out, data && data.symbol_hits, 'symbol');
   appendSemanticEvidenceHits(out, data && data.wsp_hits, 'wsp');
   appendSemanticEvidenceHits(out, data && data.docs_hits, 'docs');
   appendSemanticEvidenceHits(out, data && data.skill_hits, 'skill');
+  appendSemanticEvidenceHits(out, data && data.knowledge_hits, 'knowledge');
   return out;
 }
 
@@ -1627,7 +1604,7 @@ function collectSemanticEvidenceHits(contextPacket, scorecard) {
 }
 
 function semanticBackendErrorForTarget(target, contextPacket, scorecard) {
-  const normalized = normalizeSemanticQuery(target);
+  const normalized = semanticGroundingPolicy.normalizeSemanticQuery(target);
   const candidates = [
     contextPacket && contextPacket.semantic_target_errors,
     contextPacket && contextPacket.semantic_grounding_errors,
@@ -1639,14 +1616,14 @@ function semanticBackendErrorForTarget(target, contextPacket, scorecard) {
       continue;
     }
     if (Array.isArray(item)) {
-      if (item.some((value) => normalizeSemanticQuery(value) === normalized)) {
+      if (item.some((value) => semanticGroundingPolicy.normalizeSemanticQuery(value) === normalized)) {
         return true;
       }
       continue;
     }
     if (typeof item === 'object') {
       for (const key of Object.keys(item)) {
-        if (normalizeSemanticQuery(key) === normalized && item[key]) {
+        if (semanticGroundingPolicy.normalizeSemanticQuery(key) === normalized && item[key]) {
           return true;
         }
       }
@@ -1656,7 +1633,7 @@ function semanticBackendErrorForTarget(target, contextPacket, scorecard) {
 }
 
 function semanticHitSupportsTarget(hit, targetTokens, normalizedQuery) {
-  const normalizedText = normalizeSemanticQuery(hit && hit.text);
+  const normalizedText = semanticGroundingPolicy.normalizeSemanticQuery(hit && hit.text);
   if (!normalizedText) {
     return null;
   }
@@ -1685,8 +1662,8 @@ function buildSemanticTargetCoverage(targets, contextMode, contextPacket, scorec
   const hasHolo = !!(contextMode && String(contextMode).includes('holo'));
   const evidenceHits = collectSemanticEvidenceHits(contextPacket, scorecard);
   return semanticTargets.map((target) => {
-    const normalizedQuery = normalizeSemanticQuery(target);
-    const tokens = tokenizeSemanticQuery(target);
+    const normalizedQuery = semanticGroundingPolicy.normalizeSemanticQuery(target);
+    const tokens = semanticGroundingPolicy.tokenizeSemanticQuery(target);
     const rejectionReasons = [];
     const contentBearingHits = [];
     const evidenceRefs = [];
@@ -1712,22 +1689,29 @@ function buildSemanticTargetCoverage(targets, contextMode, contextPacket, scorec
         contentBearingHits.push({
           evidence_ref: hit.evidence_ref,
           bucket: hit.bucket,
+          evidence_category: semanticGroundingPolicy.semanticEvidenceCategory(hit),
           matched_tokens: support.matched_tokens,
           exact_phrase: support.exact_phrase === true
         });
       }
     }
-    if (!evidenceRefs.length) {
+    const uniqueEvidenceRefs = uniqueStrings(evidenceRefs);
+    const uniqueContentBearingHits = contentBearingHits.filter((hit, index) => uniqueEvidenceRefs.indexOf(hit.evidence_ref) !== -1
+      && contentBearingHits.findIndex((other) => other.evidence_ref === hit.evidence_ref) === index);
+    const evidenceQuality = semanticGroundingPolicy.assessBroadAuditEvidence(target, uniqueContentBearingHits);
+    if (!uniqueEvidenceRefs.length) {
       rejectionReasons.push('semantic_target_evidence_missing');
     }
-    const uniqueEvidenceRefs = uniqueStrings(evidenceRefs);
+    if (evidenceQuality.required && !evidenceQuality.passed) {
+      rejectionReasons.push('broad_audit_evidence_insufficient');
+    }
     return {
       target: String(target || ''),
       normalized_query: normalizedQuery,
       verdict: rejectionReasons.length === 0 ? 'SUFFICIENT' : 'UNSAFE_TO_ACT',
       evidence_refs: uniqueEvidenceRefs,
-      content_bearing_hits: contentBearingHits.filter((hit, index) => uniqueEvidenceRefs.indexOf(hit.evidence_ref) !== -1
-        && contentBearingHits.findIndex((other) => other.evidence_ref === hit.evidence_ref) === index),
+      content_bearing_hits: uniqueContentBearingHits,
+      evidence_quality: evidenceQuality,
       rejection_reasons: uniqueStrings(rejectionReasons)
     };
   });
@@ -1748,6 +1732,12 @@ function buildTypedGroundingPreflight(taskText, contextMode, contextPacket) {
   const semantic = typedTargets.semantic_targets;
   const external = typedTargets.external_research_targets;
   const quoted = typedTargets.quoted_reference_blocks;
+  const targetUniverseEmpty = repoFiles.length === 0 && semantic.length === 0 && external.length === 0;
+  const targetUniverseRequired = isSubstantiveGroundingRequest(taskText);
+
+  if (targetUniverseRequired && targetUniverseEmpty) {
+    rejectionReasons.push('grounding_target_universe_empty');
+  }
 
   if (repoFiles.length) {
     if (!scorecard || scorecard.target_recall_ok !== true) {
@@ -1786,8 +1776,11 @@ function buildTypedGroundingPreflight(taskText, contextMode, contextPacket) {
     semantic_targets_missing: semanticMissing,
     semantic_target_coverage: semanticCoverage,
     semantic_target_coverage_digest: semanticTargetCoverageDigest(semanticCoverage),
+    semantic_index_gap_detected: semanticMissing.length > 0,
     external_research_targets_count: external.length,
     quoted_reference_blocks_count: quoted.length,
+    grounding_target_universe_required: targetUniverseRequired,
+    grounding_target_universe_empty: targetUniverseEmpty,
     direct_read_required: repoFiles.length > 0,
     semantic_grounding_required: semantic.length > 0,
     external_research_required: external.length > 0,
@@ -2020,6 +2013,9 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     retrieval_mode: meta.retrieval_mode || 'unknown',
     embedding_backend: meta.embedding_backend || 'unknown',
     routing_active: meta.routing_active !== undefined ? meta.routing_active : 'unknown',
+    original_query: meta.original_query || 'unknown',
+    effective_query: meta.effective_query || 'unknown',
+    query_expansion_strategy: meta.expansion_strategy || 'unknown',
     code_hits_count: meta.code_hits !== undefined ? meta.code_hits : 'unknown',
     wsp_hits: meta.wsp_hits !== undefined ? meta.wsp_hits : 'unknown',
     code_hits: meta.code_hits !== undefined ? meta.code_hits : 'unknown',
@@ -2102,6 +2098,9 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- retrieval_mode: ' + scorecard.retrieval_mode,
     '- embedding_backend: ' + scorecard.embedding_backend,
     '- routing_active: ' + scorecard.routing_active,
+    '- holoindex_original_query: ' + scorecard.original_query,
+    '- holoindex_effective_query: ' + scorecard.effective_query,
+    '- holoindex_query_expansion_strategy: ' + scorecard.query_expansion_strategy,
     '- code_hits_count: ' + scorecard.code_hits_count,
     '- wsp_hits: ' + scorecard.wsp_hits,
     '- skill_hits: ' + scorecard.skill_hits,
@@ -5139,7 +5138,7 @@ function activate(context) {
   const installState = detectRedDogInstallState(context);
   if (installState.stale_install_detected) {
     vscode.window.showWarningMessage(
-      'RedDog 0.4.2 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
+      'RedDog 0.4.3 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
     );
   }
   context.subscriptions.push(
@@ -5367,6 +5366,9 @@ function wireFusionWebview(context, webview, worker, state) {
         ? groundingPreflight.semantic_target_coverage.slice()
         : [];
       holoScorecard.semantic_target_coverage_digest = groundingPreflight.semantic_target_coverage_digest;
+      if (groundingPreflight.semantic_index_gap_detected === true) {
+        holoScorecard.index_gap_detected = true;
+      }
       holoScorecard.external_research_targets_count = groundingPreflight.external_research_targets_count;
       holoScorecard.quoted_reference_blocks_count = groundingPreflight.quoted_reference_blocks_count;
     }
@@ -7092,7 +7094,9 @@ function classifyDirectReadFetchError(err) {
 }
 
 function holoIndexOutput(root, taskText, maxChars) {
-  const query = String(taskText || '').replace(/\s+/g, ' ').trim().slice(0, 500) || 'FoundUps RedDog WSP_00 WSP_97 WSP_15 current task';
+  const typedTargets = extractTypedTargets(taskText);
+  const queryPlan = semanticGroundingPolicy.buildEffectiveHoloQuery(taskText, typedTargets.semantic_targets);
+  const query = queryPlan.effective_query;
   const moduleHint = moduleHintFromActive(root);
   const requestedMode = resolveHoloRetrievalMode(process.env);
   const env = buildHoloQueryEnv(process.env, requestedMode);
@@ -7173,6 +7177,7 @@ function holoIndexOutput(root, taskText, maxChars) {
       meta.direct_read_fetch_arg_count = fetchTelemetry.direct_read_fetch_arg_count;
       meta.direct_read_fetch_timeout_ms = fetchTelemetry.direct_read_fetch_timeout_ms;
     }
+    Object.assign(meta, queryPlan);
     const directReadSection = buildDirectReadContentSection(output);
     return {
       output: String(output || '').slice(0, maxChars),
@@ -7191,8 +7196,9 @@ function holoIndexOutput(root, taskText, maxChars) {
         maxBuffer: Math.max(maxChars * 4, 65536),
         windowsHide: true
       });
-      const meta = holoIndexMetaFromBundle(output, true, query);
+      const meta = holoIndexMetaFromBundle(output, true, taskText);
       meta.requested_retrieval_mode = requestedMode;
+      Object.assign(meta, queryPlan);
       return {
         output: String(output || '').slice(0, maxChars),
         quality: 'HoloIndex bundle-json failed; offline lexical fallback used. Treat protocol coverage as NEEDS_VERIFICATION and propose re-index/bundle repair if WSP hits are missing.',
@@ -7202,7 +7208,7 @@ function holoIndexOutput(root, taskText, maxChars) {
       return {
         output: '[HoloIndex unavailable: ' + (offlineErr && offlineErr.message ? offlineErr.message.slice(0, 180) : 'unknown') + ']',
         quality: 'HoloIndex unavailable. Use supplied editor/git evidence only; propose HoloIndex recovery as a fix when retrieval affects the decision.',
-        meta: holoIndexMetaFromBundle('', false)
+        meta: Object.assign(holoIndexMetaFromBundle('', false, taskText), queryPlan)
       };
     }
   }

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/semantic_grounding_policy.js
+++ b/extensions/reddog/semantic_grounding_policy.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const SEMANTIC_WORK_ACTION_PATTERN = /\b(?:analy[sz]e|assess|audit|build|compare|complete|create|debug|design|determine|evaluate|fix|harden|implement|improve|inspect|investigate|plan|refactor|research|review|update|verify)\b/i;
+const BROAD_AUDIT_ACTION_PATTERN = /\b(?:analy[sz]e|assess|audit|evaluate|inspect|investigate|review|verify)\b/i;
+const BROAD_AUDIT_QUERY_TERMS = [
+  'architecture',
+  'implementation',
+  'source',
+  'tests',
+  'contracts',
+  'interface',
+  'roadmap',
+  'workflow'
+];
+const SEMANTIC_GROUNDING_STOPWORDS = new Set([
+  'about', 'after', 'against', 'agent', 'all', 'analyze', 'analyse', 'assess', 'audit',
+  'based', 'before', 'bug', 'build', 'code', 'compare', 'complete', 'concept', 'create',
+  'current', 'debug', 'design', 'determine', 'does', 'evaluate', 'everything', 'fix',
+  'following', 'foundups', 'from', 'governance', 'grounding', 'harden', 'implement',
+  'implementation', 'improve', 'inspect', 'into', 'investigate', 'issue', 'it', 'make',
+  'mapping', 'module', 'need', 'needs', 'output', 'paper', 'pipeline', 'plan', 'please',
+  'problem', 'question', 'read', 'refactor', 'repo', 'research', 'review', 'selection',
+  'should', 'something', 'system', 'that', 'the', 'them', 'this', 'through', 'to',
+  'topic', 'update', 'using', 'verify', 'whether', 'with', 'work', 'workflow', 'wsp'
+]);
+
+function collapseWhitespace(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeSemanticQuery(value) {
+  return collapseWhitespace(String(value || '')
+    .toLowerCase()
+    .replace(/[`"'()[\]{}<>]/g, ' ')
+    .replace(/[_./\\:-]+/g, ' '));
+}
+
+function tokenizeSemanticQuery(value) {
+  const tokens = normalizeSemanticQuery(value).match(/[a-z0-9]+/g) || [];
+  return Array.from(new Set(tokens.filter((token) => token.length >= 3 && !SEMANTIC_GROUNDING_STOPWORDS.has(token))));
+}
+
+function hasSubstantiveSemanticSubject(value) {
+  return tokenizeSemanticQuery(value).length > 0;
+}
+
+function semanticEvidenceText(hit) {
+  if (!hit || typeof hit !== 'object') {
+    return String(hit || '');
+  }
+  return [
+    hit.need,
+    hit.title,
+    hit.summary,
+    hit.preview,
+    hit.snippet,
+    hit.content,
+    hit.text
+  ].map((field) => String(field || '')).join(' ');
+}
+
+function semanticEvidenceCategory(hit) {
+  const source = hit && typeof hit === 'object' ? hit : {};
+  const bucket = String(source.bucket || '').toLowerCase();
+  const ref = String(source.evidence_ref || source.location || source.path || '').replace(/\\/g, '/').toLowerCase();
+  if (bucket === 'test' || /(?:^|\/)tests?(?:\/|$)|(?:^|\/)test_|[._-]test\./.test(ref)) {
+    return 'verification';
+  }
+  if (bucket === 'wsp' || bucket === 'work_ledger') {
+    return 'authoritative';
+  }
+  if (bucket === 'docs' || bucket === 'knowledge' || bucket === 'skill' || /\.(?:md|rst|txt)(?::\d+)?$/.test(ref)) {
+    return 'verification';
+  }
+  if (bucket === 'code' || bucket === 'symbol' || /\.(?:c|cc|cpp|go|java|js|jsx|mjs|py|rs|ts|tsx)(?::\d+)?$/.test(ref)) {
+    return 'implementation';
+  }
+  return 'supporting';
+}
+
+function isBroadAuditSemanticTarget(target) {
+  return BROAD_AUDIT_ACTION_PATTERN.test(String(target || ''));
+}
+
+function assessBroadAuditEvidence(target, hits) {
+  if (!isBroadAuditSemanticTarget(target)) {
+    return { required: false, passed: true, evidence_refs: [], categories: [] };
+  }
+  const records = Array.isArray(hits) ? hits : [];
+  const refs = Array.from(new Set(records.map((hit) => String(hit.evidence_ref || '')).filter(Boolean)));
+  const categories = Array.from(new Set(records.map(semanticEvidenceCategory)));
+  const hasPrimary = categories.includes('implementation') || categories.includes('authoritative');
+  const hasCorroboration = categories.includes('verification') || categories.includes('authoritative');
+  return {
+    required: true,
+    passed: refs.length >= 2 && categories.length >= 2 && hasPrimary && hasCorroboration,
+    evidence_refs: refs,
+    categories
+  };
+}
+
+function buildEffectiveHoloQuery(taskText, semanticTargets) {
+  const original = collapseWhitespace(taskText).slice(0, 500)
+    || 'FoundUps RedDog WSP_00 WSP_97 WSP_15 current task';
+  const broadAudit = (Array.isArray(semanticTargets) ? semanticTargets : []).some(isBroadAuditSemanticTarget);
+  if (!broadAudit) {
+    return {
+      original_query: original,
+      effective_query: original,
+      expansion_strategy: 'none'
+    };
+  }
+  const lower = original.toLowerCase();
+  const additions = BROAD_AUDIT_QUERY_TERMS.filter((term) => !lower.includes(term));
+  return {
+    original_query: original,
+    effective_query: collapseWhitespace(original + ' ' + additions.join(' ')).slice(0, 500),
+    expansion_strategy: 'broad_audit_v1'
+  };
+}
+
+module.exports = {
+  SEMANTIC_WORK_ACTION_PATTERN,
+  assessBroadAuditEvidence,
+  buildEffectiveHoloQuery,
+  hasSubstantiveSemanticSubject,
+  normalizeSemanticQuery,
+  semanticEvidenceCategory,
+  semanticEvidenceText,
+  tokenizeSemanticQuery
+};

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,17 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-19 - REDDOG_BROAD_SEMANTIC_GROUNDING_NONVACUITY_PHASE1
+
+- Proved `Audit pfmall.` derives one semantic target and no invented repository path, while the extension source contains no hardcoded `pfmall` literal.
+- Proved a content-bearing HoloIndex hit for the requested subject passes and an unrelated hit fails per-target semantic coverage.
+- Proved one topical hit and a path-only hit cannot certify a broad audit; distinct implementation plus test/docs evidence is required.
+- Proved a single bounded expanded HoloIndex query preserves the original query, records its strategy, remains read-only, and never adds indexing or direct-read flags.
+- Proved test, symbol, and knowledge HoloIndex buckets reach semantic evidence coverage.
+- Proved `Audit it.` fails before Fusion with `grounding_target_universe_empty` instead of passing an empty target universe.
+- Proved simple identity and pasted operational-diagnostic prompts retain their local exemptions and the grounding seam contains no runtime reindex path.
+- Proved implementation requests containing diagnostic logs do not inherit the diagnostic exemption, and mixed repo-plus-architecture prompts retain both grounding obligations.
+- Re-ran the complete Node extension contract and JavaScript syntax check.
+
 ## 2026-07-18 - REDDOG_EXPLICIT_EMPTY_FUSION_PANEL_FAIL_CLOSED_PHASE1
 
 - Proved omitted/non-list panel input still selects compatibility defaults while explicit empty and invalid-only lists remain empty.

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -203,8 +203,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.2', 'package version must be 0.4.2');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.2'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.3', 'package version must be 0.4.3');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.3'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -224,7 +224,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.2', 'README version mismatch');
+includes(readme, 'Version: 0.4.3', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -455,6 +455,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 };
 
 const orchestrator = require(path.join(extDir, 'extension.js'));
+const semanticGroundingPolicy = require(path.join(extDir, 'semantic_grounding_policy.js'));
 Module._resolveFilename = originalResolve;
 
 // REDDOG_HOLO_SEMANTIC_FIRST_PHASE1: mode selection and truth receipts.
@@ -518,6 +519,33 @@ try {
   assert.strictEqual(hsfFallback.meta.holoindex_status, 'offline_fallback', 'HSF-006: fallback status must be truthful');
   assert.strictEqual(hsfFallback.meta.requested_retrieval_mode, 'semantic', 'HSF-006: receipt must retain the requested mode');
   assert.strictEqual(hsfFallback.meta.retrieval_mode, 'lexical', 'HSF-006: receipt must expose actual lexical behavior');
+} finally {
+  cp.execFileSync = hsfOriginalExecFileSync;
+  process.env.REDDOG_HOLO_RETRIEVAL_MODE = hsfOriginalMode;
+}
+
+// HSF-007: broad audits use one bounded, read-only expanded query. The original query and
+// expansion strategy remain receipt-visible, and no indexing/direct-read flag is introduced.
+const hsfExpansionPlan = semanticGroundingPolicy.buildEffectiveHoloQuery('Audit pfmall.', ['Audit pfmall.']);
+assert.strictEqual(hsfExpansionPlan.original_query, 'Audit pfmall.', 'HSF-007: original query is preserved');
+includes(hsfExpansionPlan.effective_query, 'architecture', 'HSF-007: broad audit query gains generic architecture vocabulary');
+includes(hsfExpansionPlan.effective_query, 'tests', 'HSF-007: broad audit query gains generic verification vocabulary');
+assert.strictEqual(hsfExpansionPlan.expansion_strategy, 'broad_audit_v1', 'HSF-007: expansion strategy is explicit');
+let hsfExpandedCall = null;
+try {
+  process.env.REDDOG_HOLO_RETRIEVAL_MODE = 'lexical';
+  cp.execFileSync = function(_exe, args, options) {
+    hsfExpandedCall = { args, options };
+    return JSON.stringify({ task_retrieval: { code_hits: [], metadata: { retrieval_mode: 'lexical', code_count: 0, wsp_count: 0 } } });
+  };
+  const hsfExpanded = orchestrator.holoIndexOutput(root, 'Audit pfmall.', 18000);
+  assert.strictEqual(hsfExpandedCall.options.env.HOLOINDEX_QUERY_READONLY, '1', 'HSF-007: expanded query remains read-only');
+  assert.strictEqual(hsfExpandedCall.args.filter((arg) => arg === '--search').length, 1, 'HSF-007: exactly one search is issued');
+  assert.strictEqual(hsfExpandedCall.args.includes('--bundle-must-include'), false, 'HSF-007: semantic expansion does not invent direct-read targets');
+  assert.strictEqual(hsfExpandedCall.args.some((arg) => /(?:^|-)re-?index|^--index/.test(String(arg))), false,
+    'HSF-007: expanded query never requests indexing');
+  assert.strictEqual(hsfExpanded.meta.original_query, 'Audit pfmall.', 'HSF-007: meta preserves original query');
+  assert.strictEqual(hsfExpanded.meta.expansion_strategy, 'broad_audit_v1', 'HSF-007: meta preserves expansion strategy');
 } finally {
   cp.execFileSync = hsfOriginalExecFileSync;
   process.env.REDDOG_HOLO_RETRIEVAL_MODE = hsfOriginalMode;
@@ -1165,7 +1193,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.2', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.3', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2657,7 +2685,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.2'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.3'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2671,7 +2699,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.2'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.3'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2683,7 +2711,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.2'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.3'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3428,6 +3456,124 @@ const blockedResult = orchestrator.buildGroundingPreflightBlockedResult(external
 assert.strictEqual(blockedResult.made_network_call, false, 'TGP-005: blocked preflight does not call model/network');
 assert.strictEqual(blockedResult.reason, 'grounding_preflight_blocked', 'TGP-005: blocked reason stable');
 
+// REDDOG_BROAD_SEMANTIC_GROUNDING_NONVACUITY_PHASE1 (TGP-006..013): substantive
+// action prompts must produce a grounded target universe without repository-specific nouns.
+const broadAuditPrompt = 'Audit pfmall.';
+const broadAuditTargets = orchestrator.extractTypedTargets(broadAuditPrompt);
+assert.deepStrictEqual(broadAuditTargets.repo_file_targets, [], 'TGP-006: broad semantic audit does not invent a repo path');
+assert.deepStrictEqual(broadAuditTargets.semantic_targets, ['Audit pfmall.'], 'TGP-006: generic audit subject becomes a semantic target');
+assert(!extensionJs.includes("'pfmall'"), 'TGP-006: extension must not hardcode the regression subject');
+const broadAuditPass = orchestrator.buildTypedGroundingPreflight(broadAuditPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [
+    {
+      location: 'modules/foundups/pfmall/src/pfmall_dae.py:1',
+      title: 'PFMall FoundUp runtime',
+      need: 'pfmall implementation evidence'
+    },
+    {
+      location: 'docs/audits/pfmall_runtime.md',
+      summary: 'Independent PFMall runtime contract and test audit evidence.'
+    }
+  ]
+});
+assert.strictEqual(broadAuditPass.passed, true, 'TGP-007: content-bearing HoloIndex evidence grounds the broad audit subject');
+assert.strictEqual(broadAuditPass.semantic_targets_grounded, 1, 'TGP-007: the semantic target is independently grounded');
+assert.deepStrictEqual(broadAuditPass.semantic_target_coverage[0].evidence_quality.categories.sort(), ['implementation', 'verification'],
+  'TGP-007: broad audit requires implementation plus independent verification evidence');
+assert.strictEqual(broadAuditPass.grounding_target_universe_required, true, 'TGP-007: substantive audit requires a target universe');
+assert.strictEqual(broadAuditPass.grounding_target_universe_empty, false, 'TGP-007: derived semantic target makes the universe non-empty');
+const broadAuditSingleHit = orchestrator.buildTypedGroundingPreflight(broadAuditPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [{ location: 'modules/pfmall/runtime.py', preview: 'PFMall runtime implementation.' }]
+});
+assert.strictEqual(broadAuditSingleHit.passed, false, 'TGP-007: one topical hit cannot certify a broad audit');
+assert(broadAuditSingleHit.rejection_reasons.includes('broad_audit_evidence_insufficient'),
+  'TGP-007: one-hit broad audit has an explicit evidence-sufficiency rejection');
+assert.strictEqual(broadAuditSingleHit.semantic_index_gap_detected, true,
+  'TGP-007: insufficient semantic evidence becomes an honest index-gap signal');
+const broadAuditUnrelated = orchestrator.buildTypedGroundingPreflight(broadAuditPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [
+    { location: 'modules/infrastructure/wre_core/src/wre_master_orchestrator.py:1', title: 'WRE orchestration' }
+  ]
+});
+assert.strictEqual(broadAuditUnrelated.passed, false, 'TGP-008: unrelated HoloIndex evidence cannot ground the audit');
+assert(broadAuditUnrelated.rejection_reasons.includes('semantic_target_grounding_incomplete'), 'TGP-008: unrelated evidence reports semantic grounding failure');
+const emptyAuditPreflight = orchestrator.buildTypedGroundingPreflight('Audit it.', 'wsp_holo', {
+  semantic_evidence_hits: []
+});
+assert.strictEqual(emptyAuditPreflight.passed, false, 'TGP-009: unparseable substantive audit cannot pass vacuously');
+assert(emptyAuditPreflight.rejection_reasons.includes('grounding_target_universe_empty'), 'TGP-009: empty target universe has a stable fail-closed reason');
+assert.strictEqual(emptyAuditPreflight.no_model_call_when_failed, true, 'TGP-010: empty target universe blocks before Fusion');
+const identityPreflight = orchestrator.buildTypedGroundingPreflight('Are you RedDog?', 'none', {});
+assert.strictEqual(identityPreflight.passed, true, 'TGP-011: simple identity prompt remains exempt from grounding targets');
+assert.strictEqual(identityPreflight.grounding_target_universe_required, false, 'TGP-011: identity fast path does not require target evidence');
+const diagnosticPreflight = orchestrator.buildTypedGroundingPreflight([
+  'Assess this Run Trace:',
+  '## Run Trace',
+  '- extension_version: 0.4.2',
+  '- runtime status: stopped',
+  '- redaction gate status: BLOCKED_LOCALLY',
+  '- made_network_call: false',
+  '- stderr: timeout',
+  '- warning: worker stopped',
+  '- operator message: failed before model output'
+].join('\n'), 'none', {});
+assert.strictEqual(diagnosticPreflight.passed, true, 'TGP-012: pasted operational diagnostics remain on the local evidence path');
+assert.strictEqual(diagnosticPreflight.grounding_target_universe_required, false, 'TGP-012: operational diagnostic payload is exempt');
+assert(!/runtime[^\n]{0,80}(?:reindex|--index)/i.test(extensionJs.slice(extensionJs.indexOf('function buildTypedGroundingPreflight'), extensionJs.indexOf('function buildGroundingPreflightBlockedResult'))),
+  'TGP-013: grounding preflight remains query-only and never triggers runtime reindex');
+const actionableLogPrompt = [
+  'Implement a fix for this runtime output:',
+  '- runtime status: stopped',
+  '- stderr: timeout',
+  '- warning: worker failed',
+  '- operator message: blocked',
+  '- result: error',
+  '- output: no model response',
+  '- trace: failed'
+].join('\n');
+assert.strictEqual(orchestrator.isDaemonOutputAssessmentRequest(actionableLogPrompt), false,
+  'TGP-014: implementation request containing logs cannot use the local diagnostic exemption');
+const actionableLogPreflight = orchestrator.buildTypedGroundingPreflight(actionableLogPrompt, 'wsp_holo', {});
+assert.strictEqual(actionableLogPreflight.passed, false, 'TGP-014: action-oriented log payload cannot pass with zero targets');
+assert(actionableLogPreflight.rejection_reasons.includes('grounding_target_universe_empty'),
+  'TGP-014: action-oriented log payload fails on empty target universe');
+assert.strictEqual(orchestrator.buildGroundingPreflightBlockedResult(actionableLogPreflight).made_network_call, false,
+  'TGP-014: action-oriented log payload blocks before Fusion');
+for (const subjectless of ['Audit it.', 'Research this.', 'Review everything.']) {
+  const subjectlessPreflight = orchestrator.buildTypedGroundingPreflight(subjectless, 'wsp_holo', {});
+  assert.strictEqual(subjectlessPreflight.passed, false, 'TGP-015: subjectless work must fail: ' + subjectless);
+  assert(subjectlessPreflight.rejection_reasons.includes('grounding_target_universe_empty'),
+    'TGP-015: subjectless work gets stable empty-universe reason: ' + subjectless);
+}
+for (const genericSubject of ['Audit kosei.', 'Audit arbitrary_widget.']) {
+  assert.strictEqual(orchestrator.extractTypedTargets(genericSubject).semantic_targets.length, 1,
+    'TGP-016: arbitrary semantic subject derives without a hardcoded domain noun: ' + genericSubject);
+}
+const mixedGroundingPrompt = [
+  'Audit payment pipeline architecture.',
+  'Read first: modules/payments/core.py'
+].join('\n');
+const mixedTargets = orchestrator.extractTypedTargets(mixedGroundingPrompt);
+assert.deepStrictEqual(mixedTargets.repo_file_targets, ['modules/payments/core.py'], 'TGP-017: mixed prompt retains repo target');
+assert.deepStrictEqual(mixedTargets.semantic_targets, ['Audit payment pipeline architecture.'], 'TGP-017: mixed prompt retains semantic obligation');
+const mixedPreflight = orchestrator.buildTypedGroundingPreflight(mixedGroundingPrompt, 'wsp_holo', {
+  holoindex_scorecard: { target_recall_ok: true, required_targets_missing: [] }
+});
+assert.strictEqual(mixedPreflight.passed, false, 'TGP-017: green file recall cannot replace missing semantic evidence');
+assert(mixedPreflight.rejection_reasons.includes('semantic_target_grounding_incomplete'),
+  'TGP-017: mixed prompt reports missing semantic grounding');
+const pathOnlySemantic = orchestrator.buildTypedGroundingPreflight(broadAuditPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [{ location: 'docs/pfmall.md' }]
+});
+assert.strictEqual(pathOnlySemantic.passed, false, 'TGP-018: matching filename alone is not content-bearing evidence');
+const previewSemantic = orchestrator.buildTypedGroundingPreflight(broadAuditPrompt, 'wsp_holo', {
+  semantic_evidence_hits: [
+    { location: 'modules/pfmall/runtime.py', preview: 'PFMall runtime architecture and current implementation.' },
+    { location: 'tests/test_pfmall_runtime.py', summary: 'PFMall runtime behavior verification.' }
+  ]
+});
+assert.strictEqual(previewSemantic.passed, true, 'TGP-018: matching content preview with a citation grounds the target');
+
 // REDDOG_SEMANTIC_GROUNDING_PER_TARGET_PROOF_PHASE1 (SGP-001..012): every semantic target
 // needs its own content-bearing HoloIndex evidence. Aggregate code_hits/wsp_hits cannot ground
 // unrelated semantic targets.
@@ -3505,6 +3651,16 @@ const semanticBundleOutput = JSON.stringify({
 const semanticBundleMeta = orchestrator.holoIndexMetaFromBundle(semanticBundleOutput, false, semanticPrompt);
 assert.strictEqual(Array.isArray(semanticBundleMeta.semantic_evidence_hits), true, 'SGP-007: bundle meta projects semantic evidence hits');
 assert.strictEqual(semanticBundleMeta.semantic_evidence_hits.length, 2, 'SGP-007: projected semantic evidence hit count');
+const semanticBucketMeta = orchestrator.holoIndexMetaFromBundle(JSON.stringify({
+  task_retrieval: {
+    test_hits: [{ path: 'tests/test_pfmall.py', title: 'PFMall behavior tests' }],
+    symbol_hits: [{ path: 'modules/pfmall/runtime.py', title: 'PFMall runtime symbol' }],
+    knowledge_hits: [{ path: 'WSP_knowledge/pfmall.md', summary: 'PFMall prior verified research' }],
+    metadata: { code_count: 0, wsp_count: 0 }
+  }
+}), false, broadAuditPrompt);
+assert.deepStrictEqual(semanticBucketMeta.semantic_evidence_hits.map((hit) => hit.bucket).sort(), ['knowledge', 'symbol', 'test'],
+  'SGP-007: test, symbol, and knowledge buckets are projected for semantic evidence');
 const semanticBundlePreflight = orchestrator.buildTypedGroundingPreflight(semanticPrompt, 'wsp_holo', {
   holoindex_meta: semanticBundleMeta
 });
@@ -3562,7 +3718,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.2' } }
+      ? { id, packageJSON: { version: '0.4.3' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({

--- a/extensions/reddog/wsp_62_exemptions.yaml
+++ b/extensions/reddog/wsp_62_exemptions.yaml
@@ -1,11 +1,10 @@
 exemptions:
   - file: "extension.js"
     reason: >-
-      Legacy RedDog thin-client integration boundary. This focused security
-      slice changes only bounded panel configuration ingress and exports the
-      existing stdin bridge seam for contract testing; decomposing unrelated
-      UI, retrieval, work-order, and receipt flows would expand the reviewed
-      surface beyond the empty-panel truth fix.
+      Legacy RedDog thin-client integration boundary. Focused slices may change
+      bounded UI, retrieval, work-order, or receipt seams only when they remain
+      within this ceiling and carry focused contract coverage. Decomposing the
+      unrelated integration surfaces is tracked by the owned roadmap item.
     threshold_override: 7900
     function_threshold_override: 180
     functions:


### PR DESCRIPTION
## Summary

- derive generic semantic targets for substantive audit/research/implementation prompts without hardcoded FoundUp nouns
- reject substantive requests with an empty typed target universe before Fusion
- preserve explicit repo/external/semantic target precedence and local identity/diagnostic fast paths
- bump RedDog to 0.4.3

## WSP_97 evidence

**OBSERVED**
- `Audit pfmall.` previously produced zero targets and vacuously passed grounding
- the new path derives one semantic target and requires content-bearing HoloIndex evidence
- unrelated HoloIndex hits fail per-target semantic coverage
- `Audit it.` rejects with `grounding_target_universe_empty`
- explicit repo targets and explicit semantic headers do not gain duplicate fallback targets
- runtime remains HoloIndex query-only; no reindex, repo write, enqueue, or authority change

## Verification

- `node --check extensions/reddog/extension.js`
- `node extensions/reddog/tests/verify_extension_contract.js`: pass
- `git diff --check`: clean
- changed files: ASCII/NUL clean
- `extension.js`: exactly 7,900 lines, within the existing temporary WSP_62 ceiling

## WSP_15

Complexity 2 + Importance 5 + Deferability 5 + Impact 5 = 17 (P0).

