### PR TITLE
fix(holoindex): isolate final persisted snapshot proof

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -21,8 +21,15 @@
   baseline migration and cannot authorize a partial refresh.
 - Live migration validation found a cached sibling collection handle can lag
   the persisted Chroma state after another collection commits. Freshness proof
-  now reopens every collection through the persistent client when available;
-  one observed persisted-state mismatch still fails closed.
+  now finalizes the writer system, rebuilds the candidate receipt from reopened
+  persisted collections without loading an encoder, finalizes that proof view,
+  and verifies it again in an isolated read-only Python process. The writer's
+  Chroma system cache cannot certify its own result; lifecycle failure, child
+  failure, timeout, malformed output, or one persisted-state mismatch remains
+  fail-closed. Verification lookups explicitly disable embedding functions, and
+  the proof view is finalized on receipt-build and repository-drift failures.
+  Isolated clients reopen the canonical `<ssd>/vectors` Chroma store rather
+  than the HoloIndex storage root.
 - Corrected changed-path ownership for overlapping sources, including Python
   tests in the symbol collection, module Skillz in docs, and the canonical WSP
   test registry.

--- a/holo_index/freshness_receipt.py
+++ b/holo_index/freshness_receipt.py
@@ -421,7 +421,7 @@ def _persisted_collection_handle(holo: Any, name: str, attr_name: str) -> Any:
     client = getattr(holo, "client", None)
     if client is not None:
         try:
-            return client.get_collection(name)
+            return client.get_collection(name, embedding_function=None)
         except Exception:
             return None
     return getattr(holo, attr_name, None)

