### PR TITLE
fix(reddog): bind semantic grounding to HoloIndex owner generations

### DIFF
--- a/extensions/reddog/HOLOINDEX.md
+++ b/extensions/reddog/HOLOINDEX.md
@@ -5,11 +5,13 @@ Local retrieval manifest for the RedDog extension thin-client lane.
 ## Source Files (Tier 0 recall targets)
 
 - `extension.js` - main extension entry; Copy MD, Run Trace, Work Trail, redaction handoff
+- `holoindex_generation_bound_query.js` - owner-receipt acceptance, semantic-bucket replacement, and generation metadata
 - `package.json` - Node manifest and version
 
 ## Bridge (cross-path recall)
 
 - `scripts/advisory_model_once.py` - OpenRouter bridge and redaction gate (repo root)
+- `scripts/reddog_holoindex_owner_query_once.py` - authenticated generation-bound owner query bridge (repo root)
 
 ## Documentation
 
@@ -20,3 +22,4 @@ Local retrieval manifest for the RedDog extension thin-client lane.
 ## Symbols (high-value recall)
 
 - `buildCopyMarkdown`, `buildRunTraceSection`, `holoIndexMetaFromBundle`, `evaluateTargetRecall`
+- `isGenerationBoundHoloQueryAccepted`, `mergeGenerationBoundHoloResult`, `buildMetaFromBundle`

--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -45,7 +45,7 @@ Autonomous WRE/DAE agents are NOT 012 work. 012 provides work focus, testing, so
 |---|---|---|
 | Advisory model review | YES | OpenRouter request after Fusion redaction gate passes |
 | Bounded repo context | YES | Extension auto-gathers WSP/HoloIndex/editor/git/Skillz context by WSP_15 tier and sends it through redaction gate |
-| HoloIndex recall | YES | Read-only semantic `--bundle-json` first; actual retrieval mode/backend are receipted; offline lexical fallback only if semantic retrieval fails. Explicit opt-down: `REDDOG_HOLO_RETRIEVAL_MODE=lexical`. |
+| HoloIndex recall | YES | Semantic evidence comes from the authenticated HoloIndex owner service and requires a current generation-bound query receipt. Legacy `--bundle-json` supplies bounded direct-read/context structure only; its unbound semantic hits are discarded. Explicit lexical opt-down remains diagnostic-only. |
 | WSP_00/WSP_97/WSP_15 prompting | YES | System prompt requires role lock, truth labels, proposed fixes, and MPS priority |
 | Repo edits | NO | No write tool exposed to model |
 | Shell execution by model | NO | Extension host runs only bounded local context/bridge commands; model cannot execute Skillz/OpenClaw/Hermes |
@@ -169,6 +169,8 @@ Copy:
 ## HoloIndex Truth Boundary
 
 The model cannot access the filesystem. It receives only the bounded context packet.
+
+Extension v0.4.4 invokes `scripts/reddog_holoindex_owner_query_once.py`, which reuses the authenticated localhost owner client and emits the canonical `holoindex_query_receipt.v1`. Semantic evidence is accepted only when the owner result and receipt agree on `CURRENT` freshness, semantic mode, clean repository HEAD, generation ID, freshness-receipt digest, and query-only behavior. Missing, stale, lexical, mismatched, or unreceipted owner evidence is withheld and sets `index_gap_detected=true`. Governed direct-read bodies may supplement explicit repository targets, but they never erase a stale semantic-generation finding. RedDog does not re-index HoloIndex during a reasoning run; WRE/CI owns maintenance.
 
 If HoloIndex recall reports zero WSP hits, missing Tier-0 docs, stale/offline fallback, or unavailable output, the answer must treat protocol claims as `NEEDS_VERIFICATION` and propose retrieval/index repair before strong claims.
 

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,17 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-19 - REDDOG_HOLOINDEX_GENERATION_BOUND_QUERY_RUNTIME_PHASE1 (0.4.4)
+
+- Replaced unbound semantic evidence from the extension's direct `holo_index.py --bundle-json` subprocess with an authenticated query through the existing localhost HoloIndex owner service.
+- Added a bounded Python bridge that reuses owner bootstrap/handoff/client code and emits the canonical generation-bound query receipt without exposing the owner token or invoking any indexer.
+- Semantic hits now reach grounding only when owner result and receipt agree on CURRENT freshness, semantic retrieval, clean repository HEAD, generation ID, freshness-receipt digest, no index gap, and no runtime re-index.
+- Preserved governed direct-read bodies for explicit repository targets while preventing those bodies from masking stale semantic-generation telemetry.
+- Extracted generation-bound acceptance, bundle merge, and metadata projection to `holoindex_generation_bound_query.js`, keeping `extension.js` within its temporary WSP_62 ceiling.
+- Added Run Trace fields for owner acceptance, freshness, generation, repository HEAD, query receipt, source, error class, and query-only proof.
+- Fixed the existing owner supervisor's stale-readiness loop: authenticated terminal freshness failures now stop startup immediately instead of being retried until the five-minute startup timeout; transport/auth/malformed failures remain opaque and retry-bounded.
+- Version 0.4.3 -> 0.4.4. WSP_15: Complexity 3 + Importance 5 + Deferability 5 + Impact 5 = 18 (P0).
+
 ## 2026-07-19 - REDDOG_BROAD_SEMANTIC_GROUNDING_NONVACUITY_PHASE1 (0.4.3)
 
 - Replaced the hardcoded semantic-domain noun gate with a generic, bounded action-and-subject derivation rule, so short repository audits such as `Audit <FoundUp>` create a semantic target without embedding FoundUp-specific names or paths in the extension.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,8 +1,10 @@
 # RedDog
 
-Version: 0.4.3
+Version: 0.4.4
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
+
+Version 0.4.4 routes semantic evidence through the authenticated HoloIndex owner service and accepts it only with a current generation-bound query receipt. Legacy bundle output remains available for bounded direct-read content, but its unbound semantic hits cannot ground Fusion.
 
 RedDog is the resident FoundUps architect thin client and 012/0102 interface. Fusion is one internal reasoning mode; authority-bearing work is delegated through signed OpenClaw/WRE/Hermes receipts, not through raw webview access.
 
@@ -54,7 +56,7 @@ The extension is a bounded 0102 advisory surface:
 - WSP_97: answers must separate observed evidence, inference, and needs-verification.
 - WSP_15: substantive answers must end with a priority block: Complexity, Importance, Deferability, Impact, MPS total, and P0-P4 class.
 - Findings must include proposed fixes or an explicit defer/block reason.
-- HoloIndex recall is semantic-first: RedDog clears inherited `HOLO_SKIP_MODEL`, preserves an operator-set `HOLO_OFFLINE` network boundary, runs the read-only `--bundle-json` path, records `retrieval_mode` and `embedding_backend`, and falls back to offline lexical search only when semantic retrieval fails. `REDDOG_HOLO_RETRIEVAL_MODE=lexical` is an explicit compute-saving opt-down for tests or emergency operation; it must not be described as semantic retrieval.
+- HoloIndex recall is generation-bound: RedDog queries the authenticated read-only owner service and accepts semantic evidence only with a current `holoindex_query_receipt.v1` bound to the clean repository HEAD and freshness generation. Legacy bundle output supplies bounded direct-read/context structure, but its semantic hits are discarded. `REDDOG_HOLO_RETRIEVAL_MODE=lexical` is diagnostic-only and must not be described as semantic retrieval.
 - Free-form target derivation (v0.3.44): repo-relative paths named with read-intent anywhere in the work focus are promoted to required direct-read targets, not only paths under the exact `Required direct-read targets:` header. Recognized read-intent shapes are: the explicit required-targets header, `Read first:` / `READ BEFORE EDITING` blocks, WSP_99 M2M `READ:` arrays, M2M `CTX.FILES` / `CTX: FILES:` arrays, markdown bullet lists of paths, and inline or backticked paths in prose. When a path is named this way it drives the SAME governed direct-read fetch, so it is retrieved even when HoloIndex semantic recall misses. Command/validation fences (```powershell / ```bash with `git diff --check`, `node --check`, `python holo_index.py ...`) and scope-out / "Do NOT touch" sections are excluded, and derivation prefers precision when read-intent is ambiguous.
 - Flowing-prose read-capture tokenization + tiered strictness (v0.3.45): a `Read first:` prompt that names files in flowing PROSE (e.g. `Read first: a.md, b.json, and c.py. Determine ... the breadcrumb/handoff layer`) is now tokenized with the bounded path-token regex, so a path followed by prose (`c.py. Determine ...`) and an embedded-slash English fragment (`breadcrumb/handoff`) no longer corrupt the derived targets. Confidence tiers: FLOWING-PROSE-derived tokens (Read-first prose, inline prose, backtick prose) become required targets ONLY if they have a lowercase file extension (a file shape); a prose token with a slash but no extension is dropped from the required list and reported in the new `work_focus_targets_dropped_low_confidence` telemetry field, so it can never flip `target_recall_ok` to false. The explicit `Required direct-read targets:` header, M2M `READ:` / `CTX.FILES`, and CLEAN BULLETS keep the broader slash-OR-extension behavior (a named directory path is still accepted) -- only flowing prose is stricter. Trailing prose punctuation (`.` `,` `;` `:` `)` `]` `}`) is trimmed from derived paths. The governed direct-read gate (`bundle_json.py`) is unchanged; derived paths still flow through it.
 - Determine-block target derivation guard (v0.3.59): `Determine:` numbered questions are treated as answer/output obligations, not repo-file target intent. Slash-bearing conceptual phrases inside questions (for example `ledger/runtime`) no longer become `repo_file_targets` or block typed grounding. Explicit `Read first:` / required-target sections still drive direct read normally.
