### PR TITLE
fix(holoindex): complete and accelerate canonical source indexing

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -20,6 +20,9 @@
 - BATCH symbol embedding and collection writes in bounded chunks. This removes
   the one-model-call-per-symbol behavior observed during the 42,071-record
   canonical refresh while retaining the exact output-count proof.
+- CAP per-symbol docstring evidence at 8 KiB and publish in 1,000-record
+  batches. Current canonical docstrings remain below the cap; the boundary
+  prevents a future tracked source from amplifying model/Chroma memory.
 - RECONCILE symbols by deterministic repository-relative IDs. An unchanged
   exact document reuses its existing vector only when backend, model, and
   embedding-space fingerprint all match. Changed/new documents are re-embedded,
@@ -46,6 +49,10 @@
 - OBSERVED: the first complete batched symbol migration took 613.55 seconds.
   That is correct but too expensive for routine refresh, so stable exact-space
   reuse is required and measured separately before operational promotion.
+- OBSERVED: the stable-ID migration indexed 42,529 symbols and 72 Skillz in
+  508.41 seconds. The immediate exact-content rerun reused the stable vectors
+  and completed in 52.89 seconds (symbols: 28.68 seconds), within the resident
+  maintenance budget.
 - OBSERVED: fallback records are discoverability evidence only. They cannot
   support a symbol-level implementation claim.
 - SPECIFIED_NOT_IMPLEMENTED: routine post-merge incremental maintenance and a

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -20,6 +20,14 @@
 - BATCH symbol embedding and collection writes in bounded chunks. This removes
   the one-model-call-per-symbol behavior observed during the 42,071-record
   canonical refresh while retaining the exact output-count proof.
+- RECONCILE symbols by deterministic repository-relative IDs. An unchanged
+  exact document reuses its existing vector only when backend, model, and
+  embedding-space fingerprint all match. Changed/new documents are re-embedded,
+  stale records are deleted, and the final collection count is re-proven.
+- REMOVE worktree-absolute paths from symbol documents and metadata. Equivalent
+  clean worktrees now produce identical IDs and documents while freshness
+  receipts continue to bind the operational query generation to one exact root
+  and repository HEAD.
 - NORMALIZE heterogeneous SKILLz `agents` lists to scalar strings. Integer WSP
   and agent identifiers no longer abort an otherwise valid canonical Skillz
   source set.
@@ -35,6 +43,9 @@
 - OBSERVED: the post-fix canonical preparation pass accounted for all 3,385
   tracked Python files as 42,484 records, including 88 typed fallbacks, with
   zero source I/O failures and no cap truncation.
+- OBSERVED: the first complete batched symbol migration took 613.55 seconds.
+  That is correct but too expensive for routine refresh, so stable exact-space
+  reuse is required and measured separately before operational promotion.
 - OBSERVED: fallback records are discoverability evidence only. They cannot
   support a symbol-level implementation claim.
 - SPECIFIED_NOT_IMPLEMENTED: routine post-merge incremental maintenance and a

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,45 @@
 # HoloIndex Package ModLog
 
+## [2026-07-19] HOLOINDEX_COMPLETE_SOURCE_INDEXING_AND_BATCHING_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 34, 50, 84, 87, 97
+**Phase**: Implementation and adversarial regression validation
+**Agent**: 0102 architect for 012
+
+**Changes**:
+
+- PRESERVE complete raw-content source manifests while accounting for readable
+  tracked Python files that cannot be parsed by the current interpreter as
+  typed `unparsed_source` records. These records expose a path, error class,
+  and path digest but never claim a verified function or class.
+- KEEP source I/O failures, collection caps, embedding-count mismatches, and
+  incomplete source sets fail-closed. `IndexResult.fallback_count` makes the
+  non-symbol records visible without treating them as parser failures.
+- LOAD Python sources through `tokenize.open()` so valid UTF-8 BOM and declared
+  source encodings are handled according to Python's own rules.
+- BATCH symbol embedding and collection writes in bounded chunks. This removes
+  the one-model-call-per-symbol behavior observed during the 42,071-record
+  canonical refresh while retaining the exact output-count proof.
+- NORMALIZE heterogeneous SKILLz `agents` lists to scalar strings. Integer WSP
+  and agent identifiers no longer abort an otherwise valid canonical Skillz
+  source set.
+- ADD hard regressions for invalid syntax, BOM input, mixed valid/unparsed
+  sources, 5,001-symbol batching, real read failure, and mixed scalar Skillz
+  agent identifiers.
+
+**Truth boundary**:
+
+- OBSERVED: the pre-fix full baseline required about nineteen minutes, then
+  rejected `navigation_symbols` (125 AST failures) and `navigation_skills`
+  (two heterogeneous-agent metadata failures).
+- OBSERVED: the post-fix canonical preparation pass accounted for all 3,385
+  tracked Python files as 42,484 records, including 88 typed fallbacks, with
+  zero source I/O failures and no cap truncation.
+- OBSERVED: fallback records are discoverability evidence only. They cannot
+  support a symbol-level implementation claim.
+- SPECIFIED_NOT_IMPLEMENTED: routine post-merge incremental maintenance and a
+  clean canonical shared runtime checkout remain separate operational gates.
+
 ## [2026-07-18] HOLOINDEX_REDDOG_OPERATIONAL_TRUTH_BOUNDARY_POC_PHASE1
 
 **WSP Protocol**: WSP 00, 05, 06, 15, 22, 34, 50, 62, 64, 84, 87, 96, 97
@@ -17,8 +57,9 @@
   IN_PROGRESS invalidation, and same-HEAD final PASS publication. Incomplete
   CLI plans and receipt failures exit nonzero and leave invalid proof in place.
 - BIND every baseline collection to a versioned canonical source_scope_id.
