### PR TITLE
fix(holoindex): verify targeted collection carry-forward

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,33 @@
 # HoloIndex Package ModLog
 
+## [2026-07-19] HOLOINDEX_VERIFIED_UNCHANGED_COLLECTION_CARRY_FORWARD_PHASE1
+
+- Added maintenance-time proof for unchanged baseline collections during a
+  targeted refresh. Carry-forward now requires an internally valid base
+  generation, an exact canonical source manifest, an unchanged source-policy
+  digest, and a full document/metadata/embedding collection snapshot.
+- Added explicit receipt provenance for carried collections and included all
+  receipt and collection fields in the generation digest. Query admission now
+  recomputes v2 receipt integrity, carry evidence, and direct base-generation
+  lineage; query execution remains read-only and never reindexes.
+- Truth boundary: v2 digests provide tamper evidence inside the trusted local
+  maintenance host. They are not signatures and do not authenticate a hostile
+  same-user filesystem writer.
+- Reused the indexers' canonical source-discovery functions for code, symbols,
+  WSPs, tests, docs, knowledge, and Skillz. A targeted refresh can carry an
+  unrefreshed collection only when the exact current source set still matches.
+- Added a final full collection snapshot recheck before atomic publication to
+  close the proof-assembly/write race. Obsolete v1 receipts require a complete
+  baseline migration and cannot authorize a partial refresh.
+- Corrected changed-path ownership for overlapping sources, including Python
+  tests in the symbol collection, module Skillz in docs, and the canonical WSP
+  test registry.
+- Added fail-closed tests for source/policy drift, base-receipt and serialized
+  carry tampering, document/metadata/vector mutation, post-proof races, modern
+  JavaScript source coverage, v1 migration, and successful unchanged carry.
+
+**WSP Protocols**: WSP 00, 15, 22, 50, 62, 97
+
 ## [2026-07-19] REDDOG_DEEP_DIVE_OWNER_FAILURE_DIRECT_READ_CONTINUITY_PHASE1
 
 - Hardened governed direct-read path validation against NTFS alternate data streams.

--- a/holo_index/canonical_source_manifest.py
+++ b/holo_index/canonical_source_manifest.py
@@ -1,0 +1,243 @@
+"""Read-only canonical source-manifest probes for baseline HoloIndex collections."""
+
+from __future__ import annotations
+
+import glob
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+from holo_index.core.indexing_engine import (
+    _discover_web_assets,
+    _has_dotfile_in_relative_path,
+    _navigation_source_evidence,
+    _wsp_source_set,
+    source_file_manifest_digest,
+    source_manifest_digest,
+)
+from holo_index.source_scope import (
+    CanonicalSourceScopeError,
+    canonical_source_scope_id,
+    filter_git_tracked_files,
+)
+from holo_index.symbol_indexer import (
+    _discover_symbol_source,
+    _symbol_source_manifest,
+)
+from holo_index.test_registry_indexer import _registry_source_manifest
+
+
+class CanonicalSourceManifestError(RuntimeError):
+    """A complete canonical source manifest could not be proven."""
+
+
+@dataclass(frozen=True)
+class CanonicalSourceManifest:
+    collection_name: str
+    digest: str
+    source_scope_id: str
+
+
+def _tracked_manifest(
+    holo: Any,
+    collection_name: str,
+    files: Iterable[Path],
+) -> CanonicalSourceManifest:
+    try:
+        tracked = filter_git_tracked_files(holo.project_root, files)
+        digest = source_file_manifest_digest(
+            tracked,
+            project_root=holo.project_root,
+        )
+    except (CanonicalSourceScopeError, OSError) as exc:
+        raise CanonicalSourceManifestError(
+            f"canonical_source_manifest_unavailable:{collection_name}"
+        ) from exc
+    if not tracked or not digest:
+        raise CanonicalSourceManifestError(
+            f"canonical_source_manifest_empty:{collection_name}"
+        )
+    return CanonicalSourceManifest(
+        collection_name=collection_name,
+        digest=digest,
+        source_scope_id=canonical_source_scope_id(collection_name),
+    )
+
+
+def _code_manifest(holo: Any) -> CanonicalSourceManifest:
+    web = _discover_web_assets(holo)
+    nav_manifest, nav_failed, nav_warning = _navigation_source_evidence(holo)
+    if (
+        nav_failed
+        or nav_warning
+        or web.failed_count
+        or web.processed_count != web.discovered_count
+        or not nav_manifest
+        or not web.source_manifest_digest
+        or web.source_scope_id != canonical_source_scope_id("navigation_code")
+    ):
+        raise CanonicalSourceManifestError(
+            "canonical_source_manifest_unavailable:navigation_code"
+        )
+    digest = source_manifest_digest(
+        {
+            "navigation": sorted(holo.need_to.items()),
+            "navigation_source_manifest": nav_manifest,
+            "web_asset_source_manifest": web.source_manifest_digest,
+        }
+    )
+    return CanonicalSourceManifest(
+        collection_name="navigation_code",
+        digest=digest,
+        source_scope_id=web.source_scope_id,
+    )
+
+
+def _symbols_manifest(holo: Any) -> CanonicalSourceManifest:
+    files, scope_id, failure = _discover_symbol_source(holo, None)
+    if failure is not None or scope_id != canonical_source_scope_id(
+        "navigation_symbols"
+    ):
+        raise CanonicalSourceManifestError(
+            "canonical_source_manifest_unavailable:navigation_symbols"
+        )
+    digest, failure = _symbol_source_manifest(holo, files, scope_id=scope_id)
+    if failure is not None or not digest:
+        raise CanonicalSourceManifestError(
+            "canonical_source_manifest_unavailable:navigation_symbols"
+        )
+    return CanonicalSourceManifest("navigation_symbols", digest, scope_id)
+
+
+def _wsp_manifest(holo: Any) -> CanonicalSourceManifest:
+    files, scope_id, error = _wsp_source_set(holo, None)
+    if error or scope_id != canonical_source_scope_id("navigation_wsp"):
+        raise CanonicalSourceManifestError(
+            "canonical_source_manifest_unavailable:navigation_wsp"
+        )
+    result = _tracked_manifest(holo, "navigation_wsp", files)
+    return CanonicalSourceManifest(result.collection_name, result.digest, scope_id)
+
+
+def _docs_source_files(holo: Any) -> list[Path]:
+    """Return the exact tracked source set consumed by the docs indexer."""
+
+    bases = (
+        holo.project_root / "modules",
+        holo.project_root / "docs",
+        holo.project_root / "holo_index" / "docs",
+        holo.project_root / "WSP_framework" / "docs",
+    )
+    files: list[Path] = []
+    for base in bases:
+        if not base.exists():
+            continue
+        files.extend(
+            file_path
+            for file_path in sorted(base.rglob("*.md"))
+            if "node_modules" not in str(file_path)
+            and "CHANGELOG" not in file_path.name.upper()
+            and "package-lock" not in file_path.name.lower()
+            and not _has_dotfile_in_relative_path(file_path, base)
+            and "_backup" not in str(file_path).lower()
+            and "/archive/" not in file_path.as_posix().lower()
+        )
+    return filter_git_tracked_files(holo.project_root, files)
+
+
+def _knowledge_source_files(holo: Any) -> list[Path]:
+    """Return the exact tracked source set consumed by the knowledge indexer."""
+
+    base = holo.project_root / "WSP_knowledge" / "docs" / "Papers"
+    if not base.exists():
+        return []
+    files = [
+        file_path
+        for file_path in sorted(base.rglob("*.md"))
+        if not _has_dotfile_in_relative_path(file_path, base)
+        and "_backup" not in str(file_path).lower()
+        and "/archive/" not in file_path.as_posix().lower()
+    ]
+    return filter_git_tracked_files(holo.project_root, files)
+
+
+def _skill_source_files(holo: Any) -> list[Path]:
+    """Return the exact tracked source set consumed by the Skillz indexer."""
+
+    patterns = (
+        holo.project_root / "modules" / "**" / "skills" / "*" / "SKILLz.md",
+        holo.project_root / "modules" / "**" / "skillz" / "*" / "SKILLz.md",
+        holo.project_root / "holo_index" / "skillz" / "*" / "SKILLz.md",
+        holo.project_root / "holo_index" / "qwen_advisor" / "skills" / "*" / "SKILLz.md",
+        holo.project_root / ".claude" / "skills" / "*" / "SKILLz.md",
+        holo.project_root / ".claude" / "skillz" / "*" / "SKILLz.md",
+    )
+    files = [
+        Path(file_path)
+        for pattern in patterns
+        for file_path in glob.glob(str(pattern), recursive=True)
+    ]
+    return filter_git_tracked_files(holo.project_root, files)
+
+
+def _tests_manifest(holo: Any) -> CanonicalSourceManifest:
+    digest, error = _registry_source_manifest(
+        holo,
+        holo.project_root / "WSP_knowledge" / "WSP_Test_Registry.json",
+    )
+    if error or not digest:
+        raise CanonicalSourceManifestError(
+            "canonical_source_manifest_unavailable:navigation_tests"
+        )
+    return CanonicalSourceManifest(
+        "navigation_tests",
+        digest,
+        canonical_source_scope_id("navigation_tests"),
+    )
+
+
+_PROBES: dict[str, Callable[[Any], CanonicalSourceManifest]] = {
+    "navigation_code": _code_manifest,
+    "navigation_symbols": _symbols_manifest,
+    "navigation_wsp": _wsp_manifest,
+    "navigation_tests": _tests_manifest,
+    "navigation_skills": lambda holo: _tracked_manifest(
+        holo, "navigation_skills", _skill_source_files(holo)
+    ),
+    "navigation_docs": lambda holo: _tracked_manifest(
+        holo, "navigation_docs", _docs_source_files(holo)
+    ),
+    "navigation_knowledge": lambda holo: _tracked_manifest(
+        holo, "navigation_knowledge", _knowledge_source_files(holo)
+    ),
+}
+
+
+def probe_canonical_source_manifests(
+    holo: Any,
+    collection_names: Iterable[str],
+) -> dict[str, CanonicalSourceManifest]:
+    manifests: dict[str, CanonicalSourceManifest] = {}
+    for name in sorted(set(collection_names)):
+        probe = _PROBES.get(name)
+        if probe is None:
+            raise CanonicalSourceManifestError(
+                f"canonical_source_probe_missing:{name}"
+            )
+        manifest = probe(holo)
+        if manifest.source_scope_id != canonical_source_scope_id(name):
+            raise CanonicalSourceManifestError(
+                f"canonical_source_scope_mismatch:{name}"
+            )
+        manifests[name] = manifest
+    return manifests
+
+
+__all__ = [
+    "CanonicalSourceManifest",
+    "CanonicalSourceManifestError",
+    "_docs_source_files",
+    "_knowledge_source_files",
+    "_skill_source_files",
+    "probe_canonical_source_manifests",
+]

--- a/holo_index/core/indexing_engine.py
+++ b/holo_index/core/indexing_engine.py
@@ -15,7 +15,6 @@ WSP Compliance: WSP 87 (Size Limits), WSP 72 (Block Independence)
 
 from __future__ import annotations
 
-import ast
 import hashlib
 import json
 import logging
