### PR TITLE
fix(reddog): bind deep-dive evidence to focus

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -170,7 +170,7 @@ Copy:
 
 The model cannot access the filesystem. It receives only the bounded context packet.
 
-Extension v0.4.8 keeps repository direct-read grounding available when the generation-bound semantic owner fails, while continuing to withhold unbound semantic claims. Broad repository audits no longer interpret the generic word `repository` as an external-research request, and deterministic manifest ranking prioritizes the named subsystem over WSP/instruction words. Explicit semantic or external-research targets remain independently fail-closed. Extension v0.4.7 introduced the bounded repository deep-dive discovery gate.
+Extension v0.4.9 makes a complete named-subsystem evidence corpus authoritative for the core of a focused repository deep dive. At most two off-anchor generation-bound semantic dependencies may enter when their evidence text names the focus; unrelated hits are excluded. Focus strategy, cross-cutting paths, and manifest completeness are explicit in the Run Trace. Extension v0.4.8 keeps repository direct-read grounding available when the semantic owner fails while withholding unbound semantic claims.
 
 If HoloIndex recall reports zero WSP hits, missing Tier-0 docs, stale/offline fallback, or unavailable output, the answer must treat protocol claims as `NEEDS_VERIFICATION` and propose retrieval/index repair before strong claims.
 

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,16 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-19 - REDDOG_REPO_DEEP_DIVE_FOCUS_BOUND_TARGET_SELECTION_PHASE1 (0.4.9)
+
+- Reserved the repository deep-dive core for token-matched paths under an explicit named focus when readable implementation, test, and document evidence all exist.
+- Retained at most two off-anchor generation-bound semantic dependencies only when their evidence text explicitly names the focus; unrelated semantic hits cannot consume the 12-file budget.
+- Added fail-closed focus-pool integrity checks and Run Trace provenance for anchor source, match mode, strategy, candidate count, cross-cutting targets, and fallback reason.
+- Marked character- or count-truncated tracked-file manifests incomplete so filtering cannot turn partial repository enumeration into a completeness claim.
+- Preserved broad discovery when the focus corpus is incomplete; the existing focus-coverage gate still blocks unsupported deep dives before Fusion.
+- Added regressions for semantic decoys, bounded cross-cutting dependencies, explicit-focus parsing, substring collisions, broad fallback, gate tampering, and scorecard telemetry.
+- Version 0.4.8 -> 0.4.9. No shell, repository mutation, HoloIndex re-index, OpenClaw/Hermes execution, PR, or merge authority was added.
+
 ## 2026-07-19 - REDDOG_DEEP_DIVE_OWNER_FAILURE_DIRECT_READ_CONTINUITY_PHASE1 (0.4.8)
 
 - Preserved locally governed repository direct reads when the generation-bound semantic owner is unavailable; semantic hits remain withheld and explicit semantic obligations still fail closed.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,10 +1,10 @@
 # RedDog
 
-Version: 0.4.8
+Version: 0.4.9
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
 
-Version 0.4.8 preserves governed repository direct reads when the generation-bound semantic owner is unavailable, stops generic repository wording from inventing an external-research obligation, and prioritizes the named subsystem over instruction words during manifest ranking. Explicit semantic and external-research targets remain fail-closed. Version 0.4.7 introduced the bounded repository deep-dive discovery gate.
+Version 0.4.9 reserves the core of a focused repository deep dive for the named subsystem when that subsystem independently supplies readable implementation, test, and document evidence. It permits at most two generation-bound cross-cutting dependencies whose evidence text names the focus, excludes unrelated semantic hits, and exposes manifest completeness. Version 0.4.8 preserves governed repository direct reads when the semantic owner is unavailable.
 
 RedDog is the resident FoundUps architect thin client and 012/0102 interface. Fusion is one internal reasoning mode; authority-bearing work is delegated through signed OpenClaw/WRE/Hermes receipts, not through raw webview access.
 
@@ -228,6 +228,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.8.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.9.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -6,8 +6,9 @@ const fs = require('fs');
 const semanticGroundingPolicy = require('./semantic_grounding_policy');
 const holoGenerationBoundQuery = require('./holoindex_generation_bound_query');
 const groundedTargetContinuity = require('./grounded_target_continuity');
+const repoDeepDiveFocusPolicy = require('./repo_deep_dive_focus_policy');
 
