### PR TITLE
feat(ai-gateway): verify signed Fusion panel evidence

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -308,7 +308,10 @@ digests, explicit synthesizer, and exact catalog/selection/task/topology/policy/
 surface ID-and-digest bindings. Only then does it verify the aggregate signer,
 trusted key, key epoch, validity window and signature; optional aggregate nonce
 consumption is last. Runtime binding rejects PANEL selections unless supplied
-this verified aggregate. The API does not sign, choose models, call providers,
+this exact process-local factory-issued aggregate proof. The proof cannot be
+directly constructed, copied, replaced or serialized; runtime rechecks its
+closure-held identity seal and exact aggregate/member/context/synthesizer
+projections. The API does not sign, choose models, call providers,
 wire Fusion consumers, mutate runtime defaults or perform network/file writes.
 
 #### RedDog Model Selection Artifact Supply

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -262,8 +262,9 @@ produce a minimal RedDog bridge payload via `to_reddog_bridge_payload()`.
 The verifier role remains outside candidate panels. Catalog-only champions,
 evaluation selections, stale topology, mismatched benchmark evidence, missing
 verified production evidence, missing signed promotion receipts, and
-below-threshold evidence fail closed. Panel runtime binding is intentionally
-deferred until panel topology evidence is signed and verified. This API does not
+below-threshold evidence fail closed. Panel runtime binding accepts only a
+`VerifiedModelPanelEvidence` aggregate; independently valid member proofs alone
+remain insufficient. This API does not
 call model providers, run benchmarks, mutate the extension, persist runtime
 defaults, or write PatternMemory.
 
@@ -290,6 +291,25 @@ interface; this module never signs, never holds private keys and never imports a
 crypto signing library. Nonces are consumed only when admission explicitly
 requests it. Downstream selection and runtime checks validate immutable verified
 evidence and do not consume single-use nonces again.
+
+#### Signed Aggregate PANEL Evidence
+
+```python
+build_panel_member_evidence_binding(...) -> PanelMemberEvidenceBinding
+build_model_panel_signed_evidence_receipt(...) -> ModelPanelSignedEvidenceReceipt
+rehydrate_model_panel_signed_evidence_receipt(...)
+build_verified_model_panel_evidence(...) -> VerifiedModelPanelEvidence
+```
+
+The PANEL verifier first invokes the existing signed single-model admission
+chain for every ordered role/model/provider member. It then checks member and
+required-role uniqueness, exact selection order, per-member evidence IDs and
+digests, explicit synthesizer, and exact catalog/selection/task/topology/policy/
+surface ID-and-digest bindings. Only then does it verify the aggregate signer,
+trusted key, key epoch, validity window and signature; optional aggregate nonce
+consumption is last. Runtime binding rejects PANEL selections unless supplied
+this verified aggregate. The API does not sign, choose models, call providers,
+wire Fusion consumers, mutate runtime defaults or perform network/file writes.
 
 #### RedDog Model Selection Artifact Supply
 

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,33 @@
 # AI Gateway Module Change Log
 
+## [2026-07-18] - Signed Aggregate Fusion PANEL Evidence
+
+**Who:** 0102 Codex worker, architect-audited lane
+**Type:** Production Evidence / Runtime Binding Security
+**Slice:** MODEL_SIGNED_PANEL_EVIDENCE_PHASE1
+
+**What:** Added a separate signed aggregate PANEL envelope and required it for
+PANEL runtime binding. Every member's existing signed benchmark/promotion chain
+is verified first; the aggregate binds ordered roles, models, providers,
+per-member evidence IDs/digests, catalog, selection, task, topology, policy,
+runtime surface and explicit synthesizer before aggregate signature and nonce
+admission.
+
+**Truth Boundary:**
+- IMPLEMENTED: typed PANEL aggregate, deterministic rehydration, independent
+  member verification, anti-splice checks, signer trust/revocation/freshness,
+  replay rejection, runtime-binding gate, adversarial tests.
+- NOT IMPLEMENTED: Fusion consumer wiring, provider calls, model discovery or
+  ranking, artifact supply/bootstrap, WRE scheduling, OpenClaw/Hermes changes,
+  signing/private-key custody, durable nonce/trust stores, live execution.
+
+**WSP References:** WSP 00, WSP 15, WSP 22, WSP 50, WSP 62, WSP 97.
+
+**WSP_15 Score:** Complexity 4 + Importance 5 + Deferability 5 + Impact 5 =
+19 (P0 security boundary).
+
+---
+
 ## [2026-07-18] - Kimi K3 OpenRouter AutoResearch Candidate
 
 **Who:** 0102 Codex

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -14,9 +14,10 @@ runtime surface and explicit synthesizer before aggregate signature and nonce
 admission.
 
 **Truth Boundary:**
-- IMPLEMENTED: typed PANEL aggregate, deterministic rehydration, independent
-  member verification, anti-splice checks, signer trust/revocation/freshness,
-  replay rejection, runtime-binding gate, adversarial tests.
+- IMPLEMENTED: process-local sealed PANEL proof, deterministic rehydration,
+  independent member verification, anti-splice checks, signer trust/revocation/
+  freshness, replay rejection, exact runtime identity/projection gate, and
+  adversarial construction/replacement/copy/pickle tests.
 - NOT IMPLEMENTED: Fusion consumer wiring, provider calls, model discovery or
   ranking, artifact supply/bootstrap, WRE scheduling, OpenClaw/Hermes changes,
   signing/private-key custody, durable nonce/trust stores, live execution.

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -194,7 +194,10 @@ digests, catalog, selection, task, topology, policy and runtime-surface context,
 plus an explicit synthesizer. Aggregate trust, signature, revocation, freshness
 and optional nonce consumption are checked only after all member and anti-splice
 checks pass. This slice enables the runtime-binding receipt to represent a
-verified panel; it does not wire any Fusion consumer or choose panel members.
+verified panel. The returned proof is process-local, sealed, non-copyable and
+non-serializable; runtime binding requires the exact factory-issued identity and
+rechecks its canonical aggregate, member, context and synthesizer projections.
+This slice does not wire any Fusion consumer or choose panel members.
 
 ## RedDog Model Selection Artifact Supply
 

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -183,8 +183,18 @@ authority. Those mappings remain useful as legacy scalar projections, but
 `selection.purpose == production` requires a typed
 `VerifiedModelProductionEvidence` object that passed signed-evidence
 verification. Runtime binding also requires that verified object before a bridge
-payload can be emitted. Single-model chains can pass; panel runtime binding is
-still deferred until topology-bound panel evidence is signed and verified.
+payload can be emitted. Single-model chains pass through their existing typed
+evidence object. Panel binding requires the separate aggregate proof described
+below; a collection of otherwise-valid single-model proofs is insufficient.
+
+`src/model_panel_signed_evidence.py` verifies every member's complete existing
+single-model chain before it admits a signed PANEL envelope. The envelope binds
+the exact ordered role/model/provider members, per-member evidence IDs and
+digests, catalog, selection, task, topology, policy and runtime-surface context,
+plus an explicit synthesizer. Aggregate trust, signature, revocation, freshness
+and optional nonce consumption are checked only after all member and anti-splice
+checks pass. This slice enables the runtime-binding receipt to represent a
+verified panel; it does not wire any Fusion consumer or choose panel members.
 
 ## RedDog Model Selection Artifact Supply
 

--- a/modules/ai_intelligence/ai_gateway/ROADMAP.md
+++ b/modules/ai_intelligence/ai_gateway/ROADMAP.md
@@ -6,6 +6,24 @@
 - Task-specific routing logic
 - Usage monitoring and statistics
 
+## Dynamic RedDog Model Evidence
+
+- [x] Signed single-model benchmark and promotion evidence admission
+- [x] Signed aggregate PANEL evidence with ordered topology and runtime-context binding
+- [x] PANEL runtime binding fails closed without the verified aggregate
+- [ ] Shared verified runtime-topology resolver for RedDog/Fusion consumers
+- [ ] Outside-repository aggregate artifact supply/bootstrap and durable trust-store integration
+
+### Runtime binder decomposition
+
+- [ ] Extract receipt serialization from inherited `bind_reddog_runtime_models`
+  while preserving byte-for-byte receipt IDs and SINGLE/PANEL parity.
+
+### ModLog archive
+
+- [ ] Move closed historical epochs into a WSP_22-governed archive before the
+  module journal reaches the temporary 1,500-line ceiling.
+
 ## Phase 1: Enhanced Intelligence (Next)
 - **Cost optimization algorithms** - Auto-select cheapest provider
 - **Performance prediction models** - Choose fastest provider

--- a/modules/ai_intelligence/ai_gateway/src/model_panel_signed_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_panel_signed_evidence.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import weakref
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Mapping, Sequence
@@ -42,7 +43,6 @@ PANEL_EVIDENCE_SCHEMA_VERSION = "model_panel_signed_evidence_receipt.v1"
 VERIFIED_PANEL_EVIDENCE_SCHEMA_VERSION = "verified_model_panel_evidence.v1"
 PANEL_SIGNING_PREFIX = "reddog-model-panel-evidence.v1"
 PANEL_SUBJECT_TYPE = "panel"