--- a/holo_index/isolated_collection_snapshot_probe.py
+++ b/holo_index/isolated_collection_snapshot_probe.py
@@ -1,0 +1,286 @@
+"""Isolated persisted-state verification for HoloIndex maintenance receipts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess  # nosec B404  # Fixed interpreter/module, never a worker command.
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Callable, Mapping, Sequence
+
+from holo_index.freshness_receipt import (
+    BASELINE_QUERY_COLLECTIONS,
+    COLLECTION_ATTRS,
+    CollectionFreshness,
+    HoloIndexFreshnessReceipt,
+    collection_snapshot_matches_entry,
+    freshness_receipt_integrity_ok,
+)
+from holo_index.storage_contract import storage_path_identity
+
+
+SCHEMA_VERSION = "holoindex_isolated_snapshot_probe.v1"
+MAX_RECEIPT_BYTES = 2_000_000
+DEFAULT_TIMEOUT_SECONDS = 180.0
+
+
+class IsolatedSnapshotProbeError(RuntimeError):
+    """Stable fail-closed error raised by the parent maintenance process."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+
+@dataclass(frozen=True)
+class IsolatedSnapshotProbeResult:
+    """Secret-free persisted collection verification result."""
+
+    ok: bool
+    generation_id: str
+    mismatched_collections: tuple[str, ...]
+    error: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "ok": self.ok,
+            "generation_id": self.generation_id,
+            "mismatched_collections": list(self.mismatched_collections),
+            "error": self.error,
+        }
+
+
+def _receipt_from_mapping(value: Mapping[str, Any]) -> HoloIndexFreshnessReceipt:
+    collections = value.get("collections")
+    if not isinstance(collections, list):
+        raise ValueError("collections_required")
+    return HoloIndexFreshnessReceipt(
+        schema_version=str(value.get("schema_version") or ""),
+        generated_at=str(value.get("generated_at") or ""),
+        repo_root=str(value.get("repo_root") or ""),
+        repo_head_sha=str(value.get("repo_head_sha") or ""),
+        ssd_path=str(value.get("ssd_path") or ""),
+        source=str(value.get("source") or ""),
+        generation_id=str(value.get("generation_id") or ""),
+        base_generation_id=str(value.get("base_generation_id") or ""),
+        collections=[
+            CollectionFreshness(**entry)
+            for entry in collections
+            if isinstance(entry, Mapping)
+        ],
+    )
+
+
+def _default_client_factory(ssd_path: Path) -> Any:
+    os.environ.update(
+        {
+            "ANONYMIZED_TELEMETRY": "false",
+            "HOLOINDEX_QUERY_READONLY": "1",
+            "HOLO_OFFLINE": "1",
+            "HOLO_DISABLE_PIP_INSTALL": "1",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+    )
+    import chromadb
+
+    return chromadb.PersistentClient(path=str(ssd_path / "vectors"))
+
+
+def open_persisted_collection_view(
+    ssd_path: Path | str,
+    *,
+    client_factory: Callable[[Path], Any] | None = None,
+) -> Any:
+    """Open collection handles from persisted state without loading an encoder."""
+
+    ssd = Path(ssd_path).resolve(strict=False)
+    client = (client_factory or _default_client_factory)(ssd)
+    attributes: dict[str, Any] = {}
+    for name, attr_name in COLLECTION_ATTRS.items():
+        try:
+            attributes[attr_name] = client.get_collection(
+                name,
+                embedding_function=None,
+            )
+        except Exception:
+            attributes[attr_name] = None
+    metadata = getattr(attributes.get("code_collection"), "metadata", None)
+    embedding = metadata if isinstance(metadata, Mapping) else {}
+    return SimpleNamespace(
+        client=client,
+        **attributes,
+        index_embedding_backend=str(embedding.get("embedding_backend") or ""),
+        index_embedding_model_id=str(embedding.get("embedding_model") or ""),
+        index_embedding_space_fingerprint=str(
+            embedding.get("embedding_space_fingerprint") or ""
+        ),
+    )
+
+
+def probe_collection_snapshots(
+    receipt: HoloIndexFreshnessReceipt,
+    *,
+    ssd_path: Path | str,
+    client_factory: Callable[[Path], Any] | None = None,
+) -> IsolatedSnapshotProbeResult:
+    """Reopen the persisted store and verify every canonical collection once."""
+
+    ssd = Path(ssd_path).resolve(strict=False)
+    if not freshness_receipt_integrity_ok(receipt):
+        return IsolatedSnapshotProbeResult(
+            False, receipt.generation_id, (), "INVALID_RECEIPT_INTEGRITY"
+        )
+    if storage_path_identity(receipt.ssd_path) != storage_path_identity(ssd):
+        return IsolatedSnapshotProbeResult(
+            False, receipt.generation_id, (), "SSD_PATH_MISMATCH"
+        )
+    entries = {
+        entry.name: entry
+        for entry in receipt.collections
+        if entry.name in BASELINE_QUERY_COLLECTIONS
+    }
+    if set(entries) != set(BASELINE_QUERY_COLLECTIONS):
+        return IsolatedSnapshotProbeResult(
+            False, receipt.generation_id, (), "BASELINE_COLLECTIONS_INCOMPLETE"
+        )
+    try:
+        client = (client_factory or _default_client_factory)(ssd)
+        holo = SimpleNamespace(client=client)
+        mismatches = tuple(
+            name
+            for name in sorted(BASELINE_QUERY_COLLECTIONS)
+            if not collection_snapshot_matches_entry(holo, name, entries[name])
+        )
+    except Exception:
+        return IsolatedSnapshotProbeResult(
+            False, receipt.generation_id, (), "PERSISTED_STORE_UNAVAILABLE"
+        )
+    return IsolatedSnapshotProbeResult(
+        not mismatches,
+        receipt.generation_id,
+        mismatches,
+        "" if not mismatches else "COLLECTION_SNAPSHOT_MISMATCH",
+    )
+
+
+def _probe_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "ANONYMIZED_TELEMETRY": "false",
+            "HOLOINDEX_QUERY_READONLY": "1",
+            "HOLO_OFFLINE": "1",
+            "HOLO_DISABLE_PIP_INSTALL": "1",
+            "HF_HUB_OFFLINE": "1",
+            "TRANSFORMERS_OFFLINE": "1",
+        }
+    )
+    return environment
+
+
+def verify_collection_snapshots_isolated(
+    receipt: HoloIndexFreshnessReceipt,
+    *,
+    ssd_path: Path | str,
+    repo_root: Path | str,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[str]:
+    """Run the persisted proof in a fresh Python process or fail closed."""
+
+    command = [
+        sys.executable,
+        "-B",
+        "-m",
+        "holo_index.isolated_collection_snapshot_probe",
+        "--ssd",
+        str(Path(ssd_path).resolve(strict=False)),
+    ]
+    try:
+        completed = subprocess.run(  # nosec B603  # Fixed argv; shell is disabled.
+            command,
+            cwd=str(Path(repo_root).resolve(strict=False)),
+            env=_probe_environment(),
+            input=receipt.to_json(),
+            text=True,
+            encoding="utf-8",
+            errors="strict",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=float(timeout_seconds),
+            check=False,
+            shell=False,
+        )
+    except (OSError, subprocess.SubprocessError, ValueError):
+        raise IsolatedSnapshotProbeError("ISOLATED_PROBE_PROCESS_FAILED") from None
+    if completed.returncode != 0:
+        raise IsolatedSnapshotProbeError("ISOLATED_PROBE_PROCESS_FAILED")
+    try:
+        response = json.loads(completed.stdout)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        raise IsolatedSnapshotProbeError("ISOLATED_PROBE_RESPONSE_INVALID") from None
+    if not isinstance(response, Mapping):
+        raise IsolatedSnapshotProbeError("ISOLATED_PROBE_RESPONSE_INVALID")
+    mismatches = response.get("mismatched_collections")
+    valid_mismatches = bool(
+        isinstance(mismatches, list)
+        and all(
+            isinstance(name, str) and name in BASELINE_QUERY_COLLECTIONS
+            for name in mismatches
+        )
+        and len(mismatches) == len(set(mismatches))
+    )
+    if (
+        response.get("schema_version") != SCHEMA_VERSION
+        or response.get("generation_id") != receipt.generation_id
+        or not valid_mismatches
+    ):
+        raise IsolatedSnapshotProbeError("ISOLATED_PROBE_RESPONSE_INVALID")
+    if response.get("ok") is True and not mismatches and not response.get("error"):
+        return []
+    if response.get("error") == "COLLECTION_SNAPSHOT_MISMATCH" and mismatches:
+        return sorted(mismatches)
+    raise IsolatedSnapshotProbeError(
+        str(response.get("error") or "ISOLATED_PROBE_FAILED")
+    )
+
+
+def _read_receipt() -> HoloIndexFreshnessReceipt:
+    raw = sys.stdin.buffer.read(MAX_RECEIPT_BYTES + 1)
+    if len(raw) > MAX_RECEIPT_BYTES:
+        raise ValueError("receipt_too_large")
+    value = json.loads(raw.decode("utf-8", errors="strict"))
+    if not isinstance(value, Mapping):
+        raise ValueError("receipt_not_object")
+    return _receipt_from_mapping(value)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ssd", required=True)
+    args = parser.parse_args(argv)
+    try:
+        receipt = _read_receipt()
+        result = probe_collection_snapshots(receipt, ssd_path=args.ssd)
+    except Exception:
+        result = IsolatedSnapshotProbeResult(False, "", (), "INVALID_REQUEST")
+    sys.stdout.write(json.dumps(result.to_dict(), sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "IsolatedSnapshotProbeError",
+    "IsolatedSnapshotProbeResult",
+    "open_persisted_collection_view",
+    "probe_collection_snapshots",
+    "verify_collection_snapshots_isolated",
+]

--- a/holo_index/maintenance_session.py
+++ b/holo_index/maintenance_session.py
@@ -7,6 +7,7 @@ CLI/WRE maintenance owners. Query workers never import this writer API.
 from __future__ import annotations
 
 import atexit
+from contextlib import contextmanager
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +31,11 @@ from holo_index.maintenance_lock import (
     MaintenanceLockError,
     acquire_maintenance_lease,
     maintenance_lock_path,
+)
+from holo_index.isolated_collection_snapshot_probe import (
+    IsolatedSnapshotProbeError,
+    open_persisted_collection_view,
+    verify_collection_snapshots_isolated,
 )
 from holo_index.repository_state import read_repository_state
 from holo_index.source_scope import canonical_source_scope_id
@@ -326,22 +332,6 @@ def _verified_carry_forward_state(
         raise MaintenanceSessionError(
             "HOLOINDEX_CARRY_FORWARD_PROOF_FAILED", str(exc)
         ) from exc
-    if session.base_receipt is None:
-        return evidence
-    prior_entries = {
-        entry.name: entry for entry in session.base_receipt.collections
-    }
-    snapshot_failures = [
-        name
-        for name in carry_names
-        if name not in prior_entries
-        or not collection_snapshot_matches_entry(holo, name, prior_entries[name])
-    ]
-    if snapshot_failures:
-        raise MaintenanceSessionError(
-            "HOLOINDEX_CARRY_FORWARD_COLLECTION_MISMATCH",
-            f"collections={snapshot_failures}",
-        )
     return evidence
 
 
@@ -357,7 +347,7 @@ def _write_completed_receipt(
         ) from exc
 
 
-def _final_collection_snapshot_failures(
+def _in_process_collection_snapshot_failures(
     holo: Any,
     receipt: HoloIndexFreshnessReceipt,
 ) -> list[str]:
@@ -370,6 +360,72 @@ def _final_collection_snapshot_failures(
         and entry.verification == "PASS"
         and not collection_snapshot_matches_entry(holo, entry.name, entry)
     )
+
+
+def _requires_isolated_snapshot_probe(holo: Any) -> bool:
+    client = getattr(holo, "client", None)
+    return type(client).__module__.startswith("chromadb.")
+
+
+def _finalize_writer_store(holo: Any) -> None:
+    """Flush and stop the Chroma writer before isolated persisted proof."""
+
+    client = getattr(holo, "client", None)
+    system = getattr(client, "_system", None)
+    stop = getattr(system, "stop", None)
+    clear_cache = getattr(type(client), "clear_system_cache", None)
+    if not callable(stop) or not callable(clear_cache):
+        raise MaintenanceSessionError(
+            "HOLOINDEX_WRITER_STORE_FINALIZATION_FAILED",
+            "chroma_lifecycle_unavailable",
+        )
+    try:
+        stop()
+        clear_cache()
+    except Exception as exc:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_WRITER_STORE_FINALIZATION_FAILED",
+            type(exc).__name__,
+        ) from exc
+
+
+@contextmanager
+def _persisted_collection_proof_view(ssd_path: Path | str):
+    """Yield a fresh persisted view and always release its Chroma system."""
+
+    try:
+        proof_holo = open_persisted_collection_view(ssd_path)
+    except Exception as exc:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_PERSISTED_COLLECTION_VIEW_FAILED",
+            type(exc).__name__,
+        ) from exc
+    try:
+        yield proof_holo
+    finally:
+        _finalize_writer_store(proof_holo)
+
+
+def _final_collection_snapshot_failures(
+    session: Any,
+    holo: Any,
+    receipt: HoloIndexFreshnessReceipt,
+) -> list[str]:
+    """Verify persisted state outside Chroma's writer-process system cache."""
+
+    if not _requires_isolated_snapshot_probe(holo):
+        return _in_process_collection_snapshot_failures(holo, receipt)
+    try:
+        return verify_collection_snapshots_isolated(
+            receipt,
+            ssd_path=session.ssd_path,
+            repo_root=session.repo_root,
+        )
+    except IsolatedSnapshotProbeError as exc:
+        raise MaintenanceSessionError(
+            "HOLOINDEX_FINAL_COLLECTION_SNAPSHOT_PROBE_FAILED",
+            exc.code,
+        ) from exc
 
 
 @dataclass
@@ -470,29 +526,60 @@ class MaintenanceSession:
             holo,
             head_sha=head_sha,
         )
-        receipt = _build_completed_receipt(
-            self,
-            holo,
-            refreshed=refreshed,
-            source=source,
-            refresh_proofs=refresh_proofs,
-            source_manifests=source_manifests,
-            source_scopes=source_scopes,
-            source_policy_digests=source_policy_digests,
-            carry_forward_evidence=carry_forward_evidence,
-            head_sha=head_sha,
-        )
-        final_head = _clean_repository_head(
-            self.repo_root,
-            self._repository_state_reader,
-            require_head=False,
-        )
-        if final_head != self.starting_head_sha:
-            raise MaintenanceSessionError(
-                "HOLOINDEX_REPOSITORY_HEAD_CHANGED",
-                f"expected={self.starting_head_sha}; actual={final_head}",
+        if _requires_isolated_snapshot_probe(holo):
+            _finalize_writer_store(holo)
+            with _persisted_collection_proof_view(self.ssd_path) as proof_holo:
+                receipt = _build_completed_receipt(
+                    self,
+                    proof_holo,
+                    refreshed=refreshed,
+                    source=source,
+                    refresh_proofs=refresh_proofs,
+                    source_manifests=source_manifests,
+                    source_scopes=source_scopes,
+                    source_policy_digests=source_policy_digests,
+                    carry_forward_evidence=carry_forward_evidence,
+                    head_sha=head_sha,
+                )
+                final_head = _clean_repository_head(
+                    self.repo_root,
+                    self._repository_state_reader,
+                    require_head=False,
+                )
+                if final_head != self.starting_head_sha:
+                    raise MaintenanceSessionError(
+                        "HOLOINDEX_REPOSITORY_HEAD_CHANGED",
+                        f"expected={self.starting_head_sha}; actual={final_head}",
+                    )
+        else:
+            proof_holo = holo
+            receipt = _build_completed_receipt(
+                self,
+                proof_holo,
+                refreshed=refreshed,
+                source=source,
+                refresh_proofs=refresh_proofs,
+                source_manifests=source_manifests,
+                source_scopes=source_scopes,
+                source_policy_digests=source_policy_digests,
+                carry_forward_evidence=carry_forward_evidence,
+                head_sha=head_sha,
             )
-        snapshot_failures = _final_collection_snapshot_failures(holo, receipt)
+            final_head = _clean_repository_head(
+                self.repo_root,
+                self._repository_state_reader,
+                require_head=False,
+            )
+            if final_head != self.starting_head_sha:
+                raise MaintenanceSessionError(
+                    "HOLOINDEX_REPOSITORY_HEAD_CHANGED",
+                    f"expected={self.starting_head_sha}; actual={final_head}",
+                )
+        snapshot_failures = _final_collection_snapshot_failures(
+            self,
+            proof_holo,
+            receipt,
+        )
         if snapshot_failures:
             raise MaintenanceSessionError(
                 "HOLOINDEX_FINAL_COLLECTION_SNAPSHOT_MISMATCH",

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -169,11 +169,18 @@ def test_snapshot_verification_uses_fresh_client_collection_handle(
     persisted = SnapshotCollection("navigation_code", 3)
     candidate = _holo()
     candidate.code_collection = stale
+    lookups: list[tuple[str, object]] = []
+
+    def get_collection(name: str, *, embedding_function):
+        lookups.append((name, embedding_function))
+        return persisted if name == "navigation_code" else None
+
     candidate.client = SimpleNamespace(
-        get_collection=lambda name: persisted if name == "navigation_code" else None
+        get_collection=get_collection
     )
 
     assert collection_snapshot_matches_entry(candidate, "navigation_code", entry)
+    assert lookups == [("navigation_code", None)]
 
     candidate.client = SimpleNamespace(
         get_collection=lambda _name: (_ for _ in ()).throw(RuntimeError("unavailable"))

--- a/holo_index/tests/test_holoindex_maintenance_session.py
+++ b/holo_index/tests/test_holoindex_maintenance_session.py
@@ -73,6 +73,26 @@ def _holo() -> SimpleNamespace:
     )
 
 
+def _attach_chroma_client(
+    holo: SimpleNamespace,
+    lifecycle: list[str],
+    label: str,
+) -> None:
+    class ChromaClient:
+        __module__ = "chromadb.api.client"
+
+        def __init__(self) -> None:
+            self._system = SimpleNamespace(
+                stop=lambda: lifecycle.append(f"{label}_stopped")
+            )
+
+        @staticmethod
+        def clear_system_cache() -> None:
+            lifecycle.append(f"{label}_cache_cleared")
+
+    holo.client = ChromaClient()
+
+
 def _clean_state(head: str = "abc123") -> SimpleNamespace:
     return SimpleNamespace(proven_clean=True, head_sha=head, error="")
 
@@ -402,7 +422,7 @@ def test_targeted_refresh_rejects_collection_snapshot_mutation(tmp_path: Path) -
     holo.wsp_collection._count = 3
     with pytest.raises(
         MaintenanceSessionError,
-        match="HOLOINDEX_CARRY_FORWARD_COLLECTION_MISMATCH",
+        match="HOLOINDEX_FINAL_COLLECTION_SNAPSHOT_MISMATCH",
     ):
         session.complete(
             holo,
@@ -437,7 +457,7 @@ def test_targeted_refresh_rejects_collection_content_mutation(
     holo.wsp_collection.get = mutated_snapshot
     with pytest.raises(
         MaintenanceSessionError,
-        match="HOLOINDEX_CARRY_FORWARD_COLLECTION_MISMATCH",
+        match="HOLOINDEX_FINAL_COLLECTION_SNAPSHOT_MISMATCH",
     ):
         session.complete(
             holo,
@@ -485,6 +505,158 @@ def test_final_snapshot_recheck_blocks_post_proof_mutation(tmp_path: Path) -> No
         entry for entry in invalidation.collections if entry.name == "navigation_code"
     )
     assert code.verification == "IN_PROGRESS"
+
+
+def test_real_client_routes_final_snapshot_check_to_isolated_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections={"navigation_code"},
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+    holo = _holo()
+    calls = []
+    lifecycle = []
+
+    class ChromaClient:
+        __module__ = "chromadb.api.client"
+
+        def __init__(self) -> None:
+            self._system = SimpleNamespace(
+                stop=lambda: lifecycle.append("writer_stopped")
+            )
+
+        @staticmethod
+        def clear_system_cache() -> None:
+            lifecycle.append("cache_cleared")
+
+    holo.client = ChromaClient()
+    monkeypatch.setattr(
+        maintenance_module,
+        "open_persisted_collection_view",
+        lambda _ssd: lifecycle.append("persisted_view_opened") or holo,
+    )
+    monkeypatch.setattr(
+        maintenance_module,
+        "verify_collection_snapshots_isolated",
+        lambda receipt, **kwargs: (
+            lifecycle.append("isolated_probe"),
+            calls.append((receipt, kwargs)),
+            [],
+        )[-1],
+    )
+
+    receipt = session.complete(
+        holo,
+        refreshed_collections={"navigation_code"},
+        source="targeted",
+        refresh_proofs=_proofs("navigation_code"),
+    )
+    session.close()
+
+    assert receipt.source == "targeted"
+    assert len(calls) == 1
+    assert lifecycle == [
+        "writer_stopped",
+        "cache_cleared",
+        "persisted_view_opened",
+        "writer_stopped",
+        "cache_cleared",
+        "isolated_probe",
+    ]
+    assert calls[0][1]["ssd_path"] == tmp_path / "ssd"
+    assert calls[0][1]["repo_root"] == tmp_path / "repo"
+
+
+def test_persisted_proof_view_finalizes_when_receipt_build_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections={"navigation_code"},
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+    lifecycle: list[str] = []
+    writer = _holo()
+    proof = _holo()
+    _attach_chroma_client(writer, lifecycle, "writer")
+    _attach_chroma_client(proof, lifecycle, "proof")
+    monkeypatch.setattr(
+        maintenance_module,
+        "open_persisted_collection_view",
+        lambda _ssd: lifecycle.append("persisted_view_opened") or proof,
+    )
+    monkeypatch.setattr(
+        maintenance_module,
+        "_build_completed_receipt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("build failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="build failed"):
+        session.complete(
+            writer,
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+    assert lifecycle == [
+        "writer_stopped",
+        "writer_cache_cleared",
+        "persisted_view_opened",
+        "proof_stopped",
+        "proof_cache_cleared",
+    ]
+
+
+def test_persisted_proof_view_finalizes_when_repository_head_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MaintenanceSession.begin(
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        planned_collections={"navigation_code"},
+        repository_state_reader=lambda _root: _clean_state(HEAD_SHA),
+    )
+    states = iter((HEAD_SHA, "c" * 40))
+    session._repository_state_reader = lambda _root: _clean_state(next(states))
+    lifecycle: list[str] = []
+    writer = _holo()
+    proof = _holo()
+    _attach_chroma_client(writer, lifecycle, "writer")
+    _attach_chroma_client(proof, lifecycle, "proof")
+    monkeypatch.setattr(
+        maintenance_module,
+        "open_persisted_collection_view",
+        lambda _ssd: lifecycle.append("persisted_view_opened") or proof,
+    )
+
+    with pytest.raises(
+        MaintenanceSessionError,
+        match="HOLOINDEX_REPOSITORY_HEAD_CHANGED",
+    ):
+        session.complete(
+            writer,
+            refreshed_collections={"navigation_code"},
+            source="targeted",
+            refresh_proofs=_proofs("navigation_code"),
+        )
+    session.close()
+
+    assert lifecycle == [
+        "writer_stopped",
+        "writer_cache_cleared",
+        "persisted_view_opened",
+        "proof_stopped",
+        "proof_cache_cleared",
+    ]
 
 
 def test_serialized_carry_forward_tampering_fails_query_admission(

--- a/holo_index/tests/test_isolated_collection_snapshot_probe.py
+++ b/holo_index/tests/test_isolated_collection_snapshot_probe.py
@@ -1,0 +1,310 @@
+"""Tests for isolated persisted-state collection snapshot verification."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import holo_index.isolated_collection_snapshot_probe as probe_module
+from holo_index.freshness_receipt import (
+    ALL_COLLECTIONS,
+    BASELINE_QUERY_COLLECTIONS,
+    build_freshness_receipt,
+)
+from holo_index.isolated_collection_snapshot_probe import (
+    IsolatedSnapshotProbeError,
+    open_persisted_collection_view,
+    probe_collection_snapshots,
+    verify_collection_snapshots_isolated,
+)
+
+
+FINGERPRINT = "sha256:" + ("1" * 64)
+
+
+class _Collection:
+    def __init__(self, name: str, count: int = 2) -> None:
+        self.name = name
+        self._count = count
+        self.metadata = {
+            "embedding_backend": "test-embedding",
+            "embedding_model": "test-model",
+            "embedding_space_fingerprint": FINGERPRINT,
+        }
+
+    def count(self) -> int:
+        return self._count
+
+    def get(self, include=None):
+        return {
+            "ids": [f"{self.name}:{index}" for index in range(self._count)],
+            "documents": [
+                f"document:{self.name}:{index}" for index in range(self._count)
+            ],
+            "metadatas": [
+                {"path": f"{self.name}/item_{index}.txt"}
+                for index in range(self._count)
+            ],
+            "embeddings": [[float(index)] for index in range(self._count)],
+        }
+
+
+def test_default_client_uses_canonical_vector_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened: list[str] = []
+    client = SimpleNamespace()
+    monkeypatch.setitem(
+        sys.modules,
+        "chromadb",
+        SimpleNamespace(
+            PersistentClient=lambda *, path: opened.append(path) or client
+        ),
+    )
+
+    result = probe_module._default_client_factory(tmp_path / "ssd")
+
+    assert result is client
+    assert opened == [str(tmp_path / "ssd" / "vectors")]
+
+
+def _fixture(tmp_path: Path):
+    attr_map = {
+        "navigation_code": "code_collection",
+        "navigation_wsp": "wsp_collection",
+        "navigation_tests": "test_collection",
+        "navigation_skills": "skill_collection",
+        "navigation_symbols": "symbol_collection",
+        "navigation_docs": "docs_collection",
+        "navigation_knowledge": "knowledge_collection",
+        "navigation_work_ledger": "work_ledger_collection",
+        "navigation_vocabulary": "vocabulary_collection",
+    }
+    collections = {name: _Collection(name) for name in ALL_COLLECTIONS}
+    holo = SimpleNamespace(
+        **{attr: collections[name] for name, attr in attr_map.items()},
+        index_embedding_backend="test-embedding",
+        index_embedding_model_id="test-model",
+        index_embedding_space_fingerprint=FINGERPRINT,
+    )
+    receipt = build_freshness_receipt(
+        holo,
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+        source="manual_index",
+        generated_at="2026-07-19T00:00:00+00:00",
+        repo_head_sha="a" * 40,
+    )
+    client = SimpleNamespace(
+        get_collection=lambda name, **_kwargs: collections[name]
+    )
+    return receipt, collections, client
+
+
+def test_isolated_probe_accepts_exact_persisted_collections(tmp_path: Path) -> None:
+    receipt, collections, _client = _fixture(tmp_path)
+    calls: list[tuple[str, object]] = []
+
+    def get_collection(name: str, *, embedding_function):
+        calls.append((name, embedding_function))
+        return collections[name]
+
+    client = SimpleNamespace(get_collection=get_collection)
+
+    result = probe_collection_snapshots(
+        receipt,
+        ssd_path=tmp_path / "ssd",
+        client_factory=lambda _path: client,
+    )
+
+    assert result.ok is True
+    assert result.mismatched_collections == ()
+    assert calls
+    assert all(embedding_function is None for _name, embedding_function in calls)
+
+
+def test_isolated_probe_rejects_one_persisted_mismatch(tmp_path: Path) -> None:
+    receipt, collections, client = _fixture(tmp_path)
+    collections["navigation_skills"].get = lambda include=None: {
+        "ids": ["navigation_skills:0", "navigation_skills:1"],
+        "documents": ["mutated", "mutated"],
+        "metadatas": [{"path": "a"}, {"path": "b"}],
+        "embeddings": [[0.0], [1.0]],
+    }
+
+    result = probe_collection_snapshots(
+        receipt,
+        ssd_path=tmp_path / "ssd",
+        client_factory=lambda _path: client,
+    )
+
+    assert result.ok is False
+    assert result.mismatched_collections == ("navigation_skills",)
+    assert result.error == "COLLECTION_SNAPSHOT_MISMATCH"
+
+
+def test_isolated_probe_rejects_tampered_receipt(tmp_path: Path) -> None:
+    receipt, _collections, client = _fixture(tmp_path)
+    tampered = replace(receipt, repo_head_sha="b" * 40)
+
+    result = probe_collection_snapshots(
+        tampered,
+        ssd_path=tmp_path / "ssd",
+        client_factory=lambda _path: client,
+    )
+
+    assert result.ok is False
+    assert result.error == "INVALID_RECEIPT_INTEGRITY"
+
+
+def test_isolated_probe_requires_all_baseline_collections(tmp_path: Path) -> None:
+    receipt, _collections, client = _fixture(tmp_path)
+    incomplete = replace(
+        receipt,
+        collections=[
+            entry
+            for entry in receipt.collections
+            if entry.name not in BASELINE_QUERY_COLLECTIONS
+            or entry.name != "navigation_code"
+        ],
+    )
+
+    result = probe_collection_snapshots(
+        incomplete,
+        ssd_path=tmp_path / "ssd",
+        client_factory=lambda _path: client,
+    )
+
+    assert result.ok is False
+    assert result.error == "INVALID_RECEIPT_INTEGRITY"
+
+
+def test_persisted_view_reopens_all_collections_without_encoder(tmp_path: Path) -> None:
+    _receipt, collections, _client = _fixture(tmp_path)
+    calls: list[tuple[str, object]] = []
+
+    def get_collection(name: str, *, embedding_function):
+        calls.append((name, embedding_function))
+        return collections[name]
+
+    client = SimpleNamespace(get_collection=get_collection)
+
+    view = open_persisted_collection_view(
+        tmp_path / "ssd",
+        client_factory=lambda _path: client,
+    )
+
+    assert view.client is client
+    assert view.code_collection is collections["navigation_code"]
+    assert view.wsp_collection is collections["navigation_wsp"]
+    assert view.skill_collection is collections["navigation_skills"]
+    assert view.index_embedding_backend == "test-embedding"
+    assert view.index_embedding_model_id == "test-model"
+    assert view.index_embedding_space_fingerprint == FINGERPRINT
+    assert calls
+    assert all(embedding_function is None for _name, embedding_function in calls)
+
+
+def test_persisted_view_marks_unavailable_collection_missing(tmp_path: Path) -> None:
+    _receipt, collections, _client = _fixture(tmp_path)
+
+    def get_collection(name: str, *, embedding_function):
+        assert embedding_function is None
+        if name == "navigation_docs":
+            raise RuntimeError("missing")
+        return collections[name]
+
+    view = open_persisted_collection_view(
+        tmp_path / "ssd",
+        client_factory=lambda _path: SimpleNamespace(get_collection=get_collection),
+    )
+
+    assert view.docs_collection is None
+    assert view.code_collection is collections["navigation_code"]
+
+
+def test_parent_accepts_generation_bound_isolated_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    receipt, _collections, _client = _fixture(tmp_path)
+    response = {
+        "schema_version": "holoindex_isolated_snapshot_probe.v1",
+        "ok": True,
+        "generation_id": receipt.generation_id,
+        "mismatched_collections": [],
+        "error": "",
+    }
+    monkeypatch.setattr(
+        "holo_index.isolated_collection_snapshot_probe.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(response),
+            stderr="",
+        ),
+    )
+
+    failures = verify_collection_snapshots_isolated(
+        receipt,
+        ssd_path=tmp_path / "ssd",
+        repo_root=tmp_path / "repo",
+    )
+
+    assert failures == []
+
+
+@pytest.mark.parametrize(
+    "response",
+    (
+        "not-json",
+        json.dumps(
+            {
+                "schema_version": "holoindex_isolated_snapshot_probe.v1",
+                "ok": True,
+                "generation_id": "wrong-generation",
+                "mismatched_collections": [],
+                "error": "",
+            }
+        ),
+        json.dumps(
+            {
+                "schema_version": "holoindex_isolated_snapshot_probe.v1",
+                "ok": True,
+                "generation_id": "GENERATION_PLACEHOLDER",
+                "mismatched_collections": ["untrusted_collection"],
+                "error": "",
+            }
+        ),
+    ),
+)
+def test_parent_rejects_malformed_or_unbound_probe_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    response: str,
+) -> None:
+    receipt, _collections, _client = _fixture(tmp_path)
+    rendered = response.replace("GENERATION_PLACEHOLDER", receipt.generation_id)
+    monkeypatch.setattr(
+        "holo_index.isolated_collection_snapshot_probe.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=rendered,
+            stderr="",
+        ),
+    )
+
+    with pytest.raises(
+        IsolatedSnapshotProbeError,
+        match="ISOLATED_PROBE_RESPONSE_INVALID",
+    ):
+        verify_collection_snapshots_isolated(
+            receipt,
+            ssd_path=tmp_path / "ssd",
+            repo_root=tmp_path / "repo",
+        )


### PR DESCRIPTION
## Summary
- verify the candidate v2 receipt in a separate read-only Python process
- reopen all seven Chroma collections outside the writer process cache
- fail closed on timeout, child failure, malformed response, receipt mismatch, or any collection mismatch

## Observed runtime evidence
Same-process Chroma reads disagreed transiently after targeted collection commits while a fresh process reproduced the stable persisted digest. A retry/last-read-wins design was rejected by independent review.

## Validation
- 135 focused tests passed
- Ruff, Bandit, compileall, diff check passed
- live full + targeted refresh required before promotion