### PR TITLE
fix(holoindex): stabilize final snapshot verification

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -19,6 +19,10 @@
 - Added a final full collection snapshot recheck before atomic publication to
   close the proof-assembly/write race. Obsolete v1 receipts require a complete
   baseline migration and cannot authorize a partial refresh.
+- Live migration validation found a cached sibling collection handle can lag
+  the persisted Chroma state after another collection commits. Freshness proof
+  now reopens every collection through the persistent client when available;
+  one observed persisted-state mismatch still fails closed.
 - Corrected changed-path ownership for overlapping sources, including Python
   tests in the symbol collection, module Skillz in docs, and the canonical WSP
   test registry.

--- a/holo_index/freshness_receipt.py
+++ b/holo_index/freshness_receipt.py
@@ -415,6 +415,18 @@ def _collection_handle(holo: Any, name: str, attr_name: str) -> Any:
         return None
 
 
+def _persisted_collection_handle(holo: Any, name: str, attr_name: str) -> Any:
+    """Reopen persisted state for verification without replacing write handles."""
+
+    client = getattr(holo, "client", None)
+    if client is not None:
+        try:
+            return client.get_collection(name)
+        except Exception:
+            return None
+    return getattr(holo, attr_name, None)
+
+
 def _unrefreshed_collection_entry(name: str, collection: Any) -> CollectionFreshness:
     return CollectionFreshness(
         name=name,
@@ -700,7 +712,7 @@ def collection_snapshot_matches_entry(
     attr_name = COLLECTION_ATTRS.get(name)
     if not attr_name:
         return False
-    collection = _collection_handle(holo, name, attr_name)
+    collection = _persisted_collection_handle(holo, name, attr_name)
     count = _safe_count(collection)
     manifest = _collection_snapshot_manifest(collection, name=name, count=count)
     return bool(

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -18,6 +18,7 @@ from holo_index.freshness_receipt import (
     build_maintenance_invalidation,
     collections_for_changed_paths,
     collections_for_path,
+    collection_snapshot_matches_entry,
     evaluate_freshness_for_paths,
     freshness_receipt_path,
     load_freshness_receipt,
@@ -143,6 +144,76 @@ def test_receipt_contains_all_expected_collections(tmp_path: Path) -> None:
         _assert_sha256_digest(entry.source_manifest_digest)
         _assert_sha256_digest(entry.indexed_paths_digest)
         _assert_sha256_digest(entry.removed_paths_digest)
+
+
+def test_snapshot_verification_uses_fresh_client_collection_handle(
+    tmp_path: Path,
+) -> None:
+    baseline_holo = _holo()
+    receipt = build_freshness_receipt(
+        baseline_holo,
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-19T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+    entry = next(
+        value for value in receipt.collections if value.name == "navigation_code"
+    )
+    stale = SnapshotCollection("navigation_code", 3)
+    stale.get = lambda include=None: {
+        **SnapshotCollection("navigation_code", 3).get(include=include),
+        "documents": ["stale", "stale", "stale"],
+    }
+    persisted = SnapshotCollection("navigation_code", 3)
+    candidate = _holo()
+    candidate.code_collection = stale
+    candidate.client = SimpleNamespace(
+        get_collection=lambda name: persisted if name == "navigation_code" else None
+    )
+
+    assert collection_snapshot_matches_entry(candidate, "navigation_code", entry)
+
+    candidate.client = SimpleNamespace(
+        get_collection=lambda _name: (_ for _ in ()).throw(RuntimeError("unavailable"))
+    )
+    assert not collection_snapshot_matches_entry(candidate, "navigation_code", entry)
+
+    persisted.get = lambda include=None: {
+        **SnapshotCollection("navigation_code", 3).get(include=include),
+        "documents": ["mutated", "mutated", "mutated"],
+    }
+    candidate.client = SimpleNamespace(get_collection=lambda _name: persisted)
+    assert not collection_snapshot_matches_entry(candidate, "navigation_code", entry)
+
+
+def test_receipt_construction_uses_indexer_write_handle(
+    tmp_path: Path,
+) -> None:
+    candidate = _holo()
+    client_calls = 0
+
+    def stale_persisted_handle(_name: str):
+        nonlocal client_calls
+        client_calls += 1
+        return SnapshotCollection("navigation_code", 2)
+
+    candidate.client = SimpleNamespace(get_collection=stale_persisted_handle)
+    receipt = build_freshness_receipt(
+        candidate,
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        generated_at="2026-07-19T00:00:00+00:00",
+        repo_head_sha="abc123",
+    )
+    code = next(
+        value for value in receipt.collections if value.name == "navigation_code"
+    )
+
+    assert code.count == 3
+    assert client_calls == 0
 
 
 def test_receipt_roundtrip_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- reopen every collection through the persistent Chroma client for freshness proof instead of trusting cached HoloIndex handles
- retain one-pass fail-closed final snapshot verification
- add regression proving stale cached handles cannot create false proof failures

## Observed live failure
A full v2 migration succeeded, but a targeted docs refresh saw a navigation_code mismatch through a cached sibling handle. Reopening the persisted collection reproduced the exact baseline digest.

## Validation
- 129 focused tests passed
- Ruff, Bandit, compileall, and diff check passed
- independent review rejected a retry design; the retry was removed
- live full + targeted refresh revalidation is required before promotion