@@ -961,33 +960,9 @@ def index_docs_entries(holo: "HoloIndex") -> IndexResult:
         and optional warning message.
     """
     collection_name = "navigation_docs"
-    doc_paths = [
-        holo.project_root / "modules",
-        holo.project_root / "docs",
-        holo.project_root / "holo_index" / "docs",
-        holo.project_root / "WSP_framework" / "docs",
-    ]
+    from holo_index.canonical_source_manifest import _docs_source_files
 
-    files: List[Path] = []
-    for base in doc_paths:
-        if base.exists():
-            all_doc_files = sorted(list(base.rglob("*.md")))
-            filtered_files = [
-                f for f in all_doc_files
-                if 'node_modules' not in str(f)
-                and 'CHANGELOG' not in f.name.upper()
-                and 'package-lock' not in f.name.lower()
-                # Worktree safety fix: Check dot-prefix relative to base, not absolute path.
-                # This prevents rejecting all files when project_root is under .claude/worktrees/.
-                and not _has_dotfile_in_relative_path(f, base)
-                and '_backup' not in str(f).lower()
-                and '/archive/' not in str(f).lower()
-                and '\\archive\\' not in str(f).lower()
-                # Note: The .claude/worktrees clauses previously here are now redundant
-                # because the relative-path check ignores parent directories above base.
-            ]
-            files.extend(filtered_files)
-    files = filter_git_tracked_files(holo.project_root, files)
+    files = _docs_source_files(holo)
 
     discovered_count = len(files)
 
@@ -1137,6 +1112,7 @@ def index_knowledge_entries(holo: "HoloIndex") -> IndexResult:
     """
     collection_name = "navigation_knowledge"
     knowledge_path = holo.project_root / "WSP_knowledge" / "docs" / "Papers"
+    from holo_index.canonical_source_manifest import _knowledge_source_files
 
     if not knowledge_path.exists():
         holo._log_agent_action(f"Knowledge path not found: {knowledge_path}", "WARN")
@@ -1147,15 +1123,7 @@ def index_knowledge_entries(holo: "HoloIndex") -> IndexResult:
             warning=f"Knowledge path not found: {knowledge_path}"
         )
 
-    all_files = sorted(knowledge_path.rglob("*.md"))
-    files = [
-        f for f in all_files
-        if not _has_dotfile_in_relative_path(f, knowledge_path)
-        and '_backup' not in str(f).lower()
-        and '/archive/' not in str(f).lower()
-        and '\\archive\\' not in str(f).lower()
-    ]
-    files = filter_git_tracked_files(holo.project_root, files)
+    files = _knowledge_source_files(holo)
 
     discovered_count = len(files)
 
@@ -1279,24 +1247,11 @@ def index_skillz_entries(holo: "HoloIndex") -> IndexResult:
         IndexResult with discovered_count, indexed_count, collection_name,
         and optional warning message.
     """
-    import glob
     import yaml
+    from holo_index.canonical_source_manifest import _skill_source_files
 
     collection_name = "navigation_skills"
-    skillz_patterns = [
-        str(holo.project_root / "modules" / "**" / "skills" / "*" / "SKILLz.md"),
-        str(holo.project_root / "modules" / "**" / "skillz" / "*" / "SKILLz.md"),
-        str(holo.project_root / "holo_index" / "skillz" / "*" / "SKILLz.md"),
-        str(holo.project_root / "holo_index" / "qwen_advisor" / "skills" / "*" / "SKILLz.md"),
-        str(holo.project_root / ".claude" / "skills" / "*" / "SKILLz.md"),
-        str(holo.project_root / ".claude" / "skillz" / "*" / "SKILLz.md"),
-    ]
-
-    files: List[Path] = []
-    for pattern in skillz_patterns:
-        found = glob.glob(pattern, recursive=True)
-        files.extend(Path(f) for f in found)
-    files = filter_git_tracked_files(holo.project_root, files)
+    files = _skill_source_files(holo)
 
     discovered_count = len(files)
 

--- a/holo_index/freshness_receipt.py
+++ b/holo_index/freshness_receipt.py
@@ -8,17 +8,23 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
+import re
 import tempfile
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from holo_index.source_scope import canonical_source_scope_id
+from holo_index.verified_collection_carry_forward import (
+    carry_forward_evidence_digest,
+)
 
 
-SCHEMA_VERSION = "holoindex_freshness_receipt.v1"
+SCHEMA_VERSION = "holoindex_freshness_receipt.v2"
+COLLECTION_SCHEMA_VERSION = "holoindex_collection_freshness.v2"
 FRESHNESS_RECEIPT_FILENAME = "holoindex_freshness_receipt.json"
 
 COLLECTION_ATTRS: dict[str, str] = {
@@ -54,6 +60,8 @@ BASELINE_QUERY_FRESHNESS_PATHS = (
     "modules/_holoindex_baseline/README.md",
     "WSP_knowledge/docs/Papers/_holoindex_baseline.md",
 )
+SHA_PATTERN = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 
 
 @dataclass(frozen=True)
@@ -69,13 +77,18 @@ class CollectionFreshness:
     source_manifest_digest: str = ""
     indexed_paths_digest: str = ""
     removed_paths_digest: str = ""
-    schema_version: str = "holoindex_collection_freshness.v1"
+    schema_version: str = COLLECTION_SCHEMA_VERSION
     embedding_backend: str = ""
     embedding_model: str = ""
     embedding_space_fingerprint: str = ""
     verification: str = "UNKNOWN"
     proof_kind: str = "snapshot_only"
     source_scope_id: str = ""
+    source_policy_digest: str = ""
+    carried_from_repo_head_sha: str = ""
+    carried_from_generation_id: str = ""
+    carry_forward_evidence_digest: str = ""
+    collection_snapshot_digest: str = ""
 
 
 @dataclass(frozen=True)
@@ -196,13 +209,30 @@ def _empty_snapshot_manifest(name: str) -> dict[str, str]:
     }
 
 
-def _snapshot_values(snapshot: Any) -> tuple[list[Any], list[Any]]:
-    ids = snapshot.get("ids", []) if isinstance(snapshot, Mapping) else []
-    metadatas = snapshot.get("metadatas", []) if isinstance(snapshot, Mapping) else []
-    return (
-        ids if isinstance(ids, list) else [],
-        metadatas if isinstance(metadatas, list) else [],
-    )
+def _snapshot_list(snapshot: Any, key: str) -> list[Any]:
+    value = snapshot.get(key, []) if isinstance(snapshot, Mapping) else []
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    return value if isinstance(value, list) else []
+
+
+def _canonical_snapshot_value(value: Any) -> Any:
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("non_finite_snapshot_value")
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _canonical_snapshot_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_canonical_snapshot_value(item) for item in value]
+    raise TypeError(f"unsupported_snapshot_value:{type(value).__name__}")
 
 
 def _collection_snapshot_manifest(
@@ -223,18 +253,49 @@ def _collection_snapshot_manifest(
         return _empty_snapshot_manifest(name)
 
     try:
-        snapshot = collection.get(include=["metadatas"])
+        snapshot = collection.get(include=["documents", "metadatas", "embeddings"])
     except Exception:
         return _unavailable_snapshot_manifest("UNVERIFIED")
 
-    ids, metadatas = _snapshot_values(snapshot)
+    ids = _snapshot_list(snapshot, "ids")
+    documents = _snapshot_list(snapshot, "documents")
+    metadatas = _snapshot_list(snapshot, "metadatas")
+    embeddings = _snapshot_list(snapshot, "embeddings")
+    if (
+        len(ids) != count
+        or len(documents) != count
+        or len(metadatas) != count
+        or len(embeddings) != count
+        or len({str(item) for item in ids}) != count
+    ):
+        return _unavailable_snapshot_manifest("UNVERIFIED")
+    try:
+        rows = sorted(
+            (
+                {
+                    "id": str(item_id),
+                    "document": _canonical_snapshot_value(document),
+                    "metadata": _canonical_snapshot_value(metadata),
+                    "embedding": _canonical_snapshot_value(embedding),
+                }
+                for item_id, document, metadata, embedding in zip(
+                    ids,
+                    documents,
+                    metadatas,
+                    embeddings,
+                )
+            ),
+            key=lambda row: row["id"],
+        )
+    except (TypeError, ValueError):
+        return _unavailable_snapshot_manifest("UNVERIFIED")
     indexed_paths = sorted(
         path for path in (_metadata_path(metadata) for metadata in metadatas) if path
     )
     source_manifest = {
         "collection": name,
         "count": count,
-        "ids": sorted(str(item) for item in ids),
+        "rows": rows,
         "paths": indexed_paths,
     }
     embedding = _collection_embedding_metadata(collection)
@@ -378,6 +439,7 @@ def _refreshed_collection_entry(
     generated: str,
     source_manifest: str,
     source_scope_id: str,
+    source_policy_digest: str,
 ) -> CollectionFreshness:
     count = _safe_count(collection)
     manifest = _collection_snapshot_manifest(collection, name=name, count=count)
@@ -417,6 +479,34 @@ def _refreshed_collection_entry(
             else "snapshot_only"
         ),
         source_scope_id=source_scope_id,
+        source_policy_digest=source_policy_digest,
+        collection_snapshot_digest=manifest["source_manifest_digest"],
+    )
+
+
+def _verified_carried_entry(
+    previous: CollectionFreshness,
+    *,
+    head_sha: str,
+    evidence: Any,
+) -> CollectionFreshness:
+    return replace(
+        previous,
+        source="verified_carry_forward",
+        repo_head_sha=head_sha,
+        proof_kind="verified_unchanged_source_manifest",
+        source_policy_digest=str(
+            getattr(evidence, "source_policy_digest", "") or ""
+        ),
+        carried_from_repo_head_sha=str(
+            getattr(evidence, "carried_from_repo_head_sha", "") or ""
+        ),
+        carried_from_generation_id=str(
+            getattr(evidence, "carried_from_generation_id", "") or ""
+        ),
+        carry_forward_evidence_digest=str(
+            getattr(evidence, "evidence_digest", "") or ""
+        ),
     )
 
 
@@ -430,13 +520,23 @@ def _build_collection_entries(
     generated: str,
     source_manifests: Mapping[str, str],
     source_scopes: Mapping[str, str],
+    source_policy_digests: Mapping[str, str],
+    carry_forward_evidence: Mapping[str, Any],
 ) -> list[CollectionFreshness]:
     entries: list[CollectionFreshness] = []
     for name, attr_name in COLLECTION_ATTRS.items():
         collection = _collection_handle(holo, name, attr_name)
         if refreshed is not None and name not in refreshed:
+            previous = previous_by_name.get(name)
+            evidence = carry_forward_evidence.get(name)
             entries.append(
-                previous_by_name.get(name)
+                _verified_carried_entry(
+                    previous,
+                    head_sha=head_sha,
+                    evidence=evidence,
+                )
+                if previous is not None and evidence is not None
+                else previous
                 or _unrefreshed_collection_entry(name, collection)
             )
             continue
@@ -450,6 +550,7 @@ def _build_collection_entries(
                 generated=generated,
                 source_manifest=source_manifests.get(name, ""),
                 source_scope_id=source_scopes.get(name, ""),
+                source_policy_digest=source_policy_digests.get(name, ""),
             )
         )
     return entries
@@ -458,28 +559,23 @@ def _build_collection_entries(
 def _receipt_generation_id(
     head_sha: str,
     entries: Iterable[CollectionFreshness],
+    *,
+    generated_at: str = "",
+    base_generation_id: str = "",
+    repo_root: str = "",
+    ssd_path: str = "",
+    source: str = "",
 ) -> str:
     return _digest(
         {
             "schema_version": SCHEMA_VERSION,
+            "generated_at": generated_at,
             "repo_head_sha": head_sha,
-            "collections": [
-                {
-                    "name": entry.name,
-                    "count": entry.count,
-                    "status": entry.status,
-                    "source_manifest_digest": entry.source_manifest_digest,
-                    "indexed_paths_digest": entry.indexed_paths_digest,
-                    "removed_paths_digest": entry.removed_paths_digest,
-                    "embedding_backend": entry.embedding_backend,
-                    "embedding_model": entry.embedding_model,
-                    "embedding_space_fingerprint": entry.embedding_space_fingerprint,
-                    "verification": entry.verification,
-                    "proof_kind": entry.proof_kind,
-                    "source_scope_id": entry.source_scope_id,
-                }
-                for entry in entries
-            ],
+            "base_generation_id": base_generation_id,
+            "repo_root": repo_root,
+            "ssd_path": ssd_path,
+            "source": source,
+            "collections": [asdict(entry) for entry in entries],
         }
     )
 
@@ -523,6 +619,8 @@ def _freshness_build_state(
     base_receipt: HoloIndexFreshnessReceipt | Mapping[str, Any] | None,
     refresh_source_manifests: Mapping[str, str] | None,
     refresh_source_scopes: Mapping[str, str] | None,
+    refresh_source_policy_digests: Mapping[str, str] | None,
+    carry_forward_evidence: Mapping[str, Any] | None,
 ) -> tuple[
     str,
     str,
@@ -539,7 +637,14 @@ def _freshness_build_state(
         refresh_source_manifests,
         refresh_source_scopes,
     )
+    policies = {
+        str(name): str(digest)
+        for name, digest in (refresh_source_policy_digests or {}).items()
+        if str(name) and str(digest)
+    }
     base = _coerce_build_base_receipt(base_receipt)
+    if base is not None and not freshness_receipt_integrity_ok(base):
+        raise ValueError("invalid base freshness receipt integrity")
     previous = {entry.name: entry for entry in (base.collections if base else [])}
     collections = _build_collection_entries(
         holo,
@@ -550,8 +655,65 @@ def _freshness_build_state(
         generated=generated,
         source_manifests=manifests,
         source_scopes=scopes,
+        source_policy_digests=policies,
+        carry_forward_evidence=dict(carry_forward_evidence or {}),
     )
     return generated, head_sha, base, collections
+
+
+def freshness_receipt_integrity_ok(
+    receipt: HoloIndexFreshnessReceipt | None,
+) -> bool:
+    """Verify schema, uniqueness, and the complete generation payload."""
+
+    if receipt is None or receipt.schema_version != SCHEMA_VERSION:
+        return False
+    names = [entry.name for entry in receipt.collections]
+    return bool(
+        receipt.generation_id
+        and len(names) == len(set(names))
+        and set(names) == set(ALL_COLLECTIONS)
+        and all(
+            entry.schema_version == COLLECTION_SCHEMA_VERSION
+            for entry in receipt.collections
+        )
+        and receipt.generation_id
+        == _receipt_generation_id(
+            receipt.repo_head_sha,
+            receipt.collections,
+            generated_at=receipt.generated_at,
+            base_generation_id=receipt.base_generation_id,
+            repo_root=receipt.repo_root,
+            ssd_path=receipt.ssd_path,
+            source=receipt.source,
+        )
+    )
+
+
+def collection_snapshot_matches_entry(
+    holo: Any,
+    name: str,
+    entry: CollectionFreshness,
+) -> bool:
+    """Re-prove that an untouched collection still matches its receipt."""
+
+    attr_name = COLLECTION_ATTRS.get(name)
+    if not attr_name:
+        return False
+    collection = _collection_handle(holo, name, attr_name)
+    count = _safe_count(collection)
+    manifest = _collection_snapshot_manifest(collection, name=name, count=count)
+    return bool(
+        count == entry.count
+        and manifest["verification"] == "PASS"
+        and manifest["source_manifest_digest"] == entry.collection_snapshot_digest
+        and manifest["indexed_paths_digest"] == entry.indexed_paths_digest
+        and manifest["removed_paths_digest"] == entry.removed_paths_digest
+        and manifest["embedding_backend"] == entry.embedding_backend
+        and manifest["embedding_model"] == entry.embedding_model
+        and manifest["embedding_space_fingerprint"]
+        == entry.embedding_space_fingerprint
+    )
 
 
 def build_freshness_receipt(
@@ -566,6 +728,8 @@ def build_freshness_receipt(
     base_receipt: HoloIndexFreshnessReceipt | Mapping[str, Any] | None = None,
     refresh_source_manifests: Mapping[str, str] | None = None,
     refresh_source_scopes: Mapping[str, str] | None = None,
+    refresh_source_policy_digests: Mapping[str, str] | None = None,
+    _carry_forward_evidence: Mapping[str, Any] | None = None,
 ) -> HoloIndexFreshnessReceipt:
     """Build a truthful receipt from current and previously proven state.
 