-  Canonical proof includes Git-tracked sources, full raw-content manifests,
-  and zero recorded source-read, cap, or Python-AST failures; scoped
+  Canonical proof includes Git-tracked sources and full raw-content manifests.
+  Source-read/cap failures remain fatal; later Phase 1 hardening accounts for
+  readable Python-AST failures with typed non-symbol records. Scoped
   diagnostics cannot publish CURRENT. No blanket all-parser claim is made.
 - REQUIRE semantic backend initialization before baseline collection reset.
 - BIND PASS receipts to each collection's backend, logical model, and

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -53,6 +53,11 @@
   508.41 seconds. The immediate exact-content rerun reused the stable vectors
   and completed in 52.89 seconds (symbols: 28.68 seconds), within the resident
   maintenance budget.
+- OBSERVED: after the bounded-publish metadata update, targeted maintenance
+  completed in 80.39 seconds. The final exact-HEAD seven-collection baseline
+  completed in 186.88 seconds with all canonical proofs PASS; symbols reused
+  in 32.21 seconds and process working set stayed near 790 MiB during the
+  measured full run.
 - OBSERVED: fallback records are discoverability evidence only. They cannot
   support a symbol-level implementation claim.
 - SPECIFIED_NOT_IMPLEMENTED: routine post-merge incremental maintenance and a

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -58,6 +58,8 @@ class IndexResult:
         warning: Optional warning message (e.g., zero discovered)
         fallback_count: Sources represented by explicit non-authoritative
             fallback records instead of silently omitted from the collection.
+        reused_count: Existing records whose exact document and embedding space
+            matched, so their embeddings were retained during reconciliation.
     """
     discovered_count: int
     indexed_count: int
@@ -66,6 +68,7 @@ class IndexResult:
     processed_count: Optional[int] = None
     failed_count: int = 0
     fallback_count: int = 0
+    reused_count: int = 0
     source_manifest_digest: str = ""
     source_scope_id: str = ""
 

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -56,6 +56,8 @@ class IndexResult:
         indexed_count: Number of documents actually inserted into Chroma
         collection_name: Name of the target Chroma collection
         warning: Optional warning message (e.g., zero discovered)
+        fallback_count: Sources represented by explicit non-authoritative
+            fallback records instead of silently omitted from the collection.
     """
     discovered_count: int
     indexed_count: int
@@ -63,6 +65,7 @@ class IndexResult:
     warning: Optional[str] = None
     processed_count: Optional[int] = None
     failed_count: int = 0
+    fallback_count: int = 0
     source_manifest_digest: str = ""
     source_scope_id: str = ""
 