@@ -226,6 +228,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.3.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.4.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/ROADMAP.md
+++ b/extensions/reddog/ROADMAP.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Phase: RedDog 0.4.3 resident architect thin-client surface.
+Phase: RedDog 0.4.4 resident architect thin-client surface.
 
 Current implementation:
+
+- Semantic HoloIndex grounding is generation-bound to the authenticated owner service. Stale, lexical, unreceipted, or repository-mismatched owner results are withheld and surfaced as an index gap; RedDog never re-indexes during a reasoning run.
 
 - Cursor command: `RedDog: Open`.
 - Bottom-composer webview with scrollback output.
@@ -128,7 +130,7 @@ P2/P3
 
 - **Owner:** RedDog Maintainers.
 - **Temporary exemption expiry:** 2026-09-30 (2026-Q3 technical-architect review).
-- **Current boundary:** `extension.js` is a legacy 7,881-line thin-client integration file. The temporary exact-file threshold is 7,900 lines; this is not permission for further feature growth.
+- **Current boundary:** `extension.js` is a legacy 7,880-line thin-client integration file. The temporary exact-file threshold is 7,900 lines; this is not permission for further feature growth. New generation-bound HoloIndex logic lives in a focused module rather than expanding this file.
 - **Remediation:** extract model configuration plus stdin bridge invocation first, then UI rendering, retrieval/context assembly, and governed work-order receipt composition into separately tested JavaScript modules of at most 400 lines.
 - **Parity gate:** retain the focused Fusion panel ingress/payload contract and exhaustive extension contract across each extraction; preserve no-network, stdin-only model payloads and review-packet truth.
 - **Exit criterion:** remove `extensions/reddog/wsp_62_exemptions.yaml` once `extension.js` and its touched functions comply with WSP_62 limits. If the expiry arrives first, block additional extension feature work and renew only through a new architect-reviewed remediation slice.

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -4,8 +4,9 @@ const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
 const semanticGroundingPolicy = require('./semantic_grounding_policy');
+const holoGenerationBoundQuery = require('./holoindex_generation_bound_query');
 
-const EXTENSION_VERSION = '0.4.3';
+const EXTENSION_VERSION = '0.4.4';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -2016,6 +2017,16 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     original_query: meta.original_query || 'unknown',
     effective_query: meta.effective_query || 'unknown',
     query_expansion_strategy: meta.expansion_strategy || 'unknown',
+    holoindex_owner_query_required: meta.holoindex_owner_query_required !== undefined ? meta.holoindex_owner_query_required : 'unknown',
+    holoindex_owner_query_ok: meta.holoindex_owner_query_ok !== undefined ? meta.holoindex_owner_query_ok : 'unknown',
+    holoindex_owner_query_error: meta.holoindex_owner_query_error !== undefined ? meta.holoindex_owner_query_error : 'unknown',
+    holoindex_query_source: meta.holoindex_query_source || 'unknown',
+    holoindex_freshness: meta.holoindex_freshness || 'UNKNOWN',
+    holoindex_generation_id: meta.holoindex_generation_id || '(none)',
+    holoindex_freshness_receipt_digest: meta.holoindex_freshness_receipt_digest || '(none)',
+    holoindex_repo_head_sha: meta.holoindex_repo_head_sha || '(none)',
+    holoindex_query_receipt_id: meta.holoindex_query_receipt_id || '(none)',
+    no_holoindex_reindex_performed: meta.no_holoindex_reindex_performed !== undefined ? meta.no_holoindex_reindex_performed : 'unknown',
     code_hits_count: meta.code_hits !== undefined ? meta.code_hits : 'unknown',
     wsp_hits: meta.wsp_hits !== undefined ? meta.wsp_hits : 'unknown',
     code_hits: meta.code_hits !== undefined ? meta.code_hits : 'unknown',
@@ -2101,6 +2112,16 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- holoindex_original_query: ' + scorecard.original_query,
     '- holoindex_effective_query: ' + scorecard.effective_query,
     '- holoindex_query_expansion_strategy: ' + scorecard.query_expansion_strategy,
+    '- holoindex_owner_query_required: ' + scorecard.holoindex_owner_query_required,
+    '- holoindex_owner_query_ok: ' + scorecard.holoindex_owner_query_ok,
+    '- holoindex_owner_query_error: ' + (scorecard.holoindex_owner_query_error || '(none)'),
+    '- holoindex_query_source: ' + scorecard.holoindex_query_source,
+    '- holoindex_freshness: ' + scorecard.holoindex_freshness,
+    '- holoindex_generation_id: ' + scorecard.holoindex_generation_id,
+    '- holoindex_freshness_receipt_digest: ' + scorecard.holoindex_freshness_receipt_digest,
+    '- holoindex_repo_head_sha: ' + scorecard.holoindex_repo_head_sha,
+    '- holoindex_query_receipt_id: ' + scorecard.holoindex_query_receipt_id,
+    '- no_holoindex_reindex_performed: ' + scorecard.no_holoindex_reindex_performed,
     '- code_hits_count: ' + scorecard.code_hits_count,
     '- wsp_hits: ' + scorecard.wsp_hits,
     '- skill_hits: ' + scorecard.skill_hits,
