### PR TITLE
feat(reddog): add Fusion progress and OpenRouter usage receipts

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -8,6 +8,8 @@ It is the IDE-side thin-client surface for the resident RedDog backend and the O
 
 RedDog is the resident FoundUps architect thin client and 012/0102 interface. Fusion is one internal reasoning mode, not the product identity.
 
+Version 0.4.10 streams orchestrator-owned Fusion stage metadata to the webview and emits digest-bound progress and OpenRouter call receipts in Copy MD. Receipts include roles, requested/served models, provider routing, generation IDs, retries, timing, token counts, and cost in OpenRouter credits. Missing or retry-ambiguous provider accounting is reported as incomplete and cost remains unknown rather than zero. Receipts are integrity-checked, bound to the extension-generated process run, secret-filtered, and observational only; they are not authentication or action authority.
+
 ## RedDog and the Recursive 0102 DAE Ecosystem
 
 012 does not orchestrate every worker. 012 talks to RedDog. RedDog participates in the recursive 0102 DAE ecosystem. Autonomous WRE/DAE agents perform bounded system work under Hermes/OpenClaw/WRE governance.
@@ -170,7 +172,7 @@ Copy:
 
 The model cannot access the filesystem. It receives only the bounded context packet.
 
-Extension v0.4.9 makes a complete named-subsystem evidence corpus authoritative for the core of a focused repository deep dive. At most two off-anchor generation-bound semantic dependencies may enter when their evidence text names the focus; unrelated hits are excluded. Focus strategy, cross-cutting paths, and manifest completeness are explicit in the Run Trace. Extension v0.4.8 keeps repository direct-read grounding available when the semantic owner fails while withholding unbound semantic claims.
+Extension v0.4.10 adds bounded Fusion progress and OpenRouter usage/routing receipts. Extension v0.4.9 makes a complete named-subsystem evidence corpus authoritative for the core of a focused repository deep dive. At most two off-anchor generation-bound semantic dependencies may enter when their evidence text names the focus; unrelated hits are excluded. Focus strategy, cross-cutting paths, and manifest completeness are explicit in the Run Trace.
 
 If HoloIndex recall reports zero WSP hits, missing Tier-0 docs, stale/offline fallback, or unavailable output, the answer must treat protocol claims as `NEEDS_VERIFICATION` and propose retrieval/index repair before strong claims.
 

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,15 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-20 - REDDOG_FUSION_PROGRESS_AND_OPENROUTER_USAGE_RECEIPTS_PHASE1 (0.4.10)
+
+- Added digest-bound, hash-chained Fusion progress events and per-call OpenRouter usage/routing receipts.
+- Added chunk-safe stderr progress decoding and UI role/model/status details without exposing prompts, outputs, private reasoning, or secrets.
+- Added Run Trace totals for calls, failures, retries, duration, tokens, OpenRouter cost credits, generation IDs, and selected routes; incomplete provider cost remains explicitly unknown.
+- Kept the unkeyed progress receipt observational: process-local run binding rejects cross-run receipts, while runtime authority remains governed by the existing signed gates.
+- Kept non-streaming model calls, redaction, quorum, model selection, and execution authority unchanged.
+- Version 0.4.9 -> 0.4.10.
+
 ## 2026-07-19 - REDDOG_REPO_DEEP_DIVE_FOCUS_BOUND_TARGET_SELECTION_PHASE1 (0.4.9)
 
 - Reserved the repository deep-dive core for token-matched paths under an explicit named focus when readable implementation, test, and document evidence all exist.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,10 +1,10 @@
 # RedDog
 
-Version: 0.4.9
+Version: 0.4.10
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
 
-Version 0.4.9 reserves the core of a focused repository deep dive for the named subsystem when that subsystem independently supplies readable implementation, test, and document evidence. It permits at most two generation-bound cross-cutting dependencies whose evidence text names the focus, excludes unrelated semantic hits, and exposes manifest completeness. Version 0.4.8 preserves governed repository direct reads when the semantic owner is unavailable.
+Version 0.4.10 exposes bounded Fusion stage, model, provider-routing, token, cost-credit, retry, and timing receipts while excluding prompts, outputs, reasoning content, and secrets. Incomplete or retry-ambiguous provider accounting remains visibly incomplete with unknown cost. The receipts provide process-bound observational integrity, not authentication or action authority. Version 0.4.9 reserves the core of a focused repository deep dive for the named subsystem when that subsystem independently supplies readable implementation, test, and document evidence.
 
 RedDog is the resident FoundUps architect thin client and 012/0102 interface. Fusion is one internal reasoning mode; authority-bearing work is delegated through signed OpenClaw/WRE/Hermes receipts, not through raw webview access.
 
@@ -228,6 +228,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.9.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.10.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -3,12 +3,18 @@ const cp = require('child_process');
 const crypto = require('crypto');
 const path = require('path');
 const fs = require('fs');
+const {
+  bindFusionProgressResultToRun,
+  buildProgressMessage,
+  createFusionProgressCollector,
+  createProgressLineDecoder,
+  formatFusionProgressReceiptLines
+} = require('./fusion_progress_receipt');
 const semanticGroundingPolicy = require('./semantic_grounding_policy');
 const holoGenerationBoundQuery = require('./holoindex_generation_bound_query');
 const groundedTargetContinuity = require('./grounded_target_continuity');
 const repoDeepDiveFocusPolicy = require('./repo_deep_dive_focus_policy');
-
-const EXTENSION_VERSION = '0.4.9';
+const EXTENSION_VERSION = '0.4.10';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -206,12 +212,10 @@ function postStatusMessage(webview, text) {
   webview.postMessage({ command: 'status', text: text });
 }
 
