### PR TITLE
feat(reddog): add transport-neutral resident client

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,17 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-19: REDDOG_TRANSPORT_NEUTRAL_RESIDENT_CLIENT_AND_HERMES_ADAPTER_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 71, 97
+**Phase**: One resident RedDog authority with transport-neutral clients
+
+- Added `RedDogResidentArchitectClient` over the existing durable AgentDB cycle for submit, reconnect, cancel, and resume.
+- Bound every operation to a host-authenticated principal, exact transport source/origin, FoundUp scope, and verified grounding receipt.
+- Rejected mutable runtime-key overrides, tampered stored ownership, and any result contradicting the canonical read-only boundary.
+- Exposed only bounded status/determination metadata; the client implements no model, shell, repo mutation, Hermes execution, or indexing path.
+- Fail closed when any canonical resident-cycle safety attestation is missing or false; response digests bind acceptance and safety state.
+- HoloIndex preflight found the new transport symbols absent from the active generation, whose receipt is pinned to an older repository head. Recorded `HOLOINDEX_REDDOG_TRANSPORT_CLIENT_DISCOVERABILITY_INDEX_GAP_PHASE1`; WRE/CI owns refresh, and this runtime remains query-only.
+
 ## 2026-07-19: REDDOG_GROUNDED_TARGET_ASSIGNMENT_CONTINUITY_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 50, 62, 71, 97

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py
@@ -1,0 +1,343 @@
+"""Transport-neutral client for the canonical resident RedDog authority.
+
+Slice: REDDOG_TRANSPORT_NEUTRAL_RESIDENT_CLIENT_AND_HERMES_ADAPTER_PHASE1
+
+Editor, Hermes, and future API surfaces use this client to submit or reconnect
+to the same durable AgentDB resident cycle. The client does not implement a
+second architect, run a model, execute a shell, mutate a repository, or grant
+authority. The authenticated principal is supplied by the hosting transport,
+never trusted from request prose.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    validate_grounded_target_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    AgentDbResidentArchitectCycleStore,
+    ResidentArchitectCycleStore,
+    STATUS_CANCELLED,
+    STATUS_FAILED,
+    STATUS_TIMED_OUT,
+    run_reddog_resident_architect_durable_agentdb_cycle,
+)
+
+
+CLIENT_RESPONSE_SCHEMA = "reddog_resident_client_response.v1"
+TRANSPORT_TO_SOURCE = {
+    "editor": "editor_thin_client",
+    "hermes": "hermes_thin_client",
+    "api": "api_thin_client",
+}
+TRANSPORT_TO_ORIGIN = {
+    "editor": "extension",
+    "hermes": "hermes_agent",
+    "api": "api_client",
+}
+RESERVED_RUNTIME_KEYS = frozenset(
+    {
+        "repo_root",
+        "red_dog_intent",
+        "cycle_store",
+        "cancel_requested",
+        "retry_requested",
+    }
+)
+RUNTIME_BOUNDARY_FIELDS = (
+    "read_only_authority_only",
+    "no_shell_command_executed",
+    "no_repo_mutation_performed",
+    "no_holoindex_reindex_performed",
+    "no_hermes_dispatch_performed",
+    "no_worktree_operation_performed",
+    "no_pr_created",
+    "no_pattern_memory_promotion_performed",
+    "no_live_foundup_enqueue_performed",
+)
+
+
+class ResidentClientReason:
+    REQUEST_INVALID = "REJECT_REDDOG_RESIDENT_CLIENT_REQUEST_INVALID"
+    PRINCIPAL_MISMATCH = "REJECT_REDDOG_RESIDENT_CLIENT_PRINCIPAL_MISMATCH"
+    SOURCE_MISMATCH = "REJECT_REDDOG_RESIDENT_CLIENT_SOURCE_MISMATCH"
+    GROUNDING_REJECTED = "REJECT_REDDOG_RESIDENT_CLIENT_GROUNDING_REJECTED"
+    CYCLE_NOT_FOUND = "REJECT_REDDOG_RESIDENT_CLIENT_CYCLE_NOT_FOUND"
+    RUNTIME_FAILED = "REJECT_REDDOG_RESIDENT_CLIENT_RUNTIME_FAILED"
+    RUNTIME_CONFIGURATION = "REJECT_REDDOG_RESIDENT_CLIENT_RUNTIME_CONFIGURATION"
+
+
+@dataclass(frozen=True)
+class ResidentClientResponse:
+    schema_version: str
+    response_id: str
+    accepted: bool
+    operation: str
+    transport: str
+    intent_id: str
+    cycle_id: str
+    status: str
+    snapshot_id: str
+    determination_id: str
+    architect_action: str
+    architect_next_slice: str
+    task_status_counts: Mapping[str, int]
+    rejection_reasons: tuple[str, ...]
+    canonical_resident_cycle_used: bool = True
+    read_only_authority_only: bool = True
+    client_no_shell_command_executed: bool = True
+    client_no_repo_mutation_performed: bool = True
+    client_no_holoindex_reindex_performed: bool = True
+    client_no_hermes_execution_performed: bool = True
+    client_no_worktree_operation_performed: bool = True
+    client_no_pr_created: bool = True
+    client_no_merge_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["task_status_counts"] = dict(self.task_status_counts)
+        payload["rejection_reasons"] = list(self.rejection_reasons)
+        return payload
+
+
+class RedDogResidentArchitectClient:
+    """Thin client over the one canonical resident RedDog AgentDB cycle."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | str,
+        authenticated_principal_id: str,
+        transport: str,
+        cycle_store: ResidentArchitectCycleStore | None = None,
+        cycle_runner: Callable[..., Any] | None = None,
+        runtime_defaults: Mapping[str, Any] | None = None,
+    ) -> None:
+        principal = str(authenticated_principal_id or "").strip()
+        surface = TRANSPORT_TO_SOURCE.get(str(transport or "").strip())
+        defaults = dict(runtime_defaults or {})
+        if not principal or surface is None or RESERVED_RUNTIME_KEYS.intersection(defaults):
+            raise ValueError(ResidentClientReason.RUNTIME_CONFIGURATION)
+        self._repo_root = Path(repo_root).resolve()
+        self._principal = principal
+        self._transport = str(transport).strip()
+        self._source_surface = surface
+        self._origin = TRANSPORT_TO_ORIGIN[self._transport]
+        self._store = cycle_store or AgentDbResidentArchitectCycleStore()
+        self._runner = cycle_runner or run_reddog_resident_architect_durable_agentdb_cycle
+        self._runtime_defaults = defaults
+
+    def submit(self, intent: Mapping[str, Any] | None) -> ResidentClientResponse:
+        reasons = self._validate_submitted_intent(intent)
+        if reasons:
+            return self._reject("submit", _intent_id(intent), reasons)
+        assert isinstance(intent, Mapping)
+        return self._invoke("submit", dict(intent), cancel=False, retry=False)
+
+    def status(self, intent_id: str) -> ResidentClientResponse:
+        record, reasons = self._authorized_record(intent_id)
+        if reasons:
+            return self._reject("status", str(intent_id or ""), reasons)
+        assert record is not None
+        return self._from_record("status", record, accepted=True, canonical_cycle_used=True)
+
+    def cancel(self, intent_id: str) -> ResidentClientResponse:
+        record, reasons = self._authorized_record(intent_id)
+        if reasons:
+            return self._reject("cancel", str(intent_id or ""), reasons)
+        assert record is not None
+        return self._invoke("cancel", _record_intent(record), cancel=True, retry=False)
+
+    def resume(self, intent_id: str) -> ResidentClientResponse:
+        record, reasons = self._authorized_record(intent_id)
+        if reasons:
+            return self._reject("resume", str(intent_id or ""), reasons)
+        assert record is not None
+        retry = str(record.get("status") or "") in {STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED}
+        return self._invoke("resume", _record_intent(record), cancel=False, retry=retry)
+
+    def _validate_submitted_intent(self, intent: Mapping[str, Any] | None) -> tuple[str, ...]:
+        if not isinstance(intent, Mapping) or intent.get("schema_version") != "reddog_intent.v2":
+            return (ResidentClientReason.REQUEST_INVALID,)
+        reasons: list[str] = []
+        if not _intent_id(intent) or not str(intent.get("foundup_id") or "").strip():
+            reasons.append(ResidentClientReason.REQUEST_INVALID)
+        if _principal_id(intent) != self._principal:
+            reasons.append(ResidentClientReason.PRINCIPAL_MISMATCH)
+        if str(intent.get("source_surface") or "") != self._source_surface:
+            reasons.append(ResidentClientReason.SOURCE_MISMATCH)
+        if str(intent.get("origin") or "") != self._origin:
+            reasons.append(ResidentClientReason.SOURCE_MISMATCH)
+        if intent.get("submits_executable_authority") is not False:
+            reasons.append(ResidentClientReason.REQUEST_INVALID)
+        grounding = validate_grounded_target_receipt(
+            intent.get("grounding_receipt") if isinstance(intent.get("grounding_receipt"), Mapping) else None,
+            work_focus=str(intent.get("work_focus") or ""),
+            expected_source_surface=self._source_surface,
+        )
+        if not grounding.accepted:
+            reasons.append(ResidentClientReason.GROUNDING_REJECTED)
+        return tuple(dict.fromkeys(reasons))
+
+    def _authorized_record(self, intent_id: str) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+        value = str(intent_id or "").strip()
+        if not value:
+            return None, (ResidentClientReason.REQUEST_INVALID,)
+        record = self._store.load_cycle_by_intent(value)
+        if not isinstance(record, Mapping):
+            return None, (ResidentClientReason.CYCLE_NOT_FOUND,)
+        intent = _record_intent(record)
+        reasons = self._validate_submitted_intent(intent)
+        if _intent_id(intent) != value:
+            reasons = (*reasons, ResidentClientReason.REQUEST_INVALID)
+        if not _runtime_boundary_is_safe(record):
+            reasons = (*reasons, ResidentClientReason.RUNTIME_FAILED)
+        reasons = tuple(dict.fromkeys(reasons))
+        return (None, reasons) if reasons else (record, ())
+
+    def _invoke(
+        self,
+        operation: str,
+        intent: Mapping[str, Any],
+        *,
+        cancel: bool,
+        retry: bool,
+    ) -> ResidentClientResponse:
+        try:
+            result = self._runner(
+                repo_root=self._repo_root,
+                red_dog_intent=dict(intent),
+                cycle_store=self._store,
+                cancel_requested=cancel,
+                retry_requested=retry,
+                **self._runtime_defaults,
+            )
+        except Exception:
+            return self._reject(operation, _intent_id(intent), (ResidentClientReason.RUNTIME_FAILED,))
+        data = result.to_dict() if hasattr(result, "to_dict") else dict(result)
+        runtime_boundary_failed = not _runtime_boundary_is_safe(data)
+        if runtime_boundary_failed:
+            data = dict(data)
+            data["rejection_reasons"] = [
+                *tuple(data.get("rejection_reasons") or ()),
+                ResidentClientReason.RUNTIME_FAILED,
+            ]
+        return self._from_record(
+            operation,
+            data,
+            accepted=bool(data.get("accepted")) and not runtime_boundary_failed,
+            canonical_cycle_used=True,
+        )
+
+    def _from_record(
+        self,
+        operation: str,
+        record: Mapping[str, Any],
+        *,
+        accepted: bool,
+        canonical_cycle_used: bool,
+    ) -> ResidentClientResponse:
+        payload = {
+            "operation": operation,
+            "transport": self._transport,
+            "intent_id": str(record.get("intent_id") or ""),
+            "cycle_id": str(record.get("cycle_id") or ""),
+            "status": str(record.get("status") or ""),
+            "snapshot_id": str(record.get("snapshot_id") or ""),
+            "determination_id": str(
+                record.get("architect_determination_id") or record.get("determination_id") or ""
+            ),
+            "architect_action": str(record.get("architect_action") or ""),
+            "architect_next_slice": str(record.get("architect_next_slice") or ""),
+            "task_status_counts": dict(record.get("task_status_counts") or {}),
+            "rejection_reasons": tuple(str(item) for item in record.get("rejection_reasons", ()) if str(item)),
+        }
+        response_id = _digest(
+            {
+                "schema_version": CLIENT_RESPONSE_SCHEMA,
+                "accepted": accepted,
+                "canonical_resident_cycle_used": canonical_cycle_used,
+                "read_only_authority_only": True,
+                "client_no_shell_command_executed": True,
+                "client_no_repo_mutation_performed": True,
+                "client_no_holoindex_reindex_performed": True,
+                "client_no_hermes_execution_performed": True,
+                "client_no_worktree_operation_performed": True,
+                "client_no_pr_created": True,
+                "client_no_merge_performed": True,
+                **payload,
+            }
+        )
+        return ResidentClientResponse(
+            schema_version=CLIENT_RESPONSE_SCHEMA,
+            response_id=response_id,
+            accepted=accepted,
+            canonical_resident_cycle_used=canonical_cycle_used,
+            **payload,
+        )
+
+    def _reject(
+        self,
+        operation: str,
+        intent_id: str,
+        reasons: tuple[str, ...],
+    ) -> ResidentClientResponse:
+        return self._from_record(
+            operation,
+            {
+                "intent_id": intent_id,
+                "status": "REJECTED",
+                "rejection_reasons": reasons,
+            },
+            accepted=False,
+            canonical_cycle_used=False,
+        )
+
+
+def _record_intent(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    intent = record.get("intent")
+    return dict(intent) if isinstance(intent, Mapping) else {}
+
+
+def _intent_id(intent: Mapping[str, Any] | None) -> str:
+    return str(intent.get("intent_id") or "") if isinstance(intent, Mapping) else ""
+
+
+def _principal_id(intent: Mapping[str, Any]) -> str:
+    return str(
+        intent.get("principal_id")
+        or intent.get("principal_ref")
+        or intent.get("origin_principal")
+        or ""
+    ).strip()
+
+
+def _runtime_boundary_is_safe(record: Mapping[str, Any]) -> bool:
+    return all(record.get(key) is True for key in RUNTIME_BOUNDARY_FIELDS)
+
+
+def _digest(payload: Any) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "CLIENT_RESPONSE_SCHEMA",
+    "RedDogResidentArchitectClient",
+    "ResidentClientReason",
+    "ResidentClientResponse",
+    "RUNTIME_BOUNDARY_FIELDS",
+    "TRANSPORT_TO_SOURCE",
+]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,10 @@
+## 2026-07-19: REDDOG_TRANSPORT_NEUTRAL_RESIDENT_CLIENT_AND_HERMES_ADAPTER_PHASE1
+
+- Added resident-client tests for canonical-cycle use, status-only reconnect, cancel/retry, principal/source mismatch, runtime-key injection, stored-record substitution, and read-only boundary contradiction.
+- Added fail-closed coverage for omitted canonical safety attestations.
+- Re-ran the durable AgentDB cycle suite to preserve canonical OpenClaw audit execution behavior.
+- Validation: 17 focused client/cycle tests and 113 resident/OpenClaw/architect tests passed.
+
 ## 2026-07-18: REDDOG_RESIDENT_CONTROL_RECEIPT_TRUTH_AUTH_CONCURRENCY_PHASE1
 
 **Files**: control-receipt auth/context, signer, canary, chain-store, OpenClaw,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_client.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_client.py
