### PR TITLE
test(reddog): migrate HoloIndex runtime fixtures to v2

### DIFF
--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,11 @@
+## 2026-07-19: REDDOG_HOLOINDEX_V2_RUNTIME_FIXTURE_MIGRATION_PHASE1
+
+- Replaced stale positive HoloIndex v1 receipt fixtures with one canonical v2 helper that builds complete source-manifest, scope, policy, and collection-snapshot proofs.
+- Migrated operational snapshots, FoundUp Brain, Memex supply, OpenClaw audit planning/enqueue, backend architect determination, readonly bootstrap, end-to-end audit decisions, and the durable resident cycle.
+- Preserved the intentional v1 query-boundary compatibility adversary.
+- Validation: 150 focused runtime tests passed; the full bridge suite reached
+  3,749 passed / 8 skipped with 39 unrelated baseline/environment failures.
+
 ## 2026-07-19: REDDOG_TRANSPORT_NEUTRAL_GROUNDING_SERVICE_PHASE1
 
 - Added target-classification, receipt self-validation, current/stale generation, semantic support/corroboration, quoted-data isolation, and repo-path safety tests.

--- a/modules/communication/moltbot_bridge/tests/holoindex_freshness_receipt_test_helpers.py
+++ b/modules/communication/moltbot_bridge/tests/holoindex_freshness_receipt_test_helpers.py
@@ -1,0 +1,83 @@
+"""Canonical HoloIndex v2 freshness receipts for RedDog runtime tests."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+from holo_index.freshness_receipt import (
+    ALL_COLLECTIONS,
+    COLLECTION_ATTRS,
+    HoloIndexFreshnessReceipt,
+    build_freshness_receipt,
+)
+from holo_index.source_scope import canonical_source_scope_id
+from holo_index.verified_collection_carry_forward import (
+    collection_source_policy_digest,
+)
+
+
+class _FreshCollection:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.metadata: dict[str, str] = {}
+
+    def count(self) -> int:
+        return 1
+
+    def get(self, include=None):
+        return {
+            "ids": [f"{self.name}:fixture"],
+            "documents": [f"fresh fixture for {self.name}"],
+            "metadatas": [{"path": f"fixtures/{self.name}.json"}],
+            "embeddings": [[1.0]],
+        }
+
+
+def _fixture_digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("ascii")).hexdigest()
+
+
+def build_fresh_holoindex_receipt(
+    *,
+    repo_root: Path,
+    head_sha: str,
+    generated_at: str,
+    ssd_path: Path | str = "E:/HoloIndex",
+) -> HoloIndexFreshnessReceipt:
+    """Build the same complete source-proof shape required by runtime."""
+
+    collections = {name: _FreshCollection(name) for name in ALL_COLLECTIONS}
+    holo = SimpleNamespace(
+        **{
+            attr_name: collections[name]
+            for name, attr_name in COLLECTION_ATTRS.items()
+        },
+        index_embedding_backend="",
+        index_embedding_model_id="",
+        index_embedding_space_fingerprint="",
+    )
+    return build_freshness_receipt(
+        holo,
+        generated_at=generated_at,
+        repo_root=repo_root,
+        repo_head_sha=head_sha,
+        source="ci_targeted_reindex",
+        ssd_path=ssd_path,
+        refreshed_collections=ALL_COLLECTIONS,
+        refresh_source_manifests={
+            name: _fixture_digest(f"source:{name}") for name in ALL_COLLECTIONS
+        },
+        refresh_source_scopes={
+            name: canonical_source_scope_id(name) for name in ALL_COLLECTIONS
+        },
+        refresh_source_policy_digests={
+            name: collection_source_policy_digest(repo_root, name)
+            or _fixture_digest(f"policy:{name}")
+            for name in ALL_COLLECTIONS
+        },
+    )
+
+
+__all__ = ["build_fresh_holoindex_receipt"]

--- a/modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py
+++ b/modules/communication/moltbot_bridge/tests/test_foundup_brain_current_state.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.foundup_brain_current_state import (
     FOUNDUP_BRAIN_VIEW_ACCEPTED,
     FOUNDUP_BRAIN_VIEW_REJECTED,
@@ -13,6 +12,9 @@ from modules.communication.moltbot_bridge.src.foundup_brain_current_state import
 )
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     build_operational_context_snapshot,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -33,59 +35,10 @@ FOUNDUP_ID = "foundups-agent"
 
 
 def _snapshot(*, brain_available: bool = True, worker_claims=None, queue_items=None):
-    holo_receipt = HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    holo_receipt = build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id=(
-            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        ),
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=3,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest=(
-                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                ),
-                indexed_paths_digest=(
-                    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-                ),
-                removed_paths_digest=(
-                    "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-                ),
-                embedding_backend="test-embedding",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest=(
-                    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                ),
-                indexed_paths_digest=(
-                    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                ),
-                removed_paths_digest=(
-                    "sha256:9999999999999999999999999999999999999999999999999999999999999999"
-                ),
-                embedding_backend="test-embedding",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
     result = build_operational_context_snapshot(
         repo_state={

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -7,7 +7,7 @@ import json
 from pathlib import Path
 from typing import Any, Mapping
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
     ACTION_FIX,
     ACTION_RESEARCH_MORE,
@@ -26,7 +26,6 @@ from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_ass
 )
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_runtime import (
     DEFAULT_AUDIT_LANES,
-    READONLY_AUDIT_REPORTS_ACCEPTED,
     validate_reddog_openclaw_readonly_audit_reports,
     plan_reddog_openclaw_readonly_audit_swarm,
 )
@@ -46,6 +45,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed
 )
 from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
     model_runtime_binding_receipt,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 
@@ -125,41 +127,10 @@ def _work_state() -> dict[str, object]:
 
 
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=9,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_context_snapshot_fusion_assignment_gate.py
@@ -6,7 +6,6 @@ import ast
 from dataclasses import replace
 from pathlib import Path
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
     FUSION_ASSIGNMENT_GATE_PASSED,
     FUSION_ASSIGNMENT_GATE_REJECTED,
@@ -15,6 +14,9 @@ from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_ass
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     build_evidence_bundle,
     build_operational_context_snapshot,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 
@@ -33,41 +35,10 @@ REVISION = "sha256:work-state-revision"
 
 
 def _fresh_holo_receipt():
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=2,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=3,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 
 import pytest
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
     DEFAULT_BOOTSTRAP_CHANGED_PATHS,
     REDDOG_MAIN_BOOTSTRAP_NOT_READY,
@@ -48,6 +48,9 @@ from modules.communication.moltbot_bridge.src.reddog_backend_architect_determina
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
     _model_selection,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 from modules.infrastructure.foundups_mcp_bridge.src import (
     reddog_holoindex_owner_bootstrap as owner_bootstrap,
@@ -103,41 +106,10 @@ def _work_state() -> dict[str, object]:
 
 
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=9,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 
@@ -668,7 +640,7 @@ def test_bootstrap_memex_supply_enriches_enqueued_readonly_audit_tasks() -> None
     assert task_context["memex_view"]["snapshot_id"] == result.snapshot_receipt_id
     assert assignment["principal_id"] == "principal-012"
     assert assignment["work_order_id"] == assignment["assignment_id"]
-    assert assignment["memex_holoindex_generation_id"] == "sha256:holo-generation"
+    assert assignment["memex_holoindex_generation_id"] == _fresh_holo_receipt().generation_id
     assert assignment["memex_policy_expires_at"]
     assert task_context["memex_snapshot_supply_receipt"]["no_holoindex_reindex_performed"] is True
 
@@ -714,31 +686,10 @@ def test_bootstrap_not_ready_without_authoritative_work_state_or_holoindex_recei
 
 
 def test_bootstrap_rejects_stale_holoindex_receipt() -> None:
-    stale = HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    stale = build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha="old-head",
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha="old-head",
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha="old-head",
-                last_indexed_at=NOW,
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                count=9,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha="old-head",
-                last_indexed_at=NOW,
-            ),
-        ],
     )
 
     result = run_reddog_main_readonly_operational_bootstrap(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
     evaluate_context_snapshot_fusion_assignment_gate,
 )
@@ -37,6 +37,9 @@ from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt im
 from modules.communication.moltbot_bridge.tests.test_reddog_openclaw_readonly_audit_swarm_runtime import (
     GROUNDING_FOCUS,
     _grounding_receipt,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
@@ -81,41 +84,10 @@ class _FakeWriter:
 
 
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=2,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=8,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -6,7 +6,7 @@ import ast
 from dataclasses import replace
 from pathlib import Path
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_assignment_gate import (
     evaluate_context_snapshot_fusion_assignment_gate,
 )
@@ -30,6 +30,9 @@ from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt im
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     build_evidence_bundle,
     build_operational_context_snapshot,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 
@@ -100,41 +103,10 @@ def _grounding_receipt() -> dict[str, object]:
 
 
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=2,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=8,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_context_snapshot.py
@@ -6,7 +6,6 @@ import ast
 import json
 from pathlib import Path
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     ASSIGNMENT_CONTEXT_STALE,
     ASSIGNMENT_CONTEXT_VALID,
@@ -24,6 +23,9 @@ from modules.communication.moltbot_bridge.src.reddog_operational_context_snapsho
     load_authoritative_work_state,
     observe_repo_state,
     validate_context_before_assignment,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 
@@ -75,59 +77,10 @@ def _work_state(revision: str = REVISION):
 
 
 def _fresh_holo_receipt(head: str = HEAD):
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=head,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=head,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id=(
-            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        ),
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=3,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=head,
-                last_indexed_at=NOW,
-                source_manifest_digest=(
-                    "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-                ),
-                indexed_paths_digest=(
-                    "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
-                ),
-                removed_paths_digest=(
-                    "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-                ),
-                embedding_backend="test-embedding",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=head,
-                last_indexed_at=NOW,
-                source_manifest_digest=(
-                    "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-                ),
-                indexed_paths_digest=(
-                    "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-                ),
-                removed_paths_digest=(
-                    "sha256:9999999999999999999999999999999999999999999999999999999999999999"
-                ),
-                embedding_backend="test-embedding",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_snapshot_supplier.py
@@ -6,7 +6,7 @@ import ast
 from dataclasses import replace
 from pathlib import Path
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
     ReadOnlyAuditSwarmEnqueueReceipt,
     ReadOnlyAuditTaskSpec,
@@ -19,6 +19,9 @@ from modules.communication.moltbot_bridge.src.reddog_operational_memex_snapshot_
     OPERATIONAL_MEMEX_SUPPLY_REJECT,
     OperationalMemexReadOnlyAuditTaskWriter,
     enrich_readonly_audit_tasks_with_operational_memex,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 
@@ -35,45 +38,11 @@ NOW = "2026-07-16T00:00:00+00:00"
 HEAD = "06d823f52"
 REVISION = "sha256:work-state-memex"
 FOUNDUP_ID = "foundups_agent"
-GENERATION_ID = "sha256:holo-generation-memex"
-
-
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id=GENERATION_ID,
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=9,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 
@@ -206,7 +175,7 @@ def test_enriches_task_with_snapshot_bound_memex_view_and_worker_bindings() -> N
     assert assignment["work_order_id"] == "assignment-1"
     assert assignment["memex_source_scope"] == f"foundup:{FOUNDUP_ID}:lane:repo_code_audit"
     assert assignment["memex_source_revision"] == REVISION
-    assert assignment["memex_holoindex_generation_id"] == GENERATION_ID
+    assert assignment["memex_holoindex_generation_id"] == _fresh_holo_receipt().generation_id
     assert enriched["memex_snapshot_supply_receipt"]["no_holoindex_reindex_performed"] is True
     assert result.supply_receipt is not None
     assert result.supply_receipt["schema_version"] == "reddog_operational_memex_snapshot_supply_receipt.v1"

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from holo_index.repository_state import RepositoryState
 from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
     ARCHITECT_DETERMINATION_ACCEPT,
@@ -17,9 +17,6 @@ from modules.communication.moltbot_bridge.src.reddog_backend_architect_determina
 )
 from modules.communication.moltbot_bridge.src.reddog_main_readonly_operational_bootstrap import (
     DEFAULT_BOOTSTRAP_READ_TARGETS,
-)
-from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
-    READONLY_AUDIT_TASK_SOURCE,
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
     RepoAuditModelResult,
@@ -31,7 +28,6 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_per
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_research_decision_e2e_runtime import (
     READONLY_AUDIT_RESEARCH_DECISION_E2E_ACCEPT,
     READONLY_AUDIT_RESEARCH_DECISION_E2E_REJECT,
-    DirectReadOnlyAuditTaskExecutor,
     ReadOnlyAuditResearchDecisionE2EReason,
     run_reddog_readonly_audit_research_decision_e2e,
 )
@@ -42,6 +38,9 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executo
     READONLY_AUDIT_TASK_REPORT_REJECT,
     ReadOnlyAuditTaskExecutionResult,
     ReadOnlyAuditTaskRejectReason,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 
 
@@ -98,41 +97,10 @@ def _work_state() -> dict[str, object]:
 
 
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation-e2e",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=9,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
     )
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -8,10 +8,9 @@ from pathlib import Path
 
 import pytest
 
-from holo_index.freshness_receipt import CollectionFreshness, HoloIndexFreshnessReceipt
+from holo_index.freshness_receipt import HoloIndexFreshnessReceipt
 from holo_index.repository_state import RepositoryState
 from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
-    ARCHITECT_DETERMINATION_ACCEPT,
     ArchitectModelResult,
     InMemoryArchitectDeterminationStore,
 )
@@ -28,13 +27,14 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_
 import modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime as readonly_worker_runtime
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
     REDDOG_RESIDENT_CYCLE_ACCEPT,
-    REDDOG_RESIDENT_CYCLE_REJECT,
     STATUS_DETERMINED,
     STATUS_TIMED_OUT,
-    AgentDbResidentArchitectCycleStore,
     NoopExternalResearchRetriever,
     ResidentCycleReason,
     run_reddog_resident_architect_durable_agentdb_cycle,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
 )
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
@@ -167,41 +167,10 @@ def _foundup_work_state() -> dict[str, object]:
 
 
 def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
+    return build_fresh_holoindex_receipt(
         generated_at=NOW,
-        repo_root=str(REPO_ROOT),
-        repo_head_sha=HEAD,
-        ssd_path="E:/HoloIndex",
-        source="ci_targeted_reindex",
-        generation_id="sha256:holo-generation-resident",
-        collections=[
-            CollectionFreshness(
-                name="navigation_work_ledger",
-                count=4,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:work-ledger-manifest",
-                indexed_paths_digest="sha256:work-ledger-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-            CollectionFreshness(
-                name="navigation_symbols",
-                source_scope_id="holoindex.navigation_symbols.tracked-modules-scripts-holo.v1",
-                count=9,
-                status="indexed",
-                source="ci_targeted_reindex",
-                repo_head_sha=HEAD,
-                last_indexed_at=NOW,
-                source_manifest_digest="sha256:symbols-manifest",
-                indexed_paths_digest="sha256:symbols-paths",
-                verification="PASS",
-                proof_kind="complete_source_manifest",
-            ),
-        ],
+        repo_root=REPO_ROOT,
+        head_sha=HEAD,
     )
 
 
@@ -394,7 +363,11 @@ def test_durable_cycle_supplies_operational_memex_to_openclaw_workers() -> None:
     assert len(audit_runner.calls) == 5
     contexts = [json.loads(call["context"]) for call in audit_runner.calls]
     assert all(context["memex_query_receipt"]["source_class"] == "memex" for context in contexts)
-    assert all(context["memex_query_receipt"]["freshness_generation_id"] == "sha256:holo-generation-resident" for context in contexts)
+    assert all(
+        context["memex_query_receipt"]["freshness_generation_id"]
+        == _fresh_holo_receipt().generation_id
+        for context in contexts
+    )
     assert all(context["memex_evidence_bundle"]["records"] for context in contexts)
     completed = AgentDB().get_autonomous_tasks(status="completed", limit=10)
     readonly_contexts = [
@@ -404,7 +377,11 @@ def test_durable_cycle_supplies_operational_memex_to_openclaw_workers() -> None:
     ]
     assert readonly_contexts
     assert all(context["assignment"]["principal_id"] == "principal-012" for context in readonly_contexts)
-    assert all(context["assignment"]["memex_holoindex_generation_id"] == "sha256:holo-generation-resident" for context in readonly_contexts)
+    assert all(
+        context["assignment"]["memex_holoindex_generation_id"]
+        == _fresh_holo_receipt().generation_id
+        for context in readonly_contexts
+    )
 
 
 def test_duplicate_intent_reconnects_to_persisted_cycle_without_new_claims() -> None:


### PR DESCRIPTION
## Summary
- replace stale positive HoloIndex v1 runtime fixtures with a canonical v2 source-proof helper
- migrate RedDog snapshot, Brain, Memex, OpenClaw audit, architect, bootstrap, E2E, and durable-cycle tests
- preserve the intentional v1 query-boundary compatibility adversary

## WSP_97 evidence
- `150` affected runtime tests passed
- `python -m ruff check` passed for all changed Python files
- `git diff --check` passed
- full bridge suite: `3749 passed, 8 skipped`; `39` unrelated baseline/environment failures remain outside this diff

## Truth boundary
- test-contract migration only
- no production runtime, authority, HoloIndex mutation, worker execution, or extension changes