-function postProgressMessage(webview, stage, text) {
-  webview.postMessage({
-    command: 'progress',
-    stage: stage || null,
-    text: text || ''
-  });
+function postProgressMessage(webview, stage, text, metadata) {
+  const message = buildProgressMessage(stage, text, metadata);
+  webview.postMessage(message);
+  return message;
 }
 
 function postStatusAndProgress(webview, stage, text) {
@@ -266,7 +270,6 @@ function buildRuntimeConsumptionGate(result, validationState, mode, substantiveT
   const quorum = rp.fusion_panel_quorum && typeof rp.fusion_panel_quorum === 'object'
     ? rp.fusion_panel_quorum
     : null;
-
   if (rp.local_fast_path === 'simple_identity') {
     reasons.push('local_identity_fast_path_not_actionable');
   }
@@ -294,7 +297,6 @@ function buildRuntimeConsumptionGate(result, validationState, mode, substantiveT
   if (mode === 'foundups_fusion' && (!quorum || quorum.passed !== true)) {
     reasons.push('fusion_panel_quorum_not_passed');
   }
-
   return {
     applied: true,
     passed: reasons.length === 0,
@@ -2371,6 +2373,7 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
     lines.push('- HoloIndex/context summary: ' + sanitizeCopyMdText(String(contextSummary)).slice(0, 500));
   }
   lines.push.apply(lines, formatHoloIndexScorecardLines(holoScorecard || rp.holoindex_scorecard));
+  lines.push.apply(lines, formatFusionProgressReceiptLines(rp));
   lines.push('- unicode_normalization_applied: ' + (rp.unicode_normalization_applied === true ? 'true' : rp.unicode_normalization_applied === false ? 'false' : 'unknown'));
   lines.push('- unicode_replacements_count: ' + (typeof rp.unicode_replacements_count === 'number' ? rp.unicode_replacements_count : 'unknown'));
   lines.push('- unicode_normalization_sources: ' + (typeof rp.unicode_normalization_sources === 'string' && rp.unicode_normalization_sources.length ? rp.unicode_normalization_sources : '(none)'));
@@ -5499,22 +5502,23 @@ function wireFusionWebview(context, webview, worker, state) {
         unicode_normalization_form: bridgeResult.unicode_normalization_form
       });
     };
-    const onBridgeProgress = (stage, text) => {
-      postStatusMessage(webview, text);
-      postProgressMessage(webview, stage, text);
-      const normalized = normalizeBridgeStageToWorkTrail(stage, text);
+    const onBridgeProgress = (stage, text, metadata) => {
+      const message = postProgressMessage(webview, stage, text, metadata);
+      postStatusMessage(webview, message.text);
+      const normalized = normalizeBridgeStageToWorkTrail(stage, message.text);
       if (normalized) {
         workTrail.push(normalized.event, normalized.detail);
       }
     };
-    const onRepairBridgeProgress = (stage, text) => {
-      postStatusMessage(webview, text);
-      postProgressMessage(webview, stage, text);
-      const normalized = normalizeRepairBridgeStageToWorkTrail(stage, text);
+    const onRepairBridgeProgress = (stage, text, metadata) => {
+      const message = postProgressMessage(webview, stage, text, metadata);
+      postStatusMessage(webview, message.text);
+      const normalized = normalizeRepairBridgeStageToWorkTrail(stage, message.text);
       if (normalized) {
         workTrail.push(normalized.event, normalized.detail);
       }
     };
+    const fusionProgress = createFusionProgressCollector();
     let result;
     if (localIdentityFastPath) {
       workTrail.push('local_fast_path', 'simple_identity');
@@ -5532,6 +5536,7 @@ function wireFusionWebview(context, webview, worker, state) {
     } else {
       result = await callFusion(context, worker, wspTaskPrompt, contextPacket.text, systemPrompt, state.history, mode, onBridgeProgress, state, promptConstruction);
     }
+    fusionProgress.capture(result);
     if (holoScorecard) {
       holoScorecard.audit_context_applied = result && result.audit_context_applied === true;
       if (result && result.audit_context_requested !== undefined) {
@@ -5606,6 +5611,7 @@ function wireFusionWebview(context, webview, worker, state) {
           promptConstruction,
           { promptSource: 'repair_prompt', maxTokens: 2400 }
         );
+        fusionProgress.capture(repairResult);
         absorbUnicodeMeta(repairResult);
         if (repairResult.ok) {
           const mergeResult = mergeRepairedOutput(result.content, repairResult.content, validation.missingSections);
@@ -5759,6 +5765,13 @@ function wireFusionWebview(context, webview, worker, state) {
       workFocusDigest: promptConstruction.work_focus_digest && promptConstruction.work_focus_digest.hash,
       wspPromptDigest: promptConstruction.wsp_prompt_digest && promptConstruction.wsp_prompt_digest.hash
     });
+    if (!result.review_packet || typeof result.review_packet !== 'object') {
+      result.review_packet = {};
+    }
+    const fusionProgressReceipts = fusionProgress.snapshot();
+    const fusionProgressValidation = fusionProgress.validation();
+    result.review_packet.fusion_progress_receipts = fusionProgressReceipts;
+    result.review_packet.fusion_progress_receipt_validation = fusionProgressValidation;
     const runtimeConsumptionGate = buildRuntimeConsumptionGate(result, validationState, mode, substantiveTask);
     const actionPlanningAllowed = runtimeConsumptionGate.passed === true;
     const residentArchitectSessionEnabled = (
@@ -5824,6 +5837,8 @@ function wireFusionWebview(context, webview, worker, state) {
     );
     result.runtime_consumption_gate = runtimeConsumptionGate;
     result.review_packet.runtime_consumption_gate = runtimeConsumptionGate;
+    result.review_packet.fusion_progress_receipts = fusionProgressReceipts;
+    result.review_packet.fusion_progress_receipt_validation = fusionProgressValidation;
     result.install_state = state.installState || null;
     result.review_packet.install_state = result.install_state;
     result.governed_handoff_recommendation = handoffRecommendation;
@@ -6003,6 +6018,7 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
     const unicodeMeta = mergeUnicodeNormalizationMeta(null, Object.assign({}, promptNorm, { unicode_normalization_source: promptSource }));
     const mergedUnicodeMeta = mergeUnicodeNormalizationMeta(unicodeMeta, Object.assign({}, contextNorm, { unicode_normalization_source: 'context' }));
     const budgeted = applyBridgeContextBudget(promptNorm.text, contextNorm.text);
+    const bridgeRunId = 'reddog_bridge_run:' + crypto.randomBytes(16).toString('hex');
     onProgress(null, 'Mode: ' + mode);
     onProgress(null, 'Python interpreter: ' + interpreter.path + ' (' + interpreter.source + ')');
     onProgress(null, 'Bridge process starting');
@@ -6039,9 +6055,11 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
 
     let stdout = '';
     let stderr = '';
+    const progressDecoder = createProgressLineDecoder(onProgress);
     let stdoutBytes = 0;
     let stderrBytes = 0;
     const payload = {
+      bridge_run_id: bridgeRunId,
       mode,
       prompt: budgeted.prompt,
       context: budgeted.context,
@@ -6089,17 +6107,7 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
       }
       const text = chunk.toString();
       stderr += text;
-      for (const line of text.split(/\r?\n/)) {
-        if (!line.trim()) continue;
-        try {
-          const event = JSON.parse(line);
-          if (event && event.event === 'progress' && event.text) {
-            onProgress(event.stage || null, event.text);
-          }
-        } catch (err) {
-          // stderr can contain non-JSON diagnostics from Python dependencies.
-        }
-      }
+      progressDecoder.push(text);
     });
     child.on('error', (err) => {
       finish({ ok: false, reason: 'subprocess_failed', detail: err.message });
@@ -6109,12 +6117,13 @@ function callFusion(context, worker, prompt, boundedContext, systemPrompt, histo
         return;
       }
       try {
+        progressDecoder.flush();
         const parsed = JSON.parse(stdout || '{}');
         if (!parsed.ok && code !== 0 && !parsed.reason) {
           parsed.reason = 'subprocess_failed';
           parsed.exit_code = code;
         }
-        finish(Object.assign({}, parsed, mergedUnicodeMeta));
+        finish(bindFusionProgressResultToRun(Object.assign({}, parsed, mergedUnicodeMeta), bridgeRunId));
       } catch (err) {
         finish({ ok: false, reason: 'malformed_response', detail: stderr.slice(0, 500) });
       }
@@ -7962,7 +7971,8 @@ function renderHtml(worker, surface, logoUri, installState) {
     function applyProgressEvent(msg) {
       const matched = matchReddogProgressWeb({ stage: msg.stage, text: msg.text });
       if (matched) {
-        updateReddogTrail(matched.action, matched.pixel, '', { active: true });
+        const detail = [msg.role, msg.model, msg.status].filter(Boolean).join(' | ');
+        updateReddogTrail(matched.action, matched.pixel, detail, { active: true });
       }
     }
 
@@ -8239,6 +8249,7 @@ module.exports = {
   enrichRedactionBlockResult,
   detectMojibake,
   buildRunTraceSection,
+  formatFusionProgressReceiptLines,
   formatJudgmentVerificationLines,
   buildJudgmentVerificationSection,
   buildWorkTrailSection,

--- a/extensions/reddog/fusion_progress_receipt.js
+++ b/extensions/reddog/fusion_progress_receipt.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const SAFE_PROGRESS_KEYS = Object.freeze([
+  'run_id', 'event_id', 'sequence', 'status', 'role', 'model', 'elapsed_ms'
+]);
+const EXPECTED_RUN_ID = Symbol('reddogExpectedBridgeRunId');
+const SECRET_LIKE = /(?:sk-or-v1-[A-Za-z0-9_-]{8,}|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|xox[baprs]-[0-9A-Za-z-]{10,}|eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._~-]{8,})/gi;
+const STAGE_TEXT = Object.freeze({
+  bridge_start: 'Bridge Python started.', env_check: 'Bridge environment checked.',
+  redaction_start: 'Redaction gate started.', redaction_pass: 'Redaction gate passed.',
+  redaction_blocked: 'Redaction gate blocked.', fusion_alias_start: 'Fusion alias request started.',
+  fusion_alias_done: 'Fusion alias response received.', lead_start: 'Lead request started.',
+  lead_done: 'Lead response received.', panel_start: 'Panel requests started.',
+  panel_done: 'Panel response received.', panel_blocked: 'Panel request blocked.',
+  synthesis_start: 'Synthesis request started.', synthesis_done: 'Synthesis complete.',
+  single_start: 'OpenRouter request started.', single_done: 'OpenRouter response received.'
+});
+
+function sanitizeProgressText(stage, text) {
+  if (STAGE_TEXT[stage]) return STAGE_TEXT[stage];
+  return String(text || '').replace(SECRET_LIKE, '[REDACTED]').replace(/[\r\n\u0000-\u001f]+/g, ' ').slice(0, 240);
+}
+
+function sanitizeProgressMetadataString(value) {
+  const cleaned = String(value || '').replace(SECRET_LIKE, '').replace(/[\r\n\u0000-\u001f]+/g, '').slice(0, 256);
+  return /^[A-Za-z0-9][A-Za-z0-9._:/@+()-]*$/.test(cleaned) ? cleaned : '';
+}
+
+function bindFusionProgressResultToRun(result, expectedRunId) {
+  if (result && typeof result === 'object') {
+    Object.defineProperty(result, EXPECTED_RUN_ID, { value: String(expectedRunId || ''), enumerable: false });
+  }
+  return result;
+}
+
+function buildProgressMessage(stage, text, metadata) {
+  const source = metadata && typeof metadata === 'object' ? metadata : {};
+  const message = { command: 'progress', stage: stage || null, text: sanitizeProgressText(stage, text) };
+  for (const key of SAFE_PROGRESS_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string') {
+      const cleaned = sanitizeProgressMetadataString(value);
+      if (cleaned) message[key] = cleaned;
+    } else if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      message[key] = value;
+    }
+  }
+  return message;
+}
+
+function createProgressLineDecoder(onProgress) {
+  let buffered = '';
+  const consume = (line) => {
+    if (!line.trim()) return;
+    try {
+      const event = JSON.parse(line);
+      if (event && event.event === 'progress' && event.text) {
+        onProgress(event.stage || null, event.text, event);
+      }
+    } catch (err) {
+      // Python dependencies may write non-JSON diagnostics to stderr.
+    }
+  };
+  return {
+    push(text) {
+      buffered += String(text || '');
+      const lines = buffered.split(/\r?\n/);
+      buffered = lines.pop() || '';
+      lines.forEach(consume);
+    },
+    flush() {
+      consume(buffered);
+      buffered = '';
+    }
+  };
+}
+
+function createFusionProgressCollector() {
+  const receipts = [];
+  const rejectionReasons = [];
+  let seen = 0;
+  return {
+    capture(result) {
+      const receipt = result && result.fusion_progress_receipt;
+      if (!receipt || typeof receipt !== 'object') return;
+      seen += 1;
+      const validation = result && result.fusion_progress_receipt_validation;
+      const expectedRunId = result && result[EXPECTED_RUN_ID];
+      if (validation && validation.valid === true && expectedRunId && receipt.run_id === expectedRunId) {
+        receipts.push(receipt);
+        return;
+      }
+      const reasons = expectedRunId && receipt.run_id !== expectedRunId
+        ? ['fusion_progress_receipt_run_id_mismatch']
+        : validation && Array.isArray(validation.rejection_reasons)
+        ? validation.rejection_reasons
+        : ['fusion_progress_receipt_validation_missing'];
+      rejectionReasons.push(...reasons.map(String));
+    },
+    snapshot() {
+      return receipts.slice();
+    },
+    validation() {
+      return {
+        applied: seen > 0,
+        valid: seen > 0 && rejectionReasons.length === 0 && receipts.length === seen,
+        receipt_count: seen,
+        rejection_reasons: Array.from(new Set(rejectionReasons))
+      };
+    }
+  };
+}
+
+function formatFusionProgressReceiptLines(reviewPacket) {
+  const rp = reviewPacket && typeof reviewPacket === 'object' ? reviewPacket : {};
+  const validation = rp.fusion_progress_receipt_validation && typeof rp.fusion_progress_receipt_validation === 'object'
+    ? rp.fusion_progress_receipt_validation
+    : null;
+  const validationLines = [
+    '- fusion_progress_receipt_validation: ' + (validation && validation.applied === true ? (validation.valid === true ? 'passed' : 'failed') : 'not_applied'),
+    '- fusion_progress_receipt_rejection_reasons: ' + (validation && Array.isArray(validation.rejection_reasons) && validation.rejection_reasons.length
+      ? validation.rejection_reasons.join(', ') : '(none)')
+  ];
+  const receipts = Array.isArray(rp.fusion_progress_receipts)
+    ? rp.fusion_progress_receipts
+    : (rp.fusion_progress_receipt && typeof rp.fusion_progress_receipt === 'object' ? [rp.fusion_progress_receipt] : []);
+  if (!receipts.length) return ['- fusion_progress_receipts: 0', ...validationLines];
+  const calls = [];
+  const receiptIds = [];
+  let eventCount = 0;
+  for (const receipt of receipts) {
+    if (!receipt || typeof receipt !== 'object') continue;
+    if (receipt.receipt_id) receiptIds.push(String(receipt.receipt_id));
+    eventCount += Number(receipt.event_count) || 0;
+    if (Array.isArray(receipt.openrouter_calls)) calls.push(...receipt.openrouter_calls);
+  }
+  const usage = calls.reduce((total, call) => {
+    const item = call && call.usage && typeof call.usage === 'object' ? call.usage : {};
+    for (const key of ['prompt_tokens', 'completion_tokens', 'total_tokens', 'reasoning_tokens', 'cached_tokens', 'cost_microcredits']) {
+      total[key] += Number(item[key]) || 0;
+    }
+    return total;
+  }, { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, reasoning_tokens: 0, cached_tokens: 0, cost_microcredits: 0 });
+  const generations = calls.map((call) => String(call && call.generation_id || '')).filter(Boolean);
+  const routes = calls.map((call) => {
+    const meta = call && call.router_metadata && typeof call.router_metadata === 'object' ? call.router_metadata : {};
+    return [meta.response_provider, meta.response_model].filter(Boolean).join(':');
+  }).filter(Boolean);
+  const usageVerifiedCount = calls.filter((call) => call && call.usage_verified === true).length;
+  const costAccountingComplete = calls.length > 0
+    && calls.every((call) => call && call.cost_accounting_complete === true);
+  const failedCallCount = calls.filter((call) => call && call.status === 'FAILED').length;
+  const retryCount = calls.reduce((total, call) => total + (Number(call && call.retry_count) || 0), 0);
+  const durationMs = calls.reduce((total, call) => total + (Number(call && call.duration_ms) || 0), 0);
+  return [
+    '- fusion_progress_receipts: ' + receipts.length,
+    ...validationLines,
+    '- fusion_progress_receipt_ids: ' + (receiptIds.length ? receiptIds.join(', ') : '(none)'),
+    '- fusion_progress_events: ' + eventCount,
+    '- openrouter_calls_receipted: ' + calls.length,
+    '- openrouter_calls_failed: ' + failedCallCount,
+    '- openrouter_retries: ' + retryCount,
+    '- openrouter_duration_ms: ' + durationMs,
+    '- openrouter_usage_verified_calls: ' + usageVerifiedCount + '/' + calls.length,
+    '- openrouter_cost_accounting_complete: ' + costAccountingComplete,
+    '- openrouter_generation_ids: ' + (generations.length ? generations.join(', ') : '(none)'),
+    '- openrouter_selected_routes: ' + (routes.length ? routes.join(', ') : '(none)'),
+    '- openrouter_prompt_tokens: ' + usage.prompt_tokens,
+    '- openrouter_completion_tokens: ' + usage.completion_tokens,
+    '- openrouter_reasoning_tokens: ' + usage.reasoning_tokens,
+    '- openrouter_total_tokens: ' + usage.total_tokens,
+    '- openrouter_cached_tokens: ' + usage.cached_tokens,
+    '- openrouter_cost_microcredits: ' + (costAccountingComplete ? usage.cost_microcredits : 'unknown')
+  ];
+}
+
+module.exports = {
+  bindFusionProgressResultToRun,
+  buildProgressMessage,
+  createFusionProgressCollector,
+  createProgressLineDecoder,
+  formatFusionProgressReceiptLines
+};

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,10 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-20 - Fusion progress and OpenRouter usage receipts (0.4.10)
+
+- Added receipt digest, hash-chain, tamper, usage, routing allowlist, failed-call, cap, and redaction-block regressions.
+- Added fragmented stderr JSON decoding, bridge-run binding, safe UI projection, and Run Trace usage-summary coverage.
+
 ## 2026-07-19 - REDDOG_REPO_DEEP_DIVE_FOCUS_BOUND_TARGET_SELECTION_PHASE1
 
 - Proved a complete p.fMALL corpus activates focus-core selection and an unrelated semantic runtime hit is excluded.

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -14,6 +14,8 @@ const fixtures = require('./fixtures');
 const root = path.resolve(__dirname, '..', '..', '..');
 const extDir = path.join(root, 'extensions', 'reddog');
 const extensionJs = fs.readFileSync(path.join(extDir, 'extension.js'), 'utf8');
+const fusionProgressJs = fs.readFileSync(path.join(extDir, 'fusion_progress_receipt.js'), 'utf8');
+const fusionProgress = require(path.join(extDir, 'fusion_progress_receipt.js'));
 const holoGenerationBoundQueryJs = fs.readFileSync(path.join(extDir, 'holoindex_generation_bound_query.js'), 'utf8');
 const holoGenerationBoundQuery = require(path.join(extDir, 'holoindex_generation_bound_query.js'));
 const groundedTargetContinuity = require(path.join(extDir, 'grounded_target_continuity.js'));
@@ -208,8 +210,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.9', 'package version must be 0.4.9');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.9'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.10', 'package version must be 0.4.10');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.10'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -222,14 +224,88 @@ includes(iface, 'Fusion is one internal reasoning mode, not the product identity
 includes(roadmap, 'RedDog is the resident FoundUps architect', 'ROADMAP product identity statement missing');
 includes(extensionJs, 'id="reddogWorkingTrail"', 'working trail DOM missing');
 includes(extensionJs, 'data-reddog-pixel', 'trail pixel attribute missing');
-includes(extensionJs, "command: 'progress'", 'progress command shape missing');
+includes(fusionProgressJs, "command: 'progress'", 'progress command shape missing');
+const safeProgress = fusionProgress.buildProgressMessage('lead_start', 'Lead request started.', {
+  run_id: 'run-1', role: 'lead', model: 'model-a', status: 'STARTED', elapsed_ms: 12,
+  prompt: 'must-not-cross', reasoning: 'must-not-cross', nested: { secret: true }
+});
+assert.deepStrictEqual(safeProgress, {
+  command: 'progress', stage: 'lead_start', text: 'Lead request started.', run_id: 'run-1',
+  status: 'STARTED', role: 'lead', model: 'model-a', elapsed_ms: 12
+}, 'progress UI projection must allowlist operational metadata');
+const decodedProgress = [];
+const decoder = fusionProgress.createProgressLineDecoder((stage, text, event) => decodedProgress.push({ stage, text, event }));
+const fragmentedEvent = JSON.stringify({ event: 'progress', stage: 'critic_done', text: 'Critic complete.', role: 'critic' });
+decoder.push(fragmentedEvent.slice(0, 17));
+decoder.push(fragmentedEvent.slice(17));
+assert.strictEqual(decodedProgress.length, 0, 'unterminated fragmented progress must remain buffered');
+decoder.flush();
+assert.strictEqual(decodedProgress.length, 1, 'fragmented trailing progress must decode exactly once');
+const progressSummary = fusionProgress.formatFusionProgressReceiptLines({
+  fusion_progress_receipts: [{
+    receipt_id: 'sha256:receipt', event_count: 3,
+    openrouter_calls: [{
+      generation_id: 'gen-1',
+      status: 'COMPLETED', retry_count: 1, duration_ms: 25,
+      usage_verified: true, cost_accounting_complete: true,
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15, reasoning_tokens: 2, cached_tokens: 1, cost_microcredits: 200 },
+      router_metadata: { response_provider: 'Provider A', response_model: 'served/model' }
+    }]
+  }]
+}).join('\n');
+includes(progressSummary, '- openrouter_total_tokens: 15', 'progress token total missing');
+includes(progressSummary, '- openrouter_cost_microcredits: 200', 'OpenRouter credit total missing');
+includes(progressSummary, '- openrouter_cost_accounting_complete: true', 'complete OpenRouter accounting status missing');
+includes(progressSummary, '- openrouter_usage_verified_calls: 1/1', 'verified OpenRouter usage count missing');
+includes(progressSummary, '- openrouter_retries: 1', 'OpenRouter retry total missing');
+includes(progressSummary, '- openrouter_duration_ms: 25', 'OpenRouter duration total missing');
+includes(progressSummary, '- openrouter_selected_routes: Provider A:served/model', 'provider route missing');
+const incompleteProgressSummary = fusionProgress.formatFusionProgressReceiptLines({
+  fusion_progress_receipts: [{
+    receipt_id: 'sha256:incomplete', event_count: 1,
+    openrouter_calls: [{
+      status: 'FAILED', retry_count: 2, duration_ms: 30,
+      usage_verified: false, cost_accounting_complete: false,
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0, reasoning_tokens: 0, cached_tokens: 0, cost_microcredits: 0 },
+      router_metadata: {}
+    }]
+  }]
+}).join('\n');
+includes(incompleteProgressSummary, '- openrouter_calls_failed: 1', 'failed OpenRouter call count missing');
+includes(incompleteProgressSummary, '- openrouter_cost_accounting_complete: false', 'incomplete accounting must remain explicit');
+includes(incompleteProgressSummary, '- openrouter_cost_microcredits: unknown', 'missing provider cost must not render as zero');
+const progressCollector = fusionProgress.createFusionProgressCollector();
+progressCollector.capture({ fusion_progress_receipt: { receipt_id: 'bad' } });
+assert.strictEqual(progressCollector.snapshot().length, 0, 'unvalidated progress receipt must not be consumed');
+assert.strictEqual(progressCollector.validation().valid, false, 'missing validation must fail aggregate receipt validation');
+const validProgressCollector = fusionProgress.createFusionProgressCollector();
+const boundProgressResult = fusionProgress.bindFusionProgressResultToRun({
+  fusion_progress_receipt: { receipt_id: 'good', run_id: 'run-good' },
+  fusion_progress_receipt_validation: { applied: true, valid: true, rejection_reasons: [] }
+}, 'run-good');
+validProgressCollector.capture(boundProgressResult);
+assert.strictEqual(validProgressCollector.snapshot().length, 1, 'validated progress receipt must be retained');
+assert.strictEqual(validProgressCollector.validation().valid, true, 'validated receipt aggregate must pass');
+const foreignProgressCollector = fusionProgress.createFusionProgressCollector();
+foreignProgressCollector.capture(fusionProgress.bindFusionProgressResultToRun({
+  fusion_progress_receipt: { receipt_id: 'foreign', run_id: 'run-foreign' },
+  fusion_progress_receipt_validation: { applied: true, valid: true, rejection_reasons: [] }
+}, 'run-local'));
+assert.strictEqual(foreignProgressCollector.snapshot().length, 0, 'foreign-run receipt must not be retained');
+assert(foreignProgressCollector.validation().rejection_reasons.includes('fusion_progress_receipt_run_id_mismatch'), 'foreign-run rejection reason missing');
+const secretProgress = fusionProgress.buildProgressMessage(null, 'route sk-or-v1-THIS-IS-A-SECRET-TOKEN', {
+  model: 'sk-or-v1-THIS-IS-A-SECRET-TOKEN'
+});
+assert(!secretProgress.text.includes('sk-or-v1-'), 'progress UI must redact secret-like text');
+assert.strictEqual(secretProgress.model, undefined, 'progress UI must drop secret-like metadata');
+assert.strictEqual(fusionProgress.buildProgressMessage('lead_start', 'attacker-controlled text', {}).text, 'Lead request started.', 'known stages must use canonical UI text');
 includes(extensionJs, 'Stopped before OpenRouter. Nothing left the machine.', 'redaction operator message missing');
 assert(!extensionJs.includes("command: 'status', stage"), 'status must not carry stage field');
 includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.9', 'README version mismatch');
+includes(readme, 'Version: 0.4.10', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1422,22 +1498,42 @@ includes(extensionJs, "'- extension_version: ' + EXTENSION_VERSION", 'RTBV-001: 
 // REDDOG_EXTENSION_OPERATOR_LOOP_RUNTIME_CONSUMPTION_PHASE1:
 // Runtime action planning may consume only validated, grounded, quorum-passed recommendations.
 const runtimeGatePass = orchestrator.buildRuntimeConsumptionGate(
-  { ok: true, reason: 'ok', review_packet: { fusion_panel_quorum: { passed: true } } },
+  {
+    ok: true,
+    reason: 'ok',
+    review_packet: {
+      fusion_panel_quorum: { passed: true }
+    }
+  },
   { validated: true, judgment_verification: { applied: true, verified: true } },
   'foundups_fusion',
   true
 );
 assert.strictEqual(runtimeGatePass.passed, true, 'runtime gate should pass only after validation, judgment, and quorum pass');
 const runtimeGateNoQuorum = orchestrator.buildRuntimeConsumptionGate(
-  { ok: true, reason: 'ok', review_packet: {} },
+  {
+    ok: true,
+    reason: 'ok',
+    review_packet: {
+      fusion_progress_receipt_validation: { applied: true, valid: true, rejection_reasons: [] }
+    }
+  },
   { validated: true },
   'foundups_fusion',
   true
 );
 assert.strictEqual(runtimeGateNoQuorum.passed, false, 'runtime gate must block missing Fusion quorum');
 assert(runtimeGateNoQuorum.rejection_reasons.includes('fusion_panel_quorum_not_passed'), 'runtime gate must cite missing Fusion quorum');
+assert(!runtimeGateNoQuorum.rejection_reasons.includes('fusion_progress_receipt_invalid'), 'observational progress evidence must not participate in authority');
 const runtimeGateValidationFail = orchestrator.buildRuntimeConsumptionGate(
-  { ok: true, reason: 'ok', review_packet: { fusion_panel_quorum: { passed: true } } },
+  {
+    ok: true,
+    reason: 'ok',
+    review_packet: {
+      fusion_panel_quorum: { passed: true },
+      fusion_progress_receipt_validation: { applied: true, valid: true, rejection_reasons: [] }
+    }
+  },
   { validated: false, output_validation_failed: true },
   'foundups_fusion',
   true
@@ -1668,7 +1764,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.9', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.10', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -3174,7 +3270,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.9'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.10'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -3188,7 +3284,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.9'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.10'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -3200,7 +3296,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.9'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.10'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -4219,7 +4315,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.9' } }
+      ? { id, packageJSON: { version: '0.4.10' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({

--- a/extensions/reddog/tests/verify_fusion_panel_input_contract.js
+++ b/extensions/reddog/tests/verify_fusion_panel_input_contract.js
@@ -13,6 +13,7 @@ const bridgePython = fs.readFileSync(path.join(root, 'scripts', 'advisory_model_
 const rootExemptionYaml = fs.readFileSync(path.join(root, 'wsp_62_exemptions.yaml'), 'utf8');
 const exemptionYaml = fs.readFileSync(path.join(extDir, 'wsp_62_exemptions.yaml'), 'utf8');
 const roadmap = fs.readFileSync(path.join(extDir, 'ROADMAP.md'), 'utf8');
+const fusionProgress = require(path.join(extDir, 'fusion_progress_receipt.js'));
 const defaultPanel = packageJson.contributes.configuration.properties['reddog.panelModels'].default;
 const configState = {
   reddog: {},
@@ -79,8 +80,21 @@ function fakeBridgeChild(onPayload) {
       stdinText += String(chunk);
     },
     end: () => {
-      onPayload(JSON.parse(stdinText));
-      child.stdout.emit('data', Buffer.from(JSON.stringify({ ok: false, reason: 'contract_probe' })));
+      const payload = JSON.parse(stdinText);
+      onPayload(payload);
+      const progress = JSON.stringify({
+        event: 'progress', stage: 'lead_start', text: 'Lead request started.',
+        run_id: 'run-contract', event_id: 'event-contract', sequence: 1,
+        status: 'STARTED', role: 'lead', model: 'model-a', elapsed_ms: 3
+      });
+      child.stderr.emit('data', Buffer.from(progress.slice(0, 23)));
+      child.stderr.emit('data', Buffer.from(progress.slice(23)));
+      child.stdout.emit('data', Buffer.from(JSON.stringify({
+        ok: false,
+        reason: 'contract_probe',
+        fusion_progress_receipt: { run_id: payload.bridge_run_id, receipt_id: 'contract-receipt' },
+        fusion_progress_receipt_validation: { applied: true, valid: true, rejection_reasons: [] }
+      })));
       child.emit('close', 0);
     }
   };
@@ -92,6 +106,7 @@ async function captureBridgeInvocation(worker, mode) {
   let invocation = null;
   let payload = null;
   let spawnCount = 0;
+  const progressEvents = [];
   cp.spawn = (command, args, options) => {
     spawnCount += 1;
     invocation = { command, args, options };
@@ -101,9 +116,9 @@ async function captureBridgeInvocation(worker, mode) {
   };
   try {
     const state = { bridgeChild: null, disposed: false };
-    await reddog.callFusion({}, worker, 'contract prompt', 'bounded context', 'system prompt', [], mode,
-      () => {}, state, {}, {});
-    return { invocation, payload, spawnCount, state };
+    const result = await reddog.callFusion({}, worker, 'contract prompt', 'bounded context', 'system prompt', [], mode,
+      (stage, text, metadata) => progressEvents.push({ stage, text, metadata }), state, {}, {});
+    return { invocation, payload, progressEvents, result, spawnCount, state };
   } finally {
     cp.spawn = originalSpawn;
   }
@@ -172,7 +187,14 @@ async function assertModeCases(mode, cases) {
     );
     assert.strictEqual(captured.invocation.options.env.OPENROUTER_API_KEY, undefined);
     assert.strictEqual(captured.payload.mode, mode, mode + '/' + name + ': mode mismatch');
+    assert(/^reddog_bridge_run:[0-9a-f]{32}$/.test(captured.payload.bridge_run_id), mode + '/' + name + ': bridge run ID missing');
     assert.deepStrictEqual(captured.payload.panel_models, expected, mode + '/' + name + ': stdin mismatch');
+    const bridgeProgress = captured.progressEvents.filter((event) => event.stage === 'lead_start');
+    assert.strictEqual(bridgeProgress.length, 1, mode + '/' + name + ': fragmented progress must decode once');
+    assert.strictEqual(bridgeProgress[0].metadata.role, 'lead', mode + '/' + name + ': progress metadata missing');
+    const collector = fusionProgress.createFusionProgressCollector();
+    collector.capture(captured.result);
+    assert.strictEqual(collector.snapshot().length, 1, mode + '/' + name + ': local run binding must survive callFusion return');
     assert.strictEqual(captured.state.bridgeChild, null, mode + '/' + name + ': child state must clear');
   }
 }

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -38,6 +38,8 @@ foundups_mcp_bridge `holo_tools.py` remains a direct-store path.
 
 ### FusionAdapter (advisory Fusion worker-panel, CONTRACT-ONLY)
 
+`reddog_fusion_progress_receipt.py` records one process-local, digest-bound lifecycle receipt for each RedDog bridge invocation. It allows only stage, role, requested/served model, provider route, generation ID, retry, timing, token, and OpenRouter cost-credit fields. Missing, malformed, or retry-ambiguous provider accounting is marked incomplete rather than reported as zero cost. Prompt/context/output/reasoning content and secret-like values are excluded. These unkeyed receipts prove internal consistency, not signer authenticity, and never grant execution or promotion authority.
+
 ```python
 from modules.communication.moltbot_bridge.src.fusion_adapter import (
     FusionAdapter,            # runtime_checkable Protocol: run(FusionRequest) -> ModelContributionReceipt

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,13 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-20: REDDOG_FUSION_PROGRESS_AND_OPENROUTER_USAGE_RECEIPTS_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 71, 91, 97
+
+- Added bounded, content-free Fusion progress and OpenRouter call receipts with per-event and aggregate digest verification.
+- Recorded provider-returned tokens, cost credits, generation IDs, selected routing metadata, retries, and timing while discarding arbitrary metadata payloads.
+- Kept receipts observational and advisory; they grant no model, execution, repository, shell, worktree, PR, merge, HoloIndex, or reward authority.
+
 ## 2026-07-19: REDDOG_TRANSPORT_NEUTRAL_GROUNDING_SERVICE_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 50, 71, 97

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -1,5 +1,7 @@
 # OpenClaw Bridge = 012's Digital Twin
 
+RedDog Fusion progress observability is implemented by `src/reddog_fusion_progress_receipt.py`: bounded hash-chained stage events plus content-free OpenRouter usage and routing receipts. It does not retain prompts, outputs, hidden reasoning, or secrets, and it grants no action authority.
+
 > **OpenClaw** (formerly Moltbot/Clawdbot), trained on WSP framework, operating on Foundups-Agent codebase
 
 ## Version Note

--- a/modules/communication/moltbot_bridge/src/reddog_fusion_progress_receipt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_fusion_progress_receipt.py
@@ -1,0 +1,304 @@
+"""Bounded progress and OpenRouter usage receipts for RedDog Fusion calls.
+
+The receipt records orchestrator-owned stage transitions and provider metadata.
+It never records prompts, model output, reasoning text, response bodies, secrets,
+or authority-bearing decisions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import threading
+import time
+from typing import Any, Callable, Mapping
+
+
+PROGRESS_SCHEMA = "reddog_fusion_progress_receipt.v1"
+EVENT_SCHEMA = "reddog_fusion_progress_event.v1"
+CALL_SCHEMA = "reddog_openrouter_call_receipt.v1"
+MAX_EVENTS = 96
+MAX_CALLS = 16
+MAX_TEXT = 160
+_ROUTE_TEXT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@ +()-]*$")
+_GENERATION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_RUN_ID = re.compile(r"^reddog_bridge_run:[0-9a-f]{32}$|^run-[A-Za-z0-9._:-]{1,96}$")
+_SECRET_LIKE = re.compile(
+    r"(?:sk-or-v1-[A-Za-z0-9_-]{8,}|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9]{20,}|"
+    r"AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|xox[baprs]-[0-9A-Za-z-]{10,}|"
+    r"eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}|Bearer\s+[A-Za-z0-9._~-]{8,})",
+    re.IGNORECASE,
+)
+
+_STAGE_STATUS = {
+    "bridge_start": "STARTED", "env_check": "OBSERVED",
+    "redaction_start": "STARTED", "redaction_pass": "COMPLETED", "redaction_blocked": "BLOCKED",
+    "fusion_alias_start": "STARTED", "fusion_alias_done": "COMPLETED",
+    "lead_start": "STARTED", "lead_done": "COMPLETED",
+    "panel_start": "STARTED", "panel_done": "COMPLETED", "panel_blocked": "BLOCKED",
+    "synthesis_start": "STARTED", "synthesis_done": "COMPLETED",
+    "single_start": "STARTED", "single_done": "COMPLETED",
+}
+
+
+def _canonical(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=True, separators=(",", ":"), sort_keys=True)
+
+
+def _digest(prefix: str, value: Any) -> str:
+    body = f"{prefix}." + _canonical(value)
+    return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _text(value: Any, *, limit: int = MAX_TEXT) -> str:
+    cleaned = str(value or "").strip()
+    if not cleaned or any(ord(char) < 32 for char in cleaned) or _SECRET_LIKE.search(cleaned):
+        return ""
+    return cleaned[:limit]
+
+
+def _route_text(value: Any, *, limit: int = MAX_TEXT) -> str:
+    cleaned = _text(value, limit=limit)
+    return cleaned if cleaned and _ROUTE_TEXT.fullmatch(cleaned) else ""
+
+
+def _generation_id(value: Any) -> str:
+    cleaned = _text(value, limit=256)
+    return cleaned if cleaned and not _SECRET_LIKE.search(cleaned) and _GENERATION_ID.fullmatch(cleaned) else ""
+
+
+def _nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return min(10**15, max(0, int(value)))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _cost_microcredits(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return min(10**15, max(0, round(float(value) * 1_000_000)))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _provider_usage_verified(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens", "cost"):
+        item = value.get(key)
+        if isinstance(item, bool) or not isinstance(item, (int, float)) or not math.isfinite(float(item)) or item < 0:
+            return False
+    return int(value["total_tokens"]) == int(value["prompt_tokens"]) + int(value["completion_tokens"])
+
+
+def sanitize_openrouter_usage(value: Any) -> dict[str, int]:
+    """Return numeric accounting only; never retain content-bearing fields."""
+
+    source = value if isinstance(value, Mapping) else {}
+    completion = source.get("completion_tokens_details")
+    completion_details = completion if isinstance(completion, Mapping) else {}
+    prompt = source.get("prompt_tokens_details")
+    prompt_details = prompt if isinstance(prompt, Mapping) else {}
+    return {
+        "prompt_tokens": _nonnegative_int(source.get("prompt_tokens")),
+        "completion_tokens": _nonnegative_int(source.get("completion_tokens")),
+        "total_tokens": _nonnegative_int(source.get("total_tokens")),
+        "reasoning_tokens": _nonnegative_int(completion_details.get("reasoning_tokens")),
+        "cached_tokens": _nonnegative_int(prompt_details.get("cached_tokens")),
+        "cost_microcredits": _cost_microcredits(source.get("cost")),
+    }
+
+
+def sanitize_openrouter_metadata(value: Any) -> dict[str, Any]:
+    """Keep routing facts while dropping free-form/plugin/provider payload data."""
+
+    source = value if isinstance(value, Mapping) else {}
+    endpoints = source.get("endpoints")
+    endpoint_map = endpoints if isinstance(endpoints, Mapping) else {}
+    available = endpoint_map.get("available")
+    selected: list[dict[str, str]] = []
+    if isinstance(available, list):
+        for item in available[:8]:
+            if not isinstance(item, Mapping) or item.get("selected") is not True:
+                continue
+            selected.append({
+                "provider": _route_text(item.get("provider")),
+                "model": _route_text(item.get("model")),
+            })
+    pipeline = source.get("pipeline")
+    stages: list[dict[str, str]] = []
+    if isinstance(pipeline, list):
+        for item in pipeline[:12]:
+            if isinstance(item, Mapping):
+                stages.append({
+                    "type": _route_text(item.get("type")),
+                    "name": _route_text(item.get("name")),
+                })
+    attempt_value = source.get("attempt")
+    attempt_present = not isinstance(attempt_value, bool) and isinstance(attempt_value, int) and attempt_value >= 0
+    return {
+        "requested": _route_text(source.get("requested")),
+        "strategy": _route_text(source.get("strategy")),
+        "region": _route_text(source.get("region")),
+        "attempt": _nonnegative_int(source.get("attempt")),
+        "attempt_present": attempt_present,
+        "is_byok": source.get("is_byok") is True,
+        "response_provider": _route_text(source.get("response_provider")),
+        "response_model": _route_text(source.get("response_model")),
+        "selected_endpoints": selected,
+        "pipeline_stages": stages,
+    }
+
+
+class FusionProgressRecorder:
+    """Thread-safe, process-local recorder for one RedDog bridge invocation."""
+
+    def __init__(
+        self,
+        run_id: str,
+        *,
+        wall_clock_ms: Callable[[], int] | None = None,
+        monotonic_ns: Callable[[], int] | None = None,
+    ) -> None:
+        value = _text(run_id, limit=128)
+        if not value or not _RUN_ID.fullmatch(value):
+            raise ValueError("missing_bridge_run_id")
+        self.run_id = value
+        self._wall_clock_ms = wall_clock_ms or (lambda: int(time.time() * 1000))
+        self._monotonic_ns = monotonic_ns or time.monotonic_ns
+        self._started_ns = self._monotonic_ns()
+        self._lock = threading.Lock()
+        self._events: list[dict[str, Any]] = []
+        self._calls: dict[str, dict[str, Any]] = {}
+        self._call_sequence = 0
+
+    def emit(self, stage: str, *, role: str = "", model: str = "") -> dict[str, Any] | None:
+        normalized_stage = _text(stage, limit=64)
+        if normalized_stage not in _STAGE_STATUS:
+            return None
+        with self._lock:
+            if len(self._events) >= MAX_EVENTS:
+                return None
+            sequence = len(self._events) + 1
+            previous_event_digest = self._events[-1]["event_digest"] if self._events else "GENESIS"
+            body = {
+                "schema_version": EVENT_SCHEMA,
+                "run_id": self.run_id,
+                "sequence": sequence,
+                "stage": normalized_stage,
+                "status": _STAGE_STATUS[normalized_stage],
+                "role": _route_text(role, limit=64),
+                "model": _route_text(model),
+                "recorded_at_ms": self._wall_clock_ms(),
+                "elapsed_ms": max(0, (self._monotonic_ns() - self._started_ns) // 1_000_000),
+                "previous_event_digest": previous_event_digest,
+            }
+            event_digest = _digest("reddog_fusion_progress_event", body)
+            event = {**body, "event_id": event_digest, "event_digest": event_digest}
+            self._events.append(event)
+            return dict(event)
+
+    def begin_call(self, *, role: str, model: str, requested_max_tokens: int) -> str:
+        with self._lock:
+            if len(self._calls) >= MAX_CALLS:
+                raise ValueError("openrouter_call_receipt_limit_exceeded")
+            self._call_sequence += 1
+            seed = {
+                "run_id": self.run_id,
+                "sequence": self._call_sequence,
+                "role": _route_text(role, limit=64),
+                "model": _route_text(model),
+            }
+            call_id = _digest("reddog_openrouter_call", seed)
+            self._calls[call_id] = {
+                "sequence": self._call_sequence,
+                "role": seed["role"],
+                "model": seed["model"],
+                "requested_max_tokens": _nonnegative_int(requested_max_tokens),
+                "started_at_ms": self._wall_clock_ms(),
+                "started_ns": self._monotonic_ns(),
+            }
+            return call_id
+
+    def finish_call(
+        self,
+        call_id: str,
+        *,
+        status: str,
+        retry_count: int = 0,
+        generation_id: str = "",
+        usage: Any = None,
+        router_metadata: Any = None,
+        failure_reason: str = "",
+    ) -> dict[str, Any]:
+        with self._lock:
+            pending = self._calls.get(call_id)
+            if not pending or "receipt_id" in pending:
+                raise ValueError("unknown_or_finished_openrouter_call")
+            usage_verified = status == "COMPLETED" and _provider_usage_verified(usage)
+            safe_metadata = sanitize_openrouter_metadata(router_metadata)
+            retry_total = _nonnegative_int(retry_count)
+            body = {
+                "schema_version": CALL_SCHEMA,
+                "call_id": call_id,
+                "run_id": self.run_id,
+                "sequence": pending["sequence"],
+                "role": pending["role"],
+                "model": pending["model"],
+                "status": _text(status, limit=32),
+                "requested_max_tokens": pending["requested_max_tokens"],
+                "started_at_ms": pending["started_at_ms"],
+                "completed_at_ms": self._wall_clock_ms(),
+                "duration_ms": max(0, (self._monotonic_ns() - pending["started_ns"]) // 1_000_000),
+                "retry_count": retry_total,
+                "generation_id": _generation_id(generation_id),
+                "usage": sanitize_openrouter_usage(usage),
+                "usage_verified": usage_verified,
+                "cost_accounting_complete": (
+                    usage_verified and retry_total == 0
+                    and safe_metadata["attempt_present"] is True and safe_metadata["attempt"] == 1
+                ),
+                "router_metadata": safe_metadata,
+                "failure_reason": _text(failure_reason, limit=96),
+            }
+            receipt = {**body, "receipt_id": _digest("reddog_openrouter_call_receipt", body)}
+            self._calls[call_id] = receipt
+            return dict(receipt)
+
+    def receipt(self) -> dict[str, Any]:
+        with self._lock:
+            events = [dict(item) for item in self._events]
+            calls = [
+                dict(item)
+                for item in sorted(self._calls.values(), key=lambda value: int(value["sequence"]))
+                if "receipt_id" in item
+            ]
+        body = {
+            "schema_version": PROGRESS_SCHEMA,
+            "run_id": self.run_id,
+            "events": events,
+            "openrouter_calls": calls,
+            "event_count": len(events),
+            "openrouter_call_count": len(calls),
+            "events_digest": _digest("reddog_fusion_progress_events", events),
+            "openrouter_calls_digest": _digest("reddog_openrouter_calls", calls),
+            "contains_prompt_or_response_content": False,
+            "contains_reasoning_content": False,
+        }
+        return {**body, "receipt_id": _digest("reddog_fusion_progress_receipt", body)}
+
+
+def validate_fusion_progress_receipt(value: Any) -> tuple[bool, tuple[str, ...]]:
+    from .reddog_fusion_progress_validation import validate_fusion_progress_receipt as validate
+
+    return validate(value)
+
+
+__all__ = ["CALL_SCHEMA", "EVENT_SCHEMA", "PROGRESS_SCHEMA", "FusionProgressRecorder",
+           "sanitize_openrouter_metadata", "sanitize_openrouter_usage", "validate_fusion_progress_receipt"]

--- a/modules/communication/moltbot_bridge/src/reddog_fusion_progress_validation.py
+++ b/modules/communication/moltbot_bridge/src/reddog_fusion_progress_validation.py
@@ -1,0 +1,276 @@
+"""Exact-schema validator for content-free RedDog Fusion progress receipts."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from . import reddog_fusion_progress_receipt as receipt
+
+
+_CALL_STATUSES = frozenset({"COMPLETED", "FAILED"})
+_EVENT_KEYS = frozenset({"schema_version", "run_id", "sequence", "stage", "status", "role", "model",
+                         "recorded_at_ms", "elapsed_ms", "previous_event_digest", "event_id", "event_digest"})
+_USAGE_KEYS = frozenset({"prompt_tokens", "completion_tokens", "total_tokens", "reasoning_tokens",
+                         "cached_tokens", "cost_microcredits"})
+_ROUTER_KEYS = frozenset({"requested", "strategy", "region", "attempt", "is_byok", "response_provider",
+                          "attempt_present", "response_model", "selected_endpoints", "pipeline_stages"})
+_ENDPOINT_KEYS = frozenset({"provider", "model"})
+_PIPELINE_STAGE_KEYS = frozenset({"type", "name"})
+_CALL_KEYS = frozenset({
+    "schema_version", "call_id", "run_id", "sequence", "role", "model", "status", "requested_max_tokens",
+    "started_at_ms", "completed_at_ms", "duration_ms", "retry_count", "generation_id", "usage",
+    "usage_verified", "cost_accounting_complete", "router_metadata", "failure_reason", "receipt_id",
+})
+_RECEIPT_KEYS = frozenset({
+    "schema_version", "run_id", "events", "openrouter_calls", "event_count", "openrouter_call_count",
+    "events_digest", "openrouter_calls_digest", "contains_prompt_or_response_content",
+    "contains_reasoning_content", "receipt_id",
+})
+_REQUIRED_START = {
+    "lead_done": "lead_start", "synthesis_done": "synthesis_start", "single_done": "single_start",
+    "fusion_alias_done": "fusion_alias_start", "redaction_pass": "redaction_start",
+    "redaction_blocked": "redaction_start", "panel_done": "panel_start", "panel_blocked": "panel_start",
+}
+_START_STAGES = frozenset(_REQUIRED_START.values())
+
+
+def _valid_counter(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int) and 0 <= value <= 10**15
+
+
+def _valid_route_value(value: Any, *, limit: int = receipt.MAX_TEXT) -> bool:
+    if not isinstance(value, str) or len(value) > limit:
+        return False
+    return value == "" or (
+        receipt._SECRET_LIKE.search(value) is None and receipt._ROUTE_TEXT.fullmatch(value) is not None
+    )
+
+
+def _validate_router_metadata(metadata: Mapping[str, Any], reasons: list[str]) -> None:
+    if not all(_valid_route_value(metadata.get(key)) for key in (
+        "requested", "strategy", "region", "response_provider", "response_model"
+    )):
+        reasons.append("openrouter_router_metadata_value_invalid")
+    if (
+        not _valid_counter(metadata.get("attempt"))
+        or not isinstance(metadata.get("attempt_present"), bool)
+        or not isinstance(metadata.get("is_byok"), bool)
+    ):
+        reasons.append("openrouter_router_metadata_value_invalid")
+    if metadata.get("attempt_present") is False and metadata.get("attempt") != 0:
+        reasons.append("openrouter_router_metadata_attempt_invalid")
+
+    endpoints = metadata.get("selected_endpoints")
+    if not isinstance(endpoints, list) or len(endpoints) > 8:
+        reasons.append("openrouter_selected_endpoints_invalid")
+    else:
+        for endpoint in endpoints:
+            if not isinstance(endpoint, Mapping) or set(endpoint) != _ENDPOINT_KEYS:
+                reasons.append("openrouter_selected_endpoint_fields_invalid")
+                continue
+            if not all(_valid_route_value(endpoint.get(key)) for key in _ENDPOINT_KEYS):
+                reasons.append("openrouter_selected_endpoint_value_invalid")
+
+    stages = metadata.get("pipeline_stages")
+    if not isinstance(stages, list) or len(stages) > 12:
+        reasons.append("openrouter_pipeline_stages_invalid")
+    else:
+        for stage in stages:
+            if not isinstance(stage, Mapping) or set(stage) != _PIPELINE_STAGE_KEYS:
+                reasons.append("openrouter_pipeline_stage_fields_invalid")
+                continue
+            if not all(_valid_route_value(stage.get(key)) for key in _PIPELINE_STAGE_KEYS):
+                reasons.append("openrouter_pipeline_stage_value_invalid")
+
+
+def _validate_events(events: list[Any], run_id: Any, reasons: list[str]) -> None:
+    previous = "GENESIS"
+    started: set[tuple[str, str, str]] = set()
+    for index, event in enumerate(events, start=1):
+        if not isinstance(event, Mapping) or event.get("schema_version") != receipt.EVENT_SCHEMA:
+            reasons.append("progress_event_invalid")
+            continue
+        if set(event) != _EVENT_KEYS:
+            reasons.append("progress_event_fields_invalid")
+        event_body = {key: item for key, item in event.items() if key not in {"event_id", "event_digest"}}
+        if event.get("run_id") != run_id or event.get("sequence") != index:
+            reasons.append("progress_event_binding_invalid")
+        if not all(_valid_counter(event.get(key)) for key in ("sequence", "recorded_at_ms", "elapsed_ms")):
+            reasons.append("progress_event_numeric_invalid")
+        if not _valid_route_value(event.get("role"), limit=64) or not _valid_route_value(event.get("model")):
+            reasons.append("progress_event_route_value_invalid")
+        if event.get("previous_event_digest") != previous:
+            reasons.append("progress_event_chain_invalid")
+        stage = event.get("stage")
+        if stage not in receipt._STAGE_STATUS or event.get("status") != receipt._STAGE_STATUS.get(stage):
+            reasons.append("progress_event_status_invalid")
+        key = (str(stage), str(event.get("role") or ""), str(event.get("model") or ""))
+        if stage in _START_STAGES:
+            started.add(key)
+        required = _REQUIRED_START.get(str(stage))
+        if required:
+            found = any(item[0] == "panel_start" for item in started) if required == "panel_start" else (required, key[1], key[2]) in started
+            if not found:
+                reasons.append("progress_event_transition_invalid")
+        expected = receipt._digest("reddog_fusion_progress_event", event_body)
+        if event.get("event_id") != expected or event.get("event_digest") != expected:
+            reasons.append("progress_event_id_mismatch")
+        previous = str(event.get("event_digest") or "")
+
+
+def _validate_calls(calls: list[Any], run_id: Any, reasons: list[str]) -> None:
+    for index, call in enumerate(calls, start=1):
+        if not isinstance(call, Mapping) or call.get("schema_version") != receipt.CALL_SCHEMA:
+            reasons.append("openrouter_call_invalid")
+            continue
+        if set(call) != _CALL_KEYS:
+            reasons.append("openrouter_call_fields_invalid")
+        call_body = {key: item for key, item in call.items() if key != "receipt_id"}
+        if call.get("run_id") != run_id or call.get("sequence") != index:
+            reasons.append("openrouter_call_binding_invalid")
+        expected_call_id = receipt._digest("reddog_openrouter_call", {
+            "run_id": run_id, "sequence": index, "role": call.get("role"), "model": call.get("model"),
+        })
+        if call.get("call_id") != expected_call_id:
+            reasons.append("openrouter_call_id_mismatch")
+        numeric_keys = ("sequence", "requested_max_tokens", "started_at_ms", "completed_at_ms", "duration_ms", "retry_count")
+        if not all(_valid_counter(call.get(key)) for key in numeric_keys):
+            reasons.append("openrouter_call_numeric_invalid")
+        if _valid_counter(call.get("started_at_ms")) and _valid_counter(call.get("completed_at_ms")):
+            if call["completed_at_ms"] < call["started_at_ms"]:
+                reasons.append("openrouter_call_time_invalid")
+        if not _valid_route_value(call.get("role"), limit=64) or not _valid_route_value(call.get("model")):
+            reasons.append("openrouter_call_route_value_invalid")
+        generation_id = call.get("generation_id")
+        if not isinstance(generation_id, str) or (
+            generation_id != "" and receipt._GENERATION_ID.fullmatch(generation_id) is None
+        ):
+            reasons.append("openrouter_generation_id_invalid")
+        if not _valid_route_value(call.get("failure_reason"), limit=96):
+            reasons.append("openrouter_failure_reason_invalid")
+        if call.get("status") not in _CALL_STATUSES:
+            reasons.append("openrouter_call_status_invalid")
+        usage, metadata = call.get("usage"), call.get("router_metadata")
+        if not isinstance(usage, Mapping) or set(usage) != _USAGE_KEYS:
+            reasons.append("openrouter_usage_fields_invalid")
+        elif not all(_valid_counter(usage.get(key)) for key in _USAGE_KEYS):
+            reasons.append("openrouter_usage_value_invalid")
+        elif call.get("usage_verified") is True and usage.get("total_tokens") != (
+            usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0)
+        ):
+            reasons.append("openrouter_usage_total_invalid")
+        if not isinstance(metadata, Mapping) or set(metadata) != _ROUTER_KEYS:
+            reasons.append("openrouter_router_metadata_fields_invalid")
+        else:
+            _validate_router_metadata(metadata, reasons)
+        if not isinstance(call.get("usage_verified"), bool) or not isinstance(call.get("cost_accounting_complete"), bool):
+            reasons.append("openrouter_usage_verification_invalid")
+        elif call.get("cost_accounting_complete") is not (
+            call.get("usage_verified") is True
+            and call.get("retry_count") == 0
+            and isinstance(metadata, Mapping)
+            and metadata.get("attempt_present") is True
+            and metadata.get("attempt") == 1
+        ):
+            reasons.append("openrouter_cost_accounting_consistency_invalid")
+        if call.get("status") == "FAILED" and (call.get("usage_verified") or call.get("cost_accounting_complete")):
+            reasons.append("openrouter_failed_call_accounting_invalid")
+        if call.get("status") == "FAILED" and isinstance(usage, Mapping) and any(usage.get(key) != 0 for key in _USAGE_KEYS):
+            reasons.append("openrouter_failed_call_usage_invalid")
+        if call.get("status") == "FAILED" and not call.get("failure_reason"):
+            reasons.append("openrouter_failure_reason_missing")
+        if call.get("status") == "COMPLETED" and call.get("failure_reason"):
+            reasons.append("openrouter_completed_call_failure_reason_invalid")
+        if call.get("receipt_id") != receipt._digest("reddog_openrouter_call_receipt", call_body):
+            reasons.append("openrouter_call_receipt_id_mismatch")
+
+
+def _validate_event_call_correlation(events: list[Any], calls: list[Any], reasons: list[str]) -> None:
+    event_rows = [item for item in events if isinstance(item, Mapping)]
+    call_rows = [item for item in calls if isinstance(item, Mapping)]
+
+    def has_event(stage: str, *, model: Any = None) -> bool:
+        return any(
+            item.get("stage") == stage and (model is None or item.get("model") == model)
+            for item in event_rows
+        )
+
+    def has_call(role: str, *, model: Any = None, status: str | None = None) -> bool:
+        return any(
+            item.get("role") == role
+            and (model is None or item.get("model") == model)
+            and (status is None or item.get("status") == status)
+            for item in call_rows
+        )
+
+    start_for_role = {
+        "lead": "lead_start", "synthesis": "synthesis_start", "single": "single_start",
+        "critic": "panel_start", "fusion_alias": "fusion_alias_start",
+    }
+    for call in call_rows:
+        role = call.get("role")
+        start = start_for_role.get(role)
+        if start is None:
+            reasons.append("openrouter_call_role_invalid")
+            continue
+        model = call.get("model") if role in {"lead", "synthesis", "single"} else None
+        if not has_event(start, model=model):
+            reasons.append("openrouter_call_progress_start_missing")
+
+    terminal_bindings = {
+        "lead_done": ("lead", "COMPLETED"),
+        "synthesis_done": ("synthesis", "COMPLETED"),
+        "single_done": ("single", "COMPLETED"),
+        "fusion_alias_done": ("fusion_alias", "COMPLETED"),
+        "panel_done": ("critic", "COMPLETED"),
+        "panel_blocked": ("critic", None),
+    }
+    for event in event_rows:
+        binding = terminal_bindings.get(event.get("stage"))
+        if binding is None:
+            continue
+        role, status = binding
+        model = event.get("model") if role in {"lead", "synthesis", "single", "critic"} else None
+        if not has_call(role, model=model, status=status):
+            reasons.append("progress_terminal_call_missing")
+
+
+def validate_fusion_progress_receipt(value: Any) -> tuple[bool, tuple[str, ...]]:
+    if not isinstance(value, Mapping) or value.get("schema_version") != receipt.PROGRESS_SCHEMA:
+        return False, ("progress_receipt_schema_invalid",)
+    if set(value) != _RECEIPT_KEYS:
+        return False, ("progress_receipt_fields_invalid",)
+    body = {key: item for key, item in value.items() if key != "receipt_id"}
+    reasons: list[str] = []
+    run_id = body.get("run_id")
+    if not isinstance(run_id, str) or receipt._RUN_ID.fullmatch(run_id) is None:
+        reasons.append("progress_run_id_invalid")
+    events, calls = body.get("events"), body.get("openrouter_calls")
+    if not isinstance(events, list) or len(events) > receipt.MAX_EVENTS:
+        reasons.append("progress_events_invalid")
+    else:
+        if body.get("event_count") != len(events):
+            reasons.append("progress_event_count_mismatch")
+        if body.get("events_digest") != receipt._digest("reddog_fusion_progress_events", events):
+            reasons.append("progress_events_digest_mismatch")
+        _validate_events(events, body.get("run_id"), reasons)
+    if not isinstance(calls, list) or len(calls) > receipt.MAX_CALLS:
+        reasons.append("openrouter_calls_invalid")
+    else:
+        if body.get("openrouter_call_count") != len(calls):
+            reasons.append("openrouter_call_count_mismatch")
+        if body.get("openrouter_calls_digest") != receipt._digest("reddog_openrouter_calls", calls):
+            reasons.append("openrouter_calls_digest_mismatch")
+        _validate_calls(calls, body.get("run_id"), reasons)
+    if isinstance(events, list) and isinstance(calls, list):
+        _validate_event_call_correlation(events, calls, reasons)
+    if value.get("receipt_id") != receipt._digest("reddog_fusion_progress_receipt", body):
+        reasons.append("progress_receipt_id_mismatch")
+    if body.get("contains_prompt_or_response_content") is not False:
+        reasons.append("progress_content_boundary_invalid")
+    if body.get("contains_reasoning_content") is not False:
+        reasons.append("progress_reasoning_boundary_invalid")
+    return not reasons, tuple(dict.fromkeys(reasons))
+
+
+__all__ = ["validate_fusion_progress_receipt"]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_fusion_progress_receipt.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_fusion_progress_receipt.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from modules.communication.moltbot_bridge.src.reddog_fusion_progress_receipt import (
+    FusionProgressRecorder,
+    sanitize_openrouter_metadata,
+    sanitize_openrouter_usage,
+    validate_fusion_progress_receipt,
+)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.wall = 1_000
+        self.mono = 5_000_000_000
+
+    def wall_ms(self) -> int:
+        self.wall += 10
+        return self.wall
+
+    def monotonic_ns(self) -> int:
+        self.mono += 1_000_000
+        return self.mono
+
+
+def _recorder() -> FusionProgressRecorder:
+    clock = _Clock()
+    return FusionProgressRecorder(
+        "run-1",
+        wall_clock_ms=clock.wall_ms,
+        monotonic_ns=clock.monotonic_ns,
+    )
+
+
+def test_progress_receipt_round_trip_and_tamper_rejection() -> None:
+    recorder = _recorder()
+    recorder.emit("lead_start", role="lead", model="model-a")
+    recorder.emit("lead_done", role="lead", model="model-a")
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=400)
+    recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        generation_id="gen-1",
+        usage={"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30, "cost": 0.001},
+        router_metadata={"requested": "model-a", "strategy": "direct", "attempt": 1},
+    )
+    receipt = recorder.receipt()
+
+    assert validate_fusion_progress_receipt(receipt) == (True, ())
+    tampered = deepcopy(receipt)
+    tampered["events"][0]["model"] = "model-b"
+    valid, reasons = validate_fusion_progress_receipt(tampered)
+    assert valid is False
+    assert "progress_events_digest_mismatch" in reasons
+    assert "progress_receipt_id_mismatch" in reasons
+
+    rehashed = deepcopy(receipt)
+    rehashed["events"][0]["model"] = "model-b"
+    from modules.communication.moltbot_bridge.src import reddog_fusion_progress_receipt as receipts
+
+    rehashed["events_digest"] = receipts._digest("reddog_fusion_progress_events", rehashed["events"])
+    outer = {key: item for key, item in rehashed.items() if key != "receipt_id"}
+    rehashed["receipt_id"] = receipts._digest("reddog_fusion_progress_receipt", outer)
+    valid, reasons = validate_fusion_progress_receipt(rehashed)
+    assert valid is False
+    assert "progress_event_id_mismatch" in reasons
+
+    smuggled = deepcopy(receipt)
+    smuggled["openrouter_calls"][0]["prompt"] = "must-not-cross"
+    smuggled["openrouter_calls_digest"] = receipts._digest("reddog_openrouter_calls", smuggled["openrouter_calls"])
+    outer = {key: item for key, item in smuggled.items() if key != "receipt_id"}
+    smuggled["receipt_id"] = receipts._digest("reddog_fusion_progress_receipt", outer)
+    valid, reasons = validate_fusion_progress_receipt(smuggled)
+    assert valid is False
+    assert "openrouter_call_fields_invalid" in reasons
+
+    nested_smuggled = deepcopy(receipt)
+    nested_smuggled["openrouter_calls"][0]["router_metadata"]["selected_endpoints"] = [
+        {"provider": "Provider A", "model": "model-a", "prompt": "must-not-cross"}
+    ]
+    call = nested_smuggled["openrouter_calls"][0]
+    call_body = {key: item for key, item in call.items() if key != "receipt_id"}
+    call["receipt_id"] = receipts._digest("reddog_openrouter_call_receipt", call_body)
+    nested_smuggled["openrouter_calls_digest"] = receipts._digest(
+        "reddog_openrouter_calls", nested_smuggled["openrouter_calls"]
+    )
+    outer = {key: item for key, item in nested_smuggled.items() if key != "receipt_id"}
+    nested_smuggled["receipt_id"] = receipts._digest("reddog_fusion_progress_receipt", outer)
+    valid, reasons = validate_fusion_progress_receipt(nested_smuggled)
+    assert valid is False
+    assert "openrouter_selected_endpoint_fields_invalid" in reasons
+
+
+def test_unknown_stage_is_not_recorded() -> None:
+    recorder = _recorder()
+    assert recorder.emit("model_private_thought", role="lead") is None
+    assert recorder.receipt()["event_count"] == 0
+
+
+def test_run_id_cannot_carry_free_form_content() -> None:
+    try:
+        FusionProgressRecorder("operator prompt text")
+    except ValueError as exc:
+        assert str(exc) == "missing_bridge_run_id"
+    else:
+        raise AssertionError("expected run ID rejection")
+
+
+def test_usage_sanitizer_keeps_only_numeric_accounting() -> None:
+    usage = sanitize_openrouter_usage(
+        {
+            "prompt_tokens": 12,
+            "completion_tokens": 8,
+            "total_tokens": 20,
+            "cost": 0.000123,
+            "prompt": "secret prompt",
+            "completion_tokens_details": {"reasoning_tokens": 4, "reasoning": "private"},
+            "prompt_tokens_details": {"cached_tokens": 3, "raw": "private"},
+        }
+    )
+    assert usage == {
+        "prompt_tokens": 12,
+        "completion_tokens": 8,
+        "total_tokens": 20,
+        "reasoning_tokens": 4,
+        "cached_tokens": 3,
+        "cost_microcredits": 123,
+    }
+    assert "prompt" not in usage
+    assert "reasoning" not in usage
+
+
+def test_router_metadata_drops_free_form_pipeline_data() -> None:
+    metadata = sanitize_openrouter_metadata(
+        {
+            "requested": "model-a",
+            "strategy": "fusion",
+            "region": "iad",
+            "attempt": 2,
+            "is_byok": True,
+            "summary": "may contain provider prose",
+            "endpoints": {
+                "available": [
+                    {"provider": "Provider A", "model": "model-a", "selected": True, "token": "secret"},
+                    {"provider": "Provider B", "model": "model-a", "selected": False},
+                ]
+            },
+            "pipeline": [{"type": "guardrail", "name": "content-filter", "data": {"raw": "secret"}}],
+        }
+    )
+    assert metadata["selected_endpoints"] == [{"provider": "Provider A", "model": "model-a"}]
+    assert metadata["pipeline_stages"] == [{"type": "guardrail", "name": "content-filter"}]
+    assert metadata["response_provider"] == ""
+    assert metadata["response_model"] == ""
+    assert "summary" not in metadata
+    assert "data" not in metadata["pipeline_stages"][0]
+
+
+def test_failed_call_is_receipted_without_usage_or_content() -> None:
+    recorder = _recorder()
+    call_id = recorder.begin_call(role="critic", model="model-b", requested_max_tokens=900)
+    call = recorder.finish_call(call_id, status="FAILED", retry_count=2, failure_reason="timeout")
+    assert call["status"] == "FAILED"
+    assert call["failure_reason"] == "timeout"
+    assert call["usage"]["total_tokens"] == 0
+    assert call["usage_verified"] is False
+    assert call["cost_accounting_complete"] is False
+    assert "content" not in call
+    assert "messages" not in call
+    assert "secret" not in str(call).lower()
+
+
+def test_secret_like_route_and_failure_values_are_removed() -> None:
+    recorder = _recorder()
+    secret = "sk-or-v1-THIS-IS-A-SECRET-TOKEN"
+    call_id = recorder.begin_call(role="lead", model=secret, requested_max_tokens=1)
+    call = recorder.finish_call(
+        call_id,
+        status="FAILED",
+        failure_reason=secret,
+        router_metadata={"requested": secret, "response_provider": secret},
+    )
+    assert call["model"] == ""
+    assert call["failure_reason"] == ""
+    assert call["router_metadata"]["requested"] == ""
+    assert call["router_metadata"]["response_provider"] == ""
+    assert secret not in str(recorder.receipt())
+
+
+def test_completed_call_with_malformed_usage_is_not_verified() -> None:
+    recorder = _recorder()
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=10)
+    call = recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        usage={"prompt_tokens": -1, "completion_tokens": 2, "total_tokens": 1},
+    )
+    assert call["usage_verified"] is False
+    assert call["cost_accounting_complete"] is False
+
+
+def test_completed_call_with_inconsistent_usage_total_is_not_verified() -> None:
+    recorder = _recorder()
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=10)
+    call = recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        usage={"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 9, "cost": 0.001},
+    )
+    assert call["usage_verified"] is False
+    assert call["cost_accounting_complete"] is False
+
+
+def test_retry_success_keeps_cost_accounting_incomplete() -> None:
+    recorder = _recorder()
+    recorder.emit("lead_start", role="lead", model="model-a")
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=10)
+    call = recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        retry_count=2,
+        usage={"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5, "cost": 0.001},
+    )
+    assert call["usage_verified"] is True
+    assert call["cost_accounting_complete"] is False
+    assert validate_fusion_progress_receipt(recorder.receipt()) == (True, ())
+
+    recorder = _recorder()
+    recorder.emit("lead_start", role="lead", model="model-a")
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=10)
+    call = recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        usage={"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5, "cost": 0.001},
+    )
+    assert call["usage_verified"] is True
+    assert call["router_metadata"]["attempt_present"] is False
+    assert call["cost_accounting_complete"] is False
+    assert validate_fusion_progress_receipt(recorder.receipt()) == (True, ())
+
+    recorder = _recorder()
+    recorder.emit("lead_start", role="lead", model="model-a")
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=10)
+    call = recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        usage={"prompt_tokens": 2, "completion_tokens": 3, "total_tokens": 5, "cost": 0.001},
+        router_metadata={"attempt": 2},
+    )
+    assert call["cost_accounting_complete"] is False
+    assert validate_fusion_progress_receipt(recorder.receipt()) == (True, ())
+
+
+def test_progress_and_call_correlation_fails_closed() -> None:
+    recorder = _recorder()
+    recorder.emit("lead_start", role="lead", model="model-a")
+    recorder.emit("lead_done", role="lead", model="model-a")
+    valid, reasons = validate_fusion_progress_receipt(recorder.receipt())
+    assert valid is False
+    assert "progress_terminal_call_missing" in reasons
+
+    recorder = _recorder()
+    call_id = recorder.begin_call(role="lead", model="model-a", requested_max_tokens=1)
+    recorder.finish_call(
+        call_id,
+        status="COMPLETED",
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2, "cost": 0.001},
+    )
+    valid, reasons = validate_fusion_progress_receipt(recorder.receipt())
+    assert valid is False
+    assert "openrouter_call_progress_start_missing" in reasons
+
+
+def test_receipt_declares_content_and_reasoning_boundaries() -> None:
+    receipt = _recorder().receipt()
+    assert receipt["contains_prompt_or_response_content"] is False
+    assert receipt["contains_reasoning_content"] is False
+
+
+def test_call_limit_fails_closed() -> None:
+    recorder = _recorder()
+    for index in range(16):
+        recorder.begin_call(role="critic", model=f"model-{index}", requested_max_tokens=1)
+    try:
+        recorder.begin_call(role="critic", model="overflow", requested_max_tokens=1)
+    except ValueError as exc:
+        assert str(exc) == "openrouter_call_receipt_limit_exceeded"
+    else:
+        raise AssertionError("expected call limit rejection")

--- a/scripts/advisory_model_once.py
+++ b/scripts/advisory_model_once.py
@@ -16,6 +16,7 @@ import os
 import sys
 import urllib.error
 import urllib.request
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,10 @@ if str(REPO_ROOT) not in sys.path:
 from modules.communication.moltbot_bridge.src.fusion_redaction_gate import (  # noqa: E402
     REDACTION_GATE_PASSED,
     evaluate_redaction_gate,
+)
+from modules.communication.moltbot_bridge.src.reddog_fusion_progress_receipt import (  # noqa: E402
+    FusionProgressRecorder,
+    validate_fusion_progress_receipt,
 )
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
@@ -81,15 +86,40 @@ DEFAULT_SYSTEM_PROMPT = (
     "For every finding, include evidence, uncertainty, and an actionable proposed fix or explicit defer reason."
 )
 
+_PROGRESS_RECORDER: FusionProgressRecorder | None = None
+
 
 def _json_result(**fields: Any) -> int:
+    if _PROGRESS_RECORDER is not None:
+        receipt = _PROGRESS_RECORDER.receipt()
+        receipt_valid, receipt_reasons = validate_fusion_progress_receipt(receipt)
+        receipt_validation = {"applied": True, "valid": receipt_valid, "rejection_reasons": list(receipt_reasons)}
+        fields.setdefault("fusion_progress_receipt", receipt)
+        fields.setdefault("fusion_progress_receipt_validation", receipt_validation)
+        packet = fields.get("review_packet")
+        if isinstance(packet, dict):
+            packet.setdefault("fusion_progress_receipt", receipt)
+            packet.setdefault("fusion_progress_receipt_validation", receipt_validation)
     sys.stdout.write(json.dumps(fields, ensure_ascii=True, sort_keys=True))
     sys.stdout.write("\n")
     return 0
 
 
-def _progress(stage: str, text: str) -> None:
-    sys.stderr.write(json.dumps({"event": "progress", "stage": stage, "text": text}, ensure_ascii=True))
+def _progress(stage: str, text: str, *, role: str = "", model: str = "") -> None:
+    event: dict[str, Any] = {"event": "progress", "stage": stage, "text": text}
+    if _PROGRESS_RECORDER is not None:
+        recorded = _PROGRESS_RECORDER.emit(stage, role=role, model=model)
+        if recorded:
+            event.update({
+                "run_id": recorded["run_id"],
+                "event_id": recorded["event_id"],
+                "sequence": recorded["sequence"],
+                "status": recorded["status"],
+                "role": recorded["role"],
+                "model": recorded["model"],
+                "elapsed_ms": recorded["elapsed_ms"],
+            })
+    sys.stderr.write(json.dumps(event, ensure_ascii=True))
     sys.stderr.write("\n")
     sys.stderr.flush()
 
@@ -106,11 +136,25 @@ def _post_openrouter(api_key: str, body: dict[str, Any], timeout: int) -> tuple[
                 "Authorization": "Bearer " + api_key,
                 "Content-Type": "application/json",
                 "X-Title": "FoundUps Cursor Advisory Worker",
+                "X-OpenRouter-Metadata": "enabled",
             },
         )
         try:
             with urllib.request.urlopen(request, timeout=timeout) as response:
-                return json.loads(response.read().decode("utf-8")), retry_meta
+                data = json.loads(response.read().decode("utf-8"))
+                headers = getattr(response, "headers", None)
+                generation_id = headers.get("X-Generation-Id", "") if headers is not None else ""
+                if not generation_id and isinstance(data, dict):
+                    generation_id = data.get("id", "")
+                retry_meta["openrouter_generation_id"] = str(generation_id or "")
+                retry_meta["openrouter_usage"] = data.get("usage") if isinstance(data, dict) else None
+                metadata = data.get("openrouter_metadata") if isinstance(data, dict) else None
+                safe_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+                if isinstance(data, dict):
+                    safe_metadata["response_provider"] = data.get("provider")
+                    safe_metadata["response_model"] = data.get("model")
+                retry_meta["openrouter_metadata"] = safe_metadata
+                return data, retry_meta
         except urllib.error.HTTPError as exc:
             status = getattr(exc, "code", None)
             if status in RETRYABLE_HTTP_STATUS and attempt < MAX_HTTP_RETRIES:
@@ -166,6 +210,7 @@ def _chat_completion(
     max_tokens: int,
     temperature: float,
     timeout: int,
+    role: str = "single",
 ) -> tuple[str, dict[str, Any]]:
     body: dict[str, Any] = {
         "model": model,
@@ -180,9 +225,71 @@ def _chat_completion(
         body["reasoning"] = {"effort": "max"}
     else:
         body["temperature"] = temperature
-    data, retry_meta = _post_openrouter(api_key, body, timeout)
+    data, retry_meta = _receipted_openrouter_post(
+        api_key, body, timeout, role=role, model=model, requested_max_tokens=body["max_tokens"]
+    )
     content = data["choices"][0]["message"]["content"]
     return str(content), retry_meta
+
+
+def _receipted_openrouter_post(
+    api_key: str,
+    body: dict[str, Any],
+    timeout: int,
+    *,
+    role: str,
+    model: str,
+    requested_max_tokens: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    call_id = _begin_openrouter_call(role, model, requested_max_tokens)
+    try:
+        data, retry_meta = _post_openrouter(api_key, body, timeout)
+    except Exception as exc:
+        _finish_openrouter_failure(call_id, exc)
+        raise
+    _finish_openrouter_success(call_id, retry_meta)
+    return data, retry_meta
+
+
+def _begin_openrouter_call(role: str, model: str, requested_max_tokens: int) -> str:
+    if _PROGRESS_RECORDER is None:
+        return ""
+    return _PROGRESS_RECORDER.begin_call(
+        role=role,
+        model=model,
+        requested_max_tokens=requested_max_tokens,
+    )
+
+
+def _finish_openrouter_success(call_id: str, meta: dict[str, Any]) -> None:
+    if _PROGRESS_RECORDER is None or not call_id:
+        return
+    _PROGRESS_RECORDER.finish_call(
+        call_id,
+        status="COMPLETED",
+        retry_count=meta.get("retry_count", 0),
+        generation_id=str(meta.get("openrouter_generation_id") or ""),
+        usage=meta.get("openrouter_usage"),
+        router_metadata=meta.get("openrouter_metadata"),
+    )
+
+
+def _finish_openrouter_failure(call_id: str, exc: Exception) -> None:
+    if _PROGRESS_RECORDER is None or not call_id:
+        return
+    retry_meta = getattr(exc, "retry_meta", {})
+    if isinstance(exc, urllib.error.HTTPError):
+        reason = "http_" + str(getattr(exc, "code", "error"))
+    elif isinstance(exc, (urllib.error.URLError, TimeoutError)):
+        reason = "timeout"
+    else:
+        reason = "provider_response_error"
+    _PROGRESS_RECORDER.finish_call(
+        call_id,
+        status="FAILED",
+        retry_count=retry_meta.get("retry_count", 0) if isinstance(retry_meta, dict) else 0,
+        failure_reason=reason,
+    )
 
 
 def _effective_max_tokens(model: str, requested_max_tokens: int) -> int:
@@ -500,9 +607,12 @@ def _openrouter_fusion_alias(
             }
         ],
     }
-    _progress("fusion_alias_start", "OpenRouter Fusion alias request started. Judge: " + judge_model)
+    _progress("fusion_alias_start", "OpenRouter Fusion alias request started. Judge: " + judge_model,
+              role="fusion_alias", model=judge_model)
     try:
-        data, retry_meta = _post_openrouter(api_key, body, timeout)
+        data, retry_meta = _receipted_openrouter_post(
+            api_key, body, timeout, role="fusion_alias", model="openrouter/fusion", requested_max_tokens=0
+        )
         content = str(data["choices"][0]["message"]["content"])
     except urllib.error.HTTPError as exc:
         return _http_failure_reason(exc)
@@ -510,7 +620,8 @@ def _openrouter_fusion_alias(
         return {"ok": False, "reason": "timeout"}
     except (KeyError, IndexError, TypeError, json.JSONDecodeError):
         return {"ok": False, "reason": "fusion_alias_malformed_response"}
-    _progress("fusion_alias_done", "OpenRouter Fusion alias response received.")
+    _progress("fusion_alias_done", "OpenRouter Fusion alias response received.",
+              role="fusion_alias", model=judge_model)
     return _fusion_alias_success_packet(
         redacted_prompt=redacted_prompt,
         history=history,
@@ -565,7 +676,7 @@ def _run_foundups_fusion_core(
     lead_messages.extend(history)
     lead_messages.append({"role": "user", "content": redacted_prompt})
 
-    _progress("lead_start", "Lead request started: " + lead_model)
+    _progress("lead_start", "Lead request started: " + lead_model, role="lead", model=lead_model)
     lead_retry: dict[str, Any] = {"retry_count": 0, "final_retry_reason": None}
     try:
         lead_text, lead_retry = _chat_completion(
@@ -575,6 +686,7 @@ def _run_foundups_fusion_core(
             max_tokens=role_max_tokens["lead"],
             temperature=temperature,
             timeout=timeout,
+            role="lead",
         )
     except urllib.error.HTTPError as exc:
         return {**_http_failure_reason(exc), "lead_model": lead_model}
@@ -593,7 +705,7 @@ def _run_foundups_fusion_core(
             panel_max_tokens=panel_max_tokens,
         )
 
-    _progress("lead_done", "Lead response received: " + lead_model)
+    _progress("lead_done", "Lead response received: " + lead_model, role="lead", model=lead_model)
     critic_system = (
         base_system
         + "\n\nPanel critic pass: attack the lead answer for missing WSP_97 truth labels, missing WSP_15 scoring, unsupported evidence, weak HoloIndex retrieval, and fixes that are not actionable. Start with `Challenge:` when any evidence, claim, framing, scope, or WSP_15 priority issue exists, and explicitly mention the WSP_15 priority. Start with `No material challenge:` only when the lead framing, evidence, and priority are all sound. Do not claim authority."
@@ -604,7 +716,7 @@ def _run_foundups_fusion_core(
         {"role": "user", "content": critic_user},
     ]
     panel_results: dict[str, str] = {}
-    _progress("panel_start", "Panel requests started: " + ", ".join(panel_models))
+    _progress("panel_start", "Panel requests started: " + ", ".join(panel_models), role="panel")
     with ThreadPoolExecutor(max_workers=len(panel_models)) as executor:
         futures = {
             executor.submit(
@@ -615,6 +727,7 @@ def _run_foundups_fusion_core(
                 max_tokens=panel_max_tokens[model],
                 temperature=temperature,
                 timeout=timeout,
+                role="critic",
             ): model
             for model in panel_models
         }
@@ -622,16 +735,16 @@ def _run_foundups_fusion_core(
             model = futures[future]
             try:
                 panel_results[model], _panel_retry = future.result()
-                _progress("panel_done", "Panel response received: " + model)
+                _progress("panel_done", "Panel response received: " + model, role="critic", model=model)
             except urllib.error.HTTPError as exc:
                 panel_results[model] = "[blocked: http_error " + str(getattr(exc, "code", "")) + "]"
-                _progress("panel_blocked", "Panel blocked: " + model)
+                _progress("panel_blocked", "Panel blocked: " + model, role="critic", model=model)
             except (urllib.error.URLError, TimeoutError):
                 panel_results[model] = "[blocked: timeout]"
-                _progress("panel_blocked", "Panel network error: " + model)
+                _progress("panel_blocked", "Panel network error: " + model, role="critic", model=model)
             except (KeyError, IndexError, TypeError, json.JSONDecodeError):
                 panel_results[model] = "[blocked: malformed_response]"
-                _progress("panel_blocked", "Panel malformed response: " + model)
+                _progress("panel_blocked", "Panel malformed response: " + model, role="critic", model=model)
 
     challenging_critics = [
         model for model, text in panel_results.items() if _critic_challenges_framing_and_priority(text)
@@ -659,7 +772,7 @@ def _run_foundups_fusion_core(
             + "\n\nSynthesis pass: resolve panel disagreement, preserve useful dissent, and return the best actionable WSP-compliant recommendation. The final section must be WSP_15 Priority followed by Next safest step."
         )
     synthesis_user = _synthesis_user_prompt(redacted_prompt, lead_text, panel_results)
-    _progress("synthesis_start", "Synthesis request started: " + lead_model)
+    _progress("synthesis_start", "Synthesis request started: " + lead_model, role="synthesis", model=lead_model)
     try:
         synthesis, _syn_retry = _chat_completion(
             api_key,
@@ -671,6 +784,7 @@ def _run_foundups_fusion_core(
             max_tokens=role_max_tokens["synthesis"],
             temperature=temperature,
             timeout=timeout,
+            role="synthesis",
         )
     except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, KeyError, IndexError, TypeError, json.JSONDecodeError):
         return _fusion_quorum_packet(
@@ -684,7 +798,7 @@ def _run_foundups_fusion_core(
             challenging_critics=challenging_critics,
         )
 
-    _progress("synthesis_done", "Synthesis complete.")
+    _progress("synthesis_done", "Synthesis complete.", role="synthesis", model=lead_model)
     content = _format_panel(lead_model, lead_text, panel_results, synthesis)
     next_history = history + [
         {"role": "user", "content": redacted_prompt},
@@ -751,11 +865,21 @@ def _read_stdin_json() -> dict[str, Any]:
 
 
 def main() -> int:
-    _progress("bridge_start", "Bridge Python started.")
+    global _PROGRESS_RECORDER
+    _PROGRESS_RECORDER = None
     try:
         payload = _read_stdin_json()
     except json.JSONDecodeError:
         return _json_result(ok=False, reason="invalid_json")
+
+    bridge_run_id = str(payload.get("bridge_run_id") or "").strip()
+    if not bridge_run_id:
+        bridge_run_id = "reddog_bridge_run:" + uuid.uuid4().hex
+    try:
+        _PROGRESS_RECORDER = FusionProgressRecorder(bridge_run_id)
+    except ValueError:
+        return _json_result(ok=False, reason="invalid_bridge_run_id")
+    _progress("bridge_start", "Bridge Python started.")
 
     api_key = os.getenv(ENV_API_KEY)
     _progress("env_check", "OPENROUTER_API_KEY visible to bridge: " + ("yes" if bool(api_key) else "no"))
@@ -884,7 +1008,7 @@ def main() -> int:
     temperature = _bounded_temperature(payload.get("temperature"), 0.2)
     timeout = _bounded_int(payload.get("timeout"), 60, 1, 120)
 
-    _progress("single_start", "Regular OpenRouter request started: " + model)
+    _progress("single_start", "Regular OpenRouter request started: " + model, role="single", model=model)
     try:
         content, retry_meta = _chat_completion(
             api_key,
@@ -893,6 +1017,7 @@ def main() -> int:
             max_tokens=max_tokens,
             temperature=float(temperature),
             timeout=timeout,
+            role="single",
         )
     except urllib.error.HTTPError as exc:
         return _json_result(**_http_failure_reason(exc))
@@ -901,7 +1026,7 @@ def main() -> int:
     except (KeyError, IndexError, TypeError, json.JSONDecodeError):
         return _json_result(ok=False, reason="malformed_response")
 
-    _progress("single_done", "Regular OpenRouter response received: " + model)
+    _progress("single_done", "Regular OpenRouter response received: " + model, role="single", model=model)
     assistant_text = str(content)
     next_history = history + [
         {"role": "user", "content": redacted_user_message},

--- a/scripts/tests/test_reddog_fusion_progress_bridge.py
+++ b/scripts/tests/test_reddog_fusion_progress_bridge.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import io
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_BRIDGE_SPEC = importlib.util.spec_from_file_location(
+    "reddog_advisory_model_once_progress_test",
+    REPO_ROOT / "scripts" / "advisory_model_once.py",
+)
+if _BRIDGE_SPEC is None or _BRIDGE_SPEC.loader is None:
+    raise RuntimeError("advisory_model_once_spec_unavailable")
+bridge = importlib.util.module_from_spec(_BRIDGE_SPEC)
+sys.modules[_BRIDGE_SPEC.name] = bridge
+_BRIDGE_SPEC.loader.exec_module(bridge)
+from modules.communication.moltbot_bridge.src.reddog_fusion_progress_receipt import (
+    FusionProgressRecorder,
+    validate_fusion_progress_receipt,
+)
+
+
+class _Response:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.payload = payload
+        self.headers = {"X-Generation-Id": "gen-123"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def _run_main(payload: dict[str, object], *, api_key: str = "") -> dict[str, object]:
+    stdin = mock.Mock()
+    stdin.buffer = io.BytesIO(json.dumps(payload).encode("utf-8"))
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    env = {bridge.ENV_API_KEY: api_key} if api_key else {}
+    with mock.patch.object(sys, "stdin", stdin), mock.patch.object(sys, "stdout", stdout), mock.patch.object(
+        sys, "stderr", stderr
+    ), mock.patch.dict(os.environ, env, clear=True):
+        bridge.main()
+    return json.loads(stdout.getvalue())
+
+
+def test_openrouter_response_metadata_and_usage_are_retained_without_content() -> None:
+    response = {
+        "id": "gen-body",
+        "model": "served/model",
+        "provider": "Provider A",
+        "choices": [{"message": {"content": "model output"}}],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cost": 0.0002,
+            "completion_tokens_details": {"reasoning_tokens": 2, "reasoning": "hidden"},
+        },
+        "openrouter_metadata": {
+            "requested": "requested/model",
+            "strategy": "direct",
+            "summary": "free-form provider data",
+            "pipeline": [{"type": "guardrail", "name": "content-filter", "data": {"raw": "hidden"}}],
+        },
+    }
+    seen_request = None
+
+    def fake_urlopen(request, timeout=0):  # noqa: ARG001
+        nonlocal seen_request
+        seen_request = request
+        return _Response(response)
+
+    with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        data, meta = bridge._post_openrouter("key", {"model": "requested/model", "messages": []}, 30)
+
+    assert data["choices"][0]["message"]["content"] == "model output"
+    assert seen_request.get_header("X-openrouter-metadata") == "enabled"
+    assert meta["openrouter_generation_id"] == "gen-123"
+    assert meta["openrouter_usage"]["total_tokens"] == 15
+    assert meta["openrouter_metadata"]["response_provider"] == "Provider A"
+    assert meta["openrouter_metadata"]["response_model"] == "served/model"
+
+
+def test_chat_completion_creates_valid_content_free_receipt() -> None:
+    recorder = FusionProgressRecorder("run-test")
+    recorder.emit("lead_start", role="lead", model="requested/model")
+    prior = bridge._PROGRESS_RECORDER
+    bridge._PROGRESS_RECORDER = recorder
+    try:
+        with mock.patch.object(
+            bridge,
+            "_post_openrouter",
+            return_value=(
+                {"choices": [{"message": {"content": "private response"}}]},
+                {
+                    "retry_count": 1,
+                    "openrouter_generation_id": "gen-1",
+                    "openrouter_usage": {
+                        "prompt_tokens": 4,
+                        "completion_tokens": 3,
+                        "total_tokens": 7,
+                        "cost": 0.0001,
+                    },
+                    "openrouter_metadata": {"response_provider": "Provider A", "response_model": "served/model"},
+                },
+            ),
+        ):
+            content, _meta = bridge._chat_completion(
+                "key",
+                "requested/model",
+                [{"role": "system", "content": "system"}, {"role": "user", "content": "prompt"}],
+                max_tokens=20,
+                temperature=0.2,
+                timeout=30,
+                role="lead",
+            )
+    finally:
+        bridge._PROGRESS_RECORDER = prior
+
+    assert content == "private response"
+    receipt = recorder.receipt()
+    assert validate_fusion_progress_receipt(receipt) == (True, ())
+    serialized = json.dumps(receipt).lower()
+    assert "private response" not in serialized
+    assert '"messages"' not in serialized
+    assert receipt["openrouter_calls"][0]["usage_verified"] is True
+    assert receipt["openrouter_calls"][0]["cost_accounting_complete"] is False
+
+
+def test_missing_key_returns_bound_progress_receipt_without_network() -> None:
+    payload = {"bridge_run_id": "run-missing-key", "prompt": "hello", "mode": "openrouter_single"}
+    with mock.patch.object(bridge, "_post_openrouter") as post:
+        result = _run_main(payload)
+    assert result["reason"] == "missing_key"
+    assert post.call_count == 0
+    receipt = result["fusion_progress_receipt"]
+    assert result["fusion_progress_receipt_validation"] == {
+        "applied": True,
+        "valid": True,
+        "rejection_reasons": [],
+    }
+    assert receipt["run_id"] == "run-missing-key"
+    assert [event["stage"] for event in receipt["events"]] == ["bridge_start", "env_check"]
+    assert validate_fusion_progress_receipt(receipt) == (True, ())
+
+
+def test_redaction_block_emits_no_openrouter_call_receipt() -> None:
+    payload = {
+        "bridge_run_id": "run-blocked",
+        "prompt": "private_reasoning hidden plan",
+        "mode": "openrouter_single",
+        "model": "requested/model",
+    }
+    with mock.patch.object(bridge, "_post_openrouter") as post:
+        result = _run_main(payload, api_key="present-only-in-env")
+    assert result["reason"] == "redaction_blocked"
+    assert post.call_count == 0
+    receipt = result["fusion_progress_receipt"]
+    assert receipt["openrouter_call_count"] == 0
+    assert receipt["events"][-1]["stage"] == "redaction_blocked"
+
+
+def test_successful_single_runtime_binds_progress_events_to_call() -> None:
+    payload = {
+        "bridge_run_id": "run-single-success",
+        "prompt": "Summarize the supplied evidence.",
+        "mode": "openrouter_single",
+        "model": "requested/model",
+    }
+    response = (
+        {"choices": [{"message": {"content": "Model answer"}}]},
+        {
+            "retry_count": 0,
+            "openrouter_generation_id": "gen-1",
+            "openrouter_usage": {
+                "prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6, "cost": 0.0001,
+            },
+            "openrouter_metadata": {
+                "attempt": 1, "response_provider": "Provider A", "response_model": "served/model",
+            },
+        },
+    )
+    with mock.patch.object(bridge, "_post_openrouter", return_value=response):
+        result = _run_main(payload, api_key="present-only-in-env")
+    assert result["ok"] is True
+    assert result["fusion_progress_receipt_validation"]["valid"] is True
+    receipt = result["fusion_progress_receipt"]
+    assert [event["stage"] for event in receipt["events"]][-2:] == ["single_start", "single_done"]
+    assert receipt["openrouter_call_count"] == 1
+    assert receipt["openrouter_calls"][0]["cost_accounting_complete"] is True


### PR DESCRIPTION
## Summary
- add process-bound, integrity-checked Fusion progress receipts and per-call OpenRouter usage/routing receipts
- surface canonical live stage/role/model progress plus truthful token, retry, latency, generation, route, and cost-accounting telemetry
- keep receipts observational only: no prompt/output/reasoning/secrets and no execution or promotion authority

## WSP_97 truth boundary
- OBSERVED: OpenRouter calls remain non-streaming and redaction-gated
- OBSERVED: missing, retry-ambiguous, or provider-attempt-ambiguous cost remains `unknown`
- OBSERVED: foreign-run, malformed, rehashed-smuggled, secret-like, and event/call-inconsistent receipts are rejected from presentation
- OBSERVED: the receipt is unkeyed internal-integrity evidence, not signer authenticity and not runtime authority
- SPECIFIED_NOT_IMPLEMENTED: durable usage persistence, billing reconciliation, and signed observability receipts

## Validation
- 230 focused Python tests + 17 subtests passed
- 42 WRE red-team tests passed
- RedDog Fusion panel input contract passed
- RedDog full extension contract passed
- Python/Node syntax checks passed
- two independent WSP_97 reviewers returned GO
- `git diff --check` clean
- `extension.js` WSP_62 ceiling: 8341/8350

## Boundary
No model-selection, HoloIndex mutation, OpenClaw/Hermes execution, shell, worktree, PR, merge, reward, or authority expansion.