@@ -586,8 +750,19 @@ def build_freshness_receipt(
         base_receipt=base_receipt,
         refresh_source_manifests=refresh_source_manifests,
         refresh_source_scopes=refresh_source_scopes,
+        refresh_source_policy_digests=refresh_source_policy_digests,
+        carry_forward_evidence=_carry_forward_evidence,
     )
-    generation_id = _receipt_generation_id(head_sha, collections)
+    base_generation_id = base_receipt.generation_id if base_receipt is not None else ""
+    generation_id = _receipt_generation_id(
+        head_sha,
+        collections,
+        generated_at=generated,
+        base_generation_id=base_generation_id,
+        repo_root=str(Path(repo_root)),
+        ssd_path=str(Path(ssd_path)),
+        source=source,
+    )
 
     return HoloIndexFreshnessReceipt(
         schema_version=SCHEMA_VERSION,
@@ -597,7 +772,7 @@ def build_freshness_receipt(
         ssd_path=str(Path(ssd_path)),
         source=source,
         generation_id=generation_id,
-        base_generation_id=(base_receipt.generation_id if base_receipt is not None else ""),
+        base_generation_id=base_generation_id,
         collections=collections,
     )
 
@@ -701,7 +876,16 @@ def build_maintenance_invalidation(
         )
         for name in ALL_COLLECTIONS
     ]