-const EXTENSION_VERSION = '0.4.8';
+const EXTENSION_VERSION = '0.4.9';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -2065,10 +2066,19 @@ function extractHoloIndexScorecard(contextMode, holoMeta) {
     repo_deep_dive_requested: meta.repo_deep_dive_requested !== undefined ? meta.repo_deep_dive_requested : false,
     repo_manifest_generated: meta.repo_manifest_generated !== undefined ? meta.repo_manifest_generated : false,
     repo_manifest_file_count: meta.repo_manifest_file_count !== undefined ? meta.repo_manifest_file_count : 0,
+    repo_manifest_source_count: meta.repo_manifest_source_count !== undefined ? meta.repo_manifest_source_count : 0,
     repo_manifest_truncated: meta.repo_manifest_truncated !== undefined ? meta.repo_manifest_truncated : false,
+    repo_manifest_complete: meta.repo_manifest_complete !== undefined ? meta.repo_manifest_complete : false,
     repo_deep_dive_targets: Array.isArray(meta.repo_deep_dive_targets) ? meta.repo_deep_dive_targets : [],
     repo_deep_dive_targets_count: meta.repo_deep_dive_targets_count !== undefined ? meta.repo_deep_dive_targets_count : 0,
     repo_deep_dive_focus_anchor: meta.repo_deep_dive_focus_anchor || '(none)',
+    repo_deep_dive_focus_anchor_source: meta.repo_deep_dive_focus_anchor_source || 'none',
+    repo_deep_dive_focus_filter_applied: meta.repo_deep_dive_focus_filter_applied !== undefined ? meta.repo_deep_dive_focus_filter_applied : false,
+    repo_deep_dive_focus_candidate_count: meta.repo_deep_dive_focus_candidate_count !== undefined ? meta.repo_deep_dive_focus_candidate_count : 0,
+    repo_deep_dive_focus_match_mode: meta.repo_deep_dive_focus_match_mode || 'none',
+    repo_deep_dive_pool_strategy: meta.repo_deep_dive_pool_strategy || 'unknown',
+    repo_deep_dive_cross_cutting_targets: Array.isArray(meta.repo_deep_dive_cross_cutting_targets) ? meta.repo_deep_dive_cross_cutting_targets : [],
+    repo_deep_dive_fallback_reason: meta.repo_deep_dive_fallback_reason || '(none)',
     repo_deep_dive_focus_coverage: meta.repo_deep_dive_focus_coverage && typeof meta.repo_deep_dive_focus_coverage === 'object'
       ? Object.assign({}, meta.repo_deep_dive_focus_coverage) : {},
     repo_deep_dive_focus_coverage_passed: meta.repo_deep_dive_focus_coverage_passed !== undefined
@@ -2173,10 +2183,19 @@ function formatHoloIndexScorecardLines(scorecard) {
     '- repo_deep_dive_requested: ' + scorecard.repo_deep_dive_requested,
     '- repo_manifest_generated: ' + scorecard.repo_manifest_generated,
     '- repo_manifest_file_count: ' + scorecard.repo_manifest_file_count,
+    '- repo_manifest_source_count: ' + scorecard.repo_manifest_source_count,
     '- repo_manifest_truncated: ' + scorecard.repo_manifest_truncated,
+    '- repo_manifest_complete: ' + scorecard.repo_manifest_complete,
     '- repo_deep_dive_targets_count: ' + scorecard.repo_deep_dive_targets_count,
     '- repo_deep_dive_targets: ' + (Array.isArray(scorecard.repo_deep_dive_targets) && scorecard.repo_deep_dive_targets.length ? scorecard.repo_deep_dive_targets.join(', ') : '(none)'),
     '- repo_deep_dive_focus_anchor: ' + scorecard.repo_deep_dive_focus_anchor,
+    '- repo_deep_dive_focus_anchor_source: ' + scorecard.repo_deep_dive_focus_anchor_source,
+    '- repo_deep_dive_focus_filter_applied: ' + scorecard.repo_deep_dive_focus_filter_applied,
+    '- repo_deep_dive_focus_candidate_count: ' + scorecard.repo_deep_dive_focus_candidate_count,
+    '- repo_deep_dive_focus_match_mode: ' + scorecard.repo_deep_dive_focus_match_mode,
+    '- repo_deep_dive_pool_strategy: ' + scorecard.repo_deep_dive_pool_strategy,
+    '- repo_deep_dive_cross_cutting_targets: ' + (Array.isArray(scorecard.repo_deep_dive_cross_cutting_targets) && scorecard.repo_deep_dive_cross_cutting_targets.length ? scorecard.repo_deep_dive_cross_cutting_targets.join(', ') : '(none)'),
+    '- repo_deep_dive_fallback_reason: ' + scorecard.repo_deep_dive_fallback_reason,
     '- repo_deep_dive_focus_coverage_passed: ' + scorecard.repo_deep_dive_focus_coverage_passed,
     '- repo_deep_dive_gate_applied: ' + scorecard.repo_deep_dive_gate_applied,
     '- repo_deep_dive_gate_passed: ' + scorecard.repo_deep_dive_gate_passed,
@@ -6581,12 +6600,19 @@ function activeEditorContext(root) {
   return '### active editor ' + (selected ? 'selection' : 'file') + ': ' + rel + '\n```' + (doc.languageId || 'text') + '\n' + clipped + '\n```';
 }
 
+const GIT_OUTPUT_TRUNCATED_MARKER = '[REDDOG_GIT_OUTPUT_TRUNCATED]';
+
 function repoFileIndex(root, maxFiles) {
   const gitFiles = gitOutput(root, ['ls-files'], 1000000);
   if (gitFiles && !gitFiles.startsWith('[git context unavailable')) {
-    const files = gitFiles.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    const outputTruncated = gitFiles.includes(GIT_OUTPUT_TRUNCATED_MARKER);
+    const files = gitFiles.split(/\r?\n/).map((line) => line.trim())
+      .filter((line) => line && line !== GIT_OUTPUT_TRUNCATED_MARKER);
     if (files.length) {
-      return files.slice(0, maxFiles);
+      const selected = files.slice(0, maxFiles);
+      selected.manifest_truncated = outputTruncated || files.length > maxFiles;
+      selected.manifest_source_count = files.length;
+      return selected;
     }
   }
   const roots = ['modules', 'holo_index', '.claude', 'extensions', 'scripts', 'data'];
@@ -6597,6 +6623,8 @@ function repoFileIndex(root, maxFiles) {
       break;
     }
   }
+  files.manifest_truncated = files.length >= maxFiles;
+  files.manifest_source_count = files.length;
   return files;
 }
 
@@ -6675,58 +6703,6 @@ function repoPathFromEvidenceRef(raw) {
   return normalizeTargetPath(ref);
 }
 
-function repoDeepDiveSemanticPaths(bundleOutput) {
-  let data;
-  try {
-    data = JSON.parse(String(bundleOutput || '{}'));
-  } catch (err) {
-    return [];
-  }
-  return uniqueStrings(semanticEvidenceHitsFromBundleData(data)
-    .map((hit) => repoPathFromEvidenceRef(hit && hit.evidence_ref))
-    .filter(Boolean));
-}
-
-function scoreRepoDeepDivePath(relPath, concepts, semanticSet) {
-  const rel = String(relPath || '').replace(/\\/g, '/');
-  const lower = rel.toLowerCase();
-  const pathSegments = lower.split('/');
-  const searchable = lower.replace(/[^a-z0-9_]+/g, ' ');
-  let score = semanticSet.has(lower) ? 100 : 0;
-  for (let index = 0; index < concepts.length; index++) {
-    const concept = concepts[index];
-    // Earlier concepts are the user's focus terms after instruction/control words
-    // are removed. Weight the first focus term so a generic word such as `runtime`
-    // cannot outrank the named subsystem (the 0.4.7 p.fMALL host regression).
-    const exactWeight = index === 0 ? 40 : index < 3 ? 20 : 14;
-    const tokenWeight = index === 0 ? 24 : index < 3 ? 12 : 8;
-    if (lower.includes(concept)) {
-      score += exactWeight;
-      if (pathSegments.includes(concept)) {
-        score += index === 0 ? 24 : 10;
-      }
-    } else if (searchable.includes(concept)) {
-      score += tokenWeight;
-    }
-  }
-  if (/(?:^|\/)(?:readme|interface|spec|roadmap|modlog)\.md$/i.test(rel)) {
-    score += 4;
-  }
-  if (/(?:^|\/)(?:tests?|test_[^/]+)(?:\/|\.|$)/i.test(rel)) {
-    score += 3;
-  }
-  if (/\.(?:py|js|mjs|ts|tsx|rs|go|java)$/i.test(rel)) {
-    score += 2;
-  }
-  if (/(?:^|\/)__init__\.py$/i.test(rel)) {
-    score -= 8;
-  }
-  if (/^(?:main\.py|holo_index\.py|README\.md)$/i.test(rel)) {
-    score += 1;
-  }
-  return score;
-}
-
 function repoDeepDivePathCategory(file) {
   if (/(?:^|\/)(?:tests?|test_[^/]+)(?:\/|\.|$)/i.test(file)) {
     return 'test';
@@ -6740,7 +6716,7 @@ function repoDeepDivePathCategory(file) {
 function repoDeepDiveFocusCoverage(targets, concepts) {
   const anchor = Array.isArray(concepts) && concepts.length ? String(concepts[0] || '').toLowerCase() : '';
   const focused = Array.isArray(targets)
-    ? targets.filter((file) => anchor && String(file || '').toLowerCase().includes(anchor))
+    ? targets.filter((file) => repoDeepDiveFocusPolicy.hasFocusToken(file, anchor))
     : [];
   const categories = new Set(focused.map(repoDeepDivePathCategory));
   return {
@@ -6753,20 +6729,33 @@ function repoDeepDiveFocusCoverage(targets, concepts) {
 }
 
 function discoverRepoDeepDiveTargets(root, taskText, bundleOutput, maxTargets) {
-  const manifest = repoFileIndex(root, REPO_DEEP_DIVE_MAX_MANIFEST_FILES)
+  const indexedFiles = repoFileIndex(root, REPO_DEEP_DIVE_MAX_MANIFEST_FILES);
+  const manifest = indexedFiles
     .map((file) => String(file || '').replace(/\\/g, '/'))
     .filter(isRepoDeepDiveTextPath);
   const manifestSet = new Set(manifest.map((file) => file.toLowerCase()));
-  const semanticPaths = repoDeepDiveSemanticPaths(bundleOutput)
+  const semanticEntries = repoDeepDiveFocusPolicy.semanticEntries(bundleOutput, semanticEvidenceHitsFromBundleData, repoPathFromEvidenceRef);
+  const semanticPaths = semanticEntries.map((entry) => entry.path)
     .filter((file) => manifestSet.has(file.toLowerCase()));
   const semanticSet = new Set(semanticPaths.map((file) => file.toLowerCase()));
-  const concepts = repoDeepDiveConcepts(taskText);
-  const ranked = manifest
-    .map((file) => ({ file, score: scoreRepoDeepDivePath(file, concepts, semanticSet) }))
+  const rawConcepts = repoDeepDiveConcepts(taskText);
+  const focus = repoDeepDiveFocusPolicy.deriveFocusAnchor(taskText, rawConcepts);
+  const concepts = focus.anchor ? [focus.anchor].concat(rawConcepts.filter((item) => item !== focus.anchor)) : rawConcepts;
+  const focusAnchor = focus.anchor;
+  const pool = repoDeepDiveFocusPolicy.buildCandidatePool({
+    manifest, manifestSet, semanticEntries, anchor: focusAnchor,
+    isReadable: (file) => isRepoDeepDiveReadableFile(root, file),
+    focusCoverage: (files) => repoDeepDiveFocusCoverage(files, concepts)
+  });
+  const { candidateManifest, crossCuttingCandidates, focusCandidates, focusFilterApplied } = pool;
+  const focusSet = new Set(focusCandidates.map((file) => file.toLowerCase()));
+  const ranked = candidateManifest
+    .map((file) => ({ file, score: repoDeepDiveFocusPolicy.scorePath(file, concepts, semanticSet, focusSet) }))
     .filter((item) => item.score > 0)
-    .filter((item) => isRepoDeepDiveReadableFile(root, item.file))
+    .filter((item) => focusFilterApplied || isRepoDeepDiveReadableFile(root, item.file))
     .sort((a, b) => b.score - a.score || a.file.localeCompare(b.file));
   const limit = Math.max(1, Math.min(Number(maxTargets) || REPO_DEEP_DIVE_MAX_TARGETS, REPO_DEEP_DIVE_MAX_TARGETS));
+  const coreLimit = focusFilterApplied ? Math.max(3, limit - crossCuttingCandidates.length) : limit;
   const selected = [];
   const selectedSet = new Set();
   const addFirst = (predicate) => {
@@ -6786,7 +6775,7 @@ function discoverRepoDeepDiveTargets(root, taskText, bundleOutput, maxTargets) {
   // the bounded packet.
   for (const category of ['implementation', 'test', 'doc']) {
     for (const item of ranked) {
-      if (selected.length >= limit || selected.filter((file) => repoDeepDivePathCategory(file) === category).length >= 4) {
+      if (selected.length >= coreLimit || selected.filter((file) => repoDeepDivePathCategory(file) === category).length >= 4) {
         break;
       }
       const key = item.file.toLowerCase();
@@ -6797,7 +6786,7 @@ function discoverRepoDeepDiveTargets(root, taskText, bundleOutput, maxTargets) {
     }
   }
   for (const item of ranked) {
-    if (selected.length >= limit) {
+    if (selected.length >= coreLimit) {
       break;
     }
     const key = item.file.toLowerCase();
@@ -6806,16 +6795,33 @@ function discoverRepoDeepDiveTargets(root, taskText, bundleOutput, maxTargets) {
       selectedSet.add(key);
     }
   }
+  for (const file of crossCuttingCandidates) {
+    const key = file.toLowerCase();
+    if (selected.length < limit && !selectedSet.has(key)) {
+      selected.push(file);
+      selectedSet.add(key);
+    }
+  }
   const focusCoverage = repoDeepDiveFocusCoverage(selected, concepts);
+  const selectedCrossCutting = selected.filter((file) => crossCuttingCandidates.includes(file));
   return {
     requested: isRepoDeepDiveRequest(taskText),
     manifest_generated: true,
     manifest_file_count: manifest.length,
-    manifest_truncated: manifest.length >= REPO_DEEP_DIVE_MAX_MANIFEST_FILES,
+    manifest_source_count: Number(indexedFiles.manifest_source_count || manifest.length),
+    manifest_truncated: indexedFiles.manifest_truncated === true,
+    manifest_complete: indexedFiles.manifest_truncated !== true,
     concepts,
     semantic_paths: semanticPaths,
     targets: selected,
     focus_anchor: focusCoverage.anchor,
+    focus_anchor_source: focus.source,
+    focus_filter_applied: focusFilterApplied,
+    focus_candidate_count: focusCandidates.length,
+    focus_match_mode: 'token',
+    pool_strategy: focusFilterApplied ? 'focus_core_plus_semantic_cross_cutting' : 'broad_fallback',
+    cross_cutting_targets: selectedCrossCutting,
+    fallback_reason: focusFilterApplied ? '' : 'focus_quorum_incomplete',
     focus_coverage: focusCoverage,
     focus_coverage_passed: focusCoverage.passed
   };
@@ -6836,12 +6842,22 @@ function applyRepoDeepDiveDiscoveryMeta(meta, discovery) {
   target.repo_deep_dive_requested = d.requested === true;
   target.repo_manifest_generated = d.manifest_generated === true;
   target.repo_manifest_file_count = Number(d.manifest_file_count || 0);
+  target.repo_manifest_source_count = Number(d.manifest_source_count || 0);
   target.repo_manifest_truncated = d.manifest_truncated === true;
+  target.repo_manifest_complete = d.manifest_complete === true;
   target.repo_deep_dive_concepts = Array.isArray(d.concepts) ? d.concepts.slice() : [];
   target.repo_deep_dive_semantic_paths = Array.isArray(d.semantic_paths) ? d.semantic_paths.slice() : [];
   target.repo_deep_dive_targets = Array.isArray(d.targets) ? d.targets.slice() : [];
   target.repo_deep_dive_targets_count = target.repo_deep_dive_targets.length;
   target.repo_deep_dive_focus_anchor = String(d.focus_anchor || '');
+  target.repo_deep_dive_focus_anchor_source = String(d.focus_anchor_source || 'none');
+  target.repo_deep_dive_focus_filter_applied = d.focus_filter_applied === true;
+  target.repo_deep_dive_focus_candidate_count = Number(d.focus_candidate_count || 0);
+  target.repo_deep_dive_focus_match_mode = String(d.focus_match_mode || 'none');
+  target.repo_deep_dive_pool_strategy = String(d.pool_strategy || 'unknown');
+  target.repo_deep_dive_cross_cutting_targets = Array.isArray(d.cross_cutting_targets)
+    ? d.cross_cutting_targets.slice() : [];
+  target.repo_deep_dive_fallback_reason = String(d.fallback_reason || '');
   target.repo_deep_dive_focus_coverage = d.focus_coverage && typeof d.focus_coverage === 'object'
     ? Object.assign({}, d.focus_coverage) : {};
   target.repo_deep_dive_focus_coverage_passed = d.focus_coverage_passed === true;
@@ -6860,11 +6876,27 @@ function evaluateRepoDeepDiveGate(meta, directReadSection) {
   if (m.repo_manifest_truncated === true) {
     reasons.push('repository_manifest_truncated');
   }
+  if (m.repo_manifest_complete === false) {
+    reasons.push('repository_manifest_incomplete');
+  }
   if (!Array.isArray(m.repo_deep_dive_targets) || m.repo_deep_dive_targets.length === 0) {
     reasons.push('no_repository_targets');
   }
   if (m.repo_deep_dive_focus_coverage_passed !== true) {
     reasons.push('repository_focus_coverage_incomplete');
+  }
+  if (m.repo_deep_dive_focus_filter_applied === true) {
+    const anchor = String(m.repo_deep_dive_focus_anchor || '').toLowerCase();
+    const targets = Array.isArray(m.repo_deep_dive_targets) ? m.repo_deep_dive_targets : [];
+    const crossCutting = Array.isArray(m.repo_deep_dive_cross_cutting_targets)
+      ? m.repo_deep_dive_cross_cutting_targets : [];
+    const crossSet = new Set(crossCutting.map((file) => String(file || '').toLowerCase()));
+    const invalidCrossCutting = crossCutting.length > 2 || crossCutting.some((file) => !targets.includes(file));
+    const unsupportedTarget = targets.some((file) => !repoDeepDiveFocusPolicy.hasFocusToken(file, anchor)
+      && !crossSet.has(String(file || '').toLowerCase()));
+    if (!anchor || invalidCrossCutting || unsupportedTarget) {
+      reasons.push('repository_focus_filter_violation');
+    }
   }
   if (m.direct_read_fetch_attempted !== true) {
     reasons.push('direct_read_not_attempted');
@@ -7719,7 +7751,8 @@ function gitOutput(root, args, maxChars) {
       maxBuffer: Math.max(maxChars * 4, 65536),
       windowsHide: true
     });
-    return String(output || '').slice(0, maxChars);
+    const text = String(output || '');
+    return text.length > maxChars ? text.slice(0, maxChars) + '\n' + GIT_OUTPUT_TRUNCATED_MARKER : text;
   } catch (err) {
     return '[git context unavailable: ' + (err && err.message ? err.message.slice(0, 180) : 'unknown') + ']';
   }
@@ -8181,6 +8214,7 @@ module.exports = {
   buildBoundedRepoContext,
   isRepoDeepDiveRequest,
   repoDeepDiveConcepts,
+  repoFileIndex,
   discoverRepoDeepDiveTargets,
   taskTextWithDiscoveredRepoTargets,
   evaluateRepoDeepDiveGate,

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/repo_deep_dive_focus_policy.js
+++ b/extensions/reddog/repo_deep_dive_focus_policy.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const FOCUS_PHRASE_RE = /\bfocus(?:ed|ing)?\s+on\s+([^\n,;]+)/i;
+const FOCUS_LEADING_WORDS = new Set(['a', 'an', 'the']);
+
+function focusTokens(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/\b([a-z])\.([a-z][a-z0-9_]+)/g, '$1$2')
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function deriveFocusAnchor(taskText, fallbackConcepts) {
+  const match = FOCUS_PHRASE_RE.exec(String(taskText || ''));
+  if (match) {
+    const explicit = focusTokens(match[1]).filter((token) => !FOCUS_LEADING_WORDS.has(token));
+    if (explicit.length) {
+      return { anchor: explicit[0], source: 'explicit_focus_phrase' };
+    }
+  }
+  const fallback = Array.isArray(fallbackConcepts)
+    ? fallbackConcepts.map((item) => String(item || '').toLowerCase()).find(Boolean)
+    : '';
+  return { anchor: fallback || '', source: fallback ? 'concept_order' : 'none' };
+}
+
+function hasFocusToken(value, anchor) {
+  const normalizedAnchor = String(anchor || '').toLowerCase();
+  return !!normalizedAnchor && focusTokens(value).includes(normalizedAnchor);
+}
+
+function semanticEntries(bundleOutput, readHits, pathFromRef) {
+  let data;
+  try {
+    data = JSON.parse(String(bundleOutput || '{}'));
+  } catch (err) {
+    return [];
+  }
+  const seen = new Set();
+  return readHits(data).map((hit) => ({
+    path: pathFromRef(hit && hit.evidence_ref),
+    text: String(hit && hit.text || '')
+  })).filter((entry) => {
+    const key = entry.path.toLowerCase();
+    if (!entry.path || seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function buildCandidatePool(options) {
+  const manifest = options.manifest;
+  const anchor = options.anchor;
+  const focusCandidates = anchor
+    ? manifest.filter((file) => hasFocusToken(file, anchor)).filter(options.isReadable)
+    : [];
+  const focusFilterApplied = options.focusCoverage(focusCandidates).passed === true;
+  const crossCuttingCandidates = focusFilterApplied
+    ? options.semanticEntries
+      .filter((entry) => options.manifestSet.has(entry.path.toLowerCase()))
+      .filter((entry) => !hasFocusToken(entry.path, anchor) && hasFocusToken(entry.text, anchor))
+      .map((entry) => entry.path)
+      .filter(options.isReadable)
+      .slice(0, 2)
+    : [];
+  const candidateManifest = focusFilterApplied
+    ? Array.from(new Set(focusCandidates.concat(crossCuttingCandidates)))
+    : manifest;
+  return { candidateManifest, crossCuttingCandidates, focusCandidates, focusFilterApplied };
+}
+
+function scorePath(relPath, concepts, semanticSet, focusSet) {
+  const rel = String(relPath || '').replace(/\\/g, '/');
+  const lower = rel.toLowerCase();
+  const pathSegments = lower.split('/');
+  const searchable = lower.replace(/[^a-z0-9_]+/g, ' ');
+  let score = semanticSet.has(lower) ? 100 : 0;
+  if (focusSet && focusSet.has(lower)) {
+    score += 200;
+  }
+  for (let index = 0; index < concepts.length; index++) {
+    const concept = concepts[index];
+    const exactWeight = index === 0 ? 40 : index < 3 ? 20 : 14;
+    const tokenWeight = index === 0 ? 24 : index < 3 ? 12 : 8;
+    if (lower.includes(concept)) {
+      score += exactWeight;
+      if (pathSegments.includes(concept)) {
+        score += index === 0 ? 24 : 10;
+      }
+    } else if (searchable.includes(concept)) {
+      score += tokenWeight;
+    }
+  }
+  if (/(?:^|\/)(?:readme|interface|spec|roadmap|modlog)\.md$/i.test(rel)) score += 4;
+  if (/(?:^|\/)(?:tests?|test_[^/]+)(?:\/|\.|$)/i.test(rel)) score += 3;
+  if (/\.(?:py|js|mjs|ts|tsx|rs|go|java)$/i.test(rel)) score += 2;
+  if (/(?:^|\/)__init__\.py$/i.test(rel)) score -= 8;
+  if (/^(?:main\.py|holo_index\.py|README\.md)$/i.test(rel)) score += 1;
+  return score;
+}
+
+module.exports = {
+  buildCandidatePool,
+  deriveFocusAnchor,
+  focusTokens,
+  hasFocusToken,
+  scorePath,
+  semanticEntries
+};

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,14 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-19 - REDDOG_REPO_DEEP_DIVE_FOCUS_BOUND_TARGET_SELECTION_PHASE1
+
+- Proved a complete p.fMALL corpus activates focus-core selection and an unrelated semantic runtime hit is excluded.
+- Proved a cross-cutting semantic dependency receives a bounded slot only when its evidence text names p.fMALL.
+- Proved explicit focus phrases outrank leading prose and focus matching is token-bound (`mall` does not match `small`; `api` does not match `rapid`).
+- Proved incomplete focus corpora preserve broad discovery and off-pool targets fail the repository evidence gate.
+- Proved a character-truncated `git ls-files` manifest remains explicitly incomplete after target filtering.
+- Proved the Run Trace exposes anchor provenance, match mode, pool strategy, candidate count, cross-cutting targets, and fallback reason.
+
 ## 2026-07-19 - REDDOG_DEEP_DIVE_OWNER_FAILURE_DIRECT_READ_CONTINUITY_PHASE1
 
 - Reproduced the exact 0.4.7 p.fMALL host prompt with an unavailable semantic owner.

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -17,6 +17,7 @@ const extensionJs = fs.readFileSync(path.join(extDir, 'extension.js'), 'utf8');
 const holoGenerationBoundQueryJs = fs.readFileSync(path.join(extDir, 'holoindex_generation_bound_query.js'), 'utf8');
 const holoGenerationBoundQuery = require(path.join(extDir, 'holoindex_generation_bound_query.js'));
 const groundedTargetContinuity = require(path.join(extDir, 'grounded_target_continuity.js'));
+const repoDeepDiveFocusPolicy = require(path.join(extDir, 'repo_deep_dive_focus_policy.js'));
 const bridgePy = fs.readFileSync(path.join(root, 'scripts', 'advisory_model_once.py'), 'utf8');
 const holoOwnerBridgePy = fs.readFileSync(path.join(root, 'scripts', 'reddog_holoindex_owner_query_once.py'), 'utf8');
 const residentArchitectBridgePy = fs.readFileSync(path.join(root, 'scripts', 'reddog_resident_architect_session_once.py'), 'utf8');
@@ -207,8 +208,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.8', 'package version must be 0.4.8');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.8'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.9', 'package version must be 0.4.9');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.9'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -228,7 +229,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.8', 'README version mismatch');
+includes(readme, 'Version: 0.4.9', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -583,6 +584,8 @@ assert(rddConcepts.includes('pfmall'), 'RDD-003: dotted product name contributes
 const rddBundle = JSON.stringify({
   task_retrieval: {
     code_hits: [
+      { location: 'public/member/js/shell-bridge-interceptor.js:1', content: 'generic runtime architecture semantic decoy' },
+      { location: 'modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py:1', content: 'cross-cutting p.fMALL runtime router' },
       { location: 'modules/foundups/pfmall/http_api.py:1', content: 'p.fMALL HTTP API runtime' },
       { location: 'modules/foundups/pfmall/tests/test_http_api.py:1', content: 'p.fMALL HTTP API tests' },
       { location: 'modules/foundups/docs/PFMALL_EXTERNAL_FOUNDUP_ROUTE_CONTRACT.md:1', content: 'p.fMALL route contract' }
@@ -601,6 +604,27 @@ assert(rddDiscovery.targets.some((p) => /\.md$/i.test(p)), 'RDD-004: contract/do
 assert(!rddDiscovery.targets.some((p) => /extensions\/reddog\/extension\.js$/i.test(p)), 'RDD-004: RedDog self-file cannot satisfy discovery');
 assert.strictEqual(rddDiscovery.focus_coverage_passed, true,
   'RDD-004: selected evidence covers implementation, test, and document for the focus anchor');
+assert.strictEqual(rddDiscovery.focus_filter_applied, true,
+  'RDD-004: a complete p.fMALL corpus activates focus-bound selection');
+assert(rddDiscovery.focus_candidate_count >= 3,
+  'RDD-004: focus-bound selection records its eligible corpus size');
+assert(rddDiscovery.semantic_paths.includes('public/member/js/shell-bridge-interceptor.js'),
+  'RDD-004: the generic semantic decoy is observed before focus filtering');
+assert(!rddDiscovery.targets.includes('public/member/js/shell-bridge-interceptor.js'),
+  'RDD-004: generic semantic decoy cannot consume focused evidence budget');
+assert(rddDiscovery.targets.includes('modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py'),
+  'RDD-004: semantic cross-cutting evidence that names p.fMALL retains a bounded slot');
+assert.deepStrictEqual(rddDiscovery.cross_cutting_targets,
+  ['modules/communication/moltbot_bridge/src/openclaw_foundup_orchestrator.py'],
+  'RDD-004: cross-cutting targets are explicit and bounded');
+assert(rddDiscovery.targets.filter((p) => repoDeepDiveFocusPolicy.hasFocusToken(p, 'pfmall')).length >= 3,
+  'RDD-004: semantic dependencies cannot displace the focused implementation/test/doc core');
+assert.strictEqual(repoDeepDiveFocusPolicy.hasFocusToken('modules/small/runtime.py', 'mall'), false,
+  'RDD-004: focus matching is token-bound, not substring-bound');
+assert.strictEqual(repoDeepDiveFocusPolicy.hasFocusToken('modules/rapid/api.py', 'api'), true,
+  'RDD-004: exact path tokens remain eligible');
+assert.strictEqual(repoDeepDiveFocusPolicy.hasFocusToken('modules/rapid/runtime.py', 'api'), false,
+  'RDD-004: api cannot match rapid');
 const rddHostTyped = orchestrator.extractTypedTargets(rddHostPrompt);
 assert.deepStrictEqual(rddHostTyped.external_research_targets, [],
   'RDD-010: a repository deep dive is not an external-research request');
@@ -619,8 +643,47 @@ assert(rddHostDiscovery.targets.some((p) => /PFMALL.*\.md$/i.test(p)),
 assert.strictEqual(rddHostDiscovery.focus_anchor, 'pfmall', 'RDD-010: p.fMALL is the focus anchor');
 assert.strictEqual(rddHostDiscovery.focus_coverage_passed, true,
   'RDD-010: local evidence quorum is tied to p.fMALL, not generic repository files');
+assert.strictEqual(rddHostDiscovery.focus_filter_applied, true,
+  'RDD-010: host prompt uses only the complete p.fMALL evidence corpus');
+assert.strictEqual(rddHostDiscovery.focus_anchor_source, 'explicit_focus_phrase',
+  'RDD-010: host focus anchor comes from the explicit focusing-on phrase');
+const rddNoisyFocus = orchestrator.discoverRepoDeepDiveTargets(root,
+  'Please audit production runtime in the repository, focusing on p.fMALL.',
+  JSON.stringify({ task_retrieval: { code_hits: [], metadata: { retrieval_mode: 'semantic' } } }), 12);
+assert.strictEqual(rddNoisyFocus.focus_anchor, 'pfmall',
+  'RDD-010: leading prose cannot replace the explicit subsystem focus');
+(function rddManifestCompletenessTruth() {
+  const originalExecFileSync = cp.execFileSync;
+  cp.execFileSync = (file, args, options) => {
+    if (file === 'git' && Array.isArray(args) && args[0] === 'ls-files') {
+      return 'modules/foundups/pfmall/api.py\n' + 'x'.repeat(1000100);
+    }
+    return originalExecFileSync(file, args, options);
+  };
+  try {
+    const indexed = orchestrator.repoFileIndex(root, 20000);
+    assert.strictEqual(indexed.manifest_truncated, true,
+      'RDD-010: character-truncated git manifests cannot claim completeness');
+    assert.strictEqual(indexed.manifest_source_count, 2,
+      'RDD-010: manifest source count remains explicit after character truncation');
+  } finally {
+    cp.execFileSync = originalExecFileSync;
+  }
+})();
 assert(!rddHostDiscovery.targets.some((p) => /(?:livechat|banter|worker_help|help_command)/i.test(p)),
   'RDD-010: unrelated generic runtime/worker files cannot enter the host evidence packet');
+const rddBroadFallback = orchestrator.discoverRepoDeepDiveTargets(root,
+  'Complete deep dive into the FoundUps-Agent repository, focusing on quuxzz runtime architecture.',
+  JSON.stringify({
+    task_retrieval: {
+      code_hits: [{ location: 'main.py:1', content: 'repository runtime entry point' }],
+      metadata: { retrieval_mode: 'semantic' }
+    }
+  }), 12);
+assert.strictEqual(rddBroadFallback.focus_filter_applied, false,
+  'RDD-010: incomplete focus corpora retain the broad fail-closed discovery path');
+assert(rddBroadFallback.targets.includes('main.py'),
+  'RDD-010: broad fallback retains generation-bound semantic candidates');
 const rddAugmented = orchestrator.taskTextWithDiscoveredRepoTargets(rddPrompt, rddDiscovery.targets);
 const rddCollected = orchestrator.collectRequiredTargets(rddAugmented);
 assert.strictEqual(rddCollected.targets.length, rddDiscovery.targets.length, 'RDD-005: discovered paths enter the existing required-target contract');
@@ -661,6 +724,15 @@ assert.strictEqual(rddWrongFocusGate.passed, false,
   'RDD-007: readable but off-focus files cannot satisfy a repository deep dive');
 assert(rddWrongFocusGate.rejection_reasons.includes('repository_focus_coverage_incomplete'),
   'RDD-007: focus-coverage rejection is explicit');
+const rddFilterViolationGate = orchestrator.evaluateRepoDeepDiveGate({
+  repo_deep_dive_requested: true, repo_manifest_generated: true, repo_manifest_file_count: 3,
+  repo_deep_dive_targets: ['modules/foundups/pfmall/api.py', 'modules/other/unrelated.py'],
+  repo_deep_dive_focus_anchor: 'pfmall', repo_deep_dive_focus_filter_applied: true,
+  repo_deep_dive_focus_coverage_passed: true, direct_read_fetch_attempted: true,
+  direct_read_bytes: 1234, target_recall_ok: true
+}, { chars: 1234 });
+assert(rddFilterViolationGate.rejection_reasons.includes('repository_focus_filter_violation'),
+  'RDD-007: focus-filter metadata cannot authorize an off-focus target');
 const rddTruncatedManifestGate = orchestrator.evaluateRepoDeepDiveGate({
   repo_deep_dive_requested: true, repo_manifest_generated: true, repo_manifest_file_count: 18000,
   repo_manifest_truncated: true, repo_deep_dive_targets: rddDiscovery.targets,
@@ -687,10 +759,19 @@ const rddScorecard = orchestrator.extractHoloIndexScorecard('wsp_holo', {
   repo_deep_dive_requested: true,
   repo_manifest_generated: true,
   repo_manifest_file_count: rddDiscovery.manifest_file_count,
+  repo_manifest_source_count: rddDiscovery.manifest_source_count,
   repo_manifest_truncated: false,
+  repo_manifest_complete: true,
   repo_deep_dive_targets: rddDiscovery.targets,
   repo_deep_dive_targets_count: rddDiscovery.targets.length,
   repo_deep_dive_focus_anchor: rddDiscovery.focus_anchor,
+  repo_deep_dive_focus_anchor_source: rddDiscovery.focus_anchor_source,
+  repo_deep_dive_focus_filter_applied: rddDiscovery.focus_filter_applied,
+  repo_deep_dive_focus_candidate_count: rddDiscovery.focus_candidate_count,
+  repo_deep_dive_focus_match_mode: rddDiscovery.focus_match_mode,
+  repo_deep_dive_pool_strategy: rddDiscovery.pool_strategy,
+  repo_deep_dive_cross_cutting_targets: rddDiscovery.cross_cutting_targets,
+  repo_deep_dive_fallback_reason: rddDiscovery.fallback_reason,
   repo_deep_dive_focus_coverage: rddDiscovery.focus_coverage,
   repo_deep_dive_focus_coverage_passed: true,
   repo_deep_dive_gate_applied: true,
@@ -701,7 +782,11 @@ const rddLines = orchestrator.formatHoloIndexScorecardLines(rddScorecard).join('
 includes(rddLines, '- repo_deep_dive_gate_passed: true', 'RDD-008: Run Trace exposes acceptance gate');
 includes(rddLines, '- repo_deep_dive_targets_count: ' + rddDiscovery.targets.length, 'RDD-008: Run Trace exposes target count');
 includes(rddLines, '- repo_manifest_truncated: false', 'RDD-008: Run Trace exposes manifest completeness');
+includes(rddLines, '- repo_manifest_complete: true', 'RDD-008: Run Trace distinguishes complete manifests');
 includes(rddLines, '- repo_deep_dive_focus_coverage_passed: true', 'RDD-008: Run Trace exposes focus coverage');
+includes(rddLines, '- repo_deep_dive_focus_filter_applied: true', 'RDD-008: Run Trace exposes focus filtering');
+includes(rddLines, '- repo_deep_dive_focus_anchor_source: explicit_focus_phrase', 'RDD-008: Run Trace exposes focus provenance');
+includes(rddLines, '- repo_deep_dive_pool_strategy: focus_core_plus_semantic_cross_cutting', 'RDD-008: Run Trace exposes pool strategy');
 
 (function rdd009RealBundleRegression() {
   const result = orchestrator.holoIndexOutput(root, rddPrompt, 18000);
@@ -1583,7 +1668,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.8', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.9', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -3089,7 +3174,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.8'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.9'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -3103,7 +3188,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.8'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.9'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -3115,7 +3200,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.8'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.9'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -4134,7 +4219,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.8' } }
+      ? { id, packageJSON: { version: '0.4.9' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({


### PR DESCRIPTION
## Summary
- reserve focused repository deep-dive evidence for token-matched subsystem implementation, tests, and docs
- admit at most two generation-bound cross-cutting dependencies only when their evidence text names the focus
- fail closed on focus-pool tampering and incomplete/truncated tracked-file manifests
- expose focus provenance, strategy, cross-cutting paths, and manifest completeness in Run Trace

## WSP_97 truth boundary
- OBSERVED: the 0.4.8 live semantic p.fMALL run admitted an unrelated shell-bridge path because semantic ownership had a flat ranking bonus
- OBSERVED: the hardened 0.4.9 live path selected 12 p.fMALL targets, read 88 KB, recalled 12/12, and passed grounding even when the owner timed out
- SPECIFIED_NOT_IMPLEMENTED: no shell, repository mutation, re-index, worker execution, PR publication, or merge authority is added

## Verification
- `node extensions/reddog/tests/verify_extension_contract.js`
- `node extensions/reddog/tests/verify_fusion_panel_input_contract.js`
- `pytest -q scripts/tests/test_advisory_model_once_hardening.py modules/communication/moltbot_bridge/tests/test_fusion_redaction_gate.py holo_index/tests/test_reddog_extension_bundle_recall.py` (164 passed)
- `git diff --check`
- ASCII clean
- extension.js 8330 lines <= existing WSP-62 ceiling 8350

## CoR hardening
An independent adversarial review rejected the initial anchor-only design. This revision uses explicit focus provenance, token-bound matching, a mandatory focus quorum, bounded evidence-backed cross-cutting slots, broad fallback when the quorum is unavailable, and manifest completeness telemetry.