@@ -1,0 +1,287 @@
+"""Tests for the transport-neutral resident RedDog client."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    SCHEMA_VERSION as GROUNDING_SCHEMA_VERSION,
+    canonical_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
+    RedDogResidentArchitectClient,
+    ResidentClientReason,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MODULE_PATH = (
+    REPO_ROOT
+    / "modules"
+    / "communication"
+    / "moltbot_bridge"
+    / "src"
+    / "reddog_resident_architect_client.py"
+)
+FOCUS = "Audit RedDog resident transport continuity."
+
+
+def _grounding_receipt(*, source: str = "hermes_thin_client") -> dict:
+    typed = {
+        "repo_file_targets": ["modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py"],
+        "semantic_targets": [],
+        "external_research_targets": [],
+        "quoted_reference_blocks_count": 0,
+        "quoted_reference_blocks_digest": canonical_digest([]),
+    }
+    value = {
+        "schema_version": GROUNDING_SCHEMA_VERSION,
+        "source_surface": source,
+        "work_focus_digest": canonical_digest({"work_focus": FOCUS}),
+        "typed_targets": typed,
+        "typed_targets_digest": canonical_digest(typed),
+        "grounding_preflight_applied": True,
+        "grounding_preflight_passed": True,
+        "grounding_preflight_rejection_reasons": [],
+        "grounding_target_universe_required": True,
+        "repo_file_targets_count": 1,
+        "semantic_targets_count": 0,
+        "external_research_targets_count": 0,
+        "quoted_reference_blocks_count": 0,
+        "semantic_target_coverage": [],
+        "semantic_target_coverage_digest": canonical_digest({"semantic_target_coverage": []}),
+        "target_recall_ok": True,
+        "required_targets_missing": [],
+        "direct_read_paths": typed["repo_file_targets"],
+        "holoindex_owner_query_ok": False,
+        "holoindex_freshness": "UNKNOWN",
+        "holoindex_generation_id": "",
+        "holoindex_freshness_receipt_digest": "",
+        "holoindex_repo_head_sha": "",
+        "holoindex_query_receipt_id": "",
+        "holoindex_index_gap_detected": False,
+        "no_holoindex_reindex_performed": True,
+    }
+    value["receipt_id"] = canonical_digest(value)
+    return value
+
+
+def _intent(*, principal: str = "principal-012", source: str = "hermes_thin_client") -> dict:
+    return {
+        "schema_version": "reddog_intent.v2",
+        "intent_id": "sha256:hermes-resident-intent",
+        "source_surface": source,
+        "origin": "hermes_agent",
+        "principal_ref": principal,
+        "foundup_id": "foundups_agent",
+        "work_focus": FOCUS,
+        "grounding_receipt": _grounding_receipt(source=source),
+        "submits_executable_authority": False,
+    }
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.records = {}
+
+    def load_cycle_by_intent(self, intent_id):
+        return self.records.get(intent_id)
+
+    def upsert_cycle(self, record):
+        self.records[str(record["intent_id"])] = dict(record)
+        return {"ok": True}
+
+    def update_cycle(self, intent_id, updates):
+        record = dict(self.records[intent_id])
+        record.update(dict(updates))
+        self.records[intent_id] = record
+        return {"ok": True}
+
+    def load_task_ids(self, determination_id):
+        return ()
+
+    def load_task_status_counts(self, task_ids):
+        return {}
+
+    def delete_cycle_tasks(self, task_ids):
+        return None
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        intent = dict(kwargs["red_dog_intent"])
+        status = "CANCELLED" if kwargs["cancel_requested"] else "DETERMINED"
+        record = {
+            "accepted": not kwargs["cancel_requested"],
+            "intent_id": intent["intent_id"],
+            "cycle_id": "sha256:cycle",
+            "status": status,
+            "snapshot_id": "sha256:snapshot",
+            "architect_determination_id": "sha256:determination",
+            "architect_action": "FIX",
+            "architect_next_slice": "REDDOG_NEXT_PHASE1",
+            "task_status_counts": {"completed": 5},
+            "rejection_reasons": ["REJECT_RESIDENT_CYCLE_CANCELLED"] if status == "CANCELLED" else [],
+            "intent": intent,
+            "read_only_authority_only": True,
+            "no_shell_command_executed": True,
+            "no_repo_mutation_performed": True,
+            "no_holoindex_reindex_performed": True,
+            "no_hermes_dispatch_performed": True,
+            "no_worktree_operation_performed": True,
+            "no_pr_created": True,
+            "no_pattern_memory_promotion_performed": True,
+            "no_live_foundup_enqueue_performed": True,
+        }
+        kwargs["cycle_store"].upsert_cycle(record)
+        return record
+
+
+def _client(store=None, runner=None) -> RedDogResidentArchitectClient:
+    return RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-012",
+        transport="hermes",
+        cycle_store=store or _Store(),
+        cycle_runner=runner or _Runner(),
+    )
+
+
+def test_submit_calls_canonical_cycle_and_returns_readonly_receipt() -> None:
+    store = _Store()
+    runner = _Runner()
+    result = _client(store, runner).submit(_intent())
+
+    assert result.accepted is True
+    assert result.status == "DETERMINED"
+    assert result.canonical_resident_cycle_used is True
+    assert result.read_only_authority_only is True
+    assert result.client_no_shell_command_executed is True
+    assert result.client_no_repo_mutation_performed is True
+    assert len(runner.calls) == 1
+    assert runner.calls[0]["red_dog_intent"]["grounding_receipt"]["source_surface"] == "hermes_thin_client"
+    assert runner.calls[0]["cancel_requested"] is False
+    assert runner.calls[0]["retry_requested"] is False
+
+
+def test_status_is_reconnect_only_and_does_not_run_cycle() -> None:
+    store = _Store()
+    runner = _Runner()
+    client = _client(store, runner)
+    submitted = client.submit(_intent())
+    runner.calls.clear()
+
+    status = client.status(submitted.intent_id)
+
+    assert status.accepted is True
+    assert status.status == "DETERMINED"
+    assert runner.calls == []
+
+
+def test_cancel_and_failed_resume_use_persisted_intent_only() -> None:
+    store = _Store()
+    runner = _Runner()
+    client = _client(store, runner)
+    submitted = client.submit(_intent())
+
+    cancelled = client.cancel(submitted.intent_id)
+    resumed = client.resume(submitted.intent_id)
+
+    assert cancelled.status == "CANCELLED"
+    assert runner.calls[-2]["cancel_requested"] is True
+    assert runner.calls[-1]["retry_requested"] is True
+    assert resumed.status == "DETERMINED"
+
+
+def test_payload_principal_and_wrong_transport_never_reach_cycle() -> None:
+    runner = _Runner()
+    client = _client(runner=runner)
+
+    wrong_principal = client.submit(_intent(principal="payload-claims-012"))
+    wrong_surface = client.submit(_intent(source="editor_thin_client"))
+
+    assert ResidentClientReason.PRINCIPAL_MISMATCH in wrong_principal.rejection_reasons
+    assert ResidentClientReason.SOURCE_MISMATCH in wrong_surface.rejection_reasons
+    assert runner.calls == []
+
+
+def test_tampered_cycle_owner_or_authority_rejects_reconnect() -> None:
+    store = _Store()
+    runner = _Runner()
+    client = _client(store, runner)
+    submitted = client.submit(_intent())
+    record = dict(store.records[submitted.intent_id])
+    record["read_only_authority_only"] = False
+    record["intent"] = dict(record["intent"])
+    record["intent"]["intent_id"] = "sha256:substituted"
+    store.records[submitted.intent_id] = record
+    runner.calls.clear()
+
+    result = client.status(submitted.intent_id)
+
+    assert result.accepted is False
+    assert ResidentClientReason.REQUEST_INVALID in result.rejection_reasons
+    assert ResidentClientReason.RUNTIME_FAILED in result.rejection_reasons
+    assert runner.calls == []
+
+
+def test_runtime_defaults_cannot_override_canonical_cycle_inputs() -> None:
+    for key in ("repo_root", "red_dog_intent", "cycle_store", "cancel_requested", "retry_requested"):
+        try:
+            RedDogResidentArchitectClient(
+                repo_root=REPO_ROOT,
+                authenticated_principal_id="principal-012",
+                transport="hermes",
+                runtime_defaults={key: "attacker"},
+            )
+        except ValueError as exc:
+            assert str(exc) == ResidentClientReason.RUNTIME_CONFIGURATION
+        else:
+            raise AssertionError(f"reserved runtime key accepted: {key}")
+
+
+def test_runtime_boundary_contradiction_is_not_reported_as_safe() -> None:
+    class UnsafeRunner(_Runner):
+        def __call__(self, **kwargs):
+            result = super().__call__(**kwargs)
+            result["no_repo_mutation_performed"] = False
+            return result
+
+    result = _client(runner=UnsafeRunner()).submit(_intent())
+
+    assert result.accepted is False
+    assert result.canonical_resident_cycle_used is True
+    assert ResidentClientReason.RUNTIME_FAILED in result.rejection_reasons
+
+
+def test_missing_runtime_boundary_attestation_fails_closed() -> None:
+    class IncompleteRunner(_Runner):
+        def __call__(self, **kwargs):
+            result = super().__call__(**kwargs)
+            result.pop("no_live_foundup_enqueue_performed")
+            return result
+
+    result = _client(runner=IncompleteRunner()).submit(_intent())
+
+    assert result.accepted is False
+    assert ResidentClientReason.RUNTIME_FAILED in result.rejection_reasons
+
+
+def test_client_module_has_no_execution_or_second_model_authority() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert "subprocess" not in imported
+    assert "os" not in imported
+    for forbidden in ("HermesFoundUpBuilder", "run_repo_code_audit", "git push", "gh pr", "worktree add"):
+        assert forbidden not in source

--- a/modules/foundups/agent/INTERFACE.md
+++ b/modules/foundups/agent/INTERFACE.md
@@ -2,6 +2,23 @@
 
 Public API and schema contracts for agent lifecycle management, BuildPlan generation, controlled execution, read-only manifest provenance, source-authority contract, validated module-path resolution, and the read-only ContextBundle dry-run consumer.
 
+## Hermes -> Resident RedDog Thin Client
+
+`hermes_reddog_resident_client_adapter.py` exposes Hermes as a transport to the
+single canonical resident RedDog AgentDB cycle. It accepts only
+`hermes_reddog_resident_request.v1` operations: `submit`, `status`, `cancel`,
+and `resume`. `submit` requires an already-grounded `reddog_intent.v2` whose
+source is `hermes_thin_client`; status/cancel/resume load the persisted intent
+by ID and reject a replacement intent. The authenticated principal is supplied
+by the host, not request prose.
+
+`scripts/hermes_reddog_resident_client_once.py` is the bounded JSON instrument
+bridge. The host must set `REDDOG_AUTHENTICATED_PRINCIPAL_ID`. The bridge does
+not invoke a Hermes model or builder and grants no shell, repository-write,
+worktree, PR, merge, HoloIndex-indexing, or execution authority. Natural-language
+target extraction and grounding for non-editor channels are not fabricated by
+this adapter; an upstream governed grounding service must supply the v2 receipt.
+
 ## ContextBundle Dry-Run Consumer (WRE_CONTEXT_BUNDLE_DRYRUN_CONSUMER_PHASE1)
 
 First consumer wiring of the read-only #775 ContextBundle into the EXISTING

--- a/modules/foundups/agent/ModLog.md
+++ b/modules/foundups/agent/ModLog.md
@@ -1,5 +1,15 @@
 # Agent Module ModLog
 
+## 2026-07-19 - REDDOG_TRANSPORT_NEUTRAL_RESIDENT_CLIENT_AND_HERMES_ADAPTER_PHASE1
+
+**Author**: 0102 architect | Commander: 012 | WSP: 00, 15, 50, 71, 97
+
+- Added a Hermes transport adapter for submit/status/cancel/resume against the one canonical resident RedDog AgentDB cycle.
+- Required the host-authenticated principal to match the grounded v2 intent; payload role text never grants authority.
+- Added a bounded one-shot JSON bridge for external Hermes instruments without importing the Hermes builder/model loop.
+- Kept the route read-only: no shell, repo mutation, HoloIndex re-index, worktree, PR, merge, or Hermes execution authority.
+- Omitted unset environment paths instead of overriding canonical resident defaults with empty values.
+
 ## 2026-07-09 - WRE worktree cwd hazard guard integration
 
 **Author**: 0102 (Codex) | Commander: 012 | WSP: 00, 34, 50, 97

--- a/modules/foundups/agent/src/hermes_reddog_resident_client_adapter.py
+++ b/modules/foundups/agent/src/hermes_reddog_resident_client_adapter.py
@@ -1,0 +1,162 @@
+"""Hermes transport adapter for the canonical resident RedDog client.
+
+Hermes is a communication surface here, not a second RedDog authority. The
+hosting instrument supplies the authenticated principal. Request text, role
+labels, and payload principal fields never grant authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
+    RedDogResidentArchitectClient,
+    ResidentClientResponse,
+)
+
+
+HERMES_REQUEST_SCHEMA = "hermes_reddog_resident_request.v1"
+HERMES_RECEIPT_SCHEMA = "hermes_reddog_resident_receipt.v1"
+OPERATIONS = frozenset({"submit", "status", "cancel", "resume"})
+
+
+@dataclass(frozen=True)
+class HermesRedDogResidentReceipt:
+    schema_version: str
+    receipt_id: str
+    accepted: bool
+    request_id: str
+    operation: str
+    resident_response: Mapping[str, Any]
+    canonical_reddog_authority_used: bool = True
+    hermes_is_transport_only: bool = True
+    no_hermes_model_invoked: bool = True
+    no_hermes_execution_performed: bool = True
+    no_shell_command_executed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+    no_worktree_operation_performed: bool = True
+    no_pr_created: bool = True
+    no_merge_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["resident_response"] = dict(self.resident_response)
+        return payload
+
+
+class HermesRedDogResidentClientAdapter:
+    """Translate a Hermes instrument request into one resident client call."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | str,
+        authenticated_principal_id: str,
+        resident_client: RedDogResidentArchitectClient | None = None,
+        runtime_defaults: Mapping[str, Any] | None = None,
+    ) -> None:
+        self._client = resident_client or RedDogResidentArchitectClient(
+            repo_root=repo_root,
+            authenticated_principal_id=authenticated_principal_id,
+            transport="hermes",
+            runtime_defaults=runtime_defaults,
+        )
+
+    def handle(self, request: Mapping[str, Any] | None) -> HermesRedDogResidentReceipt:
+        data = dict(request) if isinstance(request, Mapping) else {}
+        request_id = str(data.get("request_id") or "").strip()
+        operation = str(data.get("operation") or "").strip().lower()
+        if data.get("schema_version") != HERMES_REQUEST_SCHEMA or not request_id or operation not in OPERATIONS:
+            return self._receipt(
+                request_id=request_id,
+                operation=operation,
+                response=_rejected_response(operation, "REJECT_HERMES_REDDOG_REQUEST_INVALID"),
+            )
+        if operation == "submit":
+            intent = data.get("red_dog_intent")
+            response = self._client.submit(intent if isinstance(intent, Mapping) else None)
+        else:
+            if data.get("red_dog_intent") is not None:
+                response = _rejected_response(operation, "REJECT_HERMES_REDDOG_INTENT_SUBSTITUTION")
+            else:
+                intent_id = str(data.get("intent_id") or "").strip()
+                response = {
+                    "status": self._client.status,
+                    "cancel": self._client.cancel,
+                    "resume": self._client.resume,
+                }[operation](intent_id)
+        return self._receipt(request_id=request_id, operation=operation, response=response)
+
+    @staticmethod
+    def _receipt(
+        *,
+        request_id: str,
+        operation: str,
+        response: ResidentClientResponse,
+    ) -> HermesRedDogResidentReceipt:
+        response_data = response.to_dict()
+        payload = {
+            "schema_version": HERMES_RECEIPT_SCHEMA,
+            "accepted": response.accepted,
+            "request_id": request_id,
+            "operation": operation,
+            "resident_response": response_data,
+            "canonical_reddog_authority_used": response.canonical_resident_cycle_used,
+            "hermes_is_transport_only": True,
+            "no_hermes_model_invoked": True,
+            "no_hermes_execution_performed": True,
+            "no_shell_command_executed": True,
+            "no_repo_mutation_performed": True,
+            "no_holoindex_reindex_performed": True,
+            "no_worktree_operation_performed": True,
+            "no_pr_created": True,
+            "no_merge_performed": True,
+        }
+        return HermesRedDogResidentReceipt(receipt_id=_digest(payload), **payload)
+
+
+def _rejected_response(operation: str, reason: str) -> ResidentClientResponse:
+    payload = {
+        "operation": operation,
+        "transport": "hermes",
+        "intent_id": "",
+        "cycle_id": "",
+        "status": "REJECTED",
+        "snapshot_id": "",
+        "determination_id": "",
+        "architect_action": "",
+        "architect_next_slice": "",
+        "task_status_counts": {},
+        "rejection_reasons": (reason,),
+    }
+    return ResidentClientResponse(
+        schema_version="reddog_resident_client_response.v1",
+        response_id=_digest(payload),
+        accepted=False,
+        canonical_resident_cycle_used=False,
+        **payload,
+    )
+
+
+def _digest(payload: Any) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "HERMES_RECEIPT_SCHEMA",
+    "HERMES_REQUEST_SCHEMA",
+    "HermesRedDogResidentClientAdapter",
+    "HermesRedDogResidentReceipt",
+]

--- a/modules/foundups/agent/tests/TestModLog.md
+++ b/modules/foundups/agent/tests/TestModLog.md
@@ -1,5 +1,14 @@
 # Agent Module TestModLog
 
+## 2026-07-19 - Resident RedDog Hermes thin-client tests
+
+- Proved Hermes submit uses the canonical resident client and does not invoke the Hermes model/builder path.
+- Proved reconnect, cancel, and resume use the persisted intent and reject replacement-intent substitution.
+- Proved payload identity text, wrong schema, and unsupported operations fail before the cycle runner.
+- Proved the one-shot bridge requires a host-authenticated principal and contains no shell or Hermes model imports.
+- Proved unset host paths are omitted rather than forwarded as empty runtime overrides.
+- Full `modules/foundups/agent/tests` validation: 1140 passed.
+
 ## 2026-06-20 - Package __init__ lazy-import boundary tests (FOUNDUP_AGENT_PACKAGE_INIT_LAZY_IMPORT_PHASE1)
 
 **Commands** (PYTHONIOENCODING=utf-8):

--- a/modules/foundups/agent/tests/test_hermes_reddog_resident_client_adapter.py
+++ b/modules/foundups/agent/tests/test_hermes_reddog_resident_client_adapter.py
@@ -1,0 +1,257 @@
+"""Tests for the Hermes thin-client adapter to resident RedDog."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    SCHEMA_VERSION as GROUNDING_SCHEMA_VERSION,
+    canonical_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
+    RedDogResidentArchitectClient,
+)
+from modules.foundups.agent.src.hermes_reddog_resident_client_adapter import (
+    HERMES_REQUEST_SCHEMA,
+    HermesRedDogResidentClientAdapter,
+)
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "hermes_reddog_resident_client_adapter.py"
+)
+REPO_ROOT = Path(__file__).resolve().parents[4]
+FOCUS = "Audit RedDog resident transport continuity."
+
+
+def _intent(*, principal: str = "principal-012") -> dict:
+    typed = {
+        "repo_file_targets": ["modules/foundups/agent/src/hermes_reddog_resident_client_adapter.py"],
+        "semantic_targets": [],
+        "external_research_targets": [],
+        "quoted_reference_blocks_count": 0,
+        "quoted_reference_blocks_digest": canonical_digest([]),
+    }
+    grounding = {
+        "schema_version": GROUNDING_SCHEMA_VERSION,
+        "source_surface": "hermes_thin_client",
+        "work_focus_digest": canonical_digest({"work_focus": FOCUS}),
+        "typed_targets": typed,
+        "typed_targets_digest": canonical_digest(typed),
+        "grounding_preflight_applied": True,
+        "grounding_preflight_passed": True,
+        "grounding_preflight_rejection_reasons": [],
+        "grounding_target_universe_required": True,
+        "repo_file_targets_count": 1,
+        "semantic_targets_count": 0,
+        "external_research_targets_count": 0,
+        "quoted_reference_blocks_count": 0,
+        "semantic_target_coverage": [],
+        "semantic_target_coverage_digest": canonical_digest({"semantic_target_coverage": []}),
+        "target_recall_ok": True,
+        "required_targets_missing": [],
+        "direct_read_paths": typed["repo_file_targets"],
+        "holoindex_owner_query_ok": False,
+        "holoindex_freshness": "UNKNOWN",
+        "holoindex_generation_id": "",
+        "holoindex_freshness_receipt_digest": "",
+        "holoindex_repo_head_sha": "",
+        "holoindex_query_receipt_id": "",
+        "holoindex_index_gap_detected": False,
+        "no_holoindex_reindex_performed": True,
+    }
+    grounding["receipt_id"] = canonical_digest(grounding)
+    return {
+        "schema_version": "reddog_intent.v2",
+        "intent_id": "sha256:hermes-resident-intent",
+        "source_surface": "hermes_thin_client",
+        "origin": "hermes_agent",
+        "principal_ref": principal,
+        "foundup_id": "foundups_agent",
+        "work_focus": FOCUS,
+        "grounding_receipt": grounding,
+        "submits_executable_authority": False,
+    }
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.records = {}
+
+    def load_cycle_by_intent(self, intent_id):
+        return self.records.get(intent_id)
+
+    def upsert_cycle(self, record):
+        self.records[str(record["intent_id"])] = dict(record)
+        return {"ok": True}
+
+    def update_cycle(self, intent_id, updates):
+        record = dict(self.records[intent_id])
+        record.update(dict(updates))
+        self.records[intent_id] = record
+        return {"ok": True}
+
+    def load_task_ids(self, determination_id):
+        return ()
+
+    def load_task_status_counts(self, task_ids):
+        return {}
+
+    def delete_cycle_tasks(self, task_ids):
+        return None
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(dict(kwargs))
+        intent = dict(kwargs["red_dog_intent"])
+        record = {
+            "accepted": True,
+            "intent_id": intent["intent_id"],
+            "cycle_id": "sha256:cycle",
+            "status": "DETERMINED",
+            "snapshot_id": "sha256:snapshot",
+            "architect_determination_id": "sha256:determination",
+            "architect_action": "FIX",
+            "architect_next_slice": "REDDOG_NEXT_PHASE1",
+            "task_status_counts": {"completed": 5},
+            "rejection_reasons": [],
+            "intent": intent,
+            "read_only_authority_only": True,
+            "no_shell_command_executed": True,
+            "no_repo_mutation_performed": True,
+            "no_holoindex_reindex_performed": True,
+            "no_hermes_dispatch_performed": True,
+            "no_worktree_operation_performed": True,
+            "no_pr_created": True,
+            "no_pattern_memory_promotion_performed": True,
+            "no_live_foundup_enqueue_performed": True,
+        }
+        kwargs["cycle_store"].upsert_cycle(record)
+        return record
+
+
+def _adapter(store=None, runner=None):
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-012",
+        transport="hermes",
+        cycle_store=store or _Store(),
+        cycle_runner=runner or _Runner(),
+    )
+    return HermesRedDogResidentClientAdapter(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-012",
+        resident_client=client,
+    )
+
+
+def test_hermes_submit_is_transport_only_and_uses_canonical_reddog_client() -> None:
+    runner = _Runner()
+    receipt = _adapter(runner=runner).handle(
+        {
+            "schema_version": HERMES_REQUEST_SCHEMA,
+            "request_id": "hermes-request-1",
+            "operation": "submit",
+            "red_dog_intent": _intent(),
+        }
+    )
+
+    assert receipt.accepted is True
+    assert receipt.canonical_reddog_authority_used is True
+    assert receipt.hermes_is_transport_only is True
+    assert receipt.no_hermes_model_invoked is True
+    assert receipt.no_hermes_execution_performed is True
+    assert receipt.no_repo_mutation_performed is True
+    assert len(runner.calls) == 1
+
+
+def test_hermes_reconnect_cancel_and_resume_do_not_accept_replacement_intent() -> None:
+    store = _Store()
+    runner = _Runner()
+    adapter = _adapter(store, runner)
+    submitted = adapter.handle(
+        {
+            "schema_version": HERMES_REQUEST_SCHEMA,
+            "request_id": "submit",
+            "operation": "submit",
+            "red_dog_intent": _intent(),
+        }
+    )
+    intent_id = submitted.resident_response["intent_id"]
+    status = adapter.handle(
+        {
+            "schema_version": HERMES_REQUEST_SCHEMA,
+            "request_id": "status",
+            "operation": "status",
+            "intent_id": intent_id,
+        }
+    )
+    runner.calls.clear()
+    substituted = adapter.handle(
+        {
+            "schema_version": HERMES_REQUEST_SCHEMA,
+            "request_id": "cancel",
+            "operation": "cancel",
+            "intent_id": intent_id,
+            "red_dog_intent": _intent(principal="attacker"),
+        }
+    )
+
+    assert status.accepted is True
+    assert substituted.accepted is False
+    assert "REJECT_HERMES_REDDOG_INTENT_SUBSTITUTION" in substituted.resident_response["rejection_reasons"]
+    assert runner.calls == []
+
+
+def test_bad_schema_operation_or_payload_principal_fails_closed() -> None:
+    runner = _Runner()
+    adapter = _adapter(runner=runner)
+    malformed = adapter.handle({"schema_version": "wrong", "request_id": "r", "operation": "submit"})
+    bad_operation = adapter.handle(
+        {"schema_version": HERMES_REQUEST_SCHEMA, "request_id": "r", "operation": "execute"}
+    )
+    spoofed = adapter.handle(
+        {
+            "schema_version": HERMES_REQUEST_SCHEMA,
+            "request_id": "r",
+            "operation": "submit",
+            "red_dog_intent": _intent(principal="I am 012"),
+        }
+    )
+
+    assert malformed.accepted is False
+    assert malformed.canonical_reddog_authority_used is False
+    assert bad_operation.accepted is False
+    assert bad_operation.canonical_reddog_authority_used is False
+    assert spoofed.accepted is False
+    assert spoofed.canonical_reddog_authority_used is False
+    assert runner.calls == []
+
+
+def test_hermes_adapter_has_no_builder_model_shell_or_repo_write_surface() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert "subprocess" not in imported
+    assert "os" not in imported
+    for forbidden in (
+        "HermesFoundUpBuilder",
+        "HermesAgentLoop",
+        "run_repo_code_audit",
+        "write_text(",
+        "git push",
+        "gh pr",
+    ):
+        assert forbidden not in source