-    generation_id = _receipt_generation_id(head_sha, entries)
+    base_generation_id = base.generation_id if base is not None else ""
+    generation_id = _receipt_generation_id(
+        head_sha,
+        entries,
+        generated_at=generated,
+        base_generation_id=base_generation_id,
+        repo_root=str(Path(repo_root)),
+        ssd_path=str(Path(ssd_path)),
+        source=source,
+    )
     return HoloIndexFreshnessReceipt(
         schema_version=SCHEMA_VERSION,
         generated_at=generated,
@@ -710,7 +894,7 @@ def build_maintenance_invalidation(
         ssd_path=str(Path(ssd_path)),
         source=source,
         generation_id=generation_id,
-        base_generation_id=(base.generation_id if base is not None else ""),
+        base_generation_id=base_generation_id,
         collections=entries,
     )
 
@@ -815,24 +999,39 @@ def collections_for_path(path: str | Path) -> set[str]:
     if not p or p.startswith("../") or p.startswith("/"):
         return collections
 
-    if p.startswith("WSP_framework/src/") and name.startswith("WSP_") and lower.endswith(".md"):
+    if (
+        p.startswith("WSP_framework/src/")
+        and name.startswith("WSP_")
+        and lower.endswith(".md")
+    ):
         collections.add("navigation_wsp")
-    elif p.startswith("WSP_knowledge/docs/Papers/"):
+        return collections
+    if p.startswith("WSP_knowledge/docs/Papers/"):
         collections.add("navigation_knowledge")
-    elif p.startswith("docs/0102_session_briefings/") or name in {
+        return collections
+    if p.startswith("docs/0102_session_briefings/") or name in {
         "ACTIVE_SLICE_LEDGER.md",
         "work_ledger.schema.json",
     }:
         collections.add("navigation_work_ledger")
-    elif name == "SKILLz.md":
-        collections.add("navigation_skills")
-    elif "/tests/" in p or name.startswith("test_"):
+    if name == "WSP_Test_Registry.json":
         collections.add("navigation_tests")
-    elif lower.endswith("navigation.py") or lower.endswith((".js", ".ts", ".tsx", ".jsx", ".html", ".css")):
+        return collections
+    if name == "SKILLz.md":
+        collections.add("navigation_skills")
+        if p.startswith("modules/"):
+            collections.add("navigation_docs")
+    if "/tests/" in p or name.startswith("test_"):
+        collections.add("navigation_tests")
+    if lower.endswith("navigation.py") or lower.endswith(
+        (".js", ".mjs", ".cjs", ".ts", ".tsx", ".jsx", ".html", ".css")
+    ):
         collections.add("navigation_code")
-    elif lower.endswith(".py"):
+    if lower.endswith(".py") and p.startswith(("modules/", "scripts/", "holo_index/")):
         collections.add("navigation_symbols")
-    elif lower.endswith((".md", ".json", ".yaml", ".yml", ".txt")):
+    if lower.endswith(".md") and p.startswith(
+        ("modules/", "docs/", "holo_index/docs/", "WSP_framework/docs/")
+    ):
         collections.add("navigation_docs")
 
     return collections
@@ -863,14 +1062,59 @@ def _collection_freshness_reasons(
     entry: CollectionFreshness,
     *,
     expected_repo_head_sha: str | None,
+    entry_generation_id: str,
 ) -> list[str]:
     reasons: list[str] = []
     if entry.status != "indexed" or entry.count <= 0:
         reasons.append(f"collection_not_indexed:{name}")
     if entry.verification != "PASS":
         reasons.append(f"collection_verification_not_pass:{name}")
-    if entry.proof_kind != "complete_source_manifest":
+    allowed_proofs = {
+        "complete_source_manifest",
+        "verified_unchanged_source_manifest",
+    }
+    if entry.proof_kind not in allowed_proofs:
         reasons.append(f"collection_source_proof_incomplete:{name}")
+    required_digests = {
+        "source_manifest": entry.source_manifest_digest,
+        "indexed_paths": entry.indexed_paths_digest,
+        "removed_paths": entry.removed_paths_digest,
+        "source_policy": entry.source_policy_digest,
+        "collection_snapshot": entry.collection_snapshot_digest,
+    }
+    for field_name, digest in required_digests.items():
+        if not DIGEST_PATTERN.fullmatch(digest):
+            reasons.append(f"collection_{field_name}_digest_invalid:{name}")
+    if entry.proof_kind == "verified_unchanged_source_manifest" and not all(
+        (
+            entry.source_policy_digest,
+            entry.carried_from_repo_head_sha,
+            entry.carried_from_generation_id,
+            entry.carry_forward_evidence_digest,
+            entry.collection_snapshot_digest,
+        )
+    ):
+        reasons.append(f"collection_carry_forward_proof_incomplete:{name}")
+    if entry.proof_kind == "verified_unchanged_source_manifest":
+        if entry.carried_from_generation_id != entry_generation_id:
+            reasons.append(f"collection_carry_forward_lineage_mismatch:{name}")
+        if (
+            not SHA_PATTERN.fullmatch(entry.carried_from_repo_head_sha)
+            or not DIGEST_PATTERN.fullmatch(entry.source_manifest_digest)
+            or not DIGEST_PATTERN.fullmatch(entry.source_policy_digest)
+            or not DIGEST_PATTERN.fullmatch(entry.collection_snapshot_digest)
+        ):
+            reasons.append(f"collection_carry_forward_format_invalid:{name}")
+        expected_evidence = carry_forward_evidence_digest(
+            collection_name=name,
+            source_manifest_digest=entry.source_manifest_digest,
+            source_policy_digest=entry.source_policy_digest,
+            carried_from_repo_head_sha=entry.carried_from_repo_head_sha,
+            carried_from_generation_id=entry.carried_from_generation_id,
+            current_repo_head_sha=entry.repo_head_sha,
+        )
+        if entry.carry_forward_evidence_digest != expected_evidence:
+            reasons.append(f"collection_carry_forward_evidence_invalid:{name}")
     expected_scope_id = canonical_source_scope_id(name)
     if expected_scope_id and entry.source_scope_id != expected_scope_id:
         reasons.append(f"collection_source_scope_mismatch:{name}")
@@ -915,6 +1159,7 @@ def _required_collection_failures(
             name,
             entry,
             expected_repo_head_sha=expected_repo_head_sha,
+            entry_generation_id=receipt.base_generation_id,
         )
         if entry_reasons:
             stale.add(name)
@@ -942,6 +1187,9 @@ def evaluate_freshness_for_paths(
     stale: set[str] = set()
     if receipt.schema_version != SCHEMA_VERSION:
         reasons.append("unsupported_freshness_receipt_schema")
+        stale.update(required)
+    if not freshness_receipt_integrity_ok(receipt):
+        reasons.append("invalid_freshness_receipt_integrity")
         stale.update(required)
     if required and not receipt.generation_id:
         reasons.append("missing_holoindex_generation_id")
@@ -974,10 +1222,12 @@ __all__ = [
     "BASELINE_QUERY_COLLECTIONS",
     "BASELINE_QUERY_FRESHNESS_PATHS",
     "COLLECTION_ATTRS",
+    "COLLECTION_SCHEMA_VERSION",
     "CollectionFreshness",
     "FreshnessCheck",
     "FRESHNESS_RECEIPT_FILENAME",
     "HoloIndexFreshnessReceipt",
+    "collection_snapshot_matches_entry",
     "SCHEMA_VERSION",
     "build_freshness_receipt",
     "build_maintenance_invalidation",
@@ -985,6 +1235,7 @@ __all__ = [
     "collections_for_path",
     "evaluate_freshness_for_paths",
     "freshness_receipt_path",
+    "freshness_receipt_integrity_ok",
     "load_freshness_receipt",
     "publish_maintenance_invalidation",
     "read_git_head_sha",

--- a/holo_index/maintenance_session.py
+++ b/holo_index/maintenance_session.py
@@ -13,14 +13,18 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping
 
 from holo_index.freshness_receipt import (
+    BASELINE_QUERY_COLLECTIONS,
     HoloIndexFreshnessReceipt,
     build_freshness_receipt,
+    collection_snapshot_matches_entry,
     freshness_receipt_path,
+    freshness_receipt_integrity_ok,
     load_freshness_receipt,
     publish_maintenance_invalidation,
     write_freshness_receipt,
 )
 from holo_index.embedding_space import CANONICAL_INDEX_BACKEND
+from holo_index.canonical_source_manifest import probe_canonical_source_manifests
 from holo_index.maintenance_lock import (
     MaintenanceLease,
     MaintenanceLockError,
@@ -29,6 +33,11 @@ from holo_index.maintenance_lock import (
 )
 from holo_index.repository_state import read_repository_state
 from holo_index.source_scope import canonical_source_scope_id
+from holo_index.storage_contract import storage_path_identity
+from holo_index.verified_collection_carry_forward import (
+    build_carry_forward_evidence,
+    collection_source_policy_digest,
+)
 
 
 MAINTENANCE_FAILURE_EXIT_CODE = 4
@@ -52,7 +61,8 @@ class MaintenanceSessionError(RuntimeError):
 def _complete_source_proofs(
     planned: frozenset[str],
     refresh_proofs: Mapping[str, Any] | None,
-) -> tuple[dict[str, str], dict[str, str]]:
+    repo_root: Path,
+) -> tuple[dict[str, str], dict[str, str], dict[str, str]]:
     proofs = dict(refresh_proofs or {})
     if set(proofs) != set(planned):
         raise MaintenanceSessionError(
@@ -61,6 +71,7 @@ def _complete_source_proofs(
         )
     manifests: dict[str, str] = {}
     scopes: dict[str, str] = {}
+    policies: dict[str, str] = {}
     failed: list[str] = []
     for name in sorted(planned):
         proof = proofs[name]
@@ -76,6 +87,11 @@ def _complete_source_proofs(
             failed.append(name)
             continue
         manifests[name] = digest
+        policy_digest = collection_source_policy_digest(repo_root, name)
+        if not policy_digest:
+            failed.append(name)
+            continue
+        policies[name] = policy_digest
         if scope:
             scopes[name] = scope
     if failed:
@@ -83,7 +99,35 @@ def _complete_source_proofs(
             "HOLOINDEX_MAINTENANCE_SOURCE_PROOF_INCOMPLETE",
             f"collections={failed}",
         )
-    return manifests, scopes
+    return manifests, scopes, policies
+
+
+def _validate_canonical_refresh_manifests(
+    holo: Any,
+    refreshed: frozenset[str],
+    source_manifests: Mapping[str, str],
+    source_scopes: Mapping[str, str],
+) -> None:
+    """Independently re-prove every refreshed collection source set."""
+
+    try:
+        canonical = probe_canonical_source_manifests(holo, refreshed)
+    except Exception as exc:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_REFRESH_SOURCE_PROBE_FAILED", str(exc)
+        ) from exc
+    mismatched = [
+        name
+        for name in sorted(refreshed)
+        if name not in canonical
+        or canonical[name].digest != source_manifests.get(name, "")
+        or canonical[name].source_scope_id != source_scopes.get(name, "")
+    ]
+    if mismatched:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_REFRESH_SOURCE_MANIFEST_MISMATCH",
+            f"collections={mismatched}",
+        )
 
 
 def _final_proof_failures(
@@ -107,6 +151,8 @@ def _final_proof_failures(
             or entry.count != int(getattr(refresh_proofs[name], "indexed_count", -1))
             or not entry.source_manifest_digest
             or not entry.indexed_paths_digest
+            or not entry.source_policy_digest
+            or not entry.collection_snapshot_digest
             or entry.embedding_backend != CANONICAL_INDEX_BACKEND
             or not entry.embedding_model
             or not entry.embedding_space_fingerprint.startswith("sha256:")
@@ -143,7 +189,11 @@ def _begin_invalidation(
     planned: frozenset[str],
     source: str,
     head_sha: str,
-) -> tuple[MaintenanceLease, HoloIndexFreshnessReceipt]:
+) -> tuple[
+    MaintenanceLease,
+    HoloIndexFreshnessReceipt,
+    HoloIndexFreshnessReceipt | None,
+]:
     try:
         lease = acquire_maintenance_lease(maintenance_lock_path(ssd_path))
     except MaintenanceLockError as exc:
@@ -158,6 +208,26 @@ def _begin_invalidation(
                 base_receipt = load_freshness_receipt(receipt_path)
             except (OSError, TypeError, ValueError, json.JSONDecodeError):
                 base_receipt = None
+        if base_receipt is not None:
+            base_integrity_ok = freshness_receipt_integrity_ok(base_receipt)
+            base_binding_ok = bool(
+                base_receipt.repo_root
+                and base_receipt.ssd_path
+                and storage_path_identity(base_receipt.repo_root)
+                == storage_path_identity(repo_root)
+                and storage_path_identity(base_receipt.ssd_path)
+                == storage_path_identity(ssd_path)
+            )
+            if not base_integrity_ok or not base_binding_ok:
+                if BASELINE_QUERY_COLLECTIONS.issubset(planned):
+                    base_receipt = None
+                else:
+                    code = (
+                        "HOLOINDEX_BASE_FRESHNESS_RECEIPT_INVALID"
+                        if not base_integrity_ok
+                        else "HOLOINDEX_BASE_FRESHNESS_RECEIPT_BINDING_MISMATCH"
+                    )
+                    raise MaintenanceSessionError(code)
         invalidation = publish_maintenance_invalidation(
             receipt_path,
             planned,
@@ -167,12 +237,15 @@ def _begin_invalidation(
             source=source,
             repo_head_sha=head_sha,
         )
+    except MaintenanceSessionError:
+        lease.release()
+        raise
     except Exception as exc:
         lease.release()
         raise MaintenanceSessionError(
             "HOLOINDEX_MAINTENANCE_INVALIDATION_FAILED", str(exc)
         ) from exc
-    return lease, invalidation
+    return lease, invalidation, base_receipt
 
 
 def _validate_completed_plan(
@@ -199,6 +272,8 @@ def _build_completed_receipt(
     refresh_proofs: Mapping[str, Any] | None,
     source_manifests: Mapping[str, str],
     source_scopes: Mapping[str, str],
+    source_policy_digests: Mapping[str, str],
+    carry_forward_evidence: Mapping[str, Any],
     head_sha: str,
 ) -> HoloIndexFreshnessReceipt:
     receipt = build_freshness_receipt(
@@ -208,9 +283,11 @@ def _build_completed_receipt(
         source=source,
         repo_head_sha=head_sha,
         refreshed_collections=refreshed,
-        base_receipt=session.invalidation_receipt,
+        base_receipt=session.base_receipt,
         refresh_source_manifests=source_manifests,
         refresh_source_scopes=source_scopes,
+        refresh_source_policy_digests=source_policy_digests,
+        _carry_forward_evidence=carry_forward_evidence,
     )
     failed = _final_proof_failures(
         receipt,
@@ -225,6 +302,49 @@ def _build_completed_receipt(
     return receipt
 
 
+def _verified_carry_forward_state(
+    session: Any,
+    holo: Any,
+    *,
+    head_sha: str,
+) -> Mapping[str, Any]:
+    carry_names = (
+        sorted(BASELINE_QUERY_COLLECTIONS.difference(session.planned_collections))
+        if session.base_receipt is not None
+        else []
+    )
+    try:
+        source_manifests = probe_canonical_source_manifests(holo, carry_names)
+        evidence = build_carry_forward_evidence(
+            repo_root=session.repo_root,
+            base_receipt=session.base_receipt,
+            collection_names=carry_names,
+            head_sha=head_sha,
+            current_source_manifests=source_manifests,
+        )
+    except Exception as exc:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_CARRY_FORWARD_PROOF_FAILED", str(exc)
+        ) from exc
+    if session.base_receipt is None:
+        return evidence
+    prior_entries = {
+        entry.name: entry for entry in session.base_receipt.collections
+    }
+    snapshot_failures = [
+        name
+        for name in carry_names
+        if name not in prior_entries
+        or not collection_snapshot_matches_entry(holo, name, prior_entries[name])
+    ]
+    if snapshot_failures:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_CARRY_FORWARD_COLLECTION_MISMATCH",
+            f"collections={snapshot_failures}",
+        )
+    return evidence
+
+
 def _write_completed_receipt(
     session: Any,
     receipt: HoloIndexFreshnessReceipt,
@@ -237,6 +357,21 @@ def _write_completed_receipt(
         ) from exc
 
 
+def _final_collection_snapshot_failures(
+    holo: Any,
+    receipt: HoloIndexFreshnessReceipt,
+) -> list[str]:
+    """Detect collection mutation after proof assembly and before publication."""
+
+    return sorted(
+        entry.name
+        for entry in receipt.collections
+        if entry.name in BASELINE_QUERY_COLLECTIONS
+        and entry.verification == "PASS"
+        and not collection_snapshot_matches_entry(holo, entry.name, entry)
+    )
+
+
 @dataclass
 class MaintenanceSession:
     """Exclusive maintenance lease plus an already-published invalidation."""
@@ -246,6 +381,7 @@ class MaintenanceSession:
     planned_collections: frozenset[str]
     starting_head_sha: str
     invalidation_receipt: HoloIndexFreshnessReceipt
+    base_receipt: HoloIndexFreshnessReceipt | None
     _lease: MaintenanceLease
     _repository_state_reader: Callable[[Path], Any]
     _closed: bool = False
@@ -269,7 +405,7 @@ class MaintenanceSession:
             raise MaintenanceSessionError("HOLOINDEX_MAINTENANCE_PLAN_EMPTY")
         state_reader = repository_state_reader or read_repository_state
         head_sha = _clean_repository_head(root, state_reader)
-        lease, invalidation = _begin_invalidation(
+        lease, invalidation, base_receipt = _begin_invalidation(
             ssd_path=ssd,
             repo_root=root,
             planned=planned,
@@ -283,6 +419,7 @@ class MaintenanceSession:
             planned_collections=planned,
             starting_head_sha=head_sha,
             invalidation_receipt=invalidation,
+            base_receipt=base_receipt,
             _lease=lease,
             _repository_state_reader=state_reader,
         )
@@ -307,9 +444,16 @@ class MaintenanceSession:
             self.planned_collections,
             refreshed_collections,
         )
-        source_manifests, source_scopes = _complete_source_proofs(
+        source_manifests, source_scopes, source_policy_digests = _complete_source_proofs(
             self.planned_collections,
             refresh_proofs,
+            self.repo_root,
+        )
+        _validate_canonical_refresh_manifests(
+            holo,
+            refreshed,
+            source_manifests,
+            source_scopes,
         )
         head_sha = _clean_repository_head(
             self.repo_root,
@@ -321,6 +465,11 @@ class MaintenanceSession:
                 "HOLOINDEX_REPOSITORY_HEAD_CHANGED",
                 f"expected={self.starting_head_sha}; actual={head_sha}",
             )
+        carry_forward_evidence = _verified_carry_forward_state(
+            self,
+            holo,
+            head_sha=head_sha,
+        )
         receipt = _build_completed_receipt(
             self,
             holo,
@@ -329,8 +478,26 @@ class MaintenanceSession:
             refresh_proofs=refresh_proofs,
             source_manifests=source_manifests,
             source_scopes=source_scopes,
+            source_policy_digests=source_policy_digests,
+            carry_forward_evidence=carry_forward_evidence,
             head_sha=head_sha,
         )
+        final_head = _clean_repository_head(
+            self.repo_root,
+            self._repository_state_reader,
+            require_head=False,
+        )
+        if final_head != self.starting_head_sha:
+            raise MaintenanceSessionError(
+                "HOLOINDEX_REPOSITORY_HEAD_CHANGED",
+                f"expected={self.starting_head_sha}; actual={final_head}",
+            )
+        snapshot_failures = _final_collection_snapshot_failures(holo, receipt)
+        if snapshot_failures:
+            raise MaintenanceSessionError(
+                "HOLOINDEX_FINAL_COLLECTION_SNAPSHOT_MISMATCH",
+                f"collections={snapshot_failures}",
+            )
         _write_completed_receipt(self, receipt)
         return receipt
 

--- a/holo_index/tests/test_canonical_source_manifest.py
+++ b/holo_index/tests/test_canonical_source_manifest.py
@@ -1,0 +1,90 @@
+"""Contract tests for exact read-only HoloIndex source manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import holo_index.canonical_source_manifest as manifest_module
+from holo_index.canonical_source_manifest import probe_canonical_source_manifests
+from holo_index.core.indexing_engine import (
+    WebAssetDiscovery,
+    source_file_manifest_digest,
+    source_manifest_digest,
+)
+from holo_index.source_scope import (
+    CANONICAL_WEB_EXTENSIONS,
+    canonical_source_scope_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("collection_name", "discovery_name"),
+    (
+        ("navigation_docs", "_docs_source_files"),
+        ("navigation_knowledge", "_knowledge_source_files"),
+        ("navigation_skills", "_skill_source_files"),
+    ),
+)
+def test_file_manifest_probe_uses_indexer_source_set_exactly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    collection_name: str,
+    discovery_name: str,
+) -> None:
+    first = tmp_path / "first.md"
+    second = tmp_path / "second.md"
+    first.write_text("first", encoding="utf-8")
+    second.write_text("second", encoding="utf-8")
+    files = [first, second]
+    monkeypatch.setattr(manifest_module, discovery_name, lambda _holo: files)
+    monkeypatch.setattr(
+        manifest_module,
+        "filter_git_tracked_files",
+        lambda _root, values: list(values),
+    )
+    holo = SimpleNamespace(project_root=tmp_path)
+
+    result = probe_canonical_source_manifests(holo, [collection_name])[collection_name]
+
+    assert result.digest == source_file_manifest_digest(files, project_root=tmp_path)
+    assert result.source_scope_id == canonical_source_scope_id(collection_name)
+
+
+def test_code_probe_matches_code_indexer_manifest_formula(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    web = WebAssetDiscovery(
+        entries=[],
+        discovered_count=2,
+        processed_count=2,
+        failed_count=0,
+        source_manifest_digest="sha256:" + ("a" * 64),
+        source_scope_id=canonical_source_scope_id("navigation_code"),
+    )
+    nav_manifest = "sha256:" + ("b" * 64)
+    monkeypatch.setattr(manifest_module, "_discover_web_assets", lambda _holo: web)
+    monkeypatch.setattr(
+        manifest_module,
+        "_navigation_source_evidence",
+        lambda _holo: (nav_manifest, 0, ""),
+    )
+    holo = SimpleNamespace(need_to={"beta": "b.py", "alpha": "a.py"})
+
+    result = probe_canonical_source_manifests(holo, ["navigation_code"])[
+        "navigation_code"
+    ]
+
+    assert result.digest == source_manifest_digest(
+        {
+            "navigation": sorted(holo.need_to.items()),
+            "navigation_source_manifest": nav_manifest,
+            "web_asset_source_manifest": web.source_manifest_digest,
+        }
+    )
+
+
+def test_canonical_code_scope_includes_modern_javascript_modules() -> None:
+    assert {".mjs", ".cjs"}.issubset(CANONICAL_WEB_EXTENSIONS)

--- a/holo_index/tests/test_cli_index_maintenance_integration.py
+++ b/holo_index/tests/test_cli_index_maintenance_integration.py
@@ -24,7 +24,12 @@ class _Collection:
         return 1
 
     def get(self, include=None):
-        return {"ids": ["one"], "metadatas": [{"path": "source.py"}]}
+        return {
+            "ids": ["one"],
+            "documents": ["source"],
+            "metadatas": [{"path": "source.py"}],
+            "embeddings": [[1.0]],
+        }
 
 
 class _FakeHolo:

--- a/holo_index/tests/test_holoindex_ci_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_freshness_gate.py
@@ -51,10 +51,14 @@ class SnapshotCollection:
     def get(self, include=None):
         return {
             "ids": [f"{self.name}:{index}" for index in range(self._count)],
+            "documents": [
+                f"document:{self.name}:{index}" for index in range(self._count)
+            ],
             "metadatas": [
                 {"path": f"{self.name}/item_{index}.txt"}
                 for index in range(self._count)
             ],
+            "embeddings": [[float(index)] for index in range(self._count)],
         }
 
 
@@ -77,19 +81,24 @@ def _holo(**counts: int):
 
 
 def _write_receipt(tmp_path: Path, *, sha: str = "abc123", **counts: int) -> Path:
+    collection_names = (
+        "navigation_code",
+        "navigation_wsp",
+        "navigation_tests",
+        "navigation_skills",
+        "navigation_symbols",
+        "navigation_docs",
+        "navigation_knowledge",
+        "navigation_work_ledger",
+        "navigation_vocabulary",
+    )
     complete_manifests = {
-        name: f"sha256:complete-source:{name}"
-        for name in (
-            "navigation_code",
-            "navigation_wsp",
-            "navigation_tests",
-            "navigation_skills",
-            "navigation_symbols",
-            "navigation_docs",
-            "navigation_knowledge",
-            "navigation_work_ledger",
-            "navigation_vocabulary",
-        )
+        name: "sha256:" + format(index + 1, "064x")
+        for index, name in enumerate(collection_names)
+    }
+    policy_digests = {
+        name: "sha256:" + format(index + 101, "064x")
+        for index, name in enumerate(collection_names)
     }
     receipt = build_freshness_receipt(
         _holo(**counts),
@@ -100,6 +109,7 @@ def _write_receipt(tmp_path: Path, *, sha: str = "abc123", **counts: int) -> Pat
         repo_head_sha=sha,
         refresh_source_manifests=complete_manifests,
         refresh_source_scopes=CANONICAL_SOURCE_SCOPE_IDS,
+        refresh_source_policy_digests=policy_digests,
     )
     path = freshness_receipt_path(tmp_path)
     write_freshness_receipt(receipt, path)
@@ -121,7 +131,10 @@ def test_ci_gate_passes_when_receipt_covers_changed_collections(tmp_path: Path) 
     assert result.ok is True
     assert result.status == STATUS_PASS
     assert result.configured is True
-    assert result.required_collections == ["navigation_symbols", "navigation_work_ledger"]
+    assert result.required_collections == [
+        "navigation_symbols",
+        "navigation_work_ledger",
+    ]
     assert result.stale_collections == []
     assert result.no_reindex_performed is True
     assert result.no_runtime_reindex_performed is True
@@ -174,7 +187,11 @@ def test_ci_gate_fails_on_stale_repo_sha(tmp_path: Path) -> None:
 
     assert result.ok is False
     assert result.status == STATUS_FAIL
-    assert result.stale_collections == ["navigation_work_ledger", "navigation_wsp"]
+    assert result.stale_collections == [
+        "navigation_docs",
+        "navigation_work_ledger",
+        "navigation_wsp",
+    ]
     assert "stale_repo_head_sha" in result.reasons
 
 

--- a/holo_index/tests/test_holoindex_ci_main_freshness_gate.py
+++ b/holo_index/tests/test_holoindex_ci_main_freshness_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -16,8 +17,7 @@ from holo_index.ci_main_freshness_gate import (
     run_ci_main_freshness_gate,
 )
 from holo_index.freshness_receipt import (
-    CollectionFreshness,
-    HoloIndexFreshnessReceipt,
+    build_freshness_receipt,
     freshness_receipt_path,
     write_freshness_receipt,
 )
@@ -31,30 +31,37 @@ DIGEST = "sha256:" + "0" * 64
 
 
 def _write_receipt(tmp_path: Path, *, head: str = HEAD) -> Path:
-    receipt = HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
-        generated_at="2026-07-14T00:00:00+00:00",
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=head,
-        ssd_path=str(tmp_path),
+    class _Collection:
+        metadata = {}
+
+        @staticmethod
+        def count() -> int:
+            return 2
+
+        @staticmethod
+        def get(include=None):
+            return {
+                "ids": ["ledger:0", "ledger:1"],
+                "documents": ["first", "second"],
+                "metadatas": [
+                    {"path": "docs/0102_session_briefings/work_ledger.example.json"},
+                    {"path": "docs/0102_session_briefings/work_ledger.schema.json"},
+                ],
+                "embeddings": [[0.0], [1.0]],
+            }
+
+    receipt = build_freshness_receipt(
+        SimpleNamespace(work_ledger_collection=_Collection()),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
         source="ci_targeted_reindex",
-        generation_id=DIGEST,
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=2,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=head,
-                last_indexed_at="2026-07-14T00:00:00+00:00",
-                source_manifest_digest=DIGEST,
-                indexed_paths_digest=DIGEST,
-                removed_paths_digest=DIGEST,
-                embedding_backend="ci-test",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            )
-        ],
+        generated_at="2026-07-14T00:00:00+00:00",
+        repo_head_sha=head,
+        refreshed_collections={"navigation_work_ledger"},
+        refresh_source_manifests={"navigation_work_ledger": DIGEST},
+        refresh_source_policy_digests={
+            "navigation_work_ledger": "sha256:" + ("1" * 64),
+        },
     )
     path = freshness_receipt_path(tmp_path)
     write_freshness_receipt(receipt, path)

--- a/holo_index/tests/test_holoindex_embedding_space.py
+++ b/holo_index/tests/test_holoindex_embedding_space.py
@@ -158,7 +158,12 @@ class _Collection:
         return 1
 
     def get(self, include=None):
-        return {"ids": ["one"], "metadatas": [{"path": "NAVIGATION.py"}]}
+        return {
+            "ids": ["one"],
+            "documents": ["navigation"],
+            "metadatas": [{"path": "NAVIGATION.py"}],
+            "embeddings": [[1.0]],
+        }
 
 
 def test_receipt_blanks_collection_space_when_runtime_changed(tmp_path: Path) -> None:

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -17,6 +17,7 @@ from holo_index.freshness_receipt import (
     build_freshness_receipt,
     build_maintenance_invalidation,
     collections_for_changed_paths,
+    collections_for_path,
     evaluate_freshness_for_paths,
     freshness_receipt_path,
     load_freshness_receipt,
@@ -59,10 +60,14 @@ class SnapshotCollection:
     def get(self, include=None):
         return {
             "ids": [f"{self.name}:{index}" for index in range(self._count)],
+            "documents": [
+                f"document:{self.name}:{index}" for index in range(self._count)
+            ],
             "metadatas": [
                 {"path": f"{self.name}/item_{index}.txt"}
                 for index in range(self._count)
             ],
+            "embeddings": [[float(index)] for index in range(self._count)],
         }
 
 
@@ -242,7 +247,11 @@ def test_stale_repo_sha_fails_closed_for_required_collections(tmp_path: Path) ->
     )
 
     assert check.ok is False
-    assert check.stale_collections == ["navigation_work_ledger", "navigation_wsp"]
+    assert check.stale_collections == [
+        "navigation_docs",
+        "navigation_work_ledger",
+        "navigation_wsp",
+    ]
     assert "stale_repo_head_sha" in check.reasons
 
 
@@ -263,7 +272,10 @@ def test_empty_collection_fails_closed_when_path_requires_it(tmp_path: Path) -> 
     )
 
     assert check.ok is False
-    assert check.stale_collections == ["navigation_work_ledger"]
+    assert check.stale_collections == [
+        "navigation_docs",
+        "navigation_work_ledger",
+    ]
     assert "collection_not_indexed:navigation_work_ledger" in check.reasons
     assert "collection_verification_not_pass:navigation_work_ledger" in check.reasons
 
@@ -344,6 +356,51 @@ def test_generation_id_changes_when_collection_manifest_changes(tmp_path: Path) 
     assert first.generation_id != second.generation_id
 
 
+@pytest.mark.parametrize(
+    ("scope", "field", "value"),
+    (
+        ("receipt", "generated_at", "2026-07-13T00:00:00+00:00"),
+        ("receipt", "repo_root", "O:/forged"),
+        ("receipt", "ssd_path", "O:/forged-index"),
+        ("receipt", "source", "forged-source"),
+        ("collection", "last_indexed_at", "2026-07-13T00:00:00+00:00"),
+        ("collection", "source", "forged-source"),
+        ("collection", "schema_version", "holoindex_collection_freshness.v1"),
+    ),
+)
+def test_query_rejects_tampering_of_any_generation_bound_field(
+    tmp_path: Path,
+    scope: str,
+    field: str,
+    value: str,
+) -> None:
+    receipt = build_freshness_receipt(
+        _holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-12T00:00:00+00:00",
+        repo_head_sha="abc123",
+        refresh_source_manifests={
+            "navigation_symbols": "sha256:" + ("a" * 64),
+        },
+        refresh_source_scopes={
+            "navigation_symbols": canonical_source_scope_id("navigation_symbols"),
+        },
+    ).to_dict()
+    target = receipt if scope == "receipt" else receipt["collections"][4]
+    target[field] = value
+
+    result = evaluate_freshness_for_paths(
+        receipt,
+        ["modules/example/src/example.py"],
+        expected_repo_head_sha="abc123",
+    )
+
+    assert result.ok is False
+    assert "invalid_freshness_receipt_integrity" in result.reasons
+
+
 def _assert_scoped_refresh_truth(refreshed) -> None:
     wsp_check = evaluate_freshness_for_paths(
         refreshed,
@@ -362,7 +419,31 @@ def _assert_scoped_refresh_truth(refreshed) -> None:
     )
     assert "stale_collection_sha:navigation_wsp" in wsp_check.reasons
     assert "stale_collection_sha:navigation_knowledge" in knowledge_check.reasons
-    assert test_check.ok is True
+    assert test_check.ok is False
+    assert "stale_collection_sha:navigation_symbols" in test_check.reasons
+
+
+def test_changed_path_mapping_covers_overlapping_source_sets() -> None:
+    assert collections_for_path("modules/example/tests/test_runtime.py") == {
+        "navigation_symbols",
+        "navigation_tests",
+    }
+    assert collections_for_path("modules/example/SKILLz.md") == {
+        "navigation_docs",
+        "navigation_skills",
+    }
+    assert collections_for_path("WSP_knowledge/WSP_Test_Registry.json") == {
+        "navigation_tests",
+    }
+    assert collections_for_path(
+        "docs/0102_session_briefings/work_ledger.schema.json"
+    ) == {"navigation_work_ledger"}
+    assert collections_for_path(
+        "docs/0102_session_briefings/ACTIVE_SLICE_LEDGER.md"
+    ) == {"navigation_docs", "navigation_work_ledger"}
+    assert collections_for_path("public/runtime.mjs") == {"navigation_code"}
+    assert collections_for_path("public/worker.cjs") == {"navigation_code"}
+    assert collections_for_path("WSP_framework/src/README.md") == set()
 
 
 def test_test_only_refresh_preserves_prior_wsp_and_knowledge_entries(
@@ -432,6 +513,34 @@ def test_complete_manifest_without_canonical_scope_fails_closed(
     assert "collection_source_scope_mismatch:navigation_tests" in check.reasons
 
 
+def test_complete_manifest_without_policy_digest_fails_closed(
+    tmp_path: Path,
+) -> None:
+    receipt = build_freshness_receipt(
+        _holo(),
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="test_refresh",
+        repo_head_sha="sha-b",
+        refreshed_collections={"navigation_tests"},
+        refresh_source_manifests={
+            "navigation_tests": "sha256:" + ("a" * 64),
+        },
+        refresh_source_scopes={
+            "navigation_tests": canonical_source_scope_id("navigation_tests"),
+        },
+    )
+
+    check = evaluate_freshness_for_paths(
+        receipt,
+        ["modules/example/tests/test_example.py"],
+        expected_repo_head_sha="sha-b",
+    )
+
+    assert check.ok is False
+    assert "collection_source_policy_digest_invalid:navigation_tests" in check.reasons
+
+
 def test_partial_refresh_without_base_marks_untouched_collections_unverified(
     tmp_path: Path,
 ) -> None:
@@ -491,7 +600,7 @@ def test_code_refresh_does_not_mark_skill_collection_fresh_without_skill_manifes
     )
 
     assert check.ok is False
-    assert check.stale_collections == ["navigation_skills"]
+    assert check.stale_collections == ["navigation_docs", "navigation_skills"]
     assert "collection_verification_not_pass:navigation_skills" in check.reasons
     assert "collection_manifest_missing:navigation_skills" in check.reasons
 
@@ -643,7 +752,10 @@ def test_maintenance_invalidation_preserves_only_unplanned_proof(
         expected_repo_head_sha="sha-a",
     )
     assert check.ok is False
-    assert check.stale_collections == ["navigation_tests"]
+    assert check.stale_collections == [
+        "navigation_symbols",
+        "navigation_tests",
+    ]
     assert "collection_not_indexed:navigation_tests" in check.reasons
 
 

--- a/holo_index/tests/test_holoindex_incremental_index_executor.py
+++ b/holo_index/tests/test_holoindex_incremental_index_executor.py
@@ -82,16 +82,24 @@ class FakeCollection:
         ids = kwargs.get("ids", [])
         documents = kwargs.get("documents", [])
         metadatas = kwargs.get("metadatas", [])
-        for item_id, document, metadata in zip(ids, documents, metadatas):
+        embeddings = kwargs.get("embeddings", [])
+        for item_id, document, metadata, embedding in zip(
+            ids,
+            documents,
+            metadatas,
+            embeddings,
+        ):
             self.records[item_id] = {
                 "document": document,
                 "metadata": metadata,
+                "embedding": embedding,
             }
 
     def seed(self, item_id: str, *, path: str, foundup_id: str = "paccess_001") -> None:
         self.records[item_id] = {
             "document": "legacy",
             "metadata": {"path": path, "foundup_id": foundup_id},
+            "embedding": [0.0],
         }
 
     def count(self) -> int:
@@ -100,10 +108,12 @@ class FakeCollection:
     def get(self, include=None):
         return {
             "ids": list(self.records),
+            "documents": [record["document"] for record in self.records.values()],
             "metadatas": [
                 record["metadata"]
                 for record in self.records.values()
             ],
+            "embeddings": [record["embedding"] for record in self.records.values()],
         }
 
 

--- a/holo_index/tests/test_holoindex_maintenance_session.py
+++ b/holo_index/tests/test_holoindex_maintenance_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -9,14 +10,19 @@ import pytest
 
 import holo_index.maintenance_session as maintenance_module
 from holo_index.freshness_receipt import (
+    BASELINE_QUERY_COLLECTIONS,
+    evaluate_freshness_for_paths,
     freshness_receipt_path,
     load_freshness_receipt,
+    write_freshness_receipt,
 )
 from holo_index.maintenance_lock import maintenance_lock_path, probe_maintenance_lock
 from holo_index.maintenance_session import MaintenanceSession, MaintenanceSessionError
 from holo_index.source_scope import canonical_source_scope_id
 
 SPACE_FINGERPRINT = "sha256:" + ("1" * 64)
+BASE_SHA = "a" * 40
+HEAD_SHA = "b" * 40
 
 class _Collection:
     def __init__(self, name: str, count: int = 2) -> None:
@@ -34,9 +40,15 @@ class _Collection:
     def get(self, include=None):
         return {
             "ids": [f"{self.name}:{index}" for index in range(self._count)],
+            "documents": [
+                f"document:{self.name}:{index}" for index in range(self._count)
+            ],
             "metadatas": [
                 {"path": f"{self.name}/item_{index}.py"}
                 for index in range(self._count)
+            ],
+            "embeddings": [
+                [float(index), float(index + 1)] for index in range(self._count)
             ],
         }
 
@@ -78,10 +90,56 @@ def _proofs(*names: str) -> dict[str, SimpleNamespace]:
     }
 
 
+def _manifest_probe(_holo, names) -> dict[str, SimpleNamespace]:
+    return {
+        name: SimpleNamespace(
+            digest="sha256:" + ("a" * 64),
+            source_scope_id=canonical_source_scope_id(name),
+        )
+        for name in names
+    }
+
+
+@pytest.fixture(autouse=True)
+def _canonical_manifest_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        maintenance_module,
+        "probe_canonical_source_manifests",
+        _manifest_probe,
+    )
+
+
+def _seed_baseline(tmp_path: Path) -> None:
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections=BASELINE_QUERY_COLLECTIONS,
+        repository_state_reader=lambda _root: _clean_state(BASE_SHA),
+    )
+    session.complete(
+        _holo(),
+        refreshed_collections=BASELINE_QUERY_COLLECTIONS,
+        source="baseline",
+        refresh_proofs=_proofs(*BASELINE_QUERY_COLLECTIONS),
+    )
+    session.close()
+
+
+def _targeted_session(tmp_path: Path) -> MaintenanceSession:
+    return MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections={"navigation_code"},
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+
+
 def test_session_invalidates_before_work_and_publishes_only_full_plan(
     tmp_path: Path,
 ) -> None:
-    reader = lambda _root: _clean_state()
+    def reader(_root: Path):
+        return _clean_state()
+
     session = MaintenanceSession.begin(
         ssd_path=tmp_path / "ssd",
         repo_root=tmp_path / "repo",
@@ -235,6 +293,341 @@ def test_repository_head_change_blocks_final_pass(tmp_path: Path) -> None:
             refresh_proofs=_proofs("navigation_code"),
         )
     session.close()
+
+
+def test_targeted_refresh_carries_only_verified_unchanged_collections(
+    tmp_path: Path,
+) -> None:
+    _seed_baseline(tmp_path)
+    baseline = load_freshness_receipt(freshness_receipt_path(tmp_path / "ssd"))
+    session = _targeted_session(tmp_path)
+    receipt = session.complete(
+        _holo(),
+        refreshed_collections={"navigation_code"},
+        source="targeted",
+        refresh_proofs=_proofs("navigation_code"),
+    )
+    session.close()
+
+    by_name = {entry.name: entry for entry in receipt.collections}
+    carried = BASELINE_QUERY_COLLECTIONS.difference({"navigation_code"})
+    assert all(by_name[name].repo_head_sha == HEAD_SHA for name in carried)
+    assert all(
+        by_name[name].proof_kind == "verified_unchanged_source_manifest"
+        for name in carried
+    )
+    assert all(by_name[name].carried_from_repo_head_sha == BASE_SHA for name in carried)
+    assert all(
+        by_name[name].carried_from_generation_id == baseline.generation_id
+        for name in carried
+    )
+    check = evaluate_freshness_for_paths(
+        receipt,
+        (
+            "NAVIGATION.py",
+            "modules/example/src/example.py",
+            "WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md",
+            "WSP_knowledge/WSP_Test_Registry.json",
+            "modules/example/SKILLz.md",
+            "modules/example/README.md",
+            "WSP_knowledge/docs/Papers/example.md",
+        ),
+        expected_repo_head_sha=HEAD_SHA,
+    )
+    assert check.ok is True
+
+
+def test_targeted_refresh_rejects_changed_source_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_baseline(tmp_path)
+
+    def changed_probe(holo, names):
+        manifests = _manifest_probe(holo, names)
+        manifests["navigation_wsp"] = SimpleNamespace(
+            digest="sha256:" + ("f" * 64),
+            source_scope_id=canonical_source_scope_id("navigation_wsp"),
+        )
+        return manifests
+
+    monkeypatch.setattr(
+        maintenance_module,
+        "probe_canonical_source_manifests",
+        changed_probe,
+    )
+    session = _targeted_session(tmp_path)
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_CARRY_FORWARD_PROOF_FAILED",
+    ):
+        session.complete(
+            _holo(),
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+
+def test_refreshed_collection_rejects_claimed_manifest_mismatch(
+    tmp_path: Path,
+) -> None:
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections={"navigation_code"},
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+    proofs = _proofs("navigation_code")
+    proofs["navigation_code"].source_manifest_digest = "sha256:" + ("f" * 64)
+
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_REFRESH_SOURCE_MANIFEST_MISMATCH",
+    ):
+        session.complete(
+            _holo(),
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=proofs,
+        )
+    session.close()
+
+
+def test_targeted_refresh_rejects_collection_snapshot_mutation(tmp_path: Path) -> None:
+    _seed_baseline(tmp_path)
+    session = _targeted_session(tmp_path)
+    holo = _holo()
+    holo.wsp_collection._count = 3
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_CARRY_FORWARD_COLLECTION_MISMATCH",
+    ):
+        session.complete(
+            holo,
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+
+@pytest.mark.parametrize("mutated_field", ("documents", "metadatas", "embeddings"))
+def test_targeted_refresh_rejects_collection_content_mutation(
+    tmp_path: Path,
+    mutated_field: str,
+) -> None:
+    _seed_baseline(tmp_path)
+    session = _targeted_session(tmp_path)
+    holo = _holo()
+    original_get = holo.wsp_collection.get
+
+    def mutated_snapshot(include=None):
+        snapshot = original_get(include=include)
+        snapshot[mutated_field][0] = (
+            {"path": "navigation_wsp/tampered.py"}
+            if mutated_field == "metadatas"
+            else [99.0, 100.0]
+            if mutated_field == "embeddings"
+            else "tampered document"
+        )
+        return snapshot
+
+    holo.wsp_collection.get = mutated_snapshot
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_CARRY_FORWARD_COLLECTION_MISMATCH",
+    ):
+        session.complete(
+            holo,
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+
+def test_final_snapshot_recheck_blocks_post_proof_mutation(tmp_path: Path) -> None:
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections={"navigation_code"},
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+    holo = _holo()
+    original_get = holo.code_collection.get
+    calls = 0
+
+    def changing_snapshot(include=None):
+        nonlocal calls
+        calls += 1
+        snapshot = original_get(include=include)
+        if calls > 1:
+            snapshot["documents"][0] = "changed after receipt assembly"
+        return snapshot
+
+    holo.code_collection.get = changing_snapshot
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_FINAL_COLLECTION_SNAPSHOT_MISMATCH",
+    ):
+        session.complete(
+            holo,
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+    invalidation = load_freshness_receipt(freshness_receipt_path(tmp_path / "ssd"))
+    code = next(
+        entry for entry in invalidation.collections if entry.name == "navigation_code"
+    )
+    assert code.verification == "IN_PROGRESS"
+
+
+def test_serialized_carry_forward_tampering_fails_query_admission(
+    tmp_path: Path,
+) -> None:
+    _seed_baseline(tmp_path)
+    session = _targeted_session(tmp_path)
+    receipt = session.complete(
+        _holo(),
+        refreshed_collections={"navigation_code"},
+        source="targeted",
+        refresh_proofs=_proofs("navigation_code"),
+    )
+    session.close()
+    serialized = receipt.to_dict()
+    carried = next(
+        entry
+        for entry in serialized["collections"]
+        if entry["name"] == "navigation_wsp"
+    )
+    carried["carry_forward_evidence_digest"] = "sha256:" + ("f" * 64)
+
+    result = evaluate_freshness_for_paths(
+        serialized,
+        ["WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md"],
+        expected_repo_head_sha=HEAD_SHA,
+    )
+
+    assert result.ok is False
+    assert "invalid_freshness_receipt_integrity" in result.reasons
+
+
+def test_full_refresh_migrates_obsolete_receipt_schema(tmp_path: Path) -> None:
+    _seed_baseline(tmp_path)
+    path = freshness_receipt_path(tmp_path / "ssd")
+    obsolete = replace(load_freshness_receipt(path), schema_version="v1-obsolete")
+    write_freshness_receipt(obsolete, path)
+
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections=BASELINE_QUERY_COLLECTIONS,
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+    receipt = session.complete(
+        _holo(),
+        refreshed_collections=BASELINE_QUERY_COLLECTIONS,
+        source="full_migration",
+        refresh_proofs=_proofs(*BASELINE_QUERY_COLLECTIONS),
+    )
+    session.close()
+
+    assert receipt.base_generation_id == ""
+    assert all(
+        entry.verification == "PASS"
+        for entry in receipt.collections
+        if entry.name in BASELINE_QUERY_COLLECTIONS
+    )
+
+
+def test_targeted_refresh_rejects_policy_environment_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_baseline(tmp_path)
+    monkeypatch.setenv("HOLO_SYMBOL_ROOTS", "modules")
+    session = _targeted_session(tmp_path)
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="carry_forward_policy_changed:navigation_symbols",
+    ):
+        session.complete(
+            _holo(),
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+
+def test_targeted_refresh_rejects_source_probe_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_baseline(tmp_path)
+
+    def fail_probe(_holo, _names):
+        raise RuntimeError("source probe failed")
+
+    monkeypatch.setattr(
+        maintenance_module,
+        "probe_canonical_source_manifests",
+        fail_probe,
+    )
+    session = _targeted_session(tmp_path)
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_REFRESH_SOURCE_PROBE_FAILED",
+    ):
+        session.complete(
+            _holo(),
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+
+def test_targeted_refresh_rejects_tampered_base_generation(tmp_path: Path) -> None:
+    _seed_baseline(tmp_path)
+    path = freshness_receipt_path(tmp_path / "ssd")
+    receipt = load_freshness_receipt(path)
+    receipt.collections[0] = receipt.collections[0].__class__(
+        **{
+            **receipt.collections[0].__dict__,
+            "source_manifest_digest": "sha256:" + ("f" * 64),
+        }
+    )
+    write_freshness_receipt(receipt, path)
+
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_BASE_FRESHNESS_RECEIPT_INVALID",
+    ):
+        _targeted_session(tmp_path)
+
+
+@pytest.mark.parametrize("field", ("repo_root", "ssd_path"))
+def test_targeted_refresh_rejects_cross_store_base_receipt(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    _seed_baseline(tmp_path)
+    path = freshness_receipt_path(tmp_path / "ssd")
+    receipt = load_freshness_receipt(path)
+    receipt = replace(receipt, **{field: str(tmp_path / "different" / field)})
+    write_freshness_receipt(receipt, path)
+
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_BASE_FRESHNESS_RECEIPT_INVALID",
+    ):
+        _targeted_session(tmp_path)
 
 
 @pytest.mark.parametrize(

--- a/holo_index/tests/test_index_refresh_repair.py
+++ b/holo_index/tests/test_index_refresh_repair.py
@@ -82,11 +82,14 @@ class TestDocsArchitectureRouting:
 
     def test_docs_architecture_in_docs_paths(self):
         """docs/architecture/** should be indexed by index_docs_entries."""
+        from holo_index.canonical_source_manifest import _docs_source_files
         from holo_index.core.indexing_engine import index_docs_entries
         import inspect
-        source = inspect.getsource(index_docs_entries)
+        source = inspect.getsource(_docs_source_files)
+        index_source = inspect.getsource(index_docs_entries)
         # Verify docs path is included
         assert 'project_root / "docs"' in source or '"docs"' in source
+        assert "_docs_source_files(holo)" in index_source
 
     def test_docs_indexed_separately_from_wsp(self):
         """navigation_docs collection should be separate from navigation_wsp."""

--- a/holo_index/verified_collection_carry_forward.py
+++ b/holo_index/verified_collection_carry_forward.py
@@ -1,0 +1,236 @@
+"""Verified carry-forward evidence for targeted HoloIndex maintenance."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from holo_index.source_scope import canonical_source_scope_id
+
+
+SHA_PATTERN = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
+SHARED_POLICY_FILES = (
+    "holo_index/canonical_source_manifest.py",
+    "holo_index/freshness_receipt.py",
+    "holo_index/maintenance_session.py",
+    "holo_index/cli_index_plan.py",
+    "holo_index/verified_collection_carry_forward.py",
+)
+POLICY_ENVIRONMENT: dict[str, tuple[str, ...]] = {
+    "navigation_code": (
+        "HOLO_INDEX_WEB",
+        "HOLO_WEB_INDEX_ROOTS",
+        "HOLO_WEB_INDEX_EXTENSIONS",
+        "HOLO_WEB_INDEX_MAX_FILES",
+        "HOLO_WEB_INDEX_MAX_CHARS",
+    ),
+    "navigation_symbols": (
+        "HOLO_SYMBOL_ROOTS",
+        "HOLO_SYMBOL_MAX_FILES",
+        "HOLO_SYMBOL_MAX_ENTRIES",
+    ),
+}
+POLICY_FILES: dict[str, tuple[str, ...]] = {
+    "navigation_code": (
+        "holo_index/source_scope.py",
+        "holo_index/core/holo_index.py",
+        "holo_index/core/indexing_engine.py",
+    ),
+    "navigation_symbols": (
+        "holo_index/source_scope.py",
+        "holo_index/core/indexing_engine.py",
+        "holo_index/symbol_indexer.py",
+    ),
+    "navigation_tests": (
+        "holo_index/source_scope.py",
+        "holo_index/core/indexing_engine.py",
+        "holo_index/test_registry_indexer.py",
+    ),
+    "navigation_wsp": (
+        "holo_index/source_scope.py",
+        "holo_index/core/indexing_engine.py",
+    ),
+    "navigation_skills": (
+        "holo_index/source_scope.py",
+        "holo_index/core/indexing_engine.py",
+    ),
+    "navigation_docs": (
+        "holo_index/source_scope.py",
+        "holo_index/core/indexing_engine.py",
+    ),
+    "navigation_knowledge": (
+        "holo_index/source_scope.py",
+        "holo_index/core/indexing_engine.py",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class VerifiedCarryForward:
+    collection_name: str
+    source_policy_digest: str
+    current_source_manifest_digest: str
+    carried_from_repo_head_sha: str
+    carried_from_generation_id: str
+    evidence_digest: str
+
+
+def _digest(value: Any) -> str:
+    payload = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def carry_forward_evidence_digest(
+    *,
+    collection_name: str,
+    source_manifest_digest: str,
+    source_policy_digest: str,
+    carried_from_repo_head_sha: str,
+    carried_from_generation_id: str,
+    current_repo_head_sha: str,
+) -> str:
+    """Return the canonical v2 carry-forward evidence digest."""
+
+    return _digest(
+        {
+            "schema_version": "holoindex_carry_forward_evidence.v2",
+            "collection_name": collection_name,
+            "source_manifest_digest": source_manifest_digest,
+            "source_policy_digest": source_policy_digest,
+            "carried_from_repo_head_sha": carried_from_repo_head_sha,
+            "carried_from_generation_id": carried_from_generation_id,
+            "current_repo_head_sha": current_repo_head_sha,
+        }
+    )
+
+
+def collection_source_policy_digest(
+    repo_root: Path,
+    collection_name: str,
+) -> str:
+    """Bind source-discovery code and relevant environment to one collection."""
+
+    collection_paths = POLICY_FILES.get(collection_name)
+    if not collection_paths:
+        return ""
+    relative_paths = (*SHARED_POLICY_FILES, *collection_paths)
+    policy_root = repo_root
+    if not (policy_root / ".git").exists():
+        policy_root = Path(__file__).resolve().parents[1]
+    files: list[dict[str, str]] = []
+    for relative in relative_paths:
+        path = policy_root / relative
+        try:
+            content_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        except OSError:
+            return ""
+        files.append({"path": relative, "content_sha256": content_digest})
+    environment = {
+        name: os.environ.get(name, "")
+        for name in POLICY_ENVIRONMENT.get(collection_name, ())
+    }
+    return _digest(
+        {
+            "schema_version": "holoindex_source_policy.v1",
+            "collection_name": collection_name,
+            "files": files,
+            "environment": environment,
+        }
+    )
+
+
+def build_carry_forward_evidence(
+    *,
+    repo_root: Path,
+    base_receipt: Any,
+    collection_names: Sequence[str],
+    head_sha: str,
+    current_source_manifests: Mapping[str, Any],
+) -> Mapping[str, VerifiedCarryForward]:
+    """Prove exact source-manifest and policy stability for unrefreshed collections."""
+
+    if not collection_names:
+        return {}
+    if not SHA_PATTERN.fullmatch(head_sha):
+        raise ValueError("carry_forward_head_sha_invalid")
+    raw_entries = getattr(base_receipt, "collections", ())
+    entries = {str(entry.name): entry for entry in raw_entries}
+    generation_id = str(getattr(base_receipt, "generation_id", "") or "")
+    if not generation_id:
+        raise ValueError("carry_forward_base_generation_missing")
+    evidence: dict[str, VerifiedCarryForward] = {}
+    for name in sorted(set(collection_names)):
+        entry = entries.get(name)
+        if entry is None:
+            raise ValueError(f"carry_forward_entry_missing:{name}")
+        base_sha = str(getattr(entry, "repo_head_sha", "") or "")
+        if not SHA_PATTERN.fullmatch(base_sha):
+            raise ValueError(f"carry_forward_base_sha_invalid:{name}")
+        if base_sha != str(getattr(base_receipt, "repo_head_sha", "") or ""):
+            raise ValueError(f"carry_forward_base_lineage_mismatch:{name}")
+        expected_scope = canonical_source_scope_id(name)
+        allowed_proofs = {
+            "complete_source_manifest",
+            "verified_unchanged_source_manifest",
+        }
+        if (
+            str(getattr(entry, "status", "")) != "indexed"
+            or str(getattr(entry, "verification", "")) != "PASS"
+            or str(getattr(entry, "proof_kind", "")) not in allowed_proofs
+            or not str(getattr(entry, "source_manifest_digest", "") or "")
+            or not str(getattr(entry, "indexed_paths_digest", "") or "")
+            or not str(getattr(entry, "collection_snapshot_digest", "") or "")
+            or (expected_scope and getattr(entry, "source_scope_id", "") != expected_scope)
+        ):
+            raise ValueError(f"carry_forward_prior_proof_invalid:{name}")
+        current_policy = collection_source_policy_digest(repo_root, name)
+        if not current_policy or current_policy != str(
+            getattr(entry, "source_policy_digest", "") or ""
+        ):
+            raise ValueError(f"carry_forward_policy_changed:{name}")
+        current_manifest = current_source_manifests.get(name)
+        manifest_digest = str(getattr(current_manifest, "digest", "") or "")
+        manifest_scope = str(
+            getattr(current_manifest, "source_scope_id", "") or ""
+        )
+        if (
+            not manifest_digest
+            or manifest_digest != entry.source_manifest_digest
+            or manifest_scope != expected_scope
+        ):
+            raise ValueError(f"carry_forward_source_manifest_changed:{name}")
+        evidence_digest = carry_forward_evidence_digest(
+            collection_name=name,
+            source_manifest_digest=manifest_digest,
+            source_policy_digest=current_policy,
+            carried_from_repo_head_sha=base_sha,
+            carried_from_generation_id=generation_id,
+            current_repo_head_sha=head_sha,
+        )
+        evidence[name] = VerifiedCarryForward(
+            collection_name=name,
+            source_policy_digest=current_policy,
+            current_source_manifest_digest=manifest_digest,
+            carried_from_repo_head_sha=base_sha,
+            carried_from_generation_id=generation_id,
+            evidence_digest=evidence_digest,
+        )
+    return evidence
+
+
+__all__ = [
+    "VerifiedCarryForward",
+    "build_carry_forward_evidence",
+    "carry_forward_evidence_digest",
+    "collection_source_policy_digest",
+]


### PR DESCRIPTION
## Summary
- bind freshness receipt v2 to complete collection/source manifests and roots
- verify targeted carry-forward against exact canonical source manifests and immutable collection snapshots
- fail closed on stale/tampered base receipts, refresh proof mismatches, and final-write races

## WSP_97 evidence
- 128 focused tests passed
- Ruff clean for changed production and focused test surfaces
- Bandit: no new medium/high findings (2 pre-existing low findings in indexing_engine.py)
- independent adversarial re-review: GO
- git diff --check clean

## Truth boundary
These hashes provide trusted-local-host tamper evidence, not cryptographic authentication against a hostile same-user filesystem writer. The v2 schema requires a full migration refresh before owner status can return CURRENT.