@@ -5138,7 +5159,7 @@ function activate(context) {
   const installState = detectRedDogInstallState(context);
   if (installState.stale_install_detected) {
     vscode.window.showWarningMessage(
-      'RedDog 0.4.3 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
+      'RedDog 0.4.4 detected a legacy Foundups Fusion Worker install. Keep only one RedDog extension active after migration.'
     );
   }
   context.subscriptions.push(
@@ -6913,102 +6934,11 @@ function moduleHintFromActive(root) {
 }
 
 function holoIndexMetaFromBundle(output, usedOfflineFallback, taskText) {
-  const meta = {
-    holoindex_status: usedOfflineFallback ? 'offline_fallback' : 'unknown',
-    requested_retrieval_mode: usedOfflineFallback ? 'semantic' : 'unknown',
-    retrieval_mode: usedOfflineFallback ? 'lexical' : 'unknown',
-    embedding_backend: usedOfflineFallback ? 'none' : 'unknown',
-    routing_active: false,
-    wsp_hits: 'unknown',
-    code_hits: 'unknown',
-    skill_hits: 'unknown',
-    target_recall_ok: 'unknown',
-    index_gap_detected: 'unknown',
-    direct_read_fallback_used: usedOfflineFallback ? true : false,
-    required_targets_total: 0,
-    required_targets_recalled: 0,
-    required_targets_missing: [],
-    // REDDOG_WORK_FOCUS_TARGET_DERIVATION_PHASE1: default provenance (nothing derived yet).
-    work_focus_targets_derived: false,
-    work_focus_target_derivation_sources: [],
-    // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1: default (no dropped fragments).
-    work_focus_targets_dropped_low_confidence: [],
-    // REDDOG_TYPED_TARGET_EXTRACTION_PHASE1: typed preprocessing defaults.
-    typed_target_extraction_applied: false,
-    repo_file_targets_count: 0,
-    semantic_targets_count: 0,
-    semantic_targets_required: 0,
-    semantic_targets_grounded: 0,
-    semantic_targets_missing: [],
-    semantic_target_coverage: [],
-    semantic_target_coverage_digest: semanticTargetCoverageDigest([]),
-    semantic_evidence_hits: [],
-    external_research_targets_count: 0,
-    quoted_reference_blocks_count: 0,
-    direct_read_paths: [],
-    direct_read_rejected: [],
-    direct_read_bytes: 0,
-    direct_read_truncated: [],
-    // REDDOG_DIRECT_READ_FALLBACK_TRIGGER_DIAGNOSTIC_PHASE1: attempt/error telemetry.
-    // Defaults describe "no enriched fetch attempted"; holoIndexOutput overwrites
-    // these when the index-gap trigger fires (attempted=true, error classified).
-    direct_read_fetch_attempted: false,
-    direct_read_fetch_error: null,
-    direct_read_fetch_arg_count: 0,
-    direct_read_fetch_timeout_ms: 0
-  };
-  try {
-    const data = JSON.parse(String(output || '{}'));
-    const bundleMeta = data.task_retrieval && data.task_retrieval.metadata ? data.task_retrieval.metadata : {};
-    const recall = evaluateTargetRecall(taskText, data);
-    meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'bundle_json_ok';
-    meta.retrieval_mode = usedOfflineFallback
-      ? 'lexical'
-      : String(bundleMeta.retrieval_mode || bundleMeta.mode || 'unknown');
-    meta.embedding_backend = usedOfflineFallback
-      ? 'none'
-      : String(bundleMeta.embedding_backend || 'unknown');
-    meta.routing_active = usedOfflineFallback ? false : bundleMeta.routing_active === true;
-    meta.wsp_hits = Number(bundleMeta.wsp_count || 0);
-    meta.code_hits = Number(bundleMeta.code_count || 0);
-    meta.skill_hits = bundleMeta.skill_count !== undefined ? Number(bundleMeta.skill_count) : 'unknown';
-    meta.target_recall_ok = recall.target_recall_ok;
-    meta.index_gap_detected = recall.index_gap_detected;
-    meta.recall_targets = recall.recall_targets;
-    meta.required_targets_total = recall.required_targets_total;
-    meta.required_targets_recalled = recall.required_targets_recalled;
-    meta.required_targets_missing = recall.required_targets_missing;
-    // REDDOG_WORK_FOCUS_TARGET_DERIVATION_PHASE1: surface derivation provenance from recall.
-    meta.work_focus_targets_derived = recall.work_focus_targets_derived === true;
-    meta.work_focus_target_derivation_sources = Array.isArray(recall.work_focus_target_derivation_sources)
-      ? recall.work_focus_target_derivation_sources
-      : [];
-    // REDDOG_WORK_FOCUS_READ_CAPTURE_PROSE_TOKENIZATION_PHASE1: surface dropped low-confidence prose.
-    meta.work_focus_targets_dropped_low_confidence = Array.isArray(recall.work_focus_targets_dropped_low_confidence)
-      ? recall.work_focus_targets_dropped_low_confidence
-      : [];
-    meta.typed_target_extraction_applied = recall.typed_target_extraction_applied === true;
-    meta.repo_file_targets_count = Number(recall.repo_file_targets_count || 0);
-    meta.semantic_targets_count = Number(recall.semantic_targets_count || 0);
-    meta.semantic_evidence_hits = semanticEvidenceHitsFromBundleData(data);
-    meta.external_research_targets_count = Number(recall.external_research_targets_count || 0);
-    meta.quoted_reference_blocks_count = Number(recall.quoted_reference_blocks_count || 0);
-    // REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1: surface the Python-side
-    // governed direct-read telemetry when the bundle carried a fetch.
-    const dr = data.direct_read && typeof data.direct_read === 'object' ? data.direct_read : null;
-    if (dr) {
-      meta.direct_read_fallback_used = !!dr.direct_read_fallback_used;
-      meta.direct_read_paths = Array.isArray(dr.direct_read_paths) ? dr.direct_read_paths : [];
-      meta.direct_read_rejected = Array.isArray(dr.direct_read_rejected) ? dr.direct_read_rejected : [];
-      meta.direct_read_bytes = Number(dr.direct_read_bytes || 0);
-      meta.direct_read_truncated = Array.isArray(dr.direct_read_truncated) ? dr.direct_read_truncated : [];
-    } else {
-      meta.direct_read_fallback_used = !!usedOfflineFallback;
-    }
-  } catch (err) {
-    meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'parse_error';
-  }
-  return meta;
+  return holoGenerationBoundQuery.buildMetaFromBundle(output, usedOfflineFallback, taskText, {
+    evaluateTargetRecall,
+    semanticEvidenceHitsFromBundleData,
+    semanticTargetCoverageDigest
+  });
 }
 
 // REDDOG_HOLO_SEMANTIC_FIRST_PHASE1: semantic retrieval is the production
@@ -7093,23 +7023,67 @@ function classifyDirectReadFetchError(err) {
   return 'unknown';
 }
 
+function isGenerationBoundHoloQueryAccepted(result) {
+  return holoGenerationBoundQuery.isAccepted(result);
+}
+
+function runHoloIndexOwnerQuery(root, query, limit) {
+  try {
+    const configuredPython = reddogConfigValue('pythonPath', 'python');
+    const interpreter = resolvePythonInterpreter(root, configuredPython);
+    return holoGenerationBoundQuery.runOwnerQuery({
+      cp,
+      path,
+      root,
+      query,
+      limit,
+      interpreterPath: interpreter.path,
+      env: buildBridgePythonEnv(process.env)
+    });
+  } catch (err) {
+    return holoGenerationBoundQuery.failureResult('owner_query_bridge_error', query);
+  }
+}
+
+function mergeGenerationBoundHoloResult(bundleOutput, ownerResult) {
+  return holoGenerationBoundQuery.mergeBundle(bundleOutput, ownerResult);
+}
+
 function holoIndexOutput(root, taskText, maxChars) {
   const typedTargets = extractTypedTargets(taskText);
   const queryPlan = semanticGroundingPolicy.buildEffectiveHoloQuery(taskText, typedTargets.semantic_targets);
   const query = queryPlan.effective_query;
   const moduleHint = moduleHintFromActive(root);
   const requestedMode = resolveHoloRetrievalMode(process.env);
-  const env = buildHoloQueryEnv(process.env, requestedMode);
+  // The owner is the sole semantic authority. The legacy bundle contributes
+  // structured memory and governed direct reads, so keep it lexical and avoid
+  // loading a second semantic model whose hits are discarded during merge.
+  const bundleEnv = buildHoloQueryEnv(process.env, 'lexical');
+  const ownerResult = requestedMode === 'semantic'
+    ? runHoloIndexOwnerQuery(root, query, 5)
+    : {
+        ok: false,
+        source: 'holoindex_owner_service',
+        freshness: 'UNKNOWN',
+        raw_result: {},
+        error: 'semantic_owner_not_requested',
+        index_gap_detected: true,
+        stale_reasons: ['semantic_owner_not_requested'],
+        no_holoindex_reindex_performed: true
+      };
   try {
     const baseArgs = ['-B', 'holo_index.py', '--bundle-json', '--search', query, '--bundle-module-hint', moduleHint, '--limit', '5', '--quiet-root-alerts'];
     let output = cp.execFileSync('python', baseArgs, {
       cwd: root,
-      env,
+      env: bundleEnv,
       encoding: 'utf8',
       timeout: requestedMode === 'semantic' ? 60000 : 25000,
       maxBuffer: Math.max(maxChars * 4, 65536),
       windowsHide: true
     });
+    if (requestedMode === 'semantic') {
+      output = mergeGenerationBoundHoloResult(output, ownerResult);
+    }
     let meta = holoIndexMetaFromBundle(output, false, taskText);
     meta.requested_retrieval_mode = requestedMode;
     if (requestedMode === 'semantic' && meta.retrieval_mode !== 'semantic') {
@@ -7146,14 +7120,17 @@ function holoIndexOutput(root, taskText, maxChars) {
         };
         try {
           const enrichedArgs = baseArgs.concat(mustInclude);
-          const enriched = cp.execFileSync('python', enrichedArgs, {
+          let enriched = cp.execFileSync('python', enrichedArgs, {
             cwd: root,
-            env,
+            env: bundleEnv,
             encoding: 'utf8',
             timeout: enrichedTimeoutMs,
             maxBuffer: enrichedMaxBuffer,
             windowsHide: true
           });
+          if (requestedMode === 'semantic') {
+            enriched = mergeGenerationBoundHoloResult(enriched, ownerResult);
+          }
           output = enriched;
           meta = holoIndexMetaFromBundle(enriched, false, taskText);
           meta.requested_retrieval_mode = requestedMode;
@@ -7179,16 +7156,23 @@ function holoIndexOutput(root, taskText, maxChars) {
     }
     Object.assign(meta, queryPlan);
     const directReadSection = buildDirectReadContentSection(output);
+    const generationQuality = requestedMode !== 'semantic'
+      ? summarizeHoloBundle(output) + '; lexical diagnostic mode does not carry generation authority.'
+      : isGenerationBoundHoloQueryAccepted(ownerResult)
+        ? summarizeHoloBundle(output) + '; generation-bound owner receipt accepted.'
+        : summarizeHoloBundle(output) + '; generation-bound owner query failed ('
+          + String((ownerResult && ownerResult.error) || 'unknown')
+          + '). Semantic hits were withheld; WRE/CI index maintenance is required.';
     return {
       output: String(output || '').slice(0, maxChars),
-      quality: summarizeHoloBundle(output),
+      quality: generationQuality,
       meta: meta,
       direct_read_section: directReadSection
     };
   } catch (bundleErr) {
     try {
       const fallbackEnv = buildHoloQueryEnv(process.env, 'lexical');
-      const output = cp.execFileSync('python', ['-B', 'holo_index.py', '--offline', '--search', query, '--limit', '5'], {
+      let output = cp.execFileSync('python', ['-B', 'holo_index.py', '--offline', '--search', query, '--limit', '5'], {
         cwd: root,
         env: fallbackEnv,
         encoding: 'utf8',
@@ -7196,12 +7180,21 @@ function holoIndexOutput(root, taskText, maxChars) {
         maxBuffer: Math.max(maxChars * 4, 65536),
         windowsHide: true
       });
-      const meta = holoIndexMetaFromBundle(output, true, taskText);
+      if (requestedMode === 'semantic') {
+        output = mergeGenerationBoundHoloResult(output, ownerResult);
+      }
+      const ownerAccepted = isGenerationBoundHoloQueryAccepted(ownerResult);
+      const meta = holoIndexMetaFromBundle(output, !ownerAccepted, taskText);
       meta.requested_retrieval_mode = requestedMode;
+      if (requestedMode === 'semantic' && !ownerAccepted) {
+        holoGenerationBoundQuery.applyRejectedOwnerMeta(meta, ownerResult);
+      }
       Object.assign(meta, queryPlan);
       return {
         output: String(output || '').slice(0, maxChars),
-        quality: 'HoloIndex bundle-json failed; offline lexical fallback used. Treat protocol coverage as NEEDS_VERIFICATION and propose re-index/bundle repair if WSP hits are missing.',
+        quality: ownerAccepted
+          ? 'Structured bundle assembly fell back, but semantic evidence remains generation-bound to the HoloIndex owner receipt.'
+          : 'HoloIndex bundle-json failed and no generation-bound semantic owner result was accepted. Treat protocol coverage as NEEDS_VERIFICATION and route the index gap to WRE/CI maintenance.',
         meta: meta
       };
     } catch (offlineErr) {
@@ -7858,6 +7851,9 @@ module.exports = {
   extractTargetTokensFromLine,
   holoIndexMetaFromBundle,
   holoIndexOutput,
+  isGenerationBoundHoloQueryAccepted,
+  runHoloIndexOwnerQuery,
+  mergeGenerationBoundHoloResult,
   resolveHoloRetrievalMode,
   buildHoloQueryEnv,
   summarizeHoloBundle,

--- a/extensions/reddog/holoindex_generation_bound_query.js
+++ b/extensions/reddog/holoindex_generation_bound_query.js
@@ -1,0 +1,358 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const HOLOINDEX_SEMANTIC_BUCKETS = [
+  'code_hits',
+  'wsp_hits',
+  'test_hits',
+  'skill_hits',
+  'symbol_hits',
+  'docs_hits',
+  'knowledge_hits',
+  'work_ledger_hits'
+];
+
+function failureResult(error, query) {
+  return {
+    ok: false,
+    source: 'holoindex_owner_service',
+    freshness: 'UNKNOWN',
+    raw_result: {},
+    error: String(error || 'owner_query_bridge_error'),
+    query: String(query || ''),
+    index_gap_detected: true,
+    stale_reasons: ['holoindex_owner_query_failed'],
+    no_holoindex_reindex_performed: true
+  };
+}
+
+function hasCurrentOwnerResult(value) {
+  return value.ok === true
+    && value.source === 'holoindex_owner_service'
+    && value.freshness === 'CURRENT'
+    && value.index_gap_detected === false
+    && value.retrieval_mode === 'semantic'
+    && Array.isArray(value.stale_reasons)
+    && value.stale_reasons.length === 0
+    && value.no_holoindex_reindex_performed === true
+    && typeof value.freshness_generation_id === 'string'
+    && value.freshness_generation_id.length > 0
+    && typeof value.freshness_receipt_digest === 'string'
+    && value.freshness_receipt_digest.length > 0
+    && typeof value.repo_head_sha === 'string'
+    && value.repo_head_sha.length > 0;
+}
+
+function asciiJsonString(value) {
+  return JSON.stringify(value).replace(/[\u007f-\uffff]/g, (character) => {
+    return '\\u' + character.charCodeAt(0).toString(16).padStart(4, '0');
+  });
+}
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalJson).join(',') + ']';
+  }
+  if (value && typeof value === 'object') {
+    return '{' + Object.keys(value).sort().map((key) => {
+      return asciiJsonString(key) + ':' + canonicalJson(value[key]);
+    }).join(',') + '}';
+  }
+  return typeof value === 'string' ? asciiJsonString(value) : JSON.stringify(value);
+}
+
+function queryReceiptId(receipt) {
+  const payload = Object.assign({}, receipt);
+  delete payload.receipt_id;
+  return 'sha256:' + crypto.createHash('sha256').update(canonicalJson(payload), 'utf8').digest('hex');
+}
+
+function receiptMatchesResult(receipt, value) {
+  return receipt.schema_version === 'holoindex_query_receipt.v1'
+    && receipt.source === 'holoindex_owner_service'
+    && receipt.source_class === 'holoindex'
+    && receipt.ok === true
+    && typeof value.requested_query === 'string'
+    && value.requested_query.length > 0
+    && receipt.query === value.requested_query
+    && value.query === value.requested_query
+    && receipt.freshness === 'CURRENT'
+    && receipt.index_gap_detected === false
+    && receipt.no_holoindex_reindex_performed === true
+    && receipt.freshness_generation_id === value.freshness_generation_id
+    && receipt.freshness_receipt_digest === value.freshness_receipt_digest
+    && receipt.repo_head_sha === value.repo_head_sha
+    && typeof receipt.receipt_id === 'string'
+    && receipt.receipt_id === queryReceiptId(receipt);
+}
+
+function isAccepted(result) {
+  const value = result && typeof result === 'object' ? result : {};
+  const receipt = value.query_receipt && typeof value.query_receipt === 'object'
+    ? value.query_receipt
+    : {};
+  return hasCurrentOwnerResult(value) && receiptMatchesResult(receipt, value);
+}
+
+function parseBridgeResult(stdout) {
+  const lines = String(stdout || '').trim().split('\n');
+  const result = JSON.parse(lines[lines.length - 1]);
+  return result && typeof result === 'object'
+    ? result
+    : failureResult('owner_response_invalid');
+}
+
+function runOwnerQuery(options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  try {
+    const script = opts.path.join(opts.root, 'scripts', 'reddog_holoindex_owner_query_once.py');
+    const stdout = opts.cp.execFileSync(opts.interpreterPath, ['-B', script], {
+      input: JSON.stringify({ query: String(opts.query || ''), limit: Number(opts.limit || 5) }),
+      cwd: opts.root,
+      env: opts.env,
+      encoding: 'utf8',
+      timeout: 90000,
+      maxBuffer: 32 * 1024 * 1024,
+      windowsHide: true
+    });
+    const result = parseBridgeResult(stdout);
+    result.requested_query = String(opts.query || '');
+    return result;
+  } catch (err) {
+    return failureResult('owner_query_bridge_error', opts.query);
+  }
+}
+
+function parseBundle(bundleOutput) {
+  try {
+    const value = JSON.parse(String(bundleOutput || '{}'));
+    return value && typeof value === 'object' ? value : null;
+  } catch (err) {
+    return null;
+  }
+}
+
+function replaceSemanticBuckets(task, ownerResult) {
+  const accepted = isAccepted(ownerResult);
+  const raw = accepted && ownerResult.raw_result && typeof ownerResult.raw_result === 'object'
+    ? ownerResult.raw_result
+    : {};
+  for (const bucket of HOLOINDEX_SEMANTIC_BUCKETS) {
+    task[bucket] = accepted && Array.isArray(raw[bucket]) ? raw[bucket].slice() : [];
+  }
+  return { accepted, raw };
+}
+
+function appendDirectHits(task, directHits) {
+  const seen = new Set(task.code_hits
+    .filter((hit) => hit && hit.direct_read === true)
+    .map((hit) => String((hit.location || hit.path) || '').toLowerCase()));
+  for (const hit of directHits) {
+    const identity = String(hit.location || hit.path || '').toLowerCase();
+    if (identity && seen.has(identity)) {
+      continue;
+    }
+    task.code_hits.push(hit);
+    if (identity) {
+      seen.add(identity);
+    }
+  }
+}
+
+function ownerMetadata(task, priorMeta, ownerResult, raw, accepted) {
+  const rawMeta = raw.metadata && typeof raw.metadata === 'object' ? raw.metadata : {};
+  const receipt = ownerResult && ownerResult.query_receipt && typeof ownerResult.query_receipt === 'object'
+    ? ownerResult.query_receipt
+    : {};
+  return Object.assign({}, priorMeta, rawMeta, {
+    code_count: task.code_hits.length,
+    wsp_count: task.wsp_hits.length,
+    test_count: task.test_hits.length,
+    skill_count: task.skill_hits.length,
+    symbol_count: task.symbol_hits.length,
+    docs_count: task.docs_hits.length,
+    knowledge_count: task.knowledge_hits.length,
+    work_ledger_count: task.work_ledger_hits.length,
+    owner_query_required: true,
+    owner_query_ok: accepted,
+    owner_query_error: String((ownerResult && ownerResult.error) || ''),
+    owner_query_source: String((ownerResult && ownerResult.source) || 'holoindex_owner_service'),
+    freshness: String((ownerResult && ownerResult.freshness) || 'UNKNOWN'),
+    freshness_generation_id: String((ownerResult && ownerResult.freshness_generation_id) || ''),
+    freshness_receipt_digest: String((ownerResult && ownerResult.freshness_receipt_digest) || ''),
+    repo_head_sha: String((ownerResult && ownerResult.repo_head_sha) || ''),
+    query_receipt_id: String(receipt.receipt_id || ''),
+    no_holoindex_reindex_performed: ownerResult && ownerResult.no_holoindex_reindex_performed === true
+  });
+}
+
+function ownerQuerySummary(metadata, accepted) {
+  return {
+    accepted,
+    freshness: metadata.freshness,
+    generation_id: metadata.freshness_generation_id,
+    freshness_receipt_digest: metadata.freshness_receipt_digest,
+    repo_head_sha: metadata.repo_head_sha,
+    query_receipt_id: metadata.query_receipt_id,
+    error: metadata.owner_query_error,
+    no_holoindex_reindex_performed: metadata.no_holoindex_reindex_performed
+  };
+}
+
+function mergeBundle(bundleOutput, ownerResult) {
+  const data = parseBundle(bundleOutput);
+  if (!data) {
+    return String(bundleOutput || '');
+  }
+  const task = data.task_retrieval && typeof data.task_retrieval === 'object'
+    ? Object.assign({}, data.task_retrieval)
+    : {};
+  const priorMeta = task.metadata && typeof task.metadata === 'object' ? task.metadata : {};
+  const directHits = Array.isArray(task.code_hits)
+    ? task.code_hits.filter((hit) => hit && hit.direct_read === true)
+    : [];
+  const replaced = replaceSemanticBuckets(task, ownerResult);
+  appendDirectHits(task, directHits);
+  task.metadata = ownerMetadata(task, priorMeta, ownerResult, replaced.raw, replaced.accepted);
+  data.task_retrieval = task;
+  data.holoindex_owner_query = ownerQuerySummary(task.metadata, replaced.accepted);
+  return JSON.stringify(data);
+}
+
+function newMeta(usedOfflineFallback, emptyCoverageDigest) {
+  return {
+    holoindex_status: usedOfflineFallback ? 'offline_fallback' : 'unknown', requested_retrieval_mode: usedOfflineFallback ? 'semantic' : 'unknown',
+    retrieval_mode: usedOfflineFallback ? 'lexical' : 'unknown', embedding_backend: usedOfflineFallback ? 'none' : 'unknown',
+    holoindex_owner_query_required: false,
+    holoindex_owner_query_ok: false,
+    holoindex_owner_query_error: 'unknown',
+    holoindex_query_source: 'unknown',
+    holoindex_freshness: 'UNKNOWN',
+    holoindex_generation_id: '',
+    holoindex_freshness_receipt_digest: '',
+    holoindex_repo_head_sha: '',
+    holoindex_query_receipt_id: '',
+    no_holoindex_reindex_performed: true,
+    routing_active: false,
+    wsp_hits: 'unknown', code_hits: 'unknown', skill_hits: 'unknown',
+    target_recall_ok: 'unknown', index_gap_detected: 'unknown',
+    direct_read_fallback_used: !!usedOfflineFallback,
+    required_targets_total: 0, required_targets_recalled: 0, required_targets_missing: [],
+    work_focus_targets_derived: false, work_focus_target_derivation_sources: [],
+    work_focus_targets_dropped_low_confidence: [], typed_target_extraction_applied: false,
+    repo_file_targets_count: 0, semantic_targets_count: 0,
+    semantic_targets_required: 0, semantic_targets_grounded: 0, semantic_targets_missing: [],
+    semantic_target_coverage: [], semantic_target_coverage_digest: emptyCoverageDigest,
+    semantic_evidence_hits: [], external_research_targets_count: 0,
+    quoted_reference_blocks_count: 0, direct_read_paths: [], direct_read_rejected: [],
+    direct_read_bytes: 0, direct_read_truncated: [], direct_read_fetch_attempted: false,
+    direct_read_fetch_error: null, direct_read_fetch_arg_count: 0, direct_read_fetch_timeout_ms: 0
+  };
+}
+
+function applyOwnerMetadata(meta, bundleMeta, usedOfflineFallback) {
+  meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'bundle_json_ok';
+  meta.retrieval_mode = usedOfflineFallback ? 'lexical' : String(bundleMeta.retrieval_mode || bundleMeta.mode || 'unknown');
+  meta.embedding_backend = usedOfflineFallback ? 'none' : String(bundleMeta.embedding_backend || 'unknown');
+  meta.holoindex_owner_query_required = bundleMeta.owner_query_required === true;
+  meta.holoindex_owner_query_ok = bundleMeta.owner_query_ok === true;
+  meta.holoindex_owner_query_error = String(bundleMeta.owner_query_error || '');
+  meta.holoindex_query_source = String(bundleMeta.owner_query_source || 'unknown');
+  meta.holoindex_freshness = String(bundleMeta.freshness || 'UNKNOWN');
+  meta.holoindex_generation_id = String(bundleMeta.freshness_generation_id || '');
+  meta.holoindex_freshness_receipt_digest = String(bundleMeta.freshness_receipt_digest || '');
+  meta.holoindex_repo_head_sha = String(bundleMeta.repo_head_sha || '');
+  meta.holoindex_query_receipt_id = String(bundleMeta.query_receipt_id || '');
+  meta.no_holoindex_reindex_performed = bundleMeta.no_holoindex_reindex_performed === true;
+  meta.routing_active = usedOfflineFallback ? false : bundleMeta.routing_active === true;
+  meta.wsp_hits = Number(bundleMeta.wsp_count || 0);
+  meta.code_hits = Number(bundleMeta.code_count || 0);
+  meta.skill_hits = bundleMeta.skill_count !== undefined ? Number(bundleMeta.skill_count) : 'unknown';
+}
+
+function applyRecallMetadata(meta, recall, data, dependencies) {
+  meta.target_recall_ok = recall.target_recall_ok;
+  meta.index_gap_detected = recall.index_gap_detected
+    || (meta.holoindex_owner_query_required && meta.holoindex_owner_query_ok !== true);
+  meta.recall_targets = recall.recall_targets;
+  meta.required_targets_total = recall.required_targets_total;
+  meta.required_targets_recalled = recall.required_targets_recalled;
+  meta.required_targets_missing = recall.required_targets_missing;
+  meta.work_focus_targets_derived = recall.work_focus_targets_derived === true;
+  meta.work_focus_target_derivation_sources = Array.isArray(recall.work_focus_target_derivation_sources)
+    ? recall.work_focus_target_derivation_sources : [];
+  meta.work_focus_targets_dropped_low_confidence = Array.isArray(recall.work_focus_targets_dropped_low_confidence)
+    ? recall.work_focus_targets_dropped_low_confidence : [];
+  meta.typed_target_extraction_applied = recall.typed_target_extraction_applied === true;
+  meta.repo_file_targets_count = Number(recall.repo_file_targets_count || 0);
+  meta.semantic_targets_count = Number(recall.semantic_targets_count || 0);
+  meta.semantic_evidence_hits = dependencies.semanticEvidenceHitsFromBundleData(data);
+  meta.external_research_targets_count = Number(recall.external_research_targets_count || 0);
+  meta.quoted_reference_blocks_count = Number(recall.quoted_reference_blocks_count || 0);
+}
+
+function applyDirectReadMetadata(meta, data, usedOfflineFallback) {
+  const directRead = data.direct_read && typeof data.direct_read === 'object' ? data.direct_read : null;
+  if (!directRead) {
+    meta.direct_read_fallback_used = !!usedOfflineFallback;
+    return;
+  }
+  meta.direct_read_fallback_used = !!directRead.direct_read_fallback_used;
+  meta.direct_read_paths = Array.isArray(directRead.direct_read_paths) ? directRead.direct_read_paths : [];
+  meta.direct_read_rejected = Array.isArray(directRead.direct_read_rejected) ? directRead.direct_read_rejected : [];
+  meta.direct_read_bytes = Number(directRead.direct_read_bytes || 0);
+  meta.direct_read_truncated = Array.isArray(directRead.direct_read_truncated) ? directRead.direct_read_truncated : [];
+}
+
+function buildMetaFromBundle(output, usedOfflineFallback, taskText, dependencies) {
+  const deps = dependencies && typeof dependencies === 'object' ? dependencies : {};
+  const digest = typeof deps.semanticTargetCoverageDigest === 'function'
+    ? deps.semanticTargetCoverageDigest([]) : '';
+  const meta = newMeta(usedOfflineFallback, digest);
+  try {
+    const data = JSON.parse(String(output || '{}'));
+    const bundleMeta = data.task_retrieval && data.task_retrieval.metadata ? data.task_retrieval.metadata : {};
+    const recall = deps.evaluateTargetRecall(taskText, data);
+    applyOwnerMetadata(meta, bundleMeta, usedOfflineFallback);
+    applyRecallMetadata(meta, recall, data, deps);
+    applyDirectReadMetadata(meta, data, usedOfflineFallback);
+    if (meta.holoindex_owner_query_required && meta.holoindex_owner_query_ok !== true) {
+      meta.holoindex_status = 'generation_bound_query_failed';
+    }
+  } catch (err) {
+    meta.holoindex_status = usedOfflineFallback ? 'offline_fallback' : 'parse_error';
+  }
+  return meta;
+}
+
+function applyRejectedOwnerMeta(meta, ownerResult) {
+  const value = ownerResult && typeof ownerResult === 'object' ? ownerResult : {};
+  const receipt = value.query_receipt && typeof value.query_receipt === 'object' ? value.query_receipt : {};
+  Object.assign(meta, {
+    holoindex_status: 'generation_bound_query_failed',
+    holoindex_owner_query_required: true,
+    holoindex_owner_query_ok: false,
+    holoindex_owner_query_error: String(value.error || 'unknown'),
+    holoindex_query_source: String(value.source || 'holoindex_owner_service'),
+    holoindex_freshness: String(value.freshness || 'UNKNOWN'),
+    holoindex_generation_id: String(value.freshness_generation_id || ''),
+    holoindex_freshness_receipt_digest: String(value.freshness_receipt_digest || ''),
+    holoindex_repo_head_sha: String(value.repo_head_sha || ''),
+    holoindex_query_receipt_id: String(receipt.receipt_id || ''),
+    no_holoindex_reindex_performed: value.no_holoindex_reindex_performed === true,
+    index_gap_detected: true
+  });
+  return meta;
+}
+
+module.exports = {
+  HOLOINDEX_SEMANTIC_BUCKETS,
+  failureResult,
+  queryReceiptId,
+  isAccepted,
+  runOwnerQuery,
+  mergeBundle,
+  buildMetaFromBundle,
+  applyRejectedOwnerMeta
+};

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,12 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-19 - REDDOG_HOLOINDEX_GENERATION_BOUND_QUERY_RUNTIME_PHASE1
+
+- Added HGBQ-001..010 to prove the exact generation-bound acceptance predicate, stale/lexical/mismatched/reindex rejection, unbound semantic-hit removal, governed direct-read preservation, and Run Trace generation receipts.
+- Added six Python bridge tests covering process-owned and configured owners, private handoff use, canonical query receipt creation, cleanup, bounded input validation, and secret-free failures.
+- Added owner-supervisor regression tests proving authenticated stale-generation startup stops immediately, while unauthorized, malformed, and non-loopback responses cannot forge a terminal freshness error.
+- Re-ran 69 owner-client, query-boundary, and owner-service tests plus the complete RedDog extension and Fusion ingress contracts.
+
 ## 2026-07-19 - REDDOG_BROAD_SEMANTIC_GROUNDING_NONVACUITY_PHASE1
 
 - Proved `Audit pfmall.` derives one semantic target and no invented repository path, while the extension source contains no hardcoded `pfmall` literal.

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -14,7 +14,10 @@ const fixtures = require('./fixtures');
 const root = path.resolve(__dirname, '..', '..', '..');
 const extDir = path.join(root, 'extensions', 'reddog');
 const extensionJs = fs.readFileSync(path.join(extDir, 'extension.js'), 'utf8');
+const holoGenerationBoundQueryJs = fs.readFileSync(path.join(extDir, 'holoindex_generation_bound_query.js'), 'utf8');
+const holoGenerationBoundQuery = require(path.join(extDir, 'holoindex_generation_bound_query.js'));
 const bridgePy = fs.readFileSync(path.join(root, 'scripts', 'advisory_model_once.py'), 'utf8');
+const holoOwnerBridgePy = fs.readFileSync(path.join(root, 'scripts', 'reddog_holoindex_owner_query_once.py'), 'utf8');
 const residentArchitectBridgePy = fs.readFileSync(path.join(root, 'scripts', 'reddog_resident_architect_session_once.py'), 'utf8');
 const pkg = JSON.parse(fs.readFileSync(path.join(extDir, 'package.json'), 'utf8'));
 const readme = fs.readFileSync(path.join(extDir, 'README.md'), 'utf8');
@@ -203,8 +206,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.3', 'package version must be 0.4.3');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.3'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.4', 'package version must be 0.4.4');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.4'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -224,7 +227,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.3', 'README version mismatch');
+includes(readme, 'Version: 0.4.4', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -504,7 +507,21 @@ try {
   process.env.REDDOG_HOLO_RETRIEVAL_MODE = 'semantic';
   cp.execFileSync = function(_exe, args, options) {
     hsfExecCalls += 1;
-    if (hsfExecCalls === 1) {
+    if (args.some((arg) => String(arg).endsWith('reddog_holoindex_owner_query_once.py'))) {
+      return JSON.stringify({
+        ok: false,
+        source: 'holoindex_owner_service',
+        freshness: 'UNKNOWN',
+        raw_result: {},
+        error: 'simulated_owner_unavailable',
+        index_gap_detected: true,
+        stale_reasons: ['holoindex_owner_query_failed'],
+        no_holoindex_reindex_performed: true
+      });
+    }
+    if (!args.includes('--offline')) {
+      assert.strictEqual(options.env.HOLO_SKIP_MODEL, '1',
+        'HSF-006: legacy bundle stays lexical because the owner is the sole semantic authority');
       const err = new Error('simulated semantic bundle failure');
       err.code = 'SIMULATED';
       throw err;
@@ -515,8 +532,8 @@ try {
     return '[OFFLINE] simulated lexical result';
   };
   const hsfFallback = orchestrator.holoIndexOutput(root, 'semantic fallback contract', 18000);
-  assert.strictEqual(hsfExecCalls, 2, 'HSF-006: semantic failure must invoke exactly one lexical fallback');
-  assert.strictEqual(hsfFallback.meta.holoindex_status, 'offline_fallback', 'HSF-006: fallback status must be truthful');
+  assert.strictEqual(hsfExecCalls, 3, 'HSF-006: owner proof plus semantic failure must invoke exactly one lexical fallback');
+  assert.strictEqual(hsfFallback.meta.holoindex_status, 'generation_bound_query_failed', 'HSF-006: failed owner proof must outrank the lexical fallback status');
   assert.strictEqual(hsfFallback.meta.requested_retrieval_mode, 'semantic', 'HSF-006: receipt must retain the requested mode');
   assert.strictEqual(hsfFallback.meta.retrieval_mode, 'lexical', 'HSF-006: receipt must expose actual lexical behavior');
 } finally {
@@ -550,6 +567,120 @@ try {
   cp.execFileSync = hsfOriginalExecFileSync;
   process.env.REDDOG_HOLO_RETRIEVAL_MODE = hsfOriginalMode;
 }
+
+// REDDOG_HOLOINDEX_GENERATION_BOUND_QUERY_RUNTIME_PHASE1 (HGBQ-001..010): only the
+// authenticated owner response may supply semantic hit authority. The legacy direct
+// bundle remains useful for structured-memory assembly and governed explicit direct read.
+const hgbqGeneration = 'sha256:' + 'a'.repeat(64);
+const hgbqFreshnessDigest = 'sha256:' + 'b'.repeat(64);
+const hgbqHead = 'c'.repeat(40);
+const hgbqReceipt = {
+  schema_version: 'holoindex_query_receipt.v1',
+  source: 'holoindex_owner_service',
+  source_class: 'holoindex',
+  ok: true,
+  query: 'audit pfmall',
+  freshness: 'CURRENT',
+  hits: [],
+  error: '',
+  freshness_generation_id: hgbqGeneration,
+  freshness_receipt_digest: hgbqFreshnessDigest,
+  freshness_receipt_path: 'E:/HoloIndex/indexes/holoindex_freshness_receipt.json',
+  repo_head_sha: hgbqHead,
+  index_gap_detected: false,
+  stale_reasons: [],
+  no_holoindex_reindex_performed: true
+};
+hgbqReceipt.receipt_id = holoGenerationBoundQuery.queryReceiptId(hgbqReceipt);
+const hgbqReceiptId = hgbqReceipt.receipt_id;
+const hgbqOwner = {
+  ok: true,
+  source: 'holoindex_owner_service',
+  query: 'audit pfmall',
+  requested_query: 'audit pfmall',
+  freshness: 'CURRENT',
+  raw_result: {
+    code_hits: [{ path: 'modules/foundups/pfmall/api.py', preview: 'PFMall implementation API.' }],
+    test_hits: [{ path: 'modules/foundups/pfmall/tests/test_api.py', summary: 'PFMall API verification.' }],
+    metadata: { retrieval_mode: 'semantic', embedding_backend: 'sentence_transformers' }
+  },
+  error: '',
+  index_gap_detected: false,
+  stale_reasons: [],
+  freshness_generation_id: hgbqGeneration,
+  freshness_receipt_digest: hgbqFreshnessDigest,
+  repo_head_sha: hgbqHead,
+  retrieval_mode: 'semantic',
+  no_holoindex_reindex_performed: true,
+  query_receipt: hgbqReceipt
+};
+assert.strictEqual(orchestrator.isGenerationBoundHoloQueryAccepted(hgbqOwner), true,
+  'HGBQ-001: exact generation-bound owner contract is accepted');
+for (const mutation of [
+  { freshness: 'STALE' },
+  { index_gap_detected: true },
+  { retrieval_mode: 'lexical' },
+  { freshness_generation_id: '' },
+  { query_receipt: Object.assign({}, hgbqOwner.query_receipt, { repo_head_sha: 'e'.repeat(40) }) },
+  { query_receipt: Object.assign({}, hgbqOwner.query_receipt, { source_class: 'brain' }) },
+  { requested_query: 'audit another target' },
+  { query_receipt: Object.assign({}, hgbqOwner.query_receipt, { receipt_id: 'sha256:' + 'd'.repeat(64) }) },
+  { no_holoindex_reindex_performed: false }
+]) {
+  assert.strictEqual(orchestrator.isGenerationBoundHoloQueryAccepted(Object.assign({}, hgbqOwner, mutation)), false,
+    'HGBQ-002: stale, unbound, lexical, or mutating owner evidence fails closed');
+}
+const hgbqLegacyBundle = JSON.stringify({
+  task_retrieval: {
+    code_hits: [
+      { path: 'modules/untrusted/stale.py', preview: 'unbound stale semantic result' },
+      { location: 'modules/foundups/pfmall/api.py', content: 'direct read body', direct_read: true }
+    ],
+    wsp_hits: [{ path: 'WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md' }],
+    metadata: { retrieval_mode: 'semantic', embedding_backend: 'sentence_transformers' }
+  },
+  direct_read: { direct_read_fallback_used: true }
+});
+const hgbqMerged = JSON.parse(orchestrator.mergeGenerationBoundHoloResult(hgbqLegacyBundle, hgbqOwner));
+assert.deepStrictEqual(hgbqMerged.task_retrieval.code_hits.map((hit) => hit.path || hit.location), [
+  'modules/foundups/pfmall/api.py',
+  'modules/foundups/pfmall/api.py'
+], 'HGBQ-003: owner semantic hit replaces unbound hit while governed direct-read evidence survives');
+assert.strictEqual(hgbqMerged.task_retrieval.test_hits.length, 1, 'HGBQ-003: owner test evidence survives');
+assert.strictEqual(hgbqMerged.task_retrieval.wsp_hits.length, 0, 'HGBQ-003: unbound legacy WSP hit is removed');
+assert.strictEqual(hgbqMerged.task_retrieval.metadata.owner_query_ok, true, 'HGBQ-004: accepted owner state enters bundle metadata');
+assert.strictEqual(hgbqMerged.task_retrieval.metadata.freshness_generation_id, hgbqGeneration, 'HGBQ-004: generation ID enters bundle metadata');
+assert.strictEqual(hgbqMerged.task_retrieval.metadata.query_receipt_id, hgbqReceiptId, 'HGBQ-004: query receipt enters bundle metadata');
+const hgbqRejected = JSON.parse(orchestrator.mergeGenerationBoundHoloResult(hgbqLegacyBundle, Object.assign({}, hgbqOwner, {
+  ok: false,
+  freshness: 'STALE',
+  index_gap_detected: true,
+  error: 'STALE_INDEX'
+})));
+assert.deepStrictEqual(hgbqRejected.task_retrieval.code_hits.map((hit) => hit.location), [
+  'modules/foundups/pfmall/api.py'
+], 'HGBQ-005: failed owner proof withholds every semantic hit but preserves governed direct read');
+assert.strictEqual(hgbqRejected.task_retrieval.test_hits.length, 0, 'HGBQ-005: failed owner proof withholds test hits');
+assert.strictEqual(hgbqRejected.task_retrieval.metadata.owner_query_ok, false, 'HGBQ-005: failed owner state is explicit');
+const hgbqMeta = orchestrator.holoIndexMetaFromBundle(JSON.stringify(hgbqMerged), false, 'Audit pfmall.');
+assert.strictEqual(hgbqMeta.holoindex_owner_query_ok, true, 'HGBQ-006: meta accepts generation-bound owner proof');
+assert.strictEqual(hgbqMeta.holoindex_generation_id, hgbqGeneration, 'HGBQ-006: meta exposes generation');
+assert.strictEqual(hgbqMeta.holoindex_repo_head_sha, hgbqHead, 'HGBQ-006: meta exposes bound repo HEAD');
+const hgbqLines = orchestrator.formatHoloIndexScorecardLines(
+  orchestrator.extractHoloIndexScorecard('wsp_holo', hgbqMeta)
+).join('\n');
+includes(hgbqLines, '- holoindex_owner_query_ok: true', 'HGBQ-007: Run Trace exposes owner acceptance');
+includes(hgbqLines, '- holoindex_generation_id: ' + hgbqGeneration, 'HGBQ-007: Run Trace exposes generation');
+includes(hgbqLines, '- holoindex_query_receipt_id: ' + hgbqReceiptId, 'HGBQ-007: Run Trace exposes query receipt');
+includes(hgbqLines, '- no_holoindex_reindex_performed: true', 'HGBQ-007: Run Trace proves query-only behavior');
+includes(extensionJs, "require('./holoindex_generation_bound_query')", 'HGBQ-008: extension must load the generation-bound query module');
+includes(holoGenerationBoundQueryJs, 'reddog_holoindex_owner_query_once.py', 'HGBQ-008: generation-bound query module must invoke the owner bridge');
+includes(holoOwnerBridgePy, 'query_holoindex_owner', 'HGBQ-008: bridge must reuse the owner client');
+includes(holoOwnerBridgePy, 'build_query_receipt', 'HGBQ-008: bridge must emit the canonical query receipt');
+assert(!/(?:--index|index_all\s*\(|run_incremental_index)/.test(holoOwnerBridgePy),
+  'HGBQ-009: owner bridge must never invoke an indexer');
+assert(fs.existsSync(path.join(root, 'scripts', 'reddog_holoindex_owner_query_once.py')),
+  'HGBQ-010: generation-bound owner bridge script must exist');
 
 const ultra = orchestrator.classifyTaskForRedDog('Audit OAuth auth secrets on live runtime deploy path', 'auto', 'reddog_architect');
 assert.strictEqual(ultra.tier, 'ULTRA', 'security/auth prompts must classify ULTRA');
@@ -1193,7 +1324,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.3', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.4', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -2685,7 +2816,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.3'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.4'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -2699,7 +2830,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.3'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.4'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -2711,7 +2842,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.3'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.4'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3718,7 +3849,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.3' } }
+      ? { id, packageJSON: { version: '0.4.4' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({

--- a/modules/infrastructure/foundups_mcp_bridge/src/holo_query_service_supervisor.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/holo_query_service_supervisor.py
@@ -68,7 +68,7 @@ def _read_health_payload(
     )
     response = connection.getresponse()
     body = response.read(MAX_HEALTH_RESPONSE_BYTES + 1)
-    if response.status != 200 or len(body) > MAX_HEALTH_RESPONSE_BYTES:
+    if response.status not in {200, 409} or len(body) > MAX_HEALTH_RESPONSE_BYTES:
         return None
     payload = json.loads(body.decode("utf-8"))
     return payload if isinstance(payload, Mapping) else None
@@ -137,6 +137,42 @@ def _authenticated_health_probe(
         )
     except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
         return False
+    finally:
+        connection.close()
+
+
+def _health_rejection_code(payload: Mapping[str, object] | None) -> str:
+    """Expose only authenticated, terminal freshness failures during startup."""
+    value = payload if isinstance(payload, Mapping) else {}
+    error = str(value.get("error") or "")
+    terminal = {
+        "MISSING_GENERATION_BINDING",
+        "REPO_HEAD_MISMATCH",
+        "STALE_INDEX",
+        "GENERATION_CHANGED_DURING_QUERY",
+    }
+    valid = (
+        value.get("schema_version") == HEALTH_SCHEMA_VERSION
+        and value.get("ok") is False
+        and value.get("source") == "holoindex"
+        and value.get("loopback_only") is True
+        and value.get("no_holoindex_reindex_performed") is True
+    )
+    return error if valid and error in terminal else ""
+
+
+def _authenticated_health_rejection(
+    *, host: str, port: int, token: str, timeout_seconds: float
+) -> str:
+    if not _probe_target_is_private(host, token):
+        return ""
+    connection = http.client.HTTPConnection(
+        host, int(port), timeout=max(0.01, float(timeout_seconds))
+    )
+    try:
+        return _health_rejection_code(_read_health_payload(connection, token))
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        return ""
     finally:
         connection.close()
 
@@ -342,6 +378,14 @@ class HoloQueryServiceSupervisor:
                     self._ready = True
                     self._register_cleanup()
                     return self
+                rejection = _authenticated_health_rejection(
+                    host=OWNER_HOST,
+                    port=self.port,
+                    token=self._token,
+                    timeout_seconds=min(self.probe_timeout_seconds, remaining),
+                )
+                if rejection:
+                    raise HoloQueryServiceSupervisorError(rejection)
                 time.sleep(min(self.probe_interval_seconds, remaining))
         except BaseException:
             self.stop()

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_supervisor.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_supervisor.py
@@ -197,6 +197,11 @@ def test_startup_timeout_terminates_owner_and_never_exposes_token_in_error(
         lambda **_kwargs: False,
     )
     monkeypatch.setattr(
+        supervisor_module,
+        "_authenticated_health_rejection",
+        lambda **_kwargs: "",
+    )
+    monkeypatch.setattr(
         supervisor_module.secrets,
         "token_urlsafe",
         lambda _bytes: TOKEN,
@@ -225,6 +230,59 @@ def test_startup_timeout_terminates_owner_and_never_exposes_token_in_error(
     assert captured_environment[SERVICE_TOKEN_ENV] == TOKEN
     assert process.terminated is True
     assert owner.is_ready is False
+
+
+def test_startup_stops_immediately_on_authenticated_stale_owner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess()
+    monkeypatch.setattr(
+        supervisor_module.subprocess,
+        "Popen",
+        lambda _command, **_kwargs: process,
+    )
+    monkeypatch.setattr(
+        supervisor_module,
+        "_authenticated_health_probe",
+        lambda **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        supervisor_module,
+        "_authenticated_health_rejection",
+        lambda **_kwargs: "REPO_HEAD_MISMATCH",
+    )
+    monkeypatch.setattr(
+        supervisor_module.secrets,
+        "token_urlsafe",
+        lambda _bytes: TOKEN,
+    )
+    owner = HoloQueryServiceSupervisor(
+        repo_root=tmp_path,
+        startup_timeout_seconds=300.0,
+    )
+
+    with pytest.raises(HoloQueryServiceSupervisorError) as error:
+        owner.start()
+
+    assert error.value.code == "REPO_HEAD_MISMATCH"
+    assert process.terminated is True
+    assert owner.is_ready is False
+
+
+def test_health_rejection_accepts_only_terminal_authenticated_contract() -> None:
+    base = {
+        "schema_version": HEALTH_SCHEMA_VERSION,
+        "ok": False,
+        "source": "holoindex",
+        "loopback_only": True,
+        "no_holoindex_reindex_performed": True,
+        "error": "STALE_INDEX",
+    }
+    assert supervisor_module._health_rejection_code(base) == "STALE_INDEX"
+    assert supervisor_module._health_rejection_code({**base, "error": "UNAUTHORIZED"}) == ""
+    assert supervisor_module._health_rejection_code({**base, "loopback_only": False}) == ""
+    assert supervisor_module._health_rejection_code({**base, "schema_version": "wrong"}) == ""
 
 
 def test_startup_fails_closed_when_spawned_owner_exits(

--- a/scripts/reddog_holoindex_owner_query_once.py
+++ b/scripts/reddog_holoindex_owner_query_once.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""One-shot generation-bound HoloIndex query bridge for the RedDog extension.
+
+The extension sends one bounded semantic query on stdin. This adapter starts or
+reuses the existing authenticated loopback owner, executes the query through
+``query_holoindex_owner``, and returns only the owner's secret-free response.
+It never indexes, mutates repository state, or exposes the owner bearer token.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from holo_index.query_receipt import build_query_receipt  # noqa: E402
+from modules.communication.moltbot_bridge.src.reddog_holoindex_owner_query_client import (  # noqa: E402
+    query_holoindex_owner,
+)
+from modules.infrastructure.foundups_mcp_bridge.src.reddog_holoindex_owner_bootstrap import (  # noqa: E402
+    OWNER_CONFIGURED,
+    OWNER_REUSED,
+    OWNER_STARTED,
+    cleanup_reddog_holoindex_owner,
+    ensure_reddog_holoindex_owner,
+    resolve_reddog_holoindex_owner_handoff,
+)
+
+
+MAX_QUERY_CHARS = 16_000
+MAX_LIMIT = 20
+
+
+def _failure(error: str, *, query: str = "") -> dict[str, Any]:
+    return {
+        "ok": False,
+        "source": "holoindex_owner_service",
+        "query": query,
+        "freshness": "UNKNOWN",
+        "raw_result": {},
+        "error": error,
+        "index_gap_detected": True,
+        "stale_reasons": ["holoindex_owner_query_failed"],
+        "no_holoindex_reindex_performed": True,
+    }
+
+
+def _read_payload() -> Mapping[str, Any]:
+    raw = sys.stdin.buffer.read()
+    value = json.loads(raw.decode("utf-8", errors="strict"))
+    if not isinstance(value, Mapping):
+        raise ValueError("payload_not_object")
+    return value
+
+
+def _bounded_request(payload: Mapping[str, Any]) -> tuple[str, int, str]:
+    query = payload.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return "", 0, "query_required"
+    query = query.strip()
+    if len(query) > MAX_QUERY_CHARS:
+        return "", 0, "query_too_large"
+    raw_limit = payload.get("limit", 5)
+    if isinstance(raw_limit, bool):
+        return "", 0, "limit_invalid"
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        return "", 0, "limit_invalid"
+    if limit < 1 or limit > MAX_LIMIT:
+        return "", 0, "limit_invalid"
+    return query, limit, ""
+
+
+def query_once(
+    payload: Mapping[str, Any],
+    *,
+    repo_root: Path = REPO_ROOT,
+    ensure_owner: Callable[..., Any] = ensure_reddog_holoindex_owner,
+    resolve_handoff: Callable[[], tuple[str, str] | None] = (
+        resolve_reddog_holoindex_owner_handoff
+    ),
+    query_owner: Callable[..., Mapping[str, Any]] = query_holoindex_owner,
+    cleanup_owner: Callable[..., None] = cleanup_reddog_holoindex_owner,
+) -> Mapping[str, Any]:
+    """Execute one owner-bound query and always clean up process-owned state."""
+
+    query, limit, request_error = _bounded_request(payload)
+    if request_error:
+        return _failure(request_error)
+
+    started_here = False
+    try:
+        bootstrap = ensure_owner(repo_root=repo_root, requested=True)
+        status = str(getattr(bootstrap, "status", ""))
+        if getattr(bootstrap, "ready", False) is not True:
+            return _failure(
+                str(getattr(bootstrap, "error", "") or "owner_bootstrap_failed"),
+                query=query,
+            )
+        started_here = status == OWNER_STARTED
+        service_url: str | None = None
+        service_token: str | None = None
+        if status in {OWNER_STARTED, OWNER_REUSED}:
+            handoff = resolve_handoff()
+            if handoff is None:
+                return _failure("owner_handoff_missing", query=query)
+            service_url, service_token = handoff
+        elif status != OWNER_CONFIGURED:
+            return _failure("owner_bootstrap_status_invalid", query=query)
+
+        result = query_owner(
+            repo_root=repo_root,
+            query=query,
+            limit=limit,
+            service_url=service_url,
+            service_token=service_token,
+            timeout_seconds=60.0,
+        )
+        if not isinstance(result, Mapping):
+            return _failure("owner_response_invalid", query=query)
+        receipt = build_query_receipt(
+            source="holoindex_owner_service",
+            source_class="holoindex",
+            query=query,
+            result=result,
+            require_generation=True,
+        )
+        return {**dict(result), "query_receipt": dict(receipt)}
+    except Exception as exc:
+        return _failure(type(exc).__name__, query=query)
+    finally:
+        if started_here:
+            cleanup_owner()
+
+
+def main() -> int:
+    try:
+        payload = _read_payload()
+    except (UnicodeError, ValueError, json.JSONDecodeError):
+        result: Mapping[str, Any] = _failure("invalid_json")
+    else:
+        result = query_once(payload)
+    sys.stdout.write(json.dumps(result, ensure_ascii=True, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_reddog_holoindex_owner_query_once.py
+++ b/scripts/tests/test_reddog_holoindex_owner_query_once.py
@@ -1,0 +1,169 @@
+"""Tests for the extension's one-shot generation-bound HoloIndex bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.reddog_holoindex_owner_query_once import (
+    MAX_QUERY_CHARS,
+    query_once,
+)
+
+
+def _success() -> dict:
+    return {
+        "ok": True,
+        "source": "holoindex_owner_service",
+        "query": "audit pfmall",
+        "freshness": "CURRENT",
+        "raw_result": {"code_hits": [{"path": "modules/foundups/pfmall/api.py"}]},
+        "error": "",
+        "index_gap_detected": False,
+        "stale_reasons": [],
+        "freshness_generation_id": "sha256:" + "a" * 64,
+        "freshness_receipt_digest": "sha256:" + "b" * 64,
+        "repo_head_sha": "c" * 40,
+        "retrieval_mode": "semantic",
+        "no_holoindex_reindex_performed": True,
+    }
+
+
+def test_started_owner_uses_private_handoff_and_cleans_up(tmp_path: Path) -> None:
+    calls: dict = {}
+
+    def query_owner(**kwargs):
+        calls.update(kwargs)
+        return _success()
+
+    def cleanup_owner():
+        calls["cleaned"] = True
+
+    result = query_once(
+        {"query": "audit pfmall", "limit": 5},
+        repo_root=tmp_path,
+        ensure_owner=lambda **_kwargs: SimpleNamespace(
+            ready=True, status="STARTED", error=""
+        ),
+        resolve_handoff=lambda: ("http://127.0.0.1:8127/holoindex/v1/query", "x" * 48),
+        query_owner=query_owner,
+        cleanup_owner=cleanup_owner,
+    )
+
+    assert result["ok"] is True
+    assert result["query_receipt"]["schema_version"] == "holoindex_query_receipt.v1"
+    assert result["query_receipt"]["freshness_generation_id"] == "sha256:" + "a" * 64
+    assert result["query_receipt"]["index_gap_detected"] is False
+    assert calls["repo_root"] == tmp_path
+    assert calls["service_url"].startswith("http://127.0.0.1:")
+    assert calls["service_token"] == "x" * 48
+    assert calls["timeout_seconds"] == 60.0
+    assert calls["cleaned"] is True
+
+
+def test_configured_owner_uses_environment_contract_without_cleanup(tmp_path: Path) -> None:
+    calls: dict = {}
+
+    def query_owner(**kwargs):
+        calls.update(kwargs)
+        return _success()
+
+    result = query_once(
+        {"query": "audit pfmall"},
+        repo_root=tmp_path,
+        ensure_owner=lambda **_kwargs: SimpleNamespace(
+            ready=True, status="CONFIGURED", error=""
+        ),
+        resolve_handoff=lambda: (_ for _ in ()).throw(
+            AssertionError("configured owner must use environment")
+        ),
+        query_owner=query_owner,
+        cleanup_owner=lambda: (_ for _ in ()).throw(
+            AssertionError("configured owner is not process-owned")
+        ),
+    )
+
+    assert result["ok"] is True
+    assert calls["service_url"] is None
+    assert calls["service_token"] is None
+
+
+def test_bootstrap_failure_fails_closed_before_query(tmp_path: Path) -> None:
+    result = query_once(
+        {"query": "audit pfmall"},
+        repo_root=tmp_path,
+        ensure_owner=lambda **_kwargs: SimpleNamespace(
+            ready=False, status="FAILED", error="STALE_INDEX"
+        ),
+        query_owner=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("query must not run after bootstrap failure")
+        ),
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "STALE_INDEX"
+    assert result["index_gap_detected"] is True
+    assert result["no_holoindex_reindex_performed"] is True
+
+
+def test_missing_started_handoff_fails_closed_and_cleans_up(tmp_path: Path) -> None:
+    calls: list[str] = []
+    result = query_once(
+        {"query": "audit pfmall"},
+        repo_root=tmp_path,
+        ensure_owner=lambda **_kwargs: SimpleNamespace(
+            ready=True, status="STARTED", error=""
+        ),
+        resolve_handoff=lambda: None,
+        query_owner=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("query must not run without handoff")
+        ),
+        cleanup_owner=lambda: calls.append("cleaned"),
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "owner_handoff_missing"
+    assert calls == ["cleaned"]
+
+
+def test_request_validation_is_bounded_and_has_no_side_effects(tmp_path: Path) -> None:
+    def unexpected(**_kwargs):
+        raise AssertionError("invalid request must fail before owner bootstrap")
+
+    cases = (
+        ({}, "query_required"),
+        ({"query": " "}, "query_required"),
+        ({"query": "x" * (MAX_QUERY_CHARS + 1)}, "query_too_large"),
+        ({"query": "audit", "limit": 0}, "limit_invalid"),
+        ({"query": "audit", "limit": 21}, "limit_invalid"),
+        ({"query": "audit", "limit": True}, "limit_invalid"),
+    )
+    for payload, expected in cases:
+        result = query_once(payload, repo_root=tmp_path, ensure_owner=unexpected)
+        assert result["ok"] is False
+        assert result["error"] == expected
+
+
+def test_query_exception_is_secret_free_and_cleanup_runs(tmp_path: Path) -> None:
+    cleaned: list[bool] = []
+
+    class SecretFailure(RuntimeError):
+        pass
+
+    result = query_once(
+        {"query": "audit"},
+        repo_root=tmp_path,
+        ensure_owner=lambda **_kwargs: SimpleNamespace(
+            ready=True, status="STARTED", error=""
+        ),
+        resolve_handoff=lambda: ("http://127.0.0.1:8127", "secret-token-value"),
+        query_owner=lambda **_kwargs: (_ for _ in ()).throw(
+            SecretFailure("secret-token-value")
+        ),
+        cleanup_owner=lambda: cleaned.append(True),
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "SecretFailure"
+    assert "secret-token-value" not in str(result)
+    assert cleaned == [True]


### PR DESCRIPTION
## Summary
- route RedDog semantic grounding through the authenticated HoloIndex owner service
- require a current generation-bound query receipt and discard unbound semantic bundle hits
- preserve governed direct-read evidence without masking stale index telemetry
- fail fast on authenticated stale owner startup instead of waiting five minutes
- bump RedDog to 0.4.4

## Verification
- 125 focused HoloIndex owner/freshness/client tests passed
- 6 one-shot bridge tests included in the focused count
- RedDog extension contract passed
- Fusion ingress contract passed
- live stale-owner smoke: REPO_HEAD_MISMATCH in 1.9s with cleanup
- git diff --check clean

## Truth boundary
- no HoloIndex re-index at runtime
- no model/provider change
- no OpenClaw/Hermes dispatch or execution authority
- stale/unbound/lexical semantic evidence fails closed