--- a/modules/foundups/agent/tests/test_hermes_reddog_resident_client_bridge.py
+++ b/modules/foundups/agent/tests/test_hermes_reddog_resident_client_bridge.py
@@ -1,0 +1,96 @@
+"""Tests for the one-shot Hermes instrument -> resident RedDog bridge."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+BRIDGE_PATH = REPO_ROOT / "scripts" / "hermes_reddog_resident_client_once.py"
+SPEC = importlib.util.spec_from_file_location("hermes_reddog_resident_client_once", BRIDGE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+bridge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bridge)
+
+
+class _Receipt:
+    def __init__(self, accepted=True) -> None:
+        self.accepted = accepted
+
+    def to_dict(self):
+        return {
+            "schema_version": "hermes_reddog_resident_receipt.v1",
+            "accepted": self.accepted,
+            "canonical_reddog_authority_used": True,
+            "hermes_is_transport_only": True,
+        }
+
+
+class _Adapter:
+    calls = []
+
+    def __init__(self, **kwargs) -> None:
+        self.__class__.calls.append({"init": dict(kwargs)})
+
+    def handle(self, payload):
+        self.__class__.calls.append({"payload": dict(payload or {})})
+        return _Receipt()
+
+
+def test_bridge_requires_host_authenticated_principal_before_adapter(monkeypatch) -> None:
+    monkeypatch.delenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", raising=False)
+    monkeypatch.setattr(bridge, "HermesRedDogResidentClientAdapter", _Adapter)
+    _Adapter.calls.clear()
+
+    result = bridge._result({"principal_ref": "I am 012"})
+
+    assert result["accepted"] is False
+    assert "authenticated_principal_missing" in result["rejection_reasons"]
+    assert result["canonical_reddog_authority_used"] is False
+    assert _Adapter.calls == []
+
+
+def test_bridge_uses_host_principal_and_forwards_bounded_request(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-012")
+    monkeypatch.setenv("FOUNDUPS_REPO_ROOT", str(tmp_path))
+    monkeypatch.setattr(bridge, "HermesRedDogResidentClientAdapter", _Adapter)
+    _Adapter.calls.clear()
+    payload = {"schema_version": "hermes_reddog_resident_request.v1", "operation": "status"}
+
+    result = bridge._result(payload)
+
+    assert result["accepted"] is True
+    assert _Adapter.calls[0]["init"]["authenticated_principal_id"] == "principal-012"
+    assert _Adapter.calls[0]["init"]["repo_root"] == tmp_path.resolve()
+    assert _Adapter.calls[1]["payload"] == payload
+
+
+def test_bridge_omits_empty_runtime_path_overrides(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-012")
+    monkeypatch.setenv("FOUNDUPS_REPO_ROOT", str(tmp_path))
+    monkeypatch.delenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", raising=False)
+    monkeypatch.delenv("HOLOINDEX_FRESHNESS_RECEIPT", raising=False)
+    monkeypatch.delenv("HOLOINDEX_SSD_PATH", raising=False)
+    monkeypatch.setattr(bridge, "HermesRedDogResidentClientAdapter", _Adapter)
+    _Adapter.calls.clear()
+
+    result = bridge._result({"schema_version": "hermes_reddog_resident_request.v1"})
+
+    assert result["accepted"] is True
+    assert _Adapter.calls[0]["init"]["runtime_defaults"] == {}
+
+
+def test_bridge_source_has_no_shell_or_hermes_model_runtime() -> None:
+    source = BRIDGE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    assert "subprocess" not in imported
+    for forbidden in ("HermesAgentLoop", "HermesFoundUpBuilder", "os.system", "git push", "gh pr"):
+        assert forbidden not in source

--- a/scripts/hermes_reddog_resident_client_once.py
+++ b/scripts/hermes_reddog_resident_client_once.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""One-shot Hermes instrument bridge to the canonical resident RedDog client.
+
+The host must provide REDDOG_AUTHENTICATED_PRINCIPAL_ID from its authenticated
+channel/session. A principal value inside the request body is never authority.
+Input and output are one bounded JSON document. This bridge adds no Hermes
+model, shell, repository-write, worktree, PR, merge, or HoloIndex-indexing path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Mapping
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from modules.foundups.agent.src.hermes_reddog_resident_client_adapter import (  # noqa: E402
+    HermesRedDogResidentClientAdapter,
+)
+
+
+MAX_INPUT_BYTES = 256_000
+
+
+def _result(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    principal = str(os.getenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "")).strip()
+    if not principal:
+        return _reject("authenticated_principal_missing")
+    root_text = str(os.getenv("FOUNDUPS_REPO_ROOT", "")).strip()
+    repo_root = Path(root_text).resolve() if root_text else REPO_ROOT
+    runtime_defaults = {
+        key: value
+        for key, value in {
+            "work_state_path": str(os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", "")).strip(),
+            "holoindex_receipt_path": str(os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")).strip(),
+            "holoindex_ssd_path": str(os.getenv("HOLOINDEX_SSD_PATH", "")).strip(),
+        }.items()
+        if value
+    }
+    try:
+        adapter = HermesRedDogResidentClientAdapter(
+            repo_root=repo_root,
+            authenticated_principal_id=principal,
+            runtime_defaults=runtime_defaults,
+        )
+        receipt = adapter.handle(payload)
+    except Exception as exc:
+        return _reject("hermes_reddog_bridge_failed", error_class=type(exc).__name__)
+    return receipt.to_dict()
+
+
+def _read_payload() -> Mapping[str, Any] | None:
+    raw = sys.stdin.buffer.read(MAX_INPUT_BYTES + 1)
+    if len(raw) > MAX_INPUT_BYTES:
+        return {"_bridge_error": "input_too_large"}
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return {"_bridge_error": "invalid_json"}
+    return value if isinstance(value, Mapping) else {"_bridge_error": "payload_not_mapping"}
+
+
+def _reject(reason: str, *, error_class: str = "") -> dict[str, Any]:
+    return {
+        "schema_version": "hermes_reddog_resident_bridge_rejection.v1",
+        "accepted": False,
+        "rejection_reasons": [reason],
+        "error_class": error_class,
+        "canonical_reddog_authority_used": False,
+        "hermes_is_transport_only": True,
+        "no_hermes_model_invoked": True,
+        "no_hermes_execution_performed": True,
+        "no_shell_command_executed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_merge_performed": True,
+    }
+
+
+def main() -> int:
+    payload = _read_payload()
+    if isinstance(payload, Mapping) and payload.get("_bridge_error"):
+        output = _reject(str(payload["_bridge_error"]))
+    else:
+        output = _result(payload)
+    sys.stdout.write(json.dumps(output, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add one transport-neutral client over the canonical durable AgentDB RedDog cycle
- add a Hermes thin-client adapter and bounded JSON instrument bridge
- bind requests to host-authenticated principal, exact transport, grounded v2 intent, and persisted cycle ownership
- fail closed on missing runtime safety attestations or conflicting resident results

## WSP_97 truth boundary
- RedDog/AgentDB remains the only architect authority
- Hermes is transport only; no Hermes model, builder, shell, repository write, worktree, PR, merge, or index mutation path is added
- submit currently requires an already-grounded reddog_intent.v2; natural-language backend grounding is a later slice
- HoloIndex query preflight found the active generation stale; this PR records an INDEX_GAP and does not re-index at runtime

## Validation
- pytest modules/foundups/agent/tests: 1140 passed
- focused resident/OpenClaw/architect suites: 113 passed
- focused client/cycle: 17 passed
- Python compile, ASCII/NUL checks, AST boundary checks, and git diff --check pass

Slice: REDDOG_TRANSPORT_NEUTRAL_RESIDENT_CLIENT_AND_HERMES_ADAPTER_PHASE1