-_VERIFIED_MARKER = object()
 _PANEL_STRING_FIELDS = (
     "synthesizer_model_id",
     "synthesizer_role",
@@ -194,28 +194,83 @@ class ModelPanelSignedEvidenceReceipt:
         return {"receipt_id": self.receipt_id, **self.to_signed_record()}
 
 
-@dataclass(frozen=True)
 class VerifiedModelPanelEvidence:
-    """Opaque factory result accepted by PANEL runtime binding."""
+    """Process-local sealed proof issued only by the verification factory."""
 
-    aggregate_receipt: ModelPanelSignedEvidenceReceipt
-    member_entries: tuple[VerifiedModelEvidenceEntry, ...]
-    _marker: object
-    schema_version: str = VERIFIED_PANEL_EVIDENCE_SCHEMA_VERSION
+    __slots__ = ("_aggregate_receipt", "_member_entries", "__weakref__")
+    __hash__ = object.__hash__
+
+    def __new__(cls, *_args: Any, **_kwargs: Any) -> "VerifiedModelPanelEvidence":
+        raise TypeError("verified_panel_evidence_factory_required")
+
+    def __setattr__(self, _name: str, _value: Any) -> None:
+        raise TypeError("verified_panel_evidence_is_sealed")
+
+    @property
+    def aggregate_receipt(self) -> ModelPanelSignedEvidenceReceipt:
+        return self._aggregate_receipt
+
+    @property
+    def member_entries(self) -> tuple[VerifiedModelEvidenceEntry, ...]:
+        return self._member_entries
+
+    @property
+    def schema_version(self) -> str:
+        return VERIFIED_PANEL_EVIDENCE_SCHEMA_VERSION
 
     @property
     def signed_evidence_verified(self) -> bool:
-        return self._marker is _VERIFIED_MARKER
+        return _verified_panel_seal(self) is not None
 
     @property
     def panel_signed_evidence_verified(self) -> bool:
-        return self._marker is _VERIFIED_MARKER
+        return _verified_panel_seal(self) is not None
 
     def model_ids(self) -> tuple[str, ...]:
         return tuple(member.model_id for member in self.aggregate_receipt.members)
 
     def selection_receipt_ids(self) -> tuple[str, ...]:
         return (self.aggregate_receipt.selection_receipt_id,)
+
+    def __copy__(self) -> "VerifiedModelPanelEvidence":
+        raise TypeError("verified_panel_evidence_copy_forbidden")
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> "VerifiedModelPanelEvidence":
+        raise TypeError("verified_panel_evidence_copy_forbidden")
+
+    def __reduce_ex__(self, _protocol: int) -> Any:
+        raise TypeError("verified_panel_evidence_pickle_forbidden")
+
+
+@dataclass(frozen=True)
+class _VerifiedPanelSeal:
+    aggregate_receipt: ModelPanelSignedEvidenceReceipt
+    member_entries: tuple[VerifiedModelEvidenceEntry, ...]
+    aggregate_digest: str
+    member_projection_digest: str
+    context_digest: str
+    synthesizer: tuple[str, str]
+
+
+def _build_verified_panel_registry(verifier):
+    registry: weakref.WeakKeyDictionary[VerifiedModelPanelEvidence, _VerifiedPanelSeal] = weakref.WeakKeyDictionary()
+
+    def verify_and_issue(*args: Any, **kwargs: Any) -> VerifiedModelPanelEvidence:
+        receipt, entries = verifier(*args, **kwargs)
+        proof = object.__new__(VerifiedModelPanelEvidence)
+        object.__setattr__(proof, "_aggregate_receipt", receipt)
+        object.__setattr__(proof, "_member_entries", entries)
+        registry[proof] = _panel_seal(receipt, entries)
+        return proof
+
+    def lookup(value: Any) -> _VerifiedPanelSeal | None:
+        try:
+            return registry.get(value) if isinstance(value, VerifiedModelPanelEvidence) else None
+        except Exception:
+            return None
+
+    verify_and_issue.__name__ = "build_verified_model_panel_evidence"
+    return verify_and_issue, lookup
 
 
 def build_panel_member_evidence_binding(
@@ -330,7 +385,7 @@ def rehydrate_model_panel_signed_evidence_receipt(data: Mapping[str, Any]) -> Mo
     return receipt
 
 
-def build_verified_model_panel_evidence(
+def _verify_model_panel_evidence_inputs(
     *,
     catalog_snapshot: ModelCatalogSnapshot, selection_receipt: ModelSelectionReceipt,
     member_inputs: Sequence[PanelMemberEvidenceInput],
@@ -343,14 +398,13 @@ def build_verified_model_panel_evidence(
     nonce_store: NonceStore | None = None, consume_nonce: bool = False,
     revoked_member_key_epochs: Sequence[str] = (), revoked_panel_key_epochs: Sequence[str] = (),
     leeway_s: int = 60,
-) -> VerifiedModelPanelEvidence:
+) -> tuple[ModelPanelSignedEvidenceReceipt, tuple[VerifiedModelEvidenceEntry, ...]]:
     """Verify member chains first, then the aggregate envelope and nonce last."""
-
-    receipt = aggregate_receipt if isinstance(aggregate_receipt, ModelPanelSignedEvidenceReceipt) else rehydrate_model_panel_signed_evidence_receipt(aggregate_receipt)
+    aggregate_record, benchmark_run_receipt_id = _aggregate_record_and_run(aggregate_receipt)
     entries, bindings = _verify_member_inputs(
         catalog_snapshot_id=catalog_snapshot.snapshot_id,
         selection_receipt_id=selection_receipt.receipt_id,
-        benchmark_run_receipt_id=receipt.benchmark_run_receipt_id,
+        benchmark_run_receipt_id=benchmark_run_receipt_id,
         member_inputs=member_inputs,
         key_resolver=member_key_resolver,
         signature_verifier=member_signature_verifier,
@@ -358,6 +412,7 @@ def build_verified_model_panel_evidence(
         revoked_key_epochs=revoked_member_key_epochs,
         leeway_s=leeway_s,
     )
+    receipt = rehydrate_model_panel_signed_evidence_receipt(aggregate_record)
     _assert_panel_context(
         catalog_snapshot=catalog_snapshot,
         selection_receipt=selection_receipt,
@@ -379,7 +434,30 @@ def build_verified_model_panel_evidence(
         leeway_s=leeway_s,
     )
     _consume_panel_nonce(receipt, nonce_store=nonce_store, consume_nonce=consume_nonce)
-    return VerifiedModelPanelEvidence(receipt, entries, _VERIFIED_MARKER)
+    return receipt, entries
+
+
+build_verified_model_panel_evidence, _verified_panel_seal = _build_verified_panel_registry(
+    _verify_model_panel_evidence_inputs
+)
+
+
+def _aggregate_record(
+    aggregate: ModelPanelSignedEvidenceReceipt | Mapping[str, Any],
+) -> Mapping[str, Any]:
+    if isinstance(aggregate, ModelPanelSignedEvidenceReceipt):
+        return aggregate.to_dict()
+    if not isinstance(aggregate, Mapping):
+        raise ValueError("invalid_panel_evidence_record")
+    return aggregate
+
+
+def _aggregate_record_and_run(
+    aggregate: ModelPanelSignedEvidenceReceipt | Mapping[str, Any],
+) -> tuple[Mapping[str, Any], str]:
+    record = _aggregate_record(aggregate)
+    run_id = _required("benchmark_run_receipt_id", record.get("benchmark_run_receipt_id"))
+    return record, run_id
 
 
 def _consume_panel_nonce(
@@ -436,10 +514,11 @@ def panel_runtime_context_rejections(
 ) -> tuple[str, ...]:
     """Recheck immutable aggregate context at the runtime-binding boundary."""
 
-    if not isinstance(evidence, VerifiedModelPanelEvidence) or not evidence.panel_signed_evidence_verified:
+    seal = _verified_panel_seal(evidence)
+    if seal is None:
         return ("missing_verified_panel_evidence",)
     receipt = evidence.aggregate_receipt
-    reasons: list[str] = []
+    reasons = _panel_seal_rejections(evidence, seal)
     try:
         if rehydrate_model_panel_signed_evidence_receipt(receipt.to_dict()) != receipt:
             reasons.append("panel_signed_evidence_receipt_invalid")
@@ -451,6 +530,12 @@ def panel_runtime_context_rejections(
         reasons.append("panel_signed_evidence_member_order_mismatch")
     if receipt.required_roles != tuple(selection_receipt.requirements.panel_roles):
         reasons.append("panel_signed_evidence_required_roles_mismatch")
+    synthesizers = tuple(
+        member for member in receipt.members
+        if member.role == receipt.synthesizer_role and member.model_id == receipt.synthesizer_model_id
+    )
+    if len(synthesizers) != 1 or seal.synthesizer != (receipt.synthesizer_model_id, receipt.synthesizer_role):
+        reasons.append("panel_signed_evidence_synthesizer_mismatch")
     if not _runtime_member_bindings_match(receipt, evidence.member_entries):
         reasons.append("panel_signed_evidence_member_projection_mismatch")
     expected_context = _context_values(catalog_snapshot, selection_receipt, runtime_policy)
@@ -468,6 +553,37 @@ def panel_runtime_context_rejections(
     if receipt.task_receipt_digest != _common_task_digest(evidence.member_entries):
         reasons.append("panel_signed_evidence_task_mismatch")
     return tuple(sorted(set(reasons)))
+
+
+def _panel_seal(
+    receipt: ModelPanelSignedEvidenceReceipt,
+    entries: tuple[VerifiedModelEvidenceEntry, ...],
+) -> _VerifiedPanelSeal:
+    return _VerifiedPanelSeal(
+        aggregate_receipt=receipt,
+        member_entries=entries,
+        aggregate_digest=_content_digest(receipt.to_dict()),
+        member_projection_digest=_content_digest([member.to_dict() for member in receipt.members]),
+        context_digest=_content_digest(_sealed_context_values(receipt)),
+        synthesizer=(receipt.synthesizer_model_id, receipt.synthesizer_role),
+    )
+
+
+def _panel_seal_rejections(
+    evidence: VerifiedModelPanelEvidence,
+    seal: _VerifiedPanelSeal,
+) -> list[str]:
+    receipt = evidence.aggregate_receipt
+    reasons: list[str] = []
+    if receipt is not seal.aggregate_receipt or evidence.member_entries is not seal.member_entries:
+        reasons.append("panel_verified_proof_identity_mismatch")
+    if _content_digest(receipt.to_dict()) != seal.aggregate_digest:
+        reasons.append("panel_verified_proof_aggregate_mismatch")
+    if _content_digest([member.to_dict() for member in receipt.members]) != seal.member_projection_digest:
+        reasons.append("panel_verified_proof_member_mismatch")
+    if _content_digest(_sealed_context_values(receipt)) != seal.context_digest:
+        reasons.append("panel_verified_proof_context_mismatch")
+    return reasons
 
 
 def _runtime_member_bindings_match(
@@ -568,6 +684,20 @@ def _receipt_context_values(receipt: ModelPanelSignedEvidenceReceipt) -> tuple[s
         receipt.topology_receipt_digest,
         receipt.policy_receipt_digest,
         receipt.runtime_surface_receipt_digest,
+    )
+
+
+def _sealed_context_values(receipt: ModelPanelSignedEvidenceReceipt) -> tuple[Any, ...]:
+    return (
+        receipt.panel_subject_id,
+        receipt.catalog_snapshot_id, receipt.catalog_snapshot_digest,
+        receipt.selection_receipt_id, receipt.selection_receipt_digest,
+        receipt.task_receipt_id, receipt.task_receipt_digest,
+        receipt.topology_receipt_id, receipt.topology_receipt_digest,
+        receipt.policy_receipt_id, receipt.policy_receipt_digest,
+        receipt.runtime_surface_receipt_id, receipt.runtime_surface_receipt_digest,
+        receipt.benchmark_run_receipt_id,
+        receipt.required_roles,
     )
 
 

--- a/modules/ai_intelligence/ai_gateway/src/model_panel_signed_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_panel_signed_evidence.py
@@ -1,0 +1,719 @@
+"""Signed aggregate evidence for production model panels.
+
+The aggregate is intentionally separate from single-model signed evidence.  A
+panel is admitted only after every member's existing benchmark/promotion chain
+has been independently verified.  The aggregate then binds the exact ordered
+role/model/provider topology and its runtime context before its own signature
+and optional single-use nonce are checked.
+
+This module does not sign, choose models, call providers, execute commands,
+mutate catalogs, persist runtime defaults, or wire a Fusion consumer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    NonceStore,
+    SignatureVerifier,
+    canonical_signing_input,
+    constant_time_compare,
+)
+
+from .model_intelligence_catalog import ModelCatalogSnapshot
+from .model_intelligence_outcomes import ModelBenchmarkEvidenceReceipt, ModelPromotionEvidenceReceipt
+from .model_intelligence_selection import ModelSelectionReceipt, SelectionDecision, SelectionMode, SelectionPurpose
+from .model_runtime_binding import ModelRuntimeBindingPolicy
+from .model_signed_evidence import (
+    ModelEvidenceKeyResolver,
+    ModelSignedEvidenceReceipt,
+    VerifiedModelEvidenceEntry,
+    VerifiedModelProductionEvidence,
+    build_verified_model_production_evidence,
+)
+
+
+PANEL_EVIDENCE_SCHEMA_VERSION = "model_panel_signed_evidence_receipt.v1"
+VERIFIED_PANEL_EVIDENCE_SCHEMA_VERSION = "verified_model_panel_evidence.v1"
+PANEL_SIGNING_PREFIX = "reddog-model-panel-evidence.v1"
+PANEL_SUBJECT_TYPE = "panel"
+_VERIFIED_MARKER = object()
+_PANEL_STRING_FIELDS = (
+    "synthesizer_model_id",
+    "synthesizer_role",
+    "catalog_snapshot_id",
+    "catalog_snapshot_digest",
+    "selection_receipt_id",
+    "selection_receipt_digest",
+    "task_receipt_id",
+    "task_receipt_digest",
+    "topology_receipt_id",
+    "topology_receipt_digest",
+    "policy_receipt_id",
+    "policy_receipt_digest",
+    "runtime_surface_receipt_id",
+    "runtime_surface_receipt_digest",
+    "benchmark_run_receipt_id",
+    "signer_public_key",
+    "signer_key_fingerprint",
+    "key_epoch",
+    "nonce",
+    "signature",
+)
+
+
+class PanelEvidenceSignerRole(str, Enum):
+    """Signer role authorized to attest a complete panel topology."""
+
+    PANEL_AUTHORITY = "panel_authority"
+
+
+@dataclass(frozen=True)
+class PanelMemberEvidenceInput:
+    """Independent signed single-model chain assigned to one panel role."""
+
+    role: str
+    model_id: str
+    provider: str
+    benchmark_receipt: ModelBenchmarkEvidenceReceipt | Mapping[str, Any]
+    promotion_receipt: ModelPromotionEvidenceReceipt | Mapping[str, Any]
+    benchmark_signature_receipt: ModelSignedEvidenceReceipt | Mapping[str, Any]
+    promotion_signature_receipt: ModelSignedEvidenceReceipt | Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class PanelMemberEvidenceBinding:
+    """Digest-bound projection of one independently verified member chain."""
+
+    ordinal: int
+    role: str
+    model_id: str
+    provider: str
+    member_evidence_id: str
+    member_evidence_digest: str
+    benchmark_evidence_receipt_id: str
+    benchmark_evidence_digest: str
+    promotion_evidence_receipt_id: str
+    promotion_evidence_digest: str
+    benchmark_signed_evidence_receipt_id: str
+    benchmark_signed_evidence_digest: str
+    promotion_signed_evidence_receipt_id: str
+    promotion_signed_evidence_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ordinal": self.ordinal,
+            "role": self.role,
+            "model_id": self.model_id,
+            "provider": self.provider,
+            "member_evidence_id": self.member_evidence_id,
+            "member_evidence_digest": self.member_evidence_digest,
+            "benchmark_evidence_receipt_id": self.benchmark_evidence_receipt_id,
+            "benchmark_evidence_digest": self.benchmark_evidence_digest,
+            "promotion_evidence_receipt_id": self.promotion_evidence_receipt_id,
+            "promotion_evidence_digest": self.promotion_evidence_digest,
+            "benchmark_signed_evidence_receipt_id": self.benchmark_signed_evidence_receipt_id,
+            "benchmark_signed_evidence_digest": self.benchmark_signed_evidence_digest,
+            "promotion_signed_evidence_receipt_id": self.promotion_signed_evidence_receipt_id,
+            "promotion_signed_evidence_digest": self.promotion_signed_evidence_digest,
+        }
+
+
+@dataclass(frozen=True)
+class ModelPanelSignedEvidenceReceipt:
+    """Signed envelope over an exact ordered production panel and context."""
+
+    receipt_id: str
+    panel_subject_id: str
+    members: tuple[PanelMemberEvidenceBinding, ...]
+    required_roles: tuple[str, ...]
+    synthesizer_model_id: str
+    synthesizer_role: str
+    catalog_snapshot_id: str
+    catalog_snapshot_digest: str
+    selection_receipt_id: str
+    selection_receipt_digest: str
+    task_receipt_id: str
+    task_receipt_digest: str
+    topology_receipt_id: str
+    topology_receipt_digest: str
+    policy_receipt_id: str
+    policy_receipt_digest: str
+    runtime_surface_receipt_id: str
+    runtime_surface_receipt_digest: str
+    benchmark_run_receipt_id: str
+    signer_role: PanelEvidenceSignerRole
+    signer_public_key: str
+    signer_key_fingerprint: str
+    key_epoch: str
+    issued_at: int
+    expires_at: int
+    nonce: str
+    signature: str
+    subject_type: str = PANEL_SUBJECT_TYPE
+    schema_version: str = PANEL_EVIDENCE_SCHEMA_VERSION
+
+    def to_signed_record(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "subject_type": self.subject_type,
+            "panel_subject_id": self.panel_subject_id,
+            "members": [member.to_dict() for member in self.members],
+            "required_roles": list(self.required_roles),
+            "synthesizer_model_id": self.synthesizer_model_id,
+            "synthesizer_role": self.synthesizer_role,
+            "catalog_snapshot_id": self.catalog_snapshot_id,
+            "catalog_snapshot_digest": self.catalog_snapshot_digest,
+            "selection_receipt_id": self.selection_receipt_id,
+            "selection_receipt_digest": self.selection_receipt_digest,
+            "task_receipt_id": self.task_receipt_id,
+            "task_receipt_digest": self.task_receipt_digest,
+            "topology_receipt_id": self.topology_receipt_id,
+            "topology_receipt_digest": self.topology_receipt_digest,
+            "policy_receipt_id": self.policy_receipt_id,
+            "policy_receipt_digest": self.policy_receipt_digest,
+            "runtime_surface_receipt_id": self.runtime_surface_receipt_id,
+            "runtime_surface_receipt_digest": self.runtime_surface_receipt_digest,
+            "benchmark_run_receipt_id": self.benchmark_run_receipt_id,
+            "signer_role": self.signer_role.value,
+            "signer_public_key": self.signer_public_key,
+            "signer_key_fingerprint": self.signer_key_fingerprint,
+            "key_epoch": self.key_epoch,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "nonce": self.nonce,
+            "signature": self.signature,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"receipt_id": self.receipt_id, **self.to_signed_record()}
+
+
+@dataclass(frozen=True)
+class VerifiedModelPanelEvidence:
+    """Opaque factory result accepted by PANEL runtime binding."""
+
+    aggregate_receipt: ModelPanelSignedEvidenceReceipt
+    member_entries: tuple[VerifiedModelEvidenceEntry, ...]
+    _marker: object
+    schema_version: str = VERIFIED_PANEL_EVIDENCE_SCHEMA_VERSION
+
+    @property
+    def signed_evidence_verified(self) -> bool:
+        return self._marker is _VERIFIED_MARKER
+
+    @property
+    def panel_signed_evidence_verified(self) -> bool:
+        return self._marker is _VERIFIED_MARKER
+
+    def model_ids(self) -> tuple[str, ...]:
+        return tuple(member.model_id for member in self.aggregate_receipt.members)
+
+    def selection_receipt_ids(self) -> tuple[str, ...]:
+        return (self.aggregate_receipt.selection_receipt_id,)
+
+
+def build_panel_member_evidence_binding(
+    *,
+    ordinal: int,
+    role: str,
+    model_id: str,
+    provider: str,
+    verified_evidence: VerifiedModelProductionEvidence,
+) -> PanelMemberEvidenceBinding:
+    """Project one already-verified single-model chain for panel signing."""
+
+    if not isinstance(verified_evidence, VerifiedModelProductionEvidence) or not verified_evidence.signed_evidence_verified:
+        raise ValueError("member_evidence_not_verified")
+    if len(verified_evidence.entries) != 1:
+        raise ValueError("member_evidence_entry_count_invalid")
+    entry = verified_evidence.entries[0]
+    source = PanelMemberEvidenceInput(
+        role=role,
+        model_id=model_id,
+        provider=provider,
+        benchmark_receipt=entry.benchmark_receipt,
+        promotion_receipt=entry.promotion_receipt,
+        benchmark_signature_receipt=entry.benchmark_signature_receipt,
+        promotion_signature_receipt=entry.promotion_signature_receipt,
+    )
+    return _binding_from_entry(int(ordinal), source, entry)
+
+
+def build_model_panel_signed_evidence_receipt(
+    *,
+    members: Sequence[PanelMemberEvidenceBinding | Mapping[str, Any]],
+    required_roles: Sequence[str], synthesizer_model_id: str, synthesizer_role: str,
+    catalog_snapshot_id: str, catalog_snapshot_digest: str,
+    selection_receipt_id: str, selection_receipt_digest: str,
+    task_receipt_id: str, task_receipt_digest: str,
+    topology_receipt_id: str, topology_receipt_digest: str,
+    policy_receipt_id: str, policy_receipt_digest: str,
+    runtime_surface_receipt_id: str, runtime_surface_receipt_digest: str,
+    benchmark_run_receipt_id: str, signer_role: PanelEvidenceSignerRole | str,
+    signer_public_key: str, signer_key_fingerprint: str, key_epoch: str,
+    issued_at: int, expires_at: int, nonce: str, signature: str,
+) -> ModelPanelSignedEvidenceReceipt:
+    """Build a deterministic aggregate receipt from an already-issued signature."""
+
+    raw = locals()
+    bindings = tuple(_member_binding(value) for value in members)
+    role = PanelEvidenceSignerRole(str(getattr(signer_role, "value", signer_role)))
+    body = {
+        "schema_version": PANEL_EVIDENCE_SCHEMA_VERSION,
+        "subject_type": PANEL_SUBJECT_TYPE,
+        "panel_subject_id": _panel_subject_id(bindings),
+        "members": [member.to_dict() for member in bindings],
+        "required_roles": [_required("required_role", value) for value in required_roles],
+        "signer_role": role.value,
+        "issued_at": int(issued_at),
+        "expires_at": int(expires_at),
+    }
+    body.update({name: _required(name, raw[name]) for name in _PANEL_STRING_FIELDS})
+    if body["expires_at"] <= body["issued_at"]:
+        raise ValueError("invalid_panel_evidence_ttl")
+    body["receipt_id"] = _digest_id("model_panel_signed_evidence", body)
+    body["members"] = bindings
+    body["required_roles"] = tuple(body["required_roles"])
+    body["signer_role"] = role
+    return ModelPanelSignedEvidenceReceipt(**body)
+
+
+def model_panel_signed_evidence_signing_input(
+    receipt_or_record: ModelPanelSignedEvidenceReceipt | Mapping[str, Any],
+) -> str:
+    record = receipt_or_record.to_signed_record() if isinstance(receipt_or_record, ModelPanelSignedEvidenceReceipt) else dict(receipt_or_record)
+    return canonical_signing_input(record, PANEL_SIGNING_PREFIX)
+
+
+def rehydrate_model_panel_signed_evidence_receipt(data: Mapping[str, Any]) -> ModelPanelSignedEvidenceReceipt:
+    """Rehydrate an aggregate receipt and recompute its deterministic ID."""
+
+    if data.get("schema_version") != PANEL_EVIDENCE_SCHEMA_VERSION or data.get("subject_type") != PANEL_SUBJECT_TYPE:
+        raise ValueError("invalid_panel_evidence_schema")
+    receipt = build_model_panel_signed_evidence_receipt(
+        members=_list(data, "members"),
+        required_roles=_list(data, "required_roles"),
+        synthesizer_model_id=data.get("synthesizer_model_id"),
+        synthesizer_role=data.get("synthesizer_role"),
+        catalog_snapshot_id=data.get("catalog_snapshot_id"),
+        catalog_snapshot_digest=data.get("catalog_snapshot_digest"),
+        selection_receipt_id=data.get("selection_receipt_id"),
+        selection_receipt_digest=data.get("selection_receipt_digest"),
+        task_receipt_id=data.get("task_receipt_id"),
+        task_receipt_digest=data.get("task_receipt_digest"),
+        topology_receipt_id=data.get("topology_receipt_id"),
+        topology_receipt_digest=data.get("topology_receipt_digest"),
+        policy_receipt_id=data.get("policy_receipt_id"),
+        policy_receipt_digest=data.get("policy_receipt_digest"),
+        runtime_surface_receipt_id=data.get("runtime_surface_receipt_id"),
+        runtime_surface_receipt_digest=data.get("runtime_surface_receipt_digest"),
+        benchmark_run_receipt_id=data.get("benchmark_run_receipt_id"),
+        signer_role=data.get("signer_role"),
+        signer_public_key=data.get("signer_public_key"),
+        signer_key_fingerprint=data.get("signer_key_fingerprint"),
+        key_epoch=data.get("key_epoch"),
+        issued_at=data.get("issued_at"),
+        expires_at=data.get("expires_at"),
+        nonce=data.get("nonce"),
+        signature=data.get("signature"),
+    )
+    if receipt.panel_subject_id != data.get("panel_subject_id"):
+        raise ValueError("panel_subject_id_mismatch")
+    if not constant_time_compare(receipt.receipt_id, _required("receipt_id", data.get("receipt_id"))):
+        raise ValueError("panel_evidence_receipt_id_mismatch")
+    return receipt
+
+
+def build_verified_model_panel_evidence(
+    *,
+    catalog_snapshot: ModelCatalogSnapshot, selection_receipt: ModelSelectionReceipt,
+    member_inputs: Sequence[PanelMemberEvidenceInput],
+    aggregate_receipt: ModelPanelSignedEvidenceReceipt | Mapping[str, Any],
+    runtime_policy: ModelRuntimeBindingPolicy, task_receipt_id: str,
+    topology_receipt_id: str, policy_receipt_id: str,
+    runtime_surface_receipt_id: str, member_key_resolver: ModelEvidenceKeyResolver,
+    member_signature_verifier: SignatureVerifier, panel_key_resolver: ModelEvidenceKeyResolver,
+    panel_signature_verifier: SignatureVerifier, now: int,
+    nonce_store: NonceStore | None = None, consume_nonce: bool = False,
+    revoked_member_key_epochs: Sequence[str] = (), revoked_panel_key_epochs: Sequence[str] = (),
+    leeway_s: int = 60,
+) -> VerifiedModelPanelEvidence:
+    """Verify member chains first, then the aggregate envelope and nonce last."""
+
+    receipt = aggregate_receipt if isinstance(aggregate_receipt, ModelPanelSignedEvidenceReceipt) else rehydrate_model_panel_signed_evidence_receipt(aggregate_receipt)
+    entries, bindings = _verify_member_inputs(
+        catalog_snapshot_id=catalog_snapshot.snapshot_id,
+        selection_receipt_id=selection_receipt.receipt_id,
+        benchmark_run_receipt_id=receipt.benchmark_run_receipt_id,
+        member_inputs=member_inputs,
+        key_resolver=member_key_resolver,
+        signature_verifier=member_signature_verifier,
+        now=now,
+        revoked_key_epochs=revoked_member_key_epochs,
+        leeway_s=leeway_s,
+    )
+    _assert_panel_context(
+        catalog_snapshot=catalog_snapshot,
+        selection_receipt=selection_receipt,
+        bindings=bindings,
+        entries=entries,
+        receipt=receipt,
+        runtime_policy=runtime_policy,
+        task_receipt_id=task_receipt_id,
+        topology_receipt_id=topology_receipt_id,
+        policy_receipt_id=policy_receipt_id,
+        runtime_surface_receipt_id=runtime_surface_receipt_id,
+    )
+    _verify_panel_signature(
+        receipt,
+        key_resolver=panel_key_resolver,
+        signature_verifier=panel_signature_verifier,
+        now=now,
+        revoked_key_epochs=revoked_panel_key_epochs,
+        leeway_s=leeway_s,
+    )
+    _consume_panel_nonce(receipt, nonce_store=nonce_store, consume_nonce=consume_nonce)
+    return VerifiedModelPanelEvidence(receipt, entries, _VERIFIED_MARKER)
+
+
+def _consume_panel_nonce(
+    receipt: ModelPanelSignedEvidenceReceipt, *, nonce_store: NonceStore | None, consume_nonce: bool,
+) -> None:
+    if not consume_nonce:
+        return
+    if nonce_store is None:
+        raise ValueError("panel_nonce_store_missing")
+    try:
+        consumed = nonce_store.consume(receipt.nonce)
+    except Exception:
+        consumed = False
+    if not consumed:
+        raise ValueError("panel_nonce_replay")
+
+
+def _verify_member_inputs(
+    *, catalog_snapshot_id: str, selection_receipt_id: str,
+    benchmark_run_receipt_id: str, member_inputs: Sequence[PanelMemberEvidenceInput],
+    key_resolver: ModelEvidenceKeyResolver, signature_verifier: SignatureVerifier,
+    now: int, revoked_key_epochs: Sequence[str], leeway_s: int,
+) -> tuple[tuple[VerifiedModelEvidenceEntry, ...], tuple[PanelMemberEvidenceBinding, ...]]:
+    entries: list[VerifiedModelEvidenceEntry] = []
+    bindings: list[PanelMemberEvidenceBinding] = []
+    for ordinal, source in enumerate(member_inputs):
+        verified = build_verified_model_production_evidence(
+            catalog_snapshot_id=catalog_snapshot_id,
+            selection_receipt_id=selection_receipt_id,
+            benchmark_run_receipt_id=benchmark_run_receipt_id,
+            benchmark_receipt=source.benchmark_receipt,
+            promotion_receipt=source.promotion_receipt,
+            benchmark_signature_receipt=source.benchmark_signature_receipt,
+            promotion_signature_receipt=source.promotion_signature_receipt,
+            key_resolver=key_resolver,
+            signature_verifier=signature_verifier,
+            now=now,
+            consume_nonces=False,
+            revoked_key_epochs=revoked_key_epochs,
+            leeway_s=leeway_s,
+        )
+        entry = verified.entries[0]
+        entries.append(entry)
+        bindings.append(_binding_from_entry(ordinal, source, entry))
+    return tuple(entries), tuple(bindings)
+
+
+def panel_runtime_context_rejections(
+    evidence: Any,
+    *,
+    catalog_snapshot: ModelCatalogSnapshot,
+    selection_receipt: ModelSelectionReceipt,
+    runtime_policy: ModelRuntimeBindingPolicy,
+) -> tuple[str, ...]:
+    """Recheck immutable aggregate context at the runtime-binding boundary."""
+
+    if not isinstance(evidence, VerifiedModelPanelEvidence) or not evidence.panel_signed_evidence_verified:
+        return ("missing_verified_panel_evidence",)
+    receipt = evidence.aggregate_receipt
+    reasons: list[str] = []
+    try:
+        if rehydrate_model_panel_signed_evidence_receipt(receipt.to_dict()) != receipt:
+            reasons.append("panel_signed_evidence_receipt_invalid")
+    except Exception:
+        reasons.append("panel_signed_evidence_receipt_invalid")
+    expected_assignments = tuple((a.role, a.canonical_model_id, a.provider) for a in selection_receipt.role_assignments)
+    actual_assignments = tuple((m.role, m.model_id, m.provider) for m in receipt.members)
+    if expected_assignments != actual_assignments:
+        reasons.append("panel_signed_evidence_member_order_mismatch")
+    if receipt.required_roles != tuple(selection_receipt.requirements.panel_roles):
+        reasons.append("panel_signed_evidence_required_roles_mismatch")
+    if not _runtime_member_bindings_match(receipt, evidence.member_entries):
+        reasons.append("panel_signed_evidence_member_projection_mismatch")
+    expected_context = _context_values(catalog_snapshot, selection_receipt, runtime_policy)
+    actual_context = (
+        receipt.catalog_snapshot_id,
+        receipt.catalog_snapshot_digest,
+        receipt.selection_receipt_id,
+        receipt.selection_receipt_digest,
+        receipt.topology_receipt_digest,
+        receipt.policy_receipt_digest,
+        receipt.runtime_surface_receipt_digest,
+    )
+    if expected_context != actual_context:
+        reasons.append("panel_signed_evidence_context_mismatch")
+    if receipt.task_receipt_digest != _common_task_digest(evidence.member_entries):
+        reasons.append("panel_signed_evidence_task_mismatch")
+    return tuple(sorted(set(reasons)))
+
+
+def _runtime_member_bindings_match(
+    receipt: ModelPanelSignedEvidenceReceipt,
+    entries: tuple[VerifiedModelEvidenceEntry, ...],
+) -> bool:
+    if len(receipt.members) != len(entries):
+        return False
+    for member, entry in zip(receipt.members, entries):
+        try:
+            source = PanelMemberEvidenceInput(
+                member.role, member.model_id, member.provider,
+                entry.benchmark_receipt, entry.promotion_receipt,
+                entry.benchmark_signature_receipt, entry.promotion_signature_receipt,
+            )
+            matches = _binding_from_entry(member.ordinal, source, entry) == member
+        except Exception:
+            matches = False
+        if not matches:
+            return False
+    return True
+
+
+def _assert_panel_context(
+    *,
+    catalog_snapshot: ModelCatalogSnapshot, selection_receipt: ModelSelectionReceipt,
+    bindings: tuple[PanelMemberEvidenceBinding, ...], entries: tuple[VerifiedModelEvidenceEntry, ...],
+    receipt: ModelPanelSignedEvidenceReceipt, runtime_policy: ModelRuntimeBindingPolicy,
+    task_receipt_id: str, topology_receipt_id: str,
+    policy_receipt_id: str, runtime_surface_receipt_id: str,
+) -> None:
+    _assert_panel_members(selection_receipt, bindings, receipt)
+    _assert_member_context(selection_receipt, entries)
+    if selection_receipt.catalog_snapshot_id != catalog_snapshot.snapshot_id:
+        raise ValueError("panel_selection_catalog_mismatch")
+    expected_context = _context_values(catalog_snapshot, selection_receipt, runtime_policy)
+    actual_context = _receipt_context_values(receipt)
+    if expected_context != actual_context:
+        raise ValueError("panel_context_splice")
+    exact_ids = (receipt.task_receipt_id, receipt.topology_receipt_id, receipt.policy_receipt_id, receipt.runtime_surface_receipt_id)
+    names = ("task_receipt_id", "topology_receipt_id", "policy_receipt_id", "runtime_surface_receipt_id")
+    supplied_ids = tuple(map(_required, names, (task_receipt_id, topology_receipt_id, policy_receipt_id, runtime_surface_receipt_id)))
+    if exact_ids != supplied_ids:
+        raise ValueError("panel_context_id_splice")
+    if receipt.task_receipt_digest != _common_task_digest(entries):
+        raise ValueError("panel_task_digest_splice")
+
+
+def _assert_panel_members(
+    selection_receipt: ModelSelectionReceipt,
+    bindings: tuple[PanelMemberEvidenceBinding, ...],
+    receipt: ModelPanelSignedEvidenceReceipt,
+) -> None:
+    if selection_receipt.decision != SelectionDecision.SELECTED or selection_receipt.requirements.purpose != SelectionPurpose.PRODUCTION:
+        raise ValueError("panel_selection_not_production_selected")
+    if selection_receipt.requirements.selection_mode != SelectionMode.PANEL:
+        raise ValueError("panel_selection_mode_required")
+    if not bindings or len(bindings) != len(selection_receipt.selected_model_ids):
+        raise ValueError("panel_member_count_mismatch")
+    roles = tuple(binding.role for binding in bindings)
+    models = tuple(binding.model_id for binding in bindings)
+    if len(set(roles)) != len(roles):
+        raise ValueError("duplicate_panel_roles")
+    if len(set(models)) != len(models):
+        raise ValueError("duplicate_panel_members")
+    if roles != tuple(selection_receipt.requirements.panel_roles):
+        raise ValueError("missing_or_reordered_required_panel_roles")
+    assignments = tuple((a.role, a.canonical_model_id, a.provider) for a in selection_receipt.role_assignments)
+    if tuple((m.role, m.model_id, m.provider) for m in bindings) != assignments:
+        raise ValueError("panel_role_model_provider_order_mismatch")
+    if tuple(receipt.members) != bindings:
+        raise ValueError("panel_member_evidence_substitution")
+    if receipt.required_roles != roles:
+        raise ValueError("panel_required_roles_mismatch")
+    synth = tuple(m for m in bindings if m.role == receipt.synthesizer_role)
+    if len(synth) != 1 or synth[0].model_id != receipt.synthesizer_model_id:
+        raise ValueError("panel_synthesizer_substitution")
+
+
+def _assert_member_context(
+    selection_receipt: ModelSelectionReceipt,
+    entries: tuple[VerifiedModelEvidenceEntry, ...],
+) -> None:
+    for entry in entries:
+        benchmark = entry.benchmark_receipt
+        if benchmark.task_family != selection_receipt.requirements.task_family:
+            raise ValueError("panel_member_task_mismatch")
+        if benchmark.prompt_topology_digest != selection_receipt.panel_topology_digest:
+            raise ValueError("panel_member_topology_mismatch")
+
+
+def _receipt_context_values(receipt: ModelPanelSignedEvidenceReceipt) -> tuple[str, ...]:
+    return (
+        receipt.catalog_snapshot_id,
+        receipt.catalog_snapshot_digest,
+        receipt.selection_receipt_id,
+        receipt.selection_receipt_digest,
+        receipt.topology_receipt_digest,
+        receipt.policy_receipt_digest,
+        receipt.runtime_surface_receipt_digest,
+    )
+
+
+def _verify_panel_signature(
+    receipt: ModelPanelSignedEvidenceReceipt,
+    *,
+    key_resolver: ModelEvidenceKeyResolver,
+    signature_verifier: SignatureVerifier,
+    now: int,
+    revoked_key_epochs: Sequence[str],
+    leeway_s: int,
+) -> None:
+    reasons: list[str] = []
+    if receipt.signer_role != PanelEvidenceSignerRole.PANEL_AUTHORITY:
+        reasons.append("panel_signer_role_mismatch")
+    if receipt.key_epoch in {str(value) for value in revoked_key_epochs}:
+        reasons.append("panel_key_epoch_revoked")
+    try:
+        trusted_key = key_resolver.resolve(receipt.signer_role.value, receipt.signer_key_fingerprint, receipt.key_epoch)
+    except Exception:
+        trusted_key = None
+    if not trusted_key or not constant_time_compare(str(trusted_key), receipt.signer_public_key):
+        reasons.append("panel_signer_key_untrusted")
+    if now + leeway_s < receipt.issued_at:
+        reasons.append("panel_evidence_issued_in_future")
+    if now > receipt.expires_at + leeway_s:
+        reasons.append("panel_evidence_expired")
+    try:
+        valid = signature_verifier.verify(
+            receipt.signer_public_key,
+            model_panel_signed_evidence_signing_input(receipt),
+            receipt.signature,
+        ) is True
+    except Exception:
+        valid = False
+    if not valid:
+        reasons.append("panel_signature_invalid")
+    if reasons:
+        raise ValueError("panel_signed_evidence_rejected:" + ",".join(sorted(set(reasons))))
+
+
+def _binding_from_entry(
+    ordinal: int,
+    source: PanelMemberEvidenceInput,
+    entry: VerifiedModelEvidenceEntry,
+) -> PanelMemberEvidenceBinding:
+    if _required("member_model_id", source.model_id) != entry.model_id:
+        raise ValueError("panel_member_evidence_model_mismatch")
+    benchmark = entry.benchmark_receipt.to_dict()
+    promotion = entry.promotion_receipt.to_dict()
+    benchmark_sig = entry.benchmark_signature_receipt.to_dict()
+    promotion_sig = entry.promotion_signature_receipt.to_dict()
+    member_body = {
+        "model_id": entry.model_id,
+        "benchmark": benchmark,
+        "promotion": promotion,
+        "benchmark_signature": benchmark_sig,
+        "promotion_signature": promotion_sig,
+    }
+    return PanelMemberEvidenceBinding(
+        ordinal=ordinal,
+        role=_required("member_role", source.role),
+        model_id=_required("member_model_id", source.model_id),
+        provider=_required("member_provider", source.provider),
+        member_evidence_id=_digest_id("model_panel_member_evidence", member_body),
+        member_evidence_digest=_content_digest(member_body),
+        benchmark_evidence_receipt_id=entry.benchmark_receipt.receipt_id,
+        benchmark_evidence_digest=_content_digest(benchmark),
+        promotion_evidence_receipt_id=entry.promotion_receipt.receipt_id,
+        promotion_evidence_digest=_content_digest(promotion),
+        benchmark_signed_evidence_receipt_id=entry.benchmark_signature_receipt.receipt_id,
+        benchmark_signed_evidence_digest=_content_digest(benchmark_sig),
+        promotion_signed_evidence_receipt_id=entry.promotion_signature_receipt.receipt_id,
+        promotion_signed_evidence_digest=_content_digest(promotion_sig),
+    )
+
+
+def _member_binding(value: PanelMemberEvidenceBinding | Mapping[str, Any]) -> PanelMemberEvidenceBinding:
+    if isinstance(value, PanelMemberEvidenceBinding):
+        return value
+    fields = PanelMemberEvidenceBinding.__dataclass_fields__
+    return PanelMemberEvidenceBinding(**{name: int(value[name]) if name == "ordinal" else _required(name, value.get(name)) for name in fields})
+
+
+def _context_values(
+    catalog: ModelCatalogSnapshot,
+    selection: ModelSelectionReceipt,
+    policy: ModelRuntimeBindingPolicy,
+) -> tuple[str, ...]:
+    normalized_policy = policy.normalized()
+    return (
+        catalog.snapshot_id,
+        _content_digest(catalog.to_dict()),
+        selection.receipt_id,
+        _content_digest(selection.to_dict()),
+        _required("panel_topology_digest", selection.panel_topology_digest),
+        _content_digest(normalized_policy.to_dict()),
+        _content_digest({"runtime_surface": normalized_policy.runtime_surface}),
+    )
+
+
+def _common_task_digest(entries: Sequence[VerifiedModelEvidenceEntry]) -> str:
+    digests = {entry.benchmark_receipt.task_set_digest for entry in entries}
+    return next(iter(digests)) if len(digests) == 1 else ""
+
+
+def _panel_subject_id(members: Sequence[PanelMemberEvidenceBinding]) -> str:
+    return _digest_id("model_panel_subject", {"members": [member.to_dict() for member in members]})
+
+
+def _list(data: Mapping[str, Any], name: str) -> list[Any]:
+    value = data.get(name)
+    if not isinstance(value, list):
+        raise ValueError(f"invalid_{name}")
+    return value
+
+
+def _required(name: str, value: Any) -> str:
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError(f"missing_{name}")
+    return cleaned
+
+
+def _canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str).encode("utf-8")
+
+
+def _content_digest(value: Any) -> str:
+    return "sha256:" + hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _digest_id(prefix: str, value: Any) -> str:
+    return prefix + ":" + hashlib.sha256(_canonical(value)).hexdigest()
+
+
+__all__ = [
+    "ModelPanelSignedEvidenceReceipt",
+    "PanelEvidenceSignerRole",
+    "PanelMemberEvidenceBinding",
+    "PanelMemberEvidenceInput",
+    "VerifiedModelPanelEvidence",
+    "build_model_panel_signed_evidence_receipt",
+    "build_panel_member_evidence_binding",
+    "build_verified_model_panel_evidence",
+    "model_panel_signed_evidence_signing_input",
+    "panel_runtime_context_rejections",
+    "rehydrate_model_panel_signed_evidence_receipt",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_runtime_binding.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_runtime_binding.py
@@ -250,27 +250,13 @@ def _runtime_binding_rejections(
     policy: ModelRuntimeBindingPolicy,
     verified_production_evidence: Any | None,
 ) -> list[str]:
-    reasons: list[str] = []
+    reasons = _selection_binding_rejections(catalog_snapshot, selection_receipt)
     selected_ids = tuple(selection_receipt.selected_model_ids)
     catalog_ids = {card.canonical_model_id for card in catalog_snapshot.cards}
-    if selection_receipt.catalog_snapshot_id != catalog_snapshot.snapshot_id:
-        reasons.append("catalog_snapshot_mismatch")
-    if selection_receipt.decision != SelectionDecision.SELECTED:
-        reasons.append("selection_not_selected")
-    if selection_receipt.requirements.purpose != SelectionPurpose.PRODUCTION:
-        reasons.append("selection_not_production")
-    if not getattr(verified_production_evidence, "signed_evidence_verified", False):
-        reasons.append("missing_verified_production_evidence")
-    verified_model_ids: set[str] = set()
-    verified_selection_ids: tuple[str, ...] = ()
-    if getattr(verified_production_evidence, "signed_evidence_verified", False):
-        try:
-            verified_model_ids = set(verified_production_evidence.model_ids())
-            verified_selection_ids = tuple(verified_production_evidence.selection_receipt_ids())
-        except Exception:
-            reasons.append("invalid_verified_production_evidence")
-        if verified_selection_ids and verified_selection_ids != (selection_receipt.receipt_id,):
-            reasons.append("signed_evidence_selection_receipt_mismatch")
+    evidence_reasons, verified_model_ids, is_panel = _verified_evidence_context(
+        verified_production_evidence, catalog_snapshot, selection_receipt, policy
+    )
+    reasons.extend(evidence_reasons)
     if selection_receipt.requirements.task_family != policy.task_family:
         reasons.append("task_family_mismatch")
     if not selected_ids:
@@ -279,8 +265,7 @@ def _runtime_binding_rejections(
         reasons.append("selection_verifier_threshold_missing")
     elif selection_receipt.requirements.min_verifier_pass_rate < policy.min_verifier_pass_rate:
         reasons.append("selection_threshold_below_runtime_policy")
-    if selection_receipt.requirements.selection_mode == SelectionMode.PANEL:
-        reasons.append("panel_runtime_binding_deferred")
+    if is_panel:
         if not selection_receipt.panel_topology_digest:
             reasons.append("missing_panel_topology_digest")
         if policy.required_panel_topology_digest and selection_receipt.panel_topology_digest != policy.required_panel_topology_digest:
@@ -304,6 +289,57 @@ def _runtime_binding_rejections(
             continue
         reasons.extend(_evidence_rejections(model_id, benchmark, promotion, policy, selection_receipt))
     return sorted(set(reasons))
+
+
+def _selection_binding_rejections(
+    catalog_snapshot: ModelCatalogSnapshot,
+    selection_receipt: ModelSelectionReceipt,
+) -> list[str]:
+    reasons: list[str] = []
+    if selection_receipt.catalog_snapshot_id != catalog_snapshot.snapshot_id:
+        reasons.append("catalog_snapshot_mismatch")
+    if selection_receipt.decision != SelectionDecision.SELECTED:
+        reasons.append("selection_not_selected")
+    if selection_receipt.requirements.purpose != SelectionPurpose.PRODUCTION:
+        reasons.append("selection_not_production")
+    return reasons
+
+
+def _verified_evidence_context(
+    evidence: Any | None,
+    catalog_snapshot: ModelCatalogSnapshot,
+    selection_receipt: ModelSelectionReceipt,
+    policy: ModelRuntimeBindingPolicy,
+) -> tuple[list[str], set[str], bool]:
+    reasons: list[str] = []
+    is_panel = selection_receipt.requirements.selection_mode == SelectionMode.PANEL
+    if is_panel:
+        try:
+            from .model_panel_signed_evidence import panel_runtime_context_rejections
+
+            reasons.extend(
+                panel_runtime_context_rejections(
+                    evidence,
+                    catalog_snapshot=catalog_snapshot,
+                    selection_receipt=selection_receipt,
+                    runtime_policy=policy,
+                )
+            )
+        except Exception:
+            reasons.append("missing_verified_panel_evidence")
+    elif not getattr(evidence, "signed_evidence_verified", False):
+        reasons.append("missing_verified_production_evidence")
+    model_ids: set[str] = set()
+    selection_ids: tuple[str, ...] = ()
+    if getattr(evidence, "signed_evidence_verified", False):
+        try:
+            model_ids = set(evidence.model_ids())
+            selection_ids = tuple(evidence.selection_receipt_ids())
+        except Exception:
+            reasons.append("invalid_verified_production_evidence")
+        if selection_ids and selection_ids != (selection_receipt.receipt_id,):
+            reasons.append("signed_evidence_selection_receipt_mismatch")
+    return reasons, model_ids, is_panel
 
 
 def _evidence_rejections(

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_panel_signed_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_panel_signed_evidence.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import ast
+import copy
 import hashlib
 import json
+import pickle
 from dataclasses import replace
 from pathlib import Path
 
@@ -40,6 +42,7 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import 
 from modules.ai_intelligence.ai_gateway.src.model_panel_signed_evidence import (
     PanelEvidenceSignerRole,
     PanelMemberEvidenceInput,
+    VerifiedModelPanelEvidence,
     build_model_panel_signed_evidence_receipt,
     build_panel_member_evidence_binding,
     build_verified_model_panel_evidence,
@@ -141,6 +144,7 @@ def _panel_resolver(public_key: str = PANEL_PUBLIC_KEY) -> StaticModelEvidenceKe
 
 
 def _signed_panel(case: dict, **overrides):
+    signature_override = overrides.pop("_signature_override", None)
     selection = case["selection"]
     snapshot = case["snapshot"]
     policy = case["policy"]
@@ -172,7 +176,9 @@ def _signed_panel(case: dict, **overrides):
     }
     values.update(overrides)
     placeholder = build_model_panel_signed_evidence_receipt(signature="placeholder", **values)
-    signature = deterministic_signature(PANEL_PUBLIC_KEY, model_panel_signed_evidence_signing_input(placeholder))
+    signature = signature_override or deterministic_signature(
+        values["signer_public_key"], model_panel_signed_evidence_signing_input(placeholder)
+    )
     return build_model_panel_signed_evidence_receipt(signature=signature, **values)
 
 
@@ -447,7 +453,7 @@ def test_rejects_expiry_untrusted_revoked_and_replay():
         _verify(case, panel_key_resolver=_panel_resolver("ed25519-pub-v1:other"))
     with pytest.raises(ValueError, match="panel_key_epoch_revoked"):
         _verify(case, revoked_panel_key_epochs=(KEY_EPOCH,))
-    forged = replace(case["aggregate"], signature="test-sig:forged")
+    forged = _signed_panel(case, _signature_override="test-sig:forged")
     with pytest.raises(ValueError, match="panel_signature_invalid"):
         _verify(case, aggregate=forged)
 
@@ -457,19 +463,85 @@ def test_rejects_expiry_untrusted_revoked_and_replay():
         _verify(case, nonce_store=store, consume_nonce=True)
 
 
-def test_runtime_rechecks_verified_member_projection():
+def test_verified_proof_rejects_construction_copy_replace_pickle_and_mutation():
     case = _case()
     verified = _verify(case)
-    tampered = replace(verified, member_entries=tuple(reversed(verified.member_entries)))
+    with pytest.raises(TypeError, match="factory_required"):
+        VerifiedModelPanelEvidence(case["aggregate"], verified.member_entries)
+    with pytest.raises(TypeError):
+        replace(verified, member_entries=tuple(reversed(verified.member_entries)))
+    with pytest.raises(TypeError, match="copy_forbidden"):
+        copy.copy(verified)
+    with pytest.raises(TypeError, match="copy_forbidden"):
+        copy.deepcopy(verified)
+    with pytest.raises(TypeError, match="pickle_forbidden"):
+        pickle.dumps(verified)
+    with pytest.raises(TypeError, match="is_sealed"):
+        verified.aggregate_receipt = case["aggregate"]
+
+
+def _bind_case(case: dict, evidence):
+    return bind_reddog_runtime_models(
+        catalog_snapshot=case["snapshot"],
+        selection_receipt=case["selection"],
+        benchmark_evidence_receipts=case["benchmarks"],
+        promotion_evidence_receipts=case["promotions"],
+        policy=case["policy"],
+        verified_production_evidence=evidence,
+    )
+
+
+def _unsealed_proof(case: dict, aggregate):
+    proof = object.__new__(VerifiedModelPanelEvidence)
+    object.__setattr__(proof, "_aggregate_receipt", aggregate)
+    object.__setattr__(proof, "_member_entries", _verify(case).member_entries)
+    return proof
+
+
+def test_runtime_rejects_unissued_self_consistent_aggregate_variants():
+    case = _case()
+    variants = (
+        _signed_panel(case, _signature_override="test-sig:forged"),
+        _signed_panel(case, issued_at=NOW - 7200, expires_at=NOW - 3600),
+        _signed_panel(case, signer_public_key="ed25519-pub-v1:untrusted"),
+        _signed_panel(case, synthesizer_model_id="provider/critic", synthesizer_role="principal"),
+        _signed_panel(case, policy_receipt_digest="sha256:other"),
+    )
+    for aggregate in variants:
+        receipt = _bind_case(case, _unsealed_proof(case, aggregate))
+        assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
+        assert "missing_verified_panel_evidence" in receipt.rejection_reasons
+
+
+def test_runtime_seal_rejects_low_level_aggregate_and_synthesizer_replacement():
+    case = _case()
+    verified = _verify(case)
+    changed = _signed_panel(
+        case,
+        synthesizer_model_id="provider/critic",
+        synthesizer_role="principal",
+    )
+    object.__setattr__(verified, "_aggregate_receipt", changed)
+    receipt = _bind_case(case, verified)
+    assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
+    assert "panel_verified_proof_identity_mismatch" in receipt.rejection_reasons
+    assert "panel_signed_evidence_synthesizer_mismatch" in receipt.rejection_reasons
+
+
+def test_runtime_seal_rejects_low_level_member_projection_replacement():
+    case = _case()
+    verified = _verify(case)
+    object.__setattr__(verified, "_member_entries", tuple(reversed(verified.member_entries)))
     receipt = bind_reddog_runtime_models(
         catalog_snapshot=case["snapshot"],
         selection_receipt=case["selection"],
         benchmark_evidence_receipts=case["benchmarks"],
         promotion_evidence_receipts=case["promotions"],
         policy=case["policy"],
-        verified_production_evidence=tampered,
+        verified_production_evidence=verified,
     )
     assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
+    assert "panel_verified_proof_identity_mismatch" in receipt.rejection_reasons
     assert "panel_signed_evidence_member_projection_mismatch" in receipt.rejection_reasons
 
 

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_panel_signed_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_panel_signed_evidence.py
@@ -1,0 +1,492 @@
+"""Adversarial tests for signed aggregate PANEL evidence."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from model_signed_evidence_test_helpers import (
+    BENCHMARK_PUBLIC_KEY,
+    PROMOTION_PUBLIC_KEY,
+    DeterministicSignatureVerifier,
+    InMemoryEvidenceNonceStore,
+    ModelEvidenceSignerRole,
+    StaticModelEvidenceKeyResolver,
+    deterministic_signature,
+    make_verified_production_evidence,
+)
+
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
+    ModelCapabilityCard,
+    PromotionState,
+    build_model_catalog_snapshot,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
+    ModelOutcomeMetrics,
+    build_model_benchmark_evidence_receipt,
+    build_model_promotion_evidence_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
+    ModelTaskRequirements,
+    SelectionMode,
+    SelectionPurpose,
+    select_models_for_task,
+)
+from modules.ai_intelligence.ai_gateway.src.model_panel_signed_evidence import (
+    PanelEvidenceSignerRole,
+    PanelMemberEvidenceInput,
+    build_model_panel_signed_evidence_receipt,
+    build_panel_member_evidence_binding,
+    build_verified_model_panel_evidence,
+    model_panel_signed_evidence_signing_input,
+    rehydrate_model_panel_signed_evidence_receipt,
+)
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import (
+    ModelRuntimeBindingDecision,
+    ModelRuntimeBindingPolicy,
+    bind_reddog_runtime_models,
+)
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import VerifiedModelProductionEvidence
+
+
+TASK = "architecture"
+TASK_SET = "sha256:task-set"
+HELD_OUT = "sha256:held-out"
+TOPOLOGY = "sha256:panel-topology"
+VERIFIER = "sha256:verifier"
+BENCHMARK_RUN = "model_combination_benchmark_run:panel"
+TASK_RECEIPT = "model_task_set:architecture-held-out"
+TOPOLOGY_RECEIPT = "model_panel_topology:architecture-v1"
+POLICY_RECEIPT = "model_runtime_binding_policy:architecture-v1"
+SURFACE_RECEIPT = "model_runtime_surface:reddog-fusion"
+PANEL_PUBLIC_KEY = "ed25519-pub-v1:panel"
+PANEL_FINGERPRINT = "fingerprint:panel"
+KEY_EPOCH = "epoch-1"
+NOW = 1_800_000_000
+
+
+def _digest(value) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _card(model_id: str, provider: str) -> ModelCapabilityCard:
+    return ModelCapabilityCard(
+        provider=provider,
+        model_id=model_id,
+        canonical_model_id=model_id,
+        source="test",
+        promotion_state=PromotionState.CHAMPION,
+        task_families=(TASK,),
+        benchmark_scores={TASK: 0.9},
+        verifier_pass_rate=0.95,
+    ).normalized()
+
+
+def _benchmark(model_id: str, *, topology: str = TOPOLOGY):
+    return build_model_benchmark_evidence_receipt(
+        model_id=model_id,
+        task_family=TASK,
+        task_set_digest=TASK_SET,
+        held_out_split_digest=HELD_OUT,
+        prompt_topology_digest=topology,
+        verifier_digest=VERIFIER,
+        verifier_receipt_id=f"verifier:{model_id}",
+        sample_count=20,
+        accepted_count=19,
+        metrics=ModelOutcomeMetrics(latency_ms=1000, input_tokens=500, output_tokens=200),
+    )
+
+
+def _promotion(benchmark):
+    return build_model_promotion_evidence_receipt(
+        benchmark_receipt=benchmark,
+        promotion_state=PromotionState.CHAMPION,
+        promotion_authority_receipt_id=f"authority:{benchmark.model_id}",
+        signed_promotion_receipt_id=f"signed:{benchmark.model_id}",
+        min_verifier_pass_rate=0.9,
+    )
+
+
+def _policy() -> ModelRuntimeBindingPolicy:
+    return ModelRuntimeBindingPolicy(
+        task_family=TASK,
+        runtime_surface="reddog_fusion",
+        min_verifier_pass_rate=0.9,
+        required_task_set_digest=TASK_SET,
+        required_held_out_split_digest=HELD_OUT,
+        required_verifier_digest=VERIFIER,
+        max_panel_models=4,
+        required_panel_topology_digest=TOPOLOGY,
+        authority_receipt_id="runtime-authority:1",
+    )
+
+
+def _member_resolver() -> StaticModelEvidenceKeyResolver:
+    return StaticModelEvidenceKeyResolver(
+        {
+            ModelEvidenceSignerRole.BENCHMARK_VERIFIER.value: BENCHMARK_PUBLIC_KEY,
+            ModelEvidenceSignerRole.PROMOTION_AUTHORITY.value: PROMOTION_PUBLIC_KEY,
+        }
+    )
+
+
+def _panel_resolver(public_key: str = PANEL_PUBLIC_KEY) -> StaticModelEvidenceKeyResolver:
+    return StaticModelEvidenceKeyResolver({PanelEvidenceSignerRole.PANEL_AUTHORITY.value: public_key})
+
+
+def _signed_panel(case: dict, **overrides):
+    selection = case["selection"]
+    snapshot = case["snapshot"]
+    policy = case["policy"]
+    values = {
+        "members": case["bindings"],
+        "required_roles": selection.requirements.panel_roles,
+        "synthesizer_model_id": selection.role_assignments[0].canonical_model_id,
+        "synthesizer_role": "principal",
+        "catalog_snapshot_id": snapshot.snapshot_id,
+        "catalog_snapshot_digest": _digest(snapshot.to_dict()),
+        "selection_receipt_id": selection.receipt_id,
+        "selection_receipt_digest": _digest(selection.to_dict()),
+        "task_receipt_id": TASK_RECEIPT,
+        "task_receipt_digest": TASK_SET,
+        "topology_receipt_id": TOPOLOGY_RECEIPT,
+        "topology_receipt_digest": TOPOLOGY,
+        "policy_receipt_id": POLICY_RECEIPT,
+        "policy_receipt_digest": _digest(policy.normalized().to_dict()),
+        "runtime_surface_receipt_id": SURFACE_RECEIPT,
+        "runtime_surface_receipt_digest": _digest({"runtime_surface": policy.normalized().runtime_surface}),
+        "benchmark_run_receipt_id": BENCHMARK_RUN,
+        "signer_role": PanelEvidenceSignerRole.PANEL_AUTHORITY,
+        "signer_public_key": PANEL_PUBLIC_KEY,
+        "signer_key_fingerprint": PANEL_FINGERPRINT,
+        "key_epoch": KEY_EPOCH,
+        "issued_at": NOW - 10,
+        "expires_at": NOW + 3600,
+        "nonce": "nonce:panel:1",
+    }
+    values.update(overrides)
+    placeholder = build_model_panel_signed_evidence_receipt(signature="placeholder", **values)
+    signature = deterministic_signature(PANEL_PUBLIC_KEY, model_panel_signed_evidence_signing_input(placeholder))
+    return build_model_panel_signed_evidence_receipt(signature=signature, **values)
+
+
+def _case() -> dict:
+    snapshot, benchmarks, promotions, selection = _selection_case()
+    verified_singles, member_inputs, bindings = _member_case(
+        snapshot, benchmarks, promotions, selection
+    )
+    case = {
+        "snapshot": snapshot,
+        "selection": selection,
+        "benchmarks": benchmarks,
+        "promotions": promotions,
+        "verified_singles": verified_singles,
+        "member_inputs": member_inputs,
+        "bindings": bindings,
+        "policy": _policy(),
+    }
+    case["aggregate"] = _signed_panel(case)
+    return case
+
+
+def _selection_case():
+    cards = (
+        _card("provider/principal", "a"),
+        _card("provider/researcher", "b"),
+        _card("provider/critic", "c"),
+    )
+    snapshot = build_model_catalog_snapshot(cards, generated_at="2026-07-18T00:00:00+00:00")
+    benchmarks = tuple(_benchmark(card.canonical_model_id) for card in cards)
+    promotions = tuple(_promotion(value) for value in benchmarks)
+    requirements = ModelTaskRequirements(
+        task_family=TASK,
+        purpose=SelectionPurpose.PRODUCTION,
+        selection_mode=SelectionMode.PANEL,
+        max_candidates=3,
+        min_verifier_pass_rate=0.9,
+        panel_roles=("principal", "researcher", "critic"),
+        panel_topology_digest=TOPOLOGY,
+    )
+    provisional_entries = []
+    for benchmark, promotion in zip(benchmarks, promotions):
+        provisional_entries.extend(
+            make_verified_production_evidence(
+                benchmark,
+                promotion,
+                catalog_snapshot_id=snapshot.snapshot_id,
+            ).entries
+        )
+    selection = select_models_for_task(
+        snapshot,
+        requirements,
+        production_evidence=VerifiedModelProductionEvidence(entries=tuple(provisional_entries)),
+    )
+    return snapshot, benchmarks, promotions, selection
+
+
+def _member_case(snapshot, benchmarks, promotions, selection):
+    verified_singles = tuple(
+        make_verified_production_evidence(
+            benchmark,
+            promotion,
+            catalog_snapshot_id=snapshot.snapshot_id,
+            selection_receipt_id=selection.receipt_id,
+            benchmark_run_receipt_id=BENCHMARK_RUN,
+        )
+        for benchmark, promotion in zip(benchmarks, promotions)
+    )
+    assignments = selection.role_assignments
+    member_inputs = tuple(
+        PanelMemberEvidenceInput(
+            role=assignment.role,
+            model_id=assignment.canonical_model_id,
+            provider=assignment.provider,
+            benchmark_receipt=verified.entries[0].benchmark_receipt,
+            promotion_receipt=verified.entries[0].promotion_receipt,
+            benchmark_signature_receipt=verified.entries[0].benchmark_signature_receipt,
+            promotion_signature_receipt=verified.entries[0].promotion_signature_receipt,
+        )
+        for assignment, verified in zip(assignments, verified_singles)
+    )
+    bindings = tuple(
+        build_panel_member_evidence_binding(
+            ordinal=index,
+            role=source.role,
+            model_id=source.model_id,
+            provider=source.provider,
+            verified_evidence=verified,
+        )
+        for index, (source, verified) in enumerate(zip(member_inputs, verified_singles))
+    )
+    return verified_singles, member_inputs, bindings
+
+
+def _verify(case: dict, *, aggregate=None, member_inputs=None, **overrides):
+    values = {
+        "catalog_snapshot": case["snapshot"],
+        "selection_receipt": case["selection"],
+        "member_inputs": member_inputs or case["member_inputs"],
+        "aggregate_receipt": aggregate or case["aggregate"],
+        "runtime_policy": case["policy"],
+        "task_receipt_id": TASK_RECEIPT,
+        "topology_receipt_id": TOPOLOGY_RECEIPT,
+        "policy_receipt_id": POLICY_RECEIPT,
+        "runtime_surface_receipt_id": SURFACE_RECEIPT,
+        "member_key_resolver": _member_resolver(),
+        "member_signature_verifier": DeterministicSignatureVerifier(),
+        "panel_key_resolver": _panel_resolver(),
+        "panel_signature_verifier": DeterministicSignatureVerifier(),
+        "now": NOW,
+    }
+    values.update(overrides)
+    return build_verified_model_panel_evidence(**values)
+
+
+def test_verified_panel_binds_runtime_and_round_trips():
+    case = _case()
+    assert rehydrate_model_panel_signed_evidence_receipt(case["aggregate"].to_dict()) == case["aggregate"]
+    verified = _verify(case)
+    receipt = bind_reddog_runtime_models(
+        catalog_snapshot=case["snapshot"],
+        selection_receipt=case["selection"],
+        benchmark_evidence_receipts=case["benchmarks"],
+        promotion_evidence_receipts=case["promotions"],
+        policy=case["policy"],
+        verified_production_evidence=verified,
+    )
+    assert receipt.decision == ModelRuntimeBindingDecision.BOUND
+    assert receipt.principal_model == "provider/principal"
+    assert receipt.panel_models == ("provider/researcher", "provider/critic")
+
+
+def test_panel_runtime_rejects_verified_single_collection_without_aggregate():
+    case = _case()
+    singles = VerifiedModelProductionEvidence(
+        entries=tuple(entry for value in case["verified_singles"] for entry in value.entries)
+    )
+    receipt = bind_reddog_runtime_models(
+        catalog_snapshot=case["snapshot"],
+        selection_receipt=case["selection"],
+        benchmark_evidence_receipts=case["benchmarks"],
+        promotion_evidence_receipts=case["promotions"],
+        policy=case["policy"],
+        verified_production_evidence=singles,
+    )
+    assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
+    assert "missing_verified_panel_evidence" in receipt.rejection_reasons
+
+
+def test_member_chain_is_verified_before_aggregate_signature():
+    case = _case()
+    first = case["member_inputs"][0]
+    forged_signature = replace(first.benchmark_signature_receipt, signature="test-sig:forged")
+    forged_inputs = (replace(first, benchmark_signature_receipt=forged_signature), *case["member_inputs"][1:])
+    forged_aggregate = replace(case["aggregate"], signature="test-sig:also-forged")
+    with pytest.raises(ValueError, match="benchmark_signed_evidence_rejected:signature_invalid"):
+        _verify(case, aggregate=forged_aggregate, member_inputs=forged_inputs)
+
+
+def test_rejects_independently_signed_member_with_spliced_topology():
+    case = _case()
+    first = case["member_inputs"][0]
+    benchmark = _benchmark(first.model_id, topology="sha256:other-topology")
+    promotion = _promotion(benchmark)
+    verified = make_verified_production_evidence(
+        benchmark,
+        promotion,
+        catalog_snapshot_id=case["snapshot"].snapshot_id,
+        selection_receipt_id=case["selection"].receipt_id,
+        benchmark_run_receipt_id=BENCHMARK_RUN,
+    )
+    source = PanelMemberEvidenceInput(
+        first.role,
+        first.model_id,
+        first.provider,
+        benchmark,
+        promotion,
+        verified.entries[0].benchmark_signature_receipt,
+        verified.entries[0].promotion_signature_receipt,
+    )
+    binding = build_panel_member_evidence_binding(
+        ordinal=0,
+        role=source.role,
+        model_id=source.model_id,
+        provider=source.provider,
+        verified_evidence=verified,
+    )
+    with pytest.raises(ValueError, match="panel_member_topology_mismatch"):
+        _verify(
+            case,
+            member_inputs=(source, *case["member_inputs"][1:]),
+            aggregate=_signed_panel(case, members=(binding, *case["bindings"][1:])),
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "reason"),
+    (
+        ("catalog_snapshot_id", "model_catalog_snapshot:other", "panel_context_splice"),
+        ("selection_receipt_digest", "sha256:other", "panel_context_splice"),
+        ("task_receipt_digest", "sha256:other", "panel_task_digest_splice"),
+        ("topology_receipt_digest", "sha256:other", "panel_context_splice"),
+        ("policy_receipt_digest", "sha256:other", "panel_context_splice"),
+        ("runtime_surface_receipt_digest", "sha256:other", "panel_context_splice"),
+    ),
+)
+def test_rejects_signed_context_splices(field, value, reason):
+    case = _case()
+    with pytest.raises(ValueError, match=reason):
+        _verify(case, aggregate=_signed_panel(case, **{field: value}))
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("task_receipt_id", "model_task_set:other"),
+        ("topology_receipt_id", "model_panel_topology:other"),
+        ("policy_receipt_id", "model_runtime_binding_policy:other"),
+        ("runtime_surface_receipt_id", "model_runtime_surface:other"),
+    ),
+)
+def test_rejects_signed_context_id_splices(field, value):
+    case = _case()
+    with pytest.raises(ValueError, match="panel_context_id_splice"):
+        _verify(case, aggregate=_signed_panel(case, **{field: value}))
+
+
+def test_rejects_member_reorder_substitution_and_synthesizer_substitution():
+    case = _case()
+    reordered = (case["bindings"][1], case["bindings"][0], case["bindings"][2])
+    with pytest.raises(ValueError, match="panel_member_evidence_substitution"):
+        _verify(case, aggregate=_signed_panel(case, members=reordered))
+    substituted = replace(case["bindings"][0], member_evidence_digest="sha256:substituted")
+    with pytest.raises(ValueError, match="panel_member_evidence_substitution"):
+        _verify(case, aggregate=_signed_panel(case, members=(substituted, *case["bindings"][1:])))
+    with pytest.raises(ValueError, match="panel_synthesizer_substitution"):
+        _verify(
+            case,
+            aggregate=_signed_panel(
+                case,
+                synthesizer_model_id="provider/critic",
+                synthesizer_role="principal",
+            ),
+        )
+
+
+def test_rejects_duplicate_members_roles_and_missing_required_role():
+    case = _case()
+    sources = case["member_inputs"]
+    duplicate_model = (sources[0], replace(sources[1], model_id=sources[0].model_id, benchmark_receipt=sources[0].benchmark_receipt,
+                                            promotion_receipt=sources[0].promotion_receipt,
+                                            benchmark_signature_receipt=sources[0].benchmark_signature_receipt,
+                                            promotion_signature_receipt=sources[0].promotion_signature_receipt), sources[2])
+    duplicate_model_bindings = (case["bindings"][0], replace(case["bindings"][0], ordinal=1, role="researcher"), case["bindings"][2])
+    with pytest.raises(ValueError, match="duplicate_panel_members"):
+        _verify(case, member_inputs=duplicate_model, aggregate=_signed_panel(case, members=duplicate_model_bindings))
+
+    duplicate_role = (sources[0], replace(sources[1], role="principal"), sources[2])
+    duplicate_role_bindings = (case["bindings"][0], replace(case["bindings"][1], role="principal"), case["bindings"][2])
+    with pytest.raises(ValueError, match="duplicate_panel_roles"):
+        _verify(case, member_inputs=duplicate_role, aggregate=_signed_panel(case, members=duplicate_role_bindings))
+    with pytest.raises(ValueError, match="panel_required_roles_mismatch"):
+        _verify(case, aggregate=_signed_panel(case, required_roles=("principal", "researcher")))
+
+
+def test_rejects_expiry_untrusted_revoked_and_replay():
+    case = _case()
+    expired = _signed_panel(case, issued_at=NOW - 7200, expires_at=NOW - 3600)
+    with pytest.raises(ValueError, match="panel_evidence_expired"):
+        _verify(case, aggregate=expired)
+    with pytest.raises(ValueError, match="panel_signer_key_untrusted"):
+        _verify(case, panel_key_resolver=_panel_resolver("ed25519-pub-v1:other"))
+    with pytest.raises(ValueError, match="panel_key_epoch_revoked"):
+        _verify(case, revoked_panel_key_epochs=(KEY_EPOCH,))
+    forged = replace(case["aggregate"], signature="test-sig:forged")
+    with pytest.raises(ValueError, match="panel_signature_invalid"):
+        _verify(case, aggregate=forged)
+
+    store = InMemoryEvidenceNonceStore()
+    assert _verify(case, nonce_store=store, consume_nonce=True).panel_signed_evidence_verified
+    with pytest.raises(ValueError, match="panel_nonce_replay"):
+        _verify(case, nonce_store=store, consume_nonce=True)
+
+
+def test_runtime_rechecks_verified_member_projection():
+    case = _case()
+    verified = _verify(case)
+    tampered = replace(verified, member_entries=tuple(reversed(verified.member_entries)))
+    receipt = bind_reddog_runtime_models(
+        catalog_snapshot=case["snapshot"],
+        selection_receipt=case["selection"],
+        benchmark_evidence_receipts=case["benchmarks"],
+        promotion_evidence_receipts=case["promotions"],
+        policy=case["policy"],
+        verified_production_evidence=tampered,
+    )
+    assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
+    assert "panel_signed_evidence_member_projection_mismatch" in receipt.rejection_reasons
+
+
+def test_panel_evidence_module_has_no_network_command_signer_or_runtime_mutation_imports():
+    source = Path("modules/ai_intelligence/ai_gateway/src/model_panel_signed_evidence.py").read_text()
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    banned_calls: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name) and node.func.value.id in {
+                "os", "subprocess", "requests", "urllib", "socket"
+            }:
+                banned_calls.append(f"{node.func.value.id}.{node.func.attr}")
+    assert {"subprocess", "requests", "urllib", "socket", "cryptography"}.isdisjoint(imported)
+    assert banned_calls == []

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_runtime_binding.py
@@ -243,7 +243,7 @@ def test_runtime_binding_rejects_mismatched_receipts_and_policy():
     assert "verifier_digest_mismatch" in receipt.rejection_reasons
 
 
-def test_panel_runtime_binding_remains_deferred_even_with_role_topology():
+def test_panel_runtime_binding_rejects_single_model_evidence_without_signed_aggregate():
     cards = (
         _card("provider/principal", provider="a"),
         _card("provider/researcher", provider="b"),
@@ -277,14 +277,14 @@ def test_panel_runtime_binding_remains_deferred_even_with_role_topology():
 
     assert selection.decision == SelectionDecision.SELECTED
     assert receipt.decision == ModelRuntimeBindingDecision.REJECTED
-    assert "panel_runtime_binding_deferred" in receipt.rejection_reasons
+    assert "missing_verified_panel_evidence" in receipt.rejection_reasons
     assert receipt.principal_model is None
     try:
         receipt.to_reddog_bridge_payload()
     except ValueError as exc:
         assert str(exc) == "runtime_binding_not_bound"
     else:
-        raise AssertionError("deferred panel binding must not produce a bridge payload")
+        raise AssertionError("unauthenticated panel binding must not produce a bridge payload")
 
 
 def test_panel_runtime_binding_rejects_topology_mismatch():

--- a/modules/ai_intelligence/ai_gateway/wsp_62_exemptions.yaml
+++ b/modules/ai_intelligence/ai_gateway/wsp_62_exemptions.yaml
@@ -1,0 +1,28 @@
+exemptions:
+  - file: "src/model_runtime_binding.py"
+    reason: >-
+      The inherited receipt-construction boundary remains 81 lines. This
+      focused PANEL security slice decomposes every changed validation helper
+      to 50 lines or fewer without mixing receipt serialization into the trust
+      gate change.
+    function_threshold_override: 81
+    functions: ["bind_reddog_runtime_models"]
+    temporary: true
+    owner: "AI Gateway Maintainers"
+    expires_on: "2026-09-30"
+    review_date: "2026-Q3"
+    reviewer: "0102 Technical Architect"
+    remediation: "ROADMAP.md#runtime-binder-decomposition"
+
+  - file: "ModLog.md"
+    reason: >-
+      Legacy reverse-chronological WSP_22 module journal. This slice appends a
+      bounded truth record; splitting historical entries requires a dedicated
+      archive operation that preserves traceability.
+    threshold_override: 1500
+    temporary: true
+    owner: "AI Gateway Maintainers"
+    expires_on: "2026-09-30"
+    review_date: "2026-Q3"
+    reviewer: "0102 Technical Architect"
+    remediation: "ROADMAP.md#modlog-archive"


### PR DESCRIPTION
## What changed
- add a separately signed aggregate PANEL evidence envelope over ordered roles, models, providers, member evidence, selection/catalog/task/topology/policy/surface context, and the synthesizer
- verify every existing single-model evidence chain before aggregate trust, freshness, revocation, signature, and nonce finalization
- bind PANEL runtime activation to an opaque immutable factory-issued proof while preserving SINGLE behavior
- add focused authorization-integrity regressions and WSP 62 documentation/exemptions

## Why
Fusion panels must be selected dynamically without letting runtime consumers trust an unsigned list, a replaced aggregate, or a model/provider/role/context splice. The canonical evaluator remains a verifier; it does not discover or rank models.

## Scope
No Fusion consumer wiring, provider calls, model discovery/ranking, WRE scheduling, OpenClaw/Hermes changes, signer custody, or live execution.

## Validation
- full AI Gateway suite: 249 passed
- independent code-quality review: GO
- py_compile: passed
- WSP 62/YAML/diff checks: passed
- rebased onto current main and full suite rerun: 249 passed