@@ -1353,7 +1356,11 @@ def index_skillz_entries(holo: "HoloIndex") -> IndexResult:
             metadata: Dict[str, Any] = {
                 "skill_name": name,
                 "description": description[:500],
-                "agents": ','.join(agents) if isinstance(agents, list) else str(agents),
+                "agents": (
+                    ','.join(str(agent) for agent in agents)
+                    if isinstance(agents, list)
+                    else str(agents)
+                ),
                 "primary_agent": primary_agent,
                 "intent_type": intent_type,
                 "promotion_state": promotion_state,

--- a/holo_index/symbol_indexer.py
+++ b/holo_index/symbol_indexer.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import ast
+import hashlib
 import os
+import tokenize
 from pathlib import Path
 from typing import Any, Optional
 
@@ -36,13 +38,14 @@ SKIP_DIRS = frozenset(
 )
 PreparedSymbolRecords = tuple[
     list[str],
-    list[list[float]],
     list[str],
     list[dict[str, Any]],
     int,
     int,
+    int,
     bool,
 ]
+DEFAULT_EMBED_BATCH_SIZE = 512
 
 
 def _roots(holo: Any, roots: Optional[list[Path]]) -> list[Path]:
@@ -115,6 +118,75 @@ def _symbol_record(
     return record_id, document, metadata
 
 
+def _unparsed_source_record(
+    *,
+    path: Path,
+    project_root: Path,
+    record_id: str,
+    error: Exception,
+) -> tuple[str, str, dict[str, Any]]:
+    """Account for a readable source without inventing symbols from it."""
+
+    try:
+        relative_path = path.relative_to(project_root).as_posix()
+    except ValueError:
+        relative_path = path.as_posix()
+    error_class = type(error).__name__
+    document = "\n".join(
+        (
+            "Unparsed Python source",
+            f"Path: {relative_path}",
+            f"Parse status: {error_class}",
+            "No verified symbols were extracted from this source.",
+        )
+    )
+    federation = resolve_foundup_metadata(path, project_root)
+    metadata = {
+        "symbol": "",
+        "path": str(path),
+        "line": 1,
+        "type": "unparsed_source",
+        "parse_status": error_class,
+        "source_path_digest": "sha256:"
+        + hashlib.sha256(relative_path.encode("utf-8")).hexdigest(),
+        "foundup_id": federation["foundup_id"],
+        "tenant_id": federation["tenant_id"],
+        "source_scope": federation["source_scope"],
+        "external_repo": federation["external_repo"],
+    }
+    return record_id, document, metadata
+
+
+def _embedding_batch_size() -> int:
+    raw = str(os.getenv("HOLO_SYMBOL_EMBED_BATCH_SIZE", "")).strip()
+    if not raw:
+        return DEFAULT_EMBED_BATCH_SIZE
+    try:
+        return max(1, min(int(raw), 5000))
+    except ValueError:
+        return DEFAULT_EMBED_BATCH_SIZE
+
+
+def _batch_embeddings(holo: Any, documents: list[str]) -> list[list[float]]:
+    """Encode one bounded batch, falling back for minimal/test backends."""
+
+    model = getattr(holo, "model", None)
+    encode = getattr(model, "encode", None)
+    if callable(encode):
+        try:
+            values = encode(
+                documents,
+                batch_size=_embedding_batch_size(),
+                show_progress_bar=False,
+            )
+            rows = values.tolist() if hasattr(values, "tolist") else list(values)
+            if len(rows) == len(documents):
+                return [row.tolist() if hasattr(row, "tolist") else list(row) for row in rows]
+        except (TypeError, ValueError, RuntimeError):
+            pass
+    return [holo._get_embedding(document) for document in documents]
+
+
 def _prepare_records(
     holo: Any,
     files: list[Path],
@@ -122,17 +194,42 @@ def _prepare_records(
     max_entries: int,
 ) -> PreparedSymbolRecords:
     ids: list[str] = []
-    embeddings: list[list[float]] = []
     documents: list[str] = []
     metadatas: list[dict[str, Any]] = []
     processed_files = 0
     failed_files = 0
+    fallback_files = 0
     for path in files:
         processed_files += 1
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8", errors="strict"))
-        except (OSError, UnicodeError, SyntaxError):
+            with tokenize.open(path) as source:
+                source_text = source.read()
+            tree = ast.parse(source_text)
+        except OSError:
             failed_files += 1
+            continue
+        except (UnicodeError, SyntaxError) as exc:
+            if max_entries > 0 and len(ids) >= max_entries:
+                return (
+                    ids,
+                    documents,
+                    metadatas,
+                    max(0, processed_files - 1),
+                    failed_files,
+                    fallback_files,
+                    True,
+                )
+            record_id = f"sym_{len(ids) + 1}"
+            _, document, metadata = _unparsed_source_record(
+                path=path,
+                project_root=holo.project_root,
+                record_id=record_id,
+                error=exc,
+            )
+            ids.append(record_id)
+            documents.append(document)
+            metadatas.append(metadata)
+            fallback_files += 1
             continue
         for node in ast.walk(tree):
             if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
@@ -140,11 +237,11 @@ def _prepare_records(
             if max_entries > 0 and len(ids) >= max_entries:
                 return (
                     ids,
-                    embeddings,
                     documents,
                     metadatas,
                     max(0, processed_files - 1),
                     failed_files,
+                    fallback_files,
                     True,
                 )
             record_id = f"sym_{len(ids) + 1}"
@@ -155,25 +252,36 @@ def _prepare_records(
                 record_id=record_id,
             )
             ids.append(record_id)
-            embeddings.append(holo._get_embedding(document))
             documents.append(document)
             metadatas.append(metadata)
-    return ids, embeddings, documents, metadatas, processed_files, failed_files, False
+    return (
+        ids,
+        documents,
+        metadatas,
+        processed_files,
+        failed_files,
+        fallback_files,
+        False,
+    )
 
 
 def _add_batches(
+    holo: Any,
     collection: Any,
     ids: list[str],
-    embeddings: list[list[float]],
     documents: list[str],
     metadatas: list[dict[str, Any]],
 ) -> None:
     for start in range(0, len(ids), 5000):
         end = start + 5000
+        document_batch = documents[start:end]
+        embedding_batch = _batch_embeddings(holo, document_batch)
+        if len(embedding_batch) != len(document_batch):
+            raise ValueError("HOLOINDEX_SYMBOL_EMBEDDING_BATCH_MISMATCH")
         collection.add(
             ids=ids[start:end],
-            embeddings=embeddings[start:end],
-            documents=documents[start:end],
+            embeddings=embedding_batch,
+            documents=document_batch,
             metadatas=metadatas[start:end],
         )
 
@@ -245,6 +353,7 @@ def _symbol_index_warning(
     discovered_count: int,
     entry_truncated: bool,
     failed: int,
+    fallback: int,
     indexed_count: int,
 ) -> str:
     if selected_count != discovered_count:
@@ -253,6 +362,8 @@ def _symbol_index_warning(
         return "Symbol entry cap truncated the declared source set"
     if failed:
         return f"Symbol parser failed for {failed} source files"
+    if fallback:
+        return f"Indexed {fallback} unparseable source files without verified symbols"
     if not indexed_count:
         return "Symbol index empty - no entries added"
     return ""
@@ -281,15 +392,16 @@ def index_symbol_entries(
     holo._log_agent_action("Indexing symbol entries (functions/classes)...", "INDEX")
     holo.symbol_collection = holo._reset_collection(collection_name)
     records = _prepare_records(holo, selected_files, max_entries=max_entries)
-    ids, embeddings, documents, metadatas, processed, failed, entry_truncated = records
+    ids, documents, metadatas, processed, failed, fallback, entry_truncated = records
     if ids:
-        _add_batches(holo.symbol_collection, ids, embeddings, documents, metadatas)
+        _add_batches(holo, holo.symbol_collection, ids, documents, metadatas)
         holo._log_agent_action(f"Symbol index refreshed: {len(ids)} entries", "OK")
     warning = _symbol_index_warning(
         selected_count=len(selected_files),
         discovered_count=len(discovered_files),
         entry_truncated=entry_truncated,
         failed=failed,
+        fallback=fallback,
         indexed_count=len(ids),
     )
     return IndexResult(
@@ -299,6 +411,7 @@ def index_symbol_entries(
         warning=warning or None,
         processed_count=processed,
         failed_count=failed,
+        fallback_count=fallback,
         source_manifest_digest=manifest_digest,
         source_scope_id=scope_id,
     )

--- a/holo_index/symbol_indexer.py
+++ b/holo_index/symbol_indexer.py
@@ -47,7 +47,8 @@ PreparedSymbolRecords = tuple[
     bool,
 ]
 DEFAULT_EMBED_BATCH_SIZE = 512
-PUBLISH_BATCH_SIZE = 5000
+PUBLISH_BATCH_SIZE = 1000
+SYMBOL_DOCSTRING_MAX_CHARS = 8192
 
 
 def _relative_path(path: Path, project_root: Path) -> str:
@@ -121,8 +122,10 @@ def _symbol_record(
         symbol = f"{name}({', '.join(args[:8])})"
     line_no = int(getattr(node, "lineno", 1) or 1)
     relative_path = _relative_path(path, project_root)
+    raw_docstring = ast.get_docstring(node) or ""
+    docstring = raw_docstring[:SYMBOL_DOCSTRING_MAX_CHARS]
     document = chr(10).join(
-        (symbol, ast.get_docstring(node) or "", f"{relative_path}:{line_no}")
+        (symbol, docstring, f"{relative_path}:{line_no}")
     )
     federation = resolve_foundup_metadata(path, project_root)
     metadata = {
@@ -130,6 +133,7 @@ def _symbol_record(
         "path": relative_path,
         "line": line_no,
         "type": "symbol",
+        "docstring_truncated": len(raw_docstring) > len(docstring),
         "foundup_id": federation["foundup_id"],
         "tenant_id": federation["tenant_id"],
         "source_scope": federation["source_scope"],
@@ -525,7 +529,10 @@ def index_symbol_entries(
     ids, documents, metadatas, processed, failed, fallback, entry_truncated = records
     reused = _publish_records(holo, ids, documents, metadatas)
     if ids:
-        holo._log_agent_action(f"Symbol index refreshed: {len(ids)} entries", "OK")
+        holo._log_agent_action(
+            f"Symbol index refreshed: {len(ids)} entries; reused={reused}",
+            "OK",
+        )
     warning = _symbol_index_warning(
         selected_count=len(selected_files),
         discovered_count=len(discovered_files),

--- a/holo_index/symbol_indexer.py
+++ b/holo_index/symbol_indexer.py
@@ -6,6 +6,7 @@ import ast
 import hashlib
 import os
 import tokenize
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Optional
 
@@ -46,6 +47,25 @@ PreparedSymbolRecords = tuple[
     bool,
 ]
 DEFAULT_EMBED_BATCH_SIZE = 512
+PUBLISH_BATCH_SIZE = 5000
+
+
+def _relative_path(path: Path, project_root: Path) -> str:
+    try:
+        return path.relative_to(project_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _stable_record_id(
+    relative_path: str,
+    record_type: str,
+    line_no: int,
+    symbol: str,
+) -> str:
+    payload = "\x00".join((relative_path, record_type, str(line_no), symbol))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+    return f"hidx_nav_symbols_{digest}"
 
 
 def _roots(holo: Any, roots: Optional[list[Path]]) -> list[Path]:
@@ -91,7 +111,6 @@ def _symbol_record(
     node: ast.AST,
     path: Path,
     project_root: Path,
-    record_id: str,
 ) -> tuple[str, str, dict[str, Any]]:
     name = str(getattr(node, "name", ""))
     if isinstance(node, ast.ClassDef):
@@ -101,13 +120,14 @@ def _symbol_record(
         args = [item.arg for item in raw_args if hasattr(item, "arg")]
         symbol = f"{name}({', '.join(args[:8])})"
     line_no = int(getattr(node, "lineno", 1) or 1)
+    relative_path = _relative_path(path, project_root)
     document = chr(10).join(
-        (symbol, ast.get_docstring(node) or "", f"{path}:{line_no}")
+        (symbol, ast.get_docstring(node) or "", f"{relative_path}:{line_no}")
     )
     federation = resolve_foundup_metadata(path, project_root)
     metadata = {
         "symbol": symbol,
-        "path": str(path),
+        "path": relative_path,
         "line": line_no,
         "type": "symbol",
         "foundup_id": federation["foundup_id"],
@@ -115,6 +135,7 @@ def _symbol_record(
         "source_scope": federation["source_scope"],
         "external_repo": federation["external_repo"],
     }
+    record_id = _stable_record_id(relative_path, metadata["type"], line_no, symbol)
     return record_id, document, metadata
 
 
@@ -122,15 +143,11 @@ def _unparsed_source_record(
     *,
     path: Path,
     project_root: Path,
-    record_id: str,
     error: Exception,
 ) -> tuple[str, str, dict[str, Any]]:
     """Account for a readable source without inventing symbols from it."""
 
-    try:
-        relative_path = path.relative_to(project_root).as_posix()
-    except ValueError:
-        relative_path = path.as_posix()
+    relative_path = _relative_path(path, project_root)
     error_class = type(error).__name__
     document = "\n".join(
         (
@@ -143,7 +160,7 @@ def _unparsed_source_record(
     federation = resolve_foundup_metadata(path, project_root)
     metadata = {
         "symbol": "",
-        "path": str(path),
+        "path": relative_path,
         "line": 1,
         "type": "unparsed_source",
         "parse_status": error_class,
@@ -154,6 +171,7 @@ def _unparsed_source_record(
         "source_scope": federation["source_scope"],
         "external_repo": federation["external_repo"],
     }
+    record_id = _stable_record_id(relative_path, metadata["type"], 1, "")
     return record_id, document, metadata
 
 
@@ -219,11 +237,9 @@ def _prepare_records(
                     fallback_files,
                     True,
                 )
-            record_id = f"sym_{len(ids) + 1}"
-            _, document, metadata = _unparsed_source_record(
+            record_id, document, metadata = _unparsed_source_record(
                 path=path,
                 project_root=holo.project_root,
-                record_id=record_id,
                 error=exc,
             )
             ids.append(record_id)
@@ -244,12 +260,10 @@ def _prepare_records(
                     fallback_files,
                     True,
                 )
-            record_id = f"sym_{len(ids) + 1}"
-            _, document, metadata = _symbol_record(
+            record_id, document, metadata = _symbol_record(
                 node=node,
                 path=path,
                 project_root=holo.project_root,
-                record_id=record_id,
             )
             ids.append(record_id)
             documents.append(document)
@@ -272,8 +286,8 @@ def _add_batches(
     documents: list[str],
     metadatas: list[dict[str, Any]],
 ) -> None:
-    for start in range(0, len(ids), 5000):
-        end = start + 5000
+    for start in range(0, len(ids), PUBLISH_BATCH_SIZE):
+        end = start + PUBLISH_BATCH_SIZE
         document_batch = documents[start:end]
         embedding_batch = _batch_embeddings(holo, document_batch)
         if len(embedding_batch) != len(document_batch):
@@ -284,6 +298,123 @@ def _add_batches(
             documents=document_batch,
             metadatas=metadatas[start:end],
         )
+
+
+def _embedding_space_matches(holo: Any, collection: Any) -> bool:
+    metadata = getattr(collection, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return False
+    expected = {
+        "embedding_backend": str(getattr(holo, "index_embedding_backend", "") or ""),
+        "embedding_model": str(getattr(holo, "index_embedding_model_id", "") or ""),
+        "embedding_space_fingerprint": str(
+            getattr(holo, "index_embedding_space_fingerprint", "") or ""
+        ),
+    }
+    return bool(expected["embedding_space_fingerprint"]) and all(
+        str(metadata.get(key) or "") == value for key, value in expected.items()
+    )
+
+
+def _flat_list(payload: Any, key: str) -> list[Any]:
+    if not isinstance(payload, Mapping):
+        raise ValueError("HOLOINDEX_SYMBOL_REUSE_INVALID_PAYLOAD")
+    raw = payload.get(key, [])
+    values = [] if raw is None else list(raw)
+    if values and isinstance(values[0], list):
+        values = [item for group in values for item in group]
+    return values
+
+
+def _reconciliation_capable(collection: Any) -> bool:
+    return all(
+        callable(getattr(collection, name, None))
+        for name in ("get", "upsert", "update", "delete", "count")
+    )
+
+
+def _reconcile_records(
+    holo: Any,
+    collection: Any,
+    ids: list[str],
+    documents: list[str],
+    metadatas: list[dict[str, Any]],
+) -> int:
+    """Retain embeddings only for exact documents in the same embedding space."""
+
+    snapshot = collection.get(include=["metadatas"])
+    existing_ids = {str(value) for value in _flat_list(snapshot, "ids")}
+    desired_ids = set(ids)
+    reused = 0
+    for start in range(0, len(ids), PUBLISH_BATCH_SIZE):
+        end = start + PUBLISH_BATCH_SIZE
+        batch_ids = ids[start:end]
+        batch_documents = documents[start:end]
+        batch_metadatas = metadatas[start:end]
+        current = collection.get(
+            ids=batch_ids,
+            include=["documents", "metadatas"],
+        )
+        current_ids = [str(value) for value in _flat_list(current, "ids")]
+        current_documents = _flat_list(current, "documents")
+        current_metadatas = _flat_list(current, "metadatas")
+        by_id = {
+            item_id: (document, metadata)
+            for item_id, document, metadata in zip(
+                current_ids, current_documents, current_metadatas
+            )
+        }
+        changed_ids: list[str] = []
+        changed_documents: list[str] = []
+        changed_metadatas: list[dict[str, Any]] = []
+        metadata_ids: list[str] = []
+        metadata_values: list[dict[str, Any]] = []
+        for item_id, document, metadata in zip(
+            batch_ids, batch_documents, batch_metadatas
+        ):
+            previous = by_id.get(item_id)
+            if previous is None or previous[0] != document:
+                changed_ids.append(item_id)
+                changed_documents.append(document)
+                changed_metadatas.append(metadata)
+                continue
+            reused += 1
+            if previous[1] != metadata:
+                metadata_ids.append(item_id)
+                metadata_values.append(metadata)
+        if changed_ids:
+            embeddings = _batch_embeddings(holo, changed_documents)
+            if len(embeddings) != len(changed_documents):
+                raise ValueError("HOLOINDEX_SYMBOL_EMBEDDING_BATCH_MISMATCH")
+            collection.upsert(
+                ids=changed_ids,
+                embeddings=embeddings,
+                documents=changed_documents,
+                metadatas=changed_metadatas,
+            )
+        if metadata_ids:
+            collection.update(ids=metadata_ids, metadatas=metadata_values)
+    stale_ids = sorted(existing_ids.difference(desired_ids))
+    for start in range(0, len(stale_ids), PUBLISH_BATCH_SIZE):
+        collection.delete(ids=stale_ids[start : start + PUBLISH_BATCH_SIZE])
+    if int(collection.count()) != len(ids):
+        raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_COUNT_MISMATCH")
+    return reused
+
+
+def _publish_records(
+    holo: Any,
+    ids: list[str],
+    documents: list[str],
+    metadatas: list[dict[str, Any]],
+) -> int:
+    current = getattr(holo, "symbol_collection", None)
+    if _embedding_space_matches(holo, current) and _reconciliation_capable(current):
+        return _reconcile_records(holo, current, ids, documents, metadatas)
+    holo.symbol_collection = holo._reset_collection("navigation_symbols")
+    if ids:
+        _add_batches(holo, holo.symbol_collection, ids, documents, metadatas)
+    return 0
 
 
 def _canonical_discovered_files(
@@ -390,11 +521,10 @@ def index_symbol_entries(
     if failure is not None:
         return failure
     holo._log_agent_action("Indexing symbol entries (functions/classes)...", "INDEX")
-    holo.symbol_collection = holo._reset_collection(collection_name)
     records = _prepare_records(holo, selected_files, max_entries=max_entries)
     ids, documents, metadatas, processed, failed, fallback, entry_truncated = records
+    reused = _publish_records(holo, ids, documents, metadatas)
     if ids:
-        _add_batches(holo, holo.symbol_collection, ids, documents, metadatas)
         holo._log_agent_action(f"Symbol index refreshed: {len(ids)} entries", "OK")
     warning = _symbol_index_warning(
         selected_count=len(selected_files),
@@ -412,6 +542,7 @@ def index_symbol_entries(
         processed_count=processed,
         failed_count=failed,
         fallback_count=fallback,
+        reused_count=reused,
         source_manifest_digest=manifest_digest,
         source_scope_id=scope_id,
     )

--- a/holo_index/tests/test_complete_source_indexing.py
+++ b/holo_index/tests/test_complete_source_indexing.py
@@ -168,4 +168,3 @@ def test_skillz_agent_identifiers_accept_mixed_scalar_values(tmp_path: Path) -> 
     assert result.failed_count == 0
     metadata = holo.skill_collection.add_calls[0]["metadatas"][0]
     assert metadata["agents"] == "97,66,worker"
-

--- a/holo_index/tests/test_complete_source_indexing.py
+++ b/holo_index/tests/test_complete_source_indexing.py
@@ -8,7 +8,11 @@ from typing import Any
 import pytest
 
 from holo_index.core.indexing_engine import index_skillz_entries
-from holo_index.symbol_indexer import index_symbol_entries
+from holo_index.symbol_indexer import (
+    PUBLISH_BATCH_SIZE,
+    SYMBOL_DOCSTRING_MAX_CHARS,
+    index_symbol_entries,
+)
 
 
 class _Collection:
@@ -208,8 +212,32 @@ def test_symbol_embeddings_are_bounded_into_collection_batches(tmp_path: Path) -
 
     assert result.complete is True
     assert result.indexed_count == 5001
-    assert [len(call) for call in model.calls] == [5000, 1]
-    assert [len(call["ids"]) for call in holo.symbol_collection.add_calls] == [5000, 1]
+    assert [len(call) for call in model.calls] == [1000, 1000, 1000, 1000, 1000, 1]
+    assert [len(call["ids"]) for call in holo.symbol_collection.add_calls] == [
+        PUBLISH_BATCH_SIZE,
+        PUBLISH_BATCH_SIZE,
+        PUBLISH_BATCH_SIZE,
+        PUBLISH_BATCH_SIZE,
+        PUBLISH_BATCH_SIZE,
+        1,
+    ]
+
+
+def test_symbol_docstring_evidence_is_explicitly_bounded(tmp_path: Path) -> None:
+    oversized = "X" * (SYMBOL_DOCSTRING_MAX_CHARS + 1000)
+    source = tmp_path / "oversized.py"
+    source.write_text(
+        f'def bounded():\n    """{oversized}"""\n    return True\n',
+        encoding="utf-8",
+    )
+    model = _BatchModel()
+    holo = _Holo(tmp_path, model=model)
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.complete is True
+    assert model.calls[0][0].count("X") == SYMBOL_DOCSTRING_MAX_CHARS
+    assert _symbol_metadata(holo)[0]["docstring_truncated"] is True
 
 
 def test_unchanged_stable_records_reuse_exact_space_embeddings(tmp_path: Path) -> None:

--- a/holo_index/tests/test_complete_source_indexing.py
+++ b/holo_index/tests/test_complete_source_indexing.py
@@ -1,0 +1,171 @@
+"""Regression tests for complete, bounded HoloIndex source indexing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from holo_index.core.indexing_engine import index_skillz_entries
+from holo_index.symbol_indexer import index_symbol_entries
+
+
+class _Collection:
+    def __init__(self) -> None:
+        self.add_calls: list[dict[str, Any]] = []
+
+    def add(self, **kwargs: Any) -> None:
+        self.add_calls.append(kwargs)
+
+
+class _BatchModel:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def encode(self, values: list[str], **_kwargs: Any) -> list[list[float]]:
+        self.calls.append(list(values))
+        return [[float(index), 1.0] for index, _value in enumerate(values)]
+
+
+class _Holo:
+    def __init__(self, project_root: Path, *, model: Any | None = None) -> None:
+        self.project_root = project_root
+        self.model = model
+        self.symbol_collection = _Collection()
+        self.skill_collection = _Collection()
+        self.logged: list[tuple[str, str]] = []
+
+    def _reset_collection(self, name: str) -> _Collection:
+        collection = _Collection()
+        if name == "navigation_symbols":
+            self.symbol_collection = collection
+        elif name == "navigation_skills":
+            self.skill_collection = collection
+        return collection
+
+    def _get_embedding(self, _text: str) -> list[float]:
+        return [0.1, 0.2]
+
+    def _log_agent_action(self, message: str, level: str) -> None:
+        self.logged.append((level, message))
+
+
+def _symbol_metadata(holo: _Holo) -> list[dict[str, Any]]:
+    return [
+        metadata
+        for call in holo.symbol_collection.add_calls
+        for metadata in call["metadatas"]
+    ]
+
+
+def test_unparseable_source_is_accounted_without_invented_symbol(tmp_path: Path) -> None:
+    source = tmp_path / "broken.py"
+    source.write_text("def broken(:\n    pass\n", encoding="utf-8")
+    model = _BatchModel()
+    holo = _Holo(tmp_path, model=model)
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.discovered_count == 1
+    assert result.processed_count == 1
+    assert result.failed_count == 0
+    assert result.fallback_count == 1
+    assert result.complete is True
+    assert result.indexed_count == 1
+    metadata = _symbol_metadata(holo)[0]
+    assert metadata["type"] == "unparsed_source"
+    assert metadata["symbol"] == ""
+    assert metadata["parse_status"] == "SyntaxError"
+    assert model.calls and "def broken" not in model.calls[0][0]
+
+
+def test_utf8_bom_source_is_parsed_as_python(tmp_path: Path) -> None:
+    source = tmp_path / "bom.py"
+    source.write_bytes(b"\xef\xbb\xbfdef bom_symbol():\n    return True\n")
+    holo = _Holo(tmp_path, model=_BatchModel())
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.complete is True
+    assert result.fallback_count == 0
+    metadata = _symbol_metadata(holo)[0]
+    assert metadata["type"] == "symbol"
+    assert metadata["symbol"].startswith("bom_symbol(")
+
+
+def test_unparseable_and_valid_sources_are_both_in_collection(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("def valid():\n    pass\n", encoding="utf-8")
+    (tmp_path / "b.py").write_text("class Broken(\n", encoding="utf-8")
+    holo = _Holo(tmp_path, model=_BatchModel())
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.discovered_count == result.processed_count == 2
+    assert result.indexed_count == 2
+    assert result.fallback_count == 1
+    assert result.complete is True
+    assert {item["type"] for item in _symbol_metadata(holo)} == {
+        "symbol",
+        "unparsed_source",
+    }
+
+
+def test_symbol_embeddings_are_bounded_into_collection_batches(tmp_path: Path) -> None:
+    source = tmp_path / "many.py"
+    source.write_text(
+        "\n".join(f"def symbol_{index}(): pass" for index in range(5001)),
+        encoding="utf-8",
+    )
+    model = _BatchModel()
+    holo = _Holo(tmp_path, model=model)
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.complete is True
+    assert result.indexed_count == 5001
+    assert [len(call) for call in model.calls] == [5000, 1]
+    assert [len(call["ids"]) for call in holo.symbol_collection.add_calls] == [5000, 1]
+
+
+def test_true_source_io_failure_remains_incomplete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source.py"
+    source.write_text("def present(): pass\n", encoding="utf-8")
+    import holo_index.symbol_indexer as module
+
+    def _raise(_path: Path):
+        raise OSError("simulated read failure")
+
+    monkeypatch.setattr(module.tokenize, "open", _raise)
+    result = index_symbol_entries(_Holo(tmp_path), roots=[tmp_path])
+
+    assert result.failed_count == 1
+    assert result.fallback_count == 0
+    assert result.complete is False
+
+
+def test_skillz_agent_identifiers_accept_mixed_scalar_values(tmp_path: Path) -> None:
+    skill = tmp_path / "holo_index" / "skillz" / "mixed_agents" / "SKILLz.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\n"
+        "name: mixed_agents\n"
+        "description: Mixed identifiers\n"
+        "agents: [97, 0102, worker]\n"
+        "primary_agent: worker\n"
+        "---\n"
+        "# Mixed agents\n",
+        encoding="utf-8",
+    )
+    holo = _Holo(tmp_path)
+
+    result = index_skillz_entries(holo)
+
+    assert result.complete is True
+    assert result.failed_count == 0
+    metadata = holo.skill_collection.add_calls[0]["metadatas"][0]
+    assert metadata["agents"] == "97,66,worker"
+

--- a/holo_index/tests/test_complete_source_indexing.py
+++ b/holo_index/tests/test_complete_source_indexing.py
@@ -28,6 +28,90 @@ class _BatchModel:
         return [[float(index), 1.0] for index, _value in enumerate(values)]
 
 
+class _StatefulCollection:
+    def __init__(self, metadata: dict[str, str]) -> None:
+        self.metadata = dict(metadata)
+        self.records: dict[str, dict[str, Any]] = {}
+        self.upsert_calls: list[list[str]] = []
+        self.delete_calls: list[list[str]] = []
+
+    def get(
+        self,
+        *,
+        ids: list[str] | None = None,
+        include: list[str] | None = None,
+    ) -> dict[str, Any]:
+        selected = (
+            list(self.records)
+            if ids is None
+            else [value for value in ids if value in self.records]
+        )
+        return {
+            "ids": selected,
+            "documents": [self.records[value]["document"] for value in selected],
+            "metadatas": [self.records[value]["metadata"] for value in selected],
+        }
+
+    def upsert(self, **kwargs: Any) -> None:
+        self.upsert_calls.append(list(kwargs["ids"]))
+        for item_id, document, metadata, embedding in zip(
+            kwargs["ids"],
+            kwargs["documents"],
+            kwargs["metadatas"],
+            kwargs["embeddings"],
+        ):
+            self.records[item_id] = {
+                "document": document,
+                "metadata": metadata,
+                "embedding": embedding,
+            }
+
+    def add(self, **kwargs: Any) -> None:
+        self.upsert(**kwargs)
+
+    def update(self, *, ids: list[str], metadatas: list[dict[str, Any]]) -> None:
+        for item_id, metadata in zip(ids, metadatas):
+            self.records[item_id]["metadata"] = metadata
+
+    def delete(self, *, ids: list[str]) -> None:
+        self.delete_calls.append(list(ids))
+        for item_id in ids:
+            self.records.pop(item_id, None)
+
+    def count(self) -> int:
+        return len(self.records)
+
+
+class _StatefulHolo:
+    def __init__(self, project_root: Path, model: _BatchModel) -> None:
+        self.project_root = project_root
+        self.model = model
+        self.index_embedding_backend = "sentence_transformers"
+        self.index_embedding_model_id = "test-model"
+        self.index_embedding_space_fingerprint = "sha256:" + ("a" * 64)
+        self.symbol_collection = _StatefulCollection(self.embedding_metadata)
+        self.reset_count = 0
+
+    @property
+    def embedding_metadata(self) -> dict[str, str]:
+        return {
+            "embedding_backend": self.index_embedding_backend,
+            "embedding_model": self.index_embedding_model_id,
+            "embedding_space_fingerprint": self.index_embedding_space_fingerprint,
+        }
+
+    def _reset_collection(self, _name: str) -> _StatefulCollection:
+        self.reset_count += 1
+        self.symbol_collection = _StatefulCollection(self.embedding_metadata)
+        return self.symbol_collection
+
+    def _get_embedding(self, _text: str) -> list[float]:
+        return [0.1, 0.2]
+
+    def _log_agent_action(self, _message: str, _level: str) -> None:
+        return None
+
+
 class _Holo:
     def __init__(self, project_root: Path, *, model: Any | None = None) -> None:
         self.project_root = project_root
@@ -126,6 +210,93 @@ def test_symbol_embeddings_are_bounded_into_collection_batches(tmp_path: Path) -
     assert result.indexed_count == 5001
     assert [len(call) for call in model.calls] == [5000, 1]
     assert [len(call["ids"]) for call in holo.symbol_collection.add_calls] == [5000, 1]
+
+
+def test_unchanged_stable_records_reuse_exact_space_embeddings(tmp_path: Path) -> None:
+    source = tmp_path / "source.py"
+    source.write_text("def stable():\n    return True\n", encoding="utf-8")
+    model = _BatchModel()
+    holo = _StatefulHolo(tmp_path, model)
+
+    first = index_symbol_entries(holo, roots=[tmp_path])
+    first_id = next(iter(holo.symbol_collection.records))
+    model.calls.clear()
+    second = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert first.reused_count == 0
+    assert second.reused_count == 1
+    assert model.calls == []
+    assert next(iter(holo.symbol_collection.records)) == first_id
+    assert holo.reset_count == 0
+
+
+def test_changed_document_reembeds_same_stable_symbol_id(tmp_path: Path) -> None:
+    source = tmp_path / "source.py"
+    source.write_text("def stable():\n    return True\n", encoding="utf-8")
+    model = _BatchModel()
+    holo = _StatefulHolo(tmp_path, model)
+    index_symbol_entries(holo, roots=[tmp_path])
+    first_id = next(iter(holo.symbol_collection.records))
+    model.calls.clear()
+    source.write_text(
+        "def stable():\n    \"\"\"Changed evidence.\"\"\"\n    return True\n",
+        encoding="utf-8",
+    )
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.reused_count == 0
+    assert len(model.calls) == 1
+    assert next(iter(holo.symbol_collection.records)) == first_id
+
+
+def test_stale_stable_record_is_deleted_after_reconciliation(tmp_path: Path) -> None:
+    source = tmp_path / "source.py"
+    source.write_text("def removed():\n    return True\n", encoding="utf-8")
+    holo = _StatefulHolo(tmp_path, _BatchModel())
+    index_symbol_entries(holo, roots=[tmp_path])
+    stale_id = next(iter(holo.symbol_collection.records))
+    source.unlink()
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.indexed_count == 0
+    assert stale_id not in holo.symbol_collection.records
+    assert holo.symbol_collection.delete_calls == [[stale_id]]
+
+
+def test_embedding_space_mismatch_forces_reset_and_reembedding(tmp_path: Path) -> None:
+    source = tmp_path / "source.py"
+    source.write_text("def stable():\n    return True\n", encoding="utf-8")
+    model = _BatchModel()
+    holo = _StatefulHolo(tmp_path, model)
+    index_symbol_entries(holo, roots=[tmp_path])
+    model.calls.clear()
+    holo.symbol_collection.metadata["embedding_space_fingerprint"] = (
+        "sha256:" + ("b" * 64)
+    )
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.reused_count == 0
+    assert len(model.calls) == 1
+    assert holo.reset_count == 1
+
+
+def test_stable_records_are_worktree_path_independent(tmp_path: Path) -> None:
+    roots = [tmp_path / "one", tmp_path / "two"]
+    payloads: list[dict[str, Any]] = []
+    for root in roots:
+        source = root / "modules" / "sample.py"
+        source.parent.mkdir(parents=True)
+        source.write_text("def stable():\n    return True\n", encoding="utf-8")
+        holo = _Holo(root, model=_BatchModel())
+        index_symbol_entries(holo, roots=[root / "modules"])
+        payloads.append(holo.symbol_collection.add_calls[0])
+
+    assert payloads[0]["ids"] == payloads[1]["ids"]
+    assert payloads[0]["documents"] == payloads[1]["documents"]
+    assert payloads[0]["metadatas"] == payloads[1]["metadatas"]
 
 
 def test_true_source_io_failure_remains_incomplete(


### PR DESCRIPTION
## Summary
- account for every readable tracked Python source with verified symbols or typed non-authoritative fallback records
- normalize heterogeneous Skillz agent identifiers so canonical Skillz refresh cannot abort on scalar metadata
- publish stable repository-relative symbol records and reuse embeddings only for exact documents in the exact same embedding space
- bound symbol evidence and publish batches, delete stale IDs, and re-prove the final collection count

## WSP_97 evidence
- pre-fix canonical full refresh failed closed on 125 Python parser failures and 2 Skillz metadata failures
- stable-ID migration: 42,529 symbols + 72 Skillz in 508.41s
- exact-content reuse: 52.89s total; final seven-collection exact-HEAD baseline: 186.88s, all canonical proofs PASS
- focused/maintenance matrix: 149 passed
- full HoloIndex comparison: 1099 passed, 73 known legacy/environment failures, 12 skipped, 1 xfailed, 1 pre-existing missing-fixture error (same 73/1 failure baseline; six new passes)

## Truth boundary
Fallback records prove source accounting and discoverability only; they do not prove a symbol exists. Reuse is denied on backend/model/fingerprint or document mismatch. RedDog remains query-only and no runtime re-index authority is added.