### PR TITLE
feat(reddog): harden resident cycle integrity

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -8,6 +8,8 @@ It is the IDE-side thin-client surface for the resident RedDog backend and the O
 
 RedDog is the resident FoundUps architect thin client and 012/0102 interface. Fusion is one internal reasoning mode, not the product identity.
 
+Version 0.4.11 requires the editor host to provide `REDDOG_AUTHENTICATED_PRINCIPAL_ID` and `REDDOG_AUTHORIZED_FOUNDUP_IDS`. The extension binds the selected principal and FoundUp into `reddog_intent.v2`; the Python bridge independently resolves the same host scope and submits through `RedDogResidentArchitectClient`. Missing or mismatched scope fails before the backend cycle. Resident records use canonical genesis state, full-intent binding, revision CAS, terminal cancellation, monotonic retries, and recomputed internal-integrity telemetry. These controls do not replace signed execution authority.
+
 Version 0.4.10 streams orchestrator-owned Fusion stage metadata to the webview and emits digest-bound progress and OpenRouter call receipts in Copy MD. Receipts include roles, requested/served models, provider routing, generation IDs, retries, timing, token counts, and cost in OpenRouter credits. Missing or retry-ambiguous provider accounting is reported as incomplete and cost remains unknown rather than zero. Receipts are integrity-checked, bound to the extension-generated process run, secret-filtered, and observational only; they are not authentication or action authority.
 
 ## RedDog and the Recursive 0102 DAE Ecosystem

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -2,6 +2,14 @@
 
 # ModLog - RedDog Extension
 
+## 2026-07-20 - REDDOG_RESIDENT_CYCLE_CAS_ATTESTATION_AND_INTENT_BINDING_PHASE1 (0.4.11)
+
+- Routed editor resident sessions through `RedDogResidentArchitectClient` instead of invoking the backend cycle directly.
+- Required host-authenticated principal and FoundUp scope, and bound both into the complete resident intent identity.
+- Added canonical genesis-state validation, revision-CAS transitions, terminal cancellation, monotonic retry history, and integrity-aware worker/model checkpoints.
+- Kept the nine no-effect fields explicitly process-local self-attestations; transition receipts remain internal-integrity telemetry, not signed authority.
+- Version 0.4.10 -> 0.4.11.
+
 ## 2026-07-20 - REDDOG_REPO_AUDIT_GROUNDING_FALLBACK_PHASE1 (0.4.10 unchanged)
 
 - Added entity-to-path repository/module audit grounding without replacing the generation-bound semantic owner, focused deep-dive selection, progress, usage, or signed Fusion panel behavior already present in 0.4.10.

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,10 +1,10 @@
 # RedDog
 
-Version: 0.4.10
+Version: 0.4.11
 
 This local Cursor/VS Code extension opens the RedDog resident FoundUps architect thin client as an editor webview tab.
 
-Version 0.4.10 exposes bounded Fusion stage, model, provider-routing, token, cost-credit, retry, and timing receipts while excluding prompts, outputs, reasoning content, and secrets. Incomplete or retry-ambiguous provider accounting remains visibly incomplete with unknown cost. The receipts provide process-bound observational integrity, not authentication or action authority. Version 0.4.9 reserves the core of a focused repository deep dive for the named subsystem when that subsystem independently supplies readable implementation, test, and document evidence.
+Version 0.4.11 routes editor resident sessions through the canonical host-authenticated client, binds principal and FoundUp scope into the full intent digest, and uses revision-CAS resident records whose cancellation and retry state cannot be silently overwritten. Version 0.4.10 exposes bounded Fusion progress and OpenRouter usage receipts; those receipts remain observational, not authority.
 
 RedDog is the resident FoundUps architect thin client and 012/0102 interface. Fusion is one internal reasoning mode; authority-bearing work is delegated through signed OpenClaw/WRE/Hermes receipts, not through raw webview access.
 
@@ -231,6 +231,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.10.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.11.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -15,7 +15,7 @@ const holoGenerationBoundQuery = require('./holoindex_generation_bound_query');
 const groundedTargetContinuity = require('./grounded_target_continuity');
 const repoDeepDiveFocusPolicy = require('./repo_deep_dive_focus_policy');
 const repoAuditGrounding = require('./repo_audit_grounding');
-const EXTENSION_VERSION = '0.4.10';
+const EXTENSION_VERSION = '0.4.11';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -3731,13 +3731,32 @@ function buildResidentArchitectSessionPayload(workFocus, options) {
   if (!groundedTargetContinuity.receiptReady(groundingReceipt)) {
     return { ok: false, rejection_reasons: ['grounded_target_receipt_not_ready'], payload: null };
   }
+  const authenticatedPrincipal = String(
+    opts.authenticatedPrincipal || process.env.REDDOG_AUTHENTICATED_PRINCIPAL_ID || ''
+  ).trim();
+  const authorizedFoundupIds = Array.isArray(opts.authorizedFoundupIds)
+    ? opts.authorizedFoundupIds.map((item) => String(item || '').trim()).filter(Boolean)
+    : String(process.env.REDDOG_AUTHORIZED_FOUNDUP_IDS || '').split(',').map((item) => item.trim()).filter(Boolean);
+  const foundupId = String(opts.foundupId || authorizedFoundupIds[0] || '').trim();
+  if (!authenticatedPrincipal || !foundupId || !authorizedFoundupIds.includes(foundupId)) {
+    return { ok: false, rejection_reasons: ['resident_architect_authenticated_scope_missing'], payload: null };
+  }
   const intentId = 'sha256:' + crypto.createHash('sha256')
-    .update([REDDOG_PRODUCT_IDENTITY_THIN_CLIENT_SLICE, EXTENSION_VERSION, groundingReceipt.receipt_id].join('|'), 'utf8')
+    .update([
+      REDDOG_PRODUCT_IDENTITY_THIN_CLIENT_SLICE,
+      EXTENSION_VERSION,
+      groundingReceipt.receipt_id,
+      authenticatedPrincipal,
+      foundupId
+    ].join('|'), 'utf8')
     .digest('hex');
   const redDogIntent = {
     schema_version: 'reddog_intent.v2',
     intent_id: intentId,
+    origin: 'extension',
     source_surface: 'editor_thin_client',
+    principal_ref: authenticatedPrincipal,
+    foundup_id: foundupId,
     extension_id: REDDOG_EXTENSION_ID,
     extension_version: EXTENSION_VERSION,
     work_focus: focus,

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,10 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-07-20 - Resident cycle CAS and authenticated editor client (0.4.11)
+
+- Added canonical genesis, full-intent conflict, stale-revision, transition-state tamper, cancellation race, terminal retry, legacy cancel-only, and monotonic attempt-history regressions.
+- Proved the editor bridge fails without host principal/FoundUp scope and routes accepted requests through `RedDogResidentArchitectClient`.
+
 ## 2026-07-20 - REDDOG_REPO_AUDIT_GROUNDING_FALLBACK_PHASE1 (RAG-001..RAG-012)
 
 - Proved punctuation/case aliases resolve to one safe audit entity and select content-bearing implementation plus independent test/contract evidence outside the active-editor bias.

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -210,8 +210,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.10', 'package version must be 0.4.10');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.10'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.11', 'package version must be 0.4.11');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.11'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -305,7 +305,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.10', 'README version mismatch');
+includes(readme, 'Version: 0.4.11', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1764,7 +1764,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.10', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.11', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [
@@ -3270,7 +3270,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.10'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.11'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -3284,7 +3284,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.10'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.11'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -3296,7 +3296,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.10'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.11'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -4315,7 +4315,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.10' } }
+      ? { id, packageJSON: { version: '0.4.11' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({
@@ -4333,7 +4333,9 @@ includes(extensionJs, "reddogConfigValue('enableResidentArchitectSession'", 'RAS
 includes(extensionJs, 'function runResidentArchitectSessionBridge', 'RAS-001: resident session extension bridge missing');
 includes(extensionJs, 'resident_architect_session_result', 'RAS-001: resident session result must attach to review packet');
 includes(extensionJs, 'buildResidentArchitectSessionSection', 'RAS-001: Copy MD resident session section missing');
-includes(residentArchitectBridgePy, 'run_reddog_resident_architect_durable_agentdb_cycle', 'RAS-002: bridge must delegate to resident durable runtime');
+includes(residentArchitectBridgePy, 'RedDogResidentArchitectClient', 'RAS-002: bridge must use canonical authenticated resident client');
+includes(residentArchitectBridgePy, 'REDDOG_AUTHENTICATED_PRINCIPAL_ID', 'RAS-002: bridge must require host principal');
+includes(residentArchitectBridgePy, 'REDDOG_AUTHORIZED_FOUNDUP_IDS', 'RAS-002: bridge must require host FoundUp scope');
 includes(residentArchitectBridgePy, 'explicit_resident_architect_session_requested', 'RAS-002: bridge must require explicit request');
 includes(residentArchitectBridgePy, 'no_holoindex_reindex_performed', 'RAS-002: bridge must surface no-reindex attestation');
 includes(residentArchitectBridgePy, 'no_repo_mutation_performed', 'RAS-002: bridge must surface no-repo-mutation attestation');
@@ -4350,6 +4352,9 @@ assert(residentUngrounded.rejection_reasons.includes('grounded_target_receipt_no
 
 const residentCoverage = [{ target: 'audit work', verdict: 'SUFFICIENT', evidence_refs: ['code:reddog'] }];
 const residentGroundingOptions = {
+  authenticatedPrincipal: 'principal-012',
+  authorizedFoundupIds: ['foundups_agent'],
+  foundupId: 'foundups_agent',
   groundingPreflight: {
     applied: true,
     passed: true,
@@ -4377,6 +4382,14 @@ const residentGroundingOptions = {
     no_holoindex_reindex_performed: true
   }
 };
+const residentUnauthenticated = orchestrator.buildResidentArchitectSessionPayload('audit work', Object.assign({}, residentGroundingOptions, {
+  explicitResidentArchitectSessionRequested: true,
+  authenticatedPrincipal: ' ',
+  authorizedFoundupIds: []
+}));
+assert.strictEqual(residentUnauthenticated.ok, false, 'RAS-004: missing authenticated scope fails closed');
+assert(residentUnauthenticated.rejection_reasons.includes('resident_architect_authenticated_scope_missing'),
+  'RAS-004: missing authenticated scope exposes stable rejection');
 const residentPayload = orchestrator.buildResidentArchitectSessionPayload('audit work', Object.assign({}, residentGroundingOptions, {
   explicitResidentArchitectSessionRequested: true,
   repoRoot: 'O:/Foundups-Agent',
@@ -4389,6 +4402,9 @@ assert.strictEqual(residentPayload.payload.work_focus, 'audit work', 'RAS-004: w
 assert.strictEqual(residentPayload.payload.repo_root, 'O:/Foundups-Agent', 'RAS-004: repo root preserved');
 assert.strictEqual(residentPayload.payload.timeout_seconds, 77, 'RAS-004: timeout preserved');
 assert.strictEqual(residentPayload.payload.red_dog_intent.schema_version, 'reddog_intent.v2', 'RPI-004: resident payload carries typed RedDogIntent');
+assert.strictEqual(residentPayload.payload.red_dog_intent.origin, 'extension', 'RPI-004: editor origin is explicit');
+assert.strictEqual(residentPayload.payload.red_dog_intent.principal_ref, 'principal-012', 'RPI-004: host principal is bound');
+assert.strictEqual(residentPayload.payload.red_dog_intent.foundup_id, 'foundups_agent', 'RPI-004: FoundUp scope is bound');
 assert.strictEqual(groundedTargetContinuity.receiptReady(residentPayload.payload.red_dog_intent.grounding_receipt), true,
   'GTC-001: resident intent carries an integrity-bound grounding receipt');
 assert.strictEqual(residentPayload.payload.grounding_receipt_id,

--- a/main.py
+++ b/main.py
@@ -1921,7 +1921,7 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID               FoundUp scope, default foundups_agent
         REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS               Max OpenClaw claims, default 8
         REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS          Cycle timeout, default 60
-        REDDOG_RESIDENT_ARCHITECT_RETRY=0                  Retry failed/cancelled cycle
+        REDDOG_RESIDENT_ARCHITECT_RETRY=0                  Retry failed/timed-out cycle; cancelled is terminal
         REDDOG_RESIDENT_ARCHITECT_CANCEL=0                 Cancel running cycle
         REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF=1        Auto-arm safe FIX handoff after accepted FIX
         REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE        Optional downstream queue profile, default draft-PR

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -2,6 +2,16 @@
 
 ## Public API
 
+### Durable Resident Architect Cycle
+
+`run_reddog_resident_architect_durable_agentdb_cycle()` creates one intent-bound AgentDB cycle and advances it only through revision-checked status transitions. `AgentDbResidentArchitectCycleStore.create_cycle()` is insert-only; `transition_cycle()` requires the exact revision and allowed current status. Stored intent identity and nine process-local read-only self-attestations are immutable at this boundary. These fields are not external proof that effects did not occur. Cancellation checkpoints run between OpenClaw claims and before/following architect determination, so a stale caller cannot overwrite `CANCELLED`.
+
+`RedDogResidentArchitectClient` revalidates the authenticated principal, FoundUp scope, grounding receipt, full intent digest, and all nine persisted process-local self-attestations on reconnect. Hash-chained transition history is recomputed internal-integrity telemetry, not signer authority, external authentication, or independently observed effect evidence.
+
+The editor bridge requires host-supplied `REDDOG_AUTHENTICATED_PRINCIPAL_ID` and `REDDOG_AUTHORIZED_FOUNDUP_IDS`, then invokes this canonical client. It cannot call the durable cycle directly.
+
+`CANCELLED` and `DETERMINED` are permanently terminal. Only `FAILED` and `TIMED_OUT` cycles may enter a revision-checked retry, and each retry appends one immutable prior-attempt summary. Legacy v1 rows are accepted only by the canonical cancellation path; they cannot reconnect, resume, or become authority-bearing v2 records.
+
 ### RedDog HoloIndex Query Adapter
 
     from modules.communication.moltbot_bridge.src.reddog_holoindex_query_adapter import (

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,16 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-20: REDDOG_RESIDENT_CYCLE_CAS_ATTESTATION_AND_INTENT_BINDING_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 71, 91, 97
+
+- Bound each durable cycle to the canonical full intent digest and rejected changed-principal or changed-payload reuse of an existing intent ID.
+- Replaced blind cycle updates with insert-once creation, revision CAS, a store-owned status-transition graph, immutable authority fields, and observational hash-chained transition history.
+- Persisted and enforced all nine process-local read-only runtime self-attestations at this code boundary; they are not externally observed or signer-authenticated effect receipts.
+- Made cancellation terminal across claim and determination checkpoints, preserved monotonic retry history, and bound each persisted state to recomputed internal-integrity transition telemetry.
+- Required canonical revision-zero genesis state and routed the editor session bridge through `RedDogResidentArchitectClient` with host principal and FoundUp scope.
+- Added production AgentDB reconnect, stale-writer, cancellation-race, immutable-field, and `7 -> 8` retry regressions without adding execution authority.
+
 ## 2026-07-20: REDDOG_FUSION_PROGRESS_AND_OPENROUTER_USAGE_RECEIPTS_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 50, 71, 91, 97

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -2,6 +2,10 @@
 
 RedDog Fusion progress observability is implemented by `src/reddog_fusion_progress_receipt.py`: bounded hash-chained stage events plus content-free OpenRouter usage and routing receipts. It does not retain prompts, outputs, hidden reasoning, or secrets, and it grants no action authority.
 
+The durable resident architect cycle in `src/reddog_resident_architect_durable_agentdb_cycle.py` is intent-digest-bound and revision-CAS protected. Its nine process-local read-only self-attestations are persisted and enforced at this code boundary; they are not externally observed or signer-authenticated effect receipts. Cancellation is terminal against stale workers, and retries retain monotonic attempt history. Transition receipts are recomputed internal-integrity telemetry only, not execution authority or external authentication.
+
+Fresh AgentDB cycle rows must be canonical `SUBMITTED` retry-zero records. `FAILED` and `TIMED_OUT` may retry through CAS; `CANCELLED` and `DETERMINED` never reopen. Legacy rows have a cancellation-only compatibility path and are otherwise rejected.
+
 > **OpenClaw** (formerly Moltbot/Clawdbot), trained on WSP framework, operating on Foundups-Agent codebase
 
 ## Version Note

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py
@@ -22,10 +22,13 @@ from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
     AgentDbResidentArchitectCycleStore,
+    RUNTIME_BOUNDARY_FIELDS,
     ResidentArchitectCycleStore,
+    ResidentCycleReason,
     STATUS_CANCELLED,
     STATUS_FAILED,
     STATUS_TIMED_OUT,
+    resident_intent_digest,
     run_reddog_resident_architect_durable_agentdb_cycle,
 )
 
@@ -50,19 +53,6 @@ RESERVED_RUNTIME_KEYS = frozenset(
         "retry_requested",
     }
 )
-RUNTIME_BOUNDARY_FIELDS = (
-    "read_only_authority_only",
-    "no_shell_command_executed",
-    "no_repo_mutation_performed",
-    "no_holoindex_reindex_performed",
-    "no_hermes_dispatch_performed",
-    "no_worktree_operation_performed",
-    "no_pr_created",
-    "no_pattern_memory_promotion_performed",
-    "no_live_foundup_enqueue_performed",
-)
-
-
 class ResidentClientReason:
     REQUEST_INVALID = "REJECT_REDDOG_RESIDENT_CLIENT_REQUEST_INVALID"
     PRINCIPAL_MISMATCH = "REJECT_REDDOG_RESIDENT_CLIENT_PRINCIPAL_MISMATCH"
@@ -90,6 +80,14 @@ class ResidentClientResponse:
     architect_next_slice: str
     task_status_counts: Mapping[str, int]
     rejection_reasons: tuple[str, ...]
+    record_revision: int = 0
+    intent_digest: str = ""
+    swarm_id: str = ""
+    task_ids: tuple[str, ...] = ()
+    openclaw_claim_count: int = 0
+    queue_candidate_count: int = 0
+    recovered_existing_cycle: bool = False
+    duplicate_intent_reused: bool = False
     canonical_resident_cycle_used: bool = True
     read_only_authority_only: bool = True
     client_no_shell_command_executed: bool = True
@@ -163,17 +161,27 @@ class RedDogResidentArchitectClient:
 
     def cancel(self, intent_id: str) -> ResidentClientResponse:
         record, reasons = self._authorized_record(intent_id)
+        legacy_cancel = False
         if reasons:
-            return self._reject("cancel", str(intent_id or ""), reasons)
+            record, legacy_reasons = self._authorized_legacy_cancel_record(intent_id)
+            if legacy_reasons:
+                return self._reject("cancel", str(intent_id or ""), reasons)
+            legacy_cancel = True
         assert record is not None
-        return self._invoke("cancel", _record_intent(record), cancel=True, retry=False)
+        return self._invoke(
+            "cancel",
+            _record_intent(record),
+            cancel=True,
+            retry=False,
+            legacy_cancel=legacy_cancel,
+        )
 
     def resume(self, intent_id: str) -> ResidentClientResponse:
         record, reasons = self._authorized_record(intent_id)
         if reasons:
             return self._reject("resume", str(intent_id or ""), reasons)
         assert record is not None
-        retry = str(record.get("status") or "") in {STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED}
+        retry = str(record.get("status") or "") in {STATUS_FAILED, STATUS_TIMED_OUT}
         return self._invoke("resume", _record_intent(record), cancel=False, retry=retry)
 
     def _validate_submitted_intent(self, intent: Mapping[str, Any] | None) -> tuple[str, ...]:
@@ -212,10 +220,37 @@ class RedDogResidentArchitectClient:
         reasons = self._validate_submitted_intent(intent)
         if _intent_id(intent) != value:
             reasons = (*reasons, ResidentClientReason.REQUEST_INVALID)
+        if str(record.get("intent_digest") or "") != resident_intent_digest(intent):
+            reasons = (*reasons, ResidentClientReason.REQUEST_INVALID)
+        if record.get("_store_integrity_valid") is not True:
+            reasons = (*reasons, ResidentClientReason.RUNTIME_FAILED)
         if not _runtime_boundary_is_safe(record):
             reasons = (*reasons, ResidentClientReason.RUNTIME_FAILED)
         reasons = tuple(dict.fromkeys(reasons))
         return (None, reasons) if reasons else (record, ())
+
+    def _authorized_legacy_cancel_record(
+        self,
+        intent_id: str,
+    ) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+        value = str(intent_id or "").strip()
+        record = self._store.load_cycle_by_intent(value) if value else None
+        if not isinstance(record, Mapping):
+            return None, (ResidentClientReason.CYCLE_NOT_FOUND,)
+        intent = _record_intent(record)
+        reasons = list(self._validate_submitted_intent(intent))
+        if (
+            record.get("schema_version") != "reddog_resident_architect_cycle.v1"
+            or str(record.get("intent_digest") or "")
+            or _intent_id(intent) != value
+            or (
+                str(record.get("status") or "") != STATUS_CANCELLED
+                and "record_revision" in record
+            )
+        ):
+            reasons.append(ResidentClientReason.RUNTIME_FAILED)
+        reasons = list(dict.fromkeys(reasons))
+        return (None, tuple(reasons)) if reasons else (record, ())
 
     def _invoke(
         self,
@@ -224,6 +259,7 @@ class RedDogResidentArchitectClient:
         *,
         cancel: bool,
         retry: bool,
+        legacy_cancel: bool = False,
     ) -> ResidentClientResponse:
         try:
             result = self._runner(
@@ -237,7 +273,12 @@ class RedDogResidentArchitectClient:
         except Exception:
             return self._reject(operation, _intent_id(intent), (ResidentClientReason.RUNTIME_FAILED,))
         data = result.to_dict() if hasattr(result, "to_dict") else dict(result)
-        runtime_boundary_failed = not _runtime_boundary_is_safe(data)
+        legacy_cancelled = bool(
+            legacy_cancel
+            and str(data.get("status") or "") == STATUS_CANCELLED
+            and ResidentCycleReason.CANCELLED in tuple(data.get("rejection_reasons") or ())
+        )
+        runtime_boundary_failed = not _runtime_boundary_is_safe(data) and not legacy_cancelled
         if runtime_boundary_failed:
             data = dict(data)
             data["rejection_reasons"] = [
@@ -248,7 +289,7 @@ class RedDogResidentArchitectClient:
             operation,
             data,
             accepted=bool(data.get("accepted")) and not runtime_boundary_failed,
-            canonical_cycle_used=True,
+            canonical_cycle_used=not legacy_cancel,
         )
 
     def _from_record(
@@ -272,6 +313,14 @@ class RedDogResidentArchitectClient:
             "architect_action": str(record.get("architect_action") or ""),
             "architect_next_slice": str(record.get("architect_next_slice") or ""),
             "task_status_counts": dict(record.get("task_status_counts") or {}),
+            "record_revision": int(record.get("record_revision") or 0),
+            "intent_digest": str(record.get("intent_digest") or ""),
+            "swarm_id": str(record.get("swarm_id") or ""),
+            "task_ids": tuple(str(item) for item in record.get("task_ids", ()) if str(item)),
+            "openclaw_claim_count": len(record.get("openclaw_claims") or ()),
+            "queue_candidate_count": int(record.get("queue_candidate_count") or 0),
+            "recovered_existing_cycle": bool(record.get("recovered_existing_cycle")),
+            "duplicate_intent_reused": bool(record.get("duplicate_intent_reused")),
             "rejection_reasons": tuple(str(item) for item in record.get("rejection_reasons", ()) if str(item)),
         }
         response_id = _digest(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -75,6 +75,60 @@ STATUS_TIMED_OUT = "TIMED_OUT"
 STATUS_CANCELLED = "CANCELLED"
 
 TERMINAL_STATUSES = frozenset({STATUS_DETERMINED, STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED})
+RUNTIME_BOUNDARY_FIELDS = (
+    "read_only_authority_only",
+    "no_shell_command_executed",
+    "no_repo_mutation_performed",
+    "no_holoindex_reindex_performed",
+    "no_hermes_dispatch_performed",
+    "no_worktree_operation_performed",
+    "no_pr_created",
+    "no_pattern_memory_promotion_performed",
+    "no_live_foundup_enqueue_performed",
+)
+ALLOWED_STATUS_TRANSITIONS = {
+    STATUS_SUBMITTED: frozenset({STATUS_ENQUEUED, STATUS_FAILED, STATUS_CANCELLED}),
+    STATUS_ENQUEUED: frozenset({STATUS_RUNNING, STATUS_CANCELLED}),
+    STATUS_RUNNING: frozenset(
+        {STATUS_RUNNING, STATUS_DETERMINED, STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED}
+    ),
+}
+IMMUTABLE_CYCLE_FIELDS = frozenset(
+    {
+        "schema_version",
+        "intent_id",
+        "intent_digest",
+        "intent",
+        "created_at",
+        "genesis_state_digest",
+        *RUNTIME_BOUNDARY_FIELDS,
+    }
+)
+GENESIS_RECORD_FIELDS = frozenset(
+    {
+        "schema_version",
+        "intent_id",
+        "intent_digest",
+        "cycle_id",
+        "status",
+        "intent",
+        "snapshot_id",
+        "determination_id",
+        "swarm_id",
+        "task_ids",
+        "task_status_counts",
+        "openclaw_claims",
+        "retry_count",
+        "record_revision",
+        "attempt_history",
+        "transition_history",
+        "created_at",
+        "updated_at",
+        "rejection_reasons",
+        "genesis_state_digest",
+        *RUNTIME_BOUNDARY_FIELDS,
+    }
+)
 
 
 class ResidentCycleReason:
@@ -92,14 +146,26 @@ class ResidentCycleReason:
     RETRY_NOT_ALLOWED = "REJECT_RESIDENT_CYCLE_RETRY_NOT_ALLOWED"
     CANCELLED = "REJECT_RESIDENT_CYCLE_CANCELLED"
     STORE_REJECTED = "REJECT_RESIDENT_CYCLE_STORE_REJECTED"
+    INTENT_CONFLICT = "REJECT_RESIDENT_CYCLE_INTENT_CONFLICT"
+    ACTIVE_INTENT = "REJECT_RESIDENT_CYCLE_ACTIVE_INTENT"
+    TRANSITION_CONFLICT = "REJECT_RESIDENT_CYCLE_TRANSITION_CONFLICT"
+    CANCELLATION_CONFLICT = "REJECT_RESIDENT_CYCLE_CANCELLATION_CONFLICT"
 
 
 class ResidentArchitectCycleStore(Protocol):
     def load_cycle_by_intent(self, intent_id: str) -> Optional[Mapping[str, Any]]: ...
 
-    def upsert_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def create_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]: ...
 
-    def update_cycle(self, intent_id: str, updates: Mapping[str, Any]) -> Mapping[str, Any]: ...
+    def transition_cycle(
+        self,
+        intent_id: str,
+        *,
+        expected_revision: int,
+        expected_statuses: Sequence[str],
+        updates: Mapping[str, Any],
+        allow_terminal_retry: bool = False,
+    ) -> Mapping[str, Any]: ...
 
     def load_task_ids(self, determination_id: str) -> tuple[str, ...]: ...
 
@@ -147,6 +213,8 @@ class RedDogResidentArchitectCycleResult:
     duplicate_intent_reused: bool
     recovered_existing_cycle: bool
     retry_count: int
+    record_revision: int
+    intent_digest: str
     rejection_reasons: tuple[str, ...]
     no_shell_command_executed: bool = True
     no_repo_mutation_performed: bool = True
@@ -177,51 +245,221 @@ class AgentDbResidentArchitectCycleStore:
         db = self._agent_db()
         self._ensure_table(db)
         rows = db.db.execute_query(
-            "SELECT cycle_json FROM reddog_resident_architect_cycles WHERE intent_id = ?",
+            "SELECT revision, cycle_json FROM reddog_resident_architect_cycles WHERE intent_id = ?",
             (intent_id,),
         )
         if not rows:
             return None
-        value = rows[0]["cycle_json"] if isinstance(rows[0], Mapping) else rows[0][0]
-        return json.loads(value)
+        row = rows[0]
+        try:
+            revision = int(row["revision"] if isinstance(row, Mapping) else row[0])
+            value = row["cycle_json"] if isinstance(row, Mapping) else row[1]
+            record = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError, KeyError, IndexError):
+            return {
+                "intent_id": intent_id,
+                "status": STATUS_FAILED,
+                "_store_revision": -1,
+                "_store_integrity_valid": False,
+            }
+        if not isinstance(record, dict):
+            return {
+                "intent_id": intent_id,
+                "status": STATUS_FAILED,
+                "_store_revision": revision,
+                "_store_integrity_valid": False,
+            }
+        record["_store_revision"] = revision
+        record["_store_integrity_valid"] = (
+            int(record.get("record_revision", -1)) == revision
+            and _transition_history_is_valid(record, revision=revision)
+        )
+        return record
 
-    def upsert_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+    def create_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
         db = self._agent_db()
         self._ensure_table(db)
-        payload = _canonical_json(record)
+        value = dict(record)
+        supplied_revision = _parse_nonnegative_int(value.get("record_revision"))
+        value["record_revision"] = 0
+        intent = value.get("intent")
+        intent_id = str(value.get("intent_id") or "")
+        retry_count = _parse_nonnegative_int(value.get("retry_count"))
+        expected_cycle_id = _digest(
+            {"intent_id": intent_id, "retry_count": 0, "slice": "resident_agentdb_cycle"}
+        )
+        if (
+            value.get("schema_version") != "reddog_resident_architect_cycle.v2"
+            or not isinstance(intent, Mapping)
+            or not intent_id
+            or str(intent.get("intent_id") or "") != intent_id
+            or bool(_validate_intent(intent))
+            or str(value.get("intent_digest") or "") != resident_intent_digest(intent)
+            or any(value.get(field) is not True for field in RUNTIME_BOUNDARY_FIELDS)
+            or frozenset(value) != GENESIS_RECORD_FIELDS
+            or str(value.get("genesis_state_digest") or "") != _genesis_state_digest(value)
+            or value.get("status") != STATUS_SUBMITTED
+            or str(value.get("cycle_id") or "") != expected_cycle_id
+            or retry_count != 0
+            or supplied_revision != 0
+            or value.get("transition_history") != []
+            or value.get("attempt_history") != []
+            or value.get("task_ids") != []
+            or value.get("task_status_counts") != {}
+            or value.get("openclaw_claims") != []
+            or value.get("rejection_reasons") != []
+            or value.get("snapshot_id") is not None
+            or value.get("determination_id") is not None
+            or value.get("swarm_id") is not None
+        ):
+            return {"ok": False, "stored": False, "reason": "invalid_cycle_record", "record": None}
+        payload = _canonical_json(value)
         with db.db.get_connection() as conn:
-            conn.execute(
+            cursor = conn.execute(
                 """
                 INSERT INTO reddog_resident_architect_cycles
-                (intent_id, cycle_id, status, snapshot_id, determination_id, cycle_json, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(intent_id) DO UPDATE SET
-                    cycle_id = excluded.cycle_id,
-                    status = excluded.status,
-                    snapshot_id = excluded.snapshot_id,
-                    determination_id = excluded.determination_id,
-                    cycle_json = excluded.cycle_json,
-                    updated_at = excluded.updated_at
+                (intent_id, cycle_id, status, snapshot_id, determination_id, revision, cycle_json, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(intent_id) DO NOTHING
                 """,
                 (
-                    record.get("intent_id"),
-                    record.get("cycle_id"),
-                    record.get("status"),
-                    record.get("snapshot_id"),
-                    record.get("determination_id"),
+                    value.get("intent_id"),
+                    value.get("cycle_id"),
+                    value.get("status"),
+                    value.get("snapshot_id"),
+                    value.get("determination_id"),
+                    0,
                     payload,
                     _now_iso(),
                 ),
             )
-        return {"ok": True, "stored": True}
+        return {
+            "ok": cursor.rowcount == 1,
+            "stored": cursor.rowcount == 1,
+            "reason": "" if cursor.rowcount == 1 else "cycle_exists",
+            "record": value if cursor.rowcount == 1 else None,
+        }
+
+    def transition_cycle(
+        self,
+        intent_id: str,
+        *,
+        expected_revision: int,
+        expected_statuses: Sequence[str],
+        updates: Mapping[str, Any],
+        allow_terminal_retry: bool = False,
+    ) -> Mapping[str, Any]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        allowed = frozenset(str(status) for status in expected_statuses)
+        with db.db.get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT revision, cycle_json
+                FROM reddog_resident_architect_cycles
+                WHERE intent_id = ?
+                """,
+                (intent_id,),
+            ).fetchone()
+            if row is None:
+                return {"ok": False, "reason": "missing_cycle"}
+            revision = int(row["revision"] if isinstance(row, Mapping) else row[0])
+            current = json.loads(
+                row["cycle_json"] if isinstance(row, Mapping) else row[1]
+            )
+            status = str(current.get("status") or "")
+            next_status = str(updates.get("status") or status)
+            legacy_cancel = bool(
+                next_status == STATUS_CANCELLED
+                and "record_revision" not in current
+                and "intent_digest" not in current
+            )
+            if revision != int(expected_revision) or (
+                int(current.get("record_revision", -1)) != revision and not legacy_cancel
+            ):
+                return {"ok": False, "reason": "revision_conflict"}
+            if not legacy_cancel and not _transition_history_is_valid(current, revision=revision):
+                return {"ok": False, "reason": "transition_history_invalid"}
+            if status not in allowed:
+                return {"ok": False, "reason": "status_conflict"}
+            if status in TERMINAL_STATUSES and not (
+                allow_terminal_retry
+                and status in {STATUS_FAILED, STATUS_TIMED_OUT}
+                and next_status == STATUS_SUBMITTED
+            ):
+                return {"ok": False, "reason": "terminal_status"}
+            if status not in TERMINAL_STATUSES and next_status not in ALLOWED_STATUS_TRANSITIONS.get(status, ()):
+                return {"ok": False, "reason": "invalid_status_transition"}
+            for field in IMMUTABLE_CYCLE_FIELDS:
+                if field in updates and updates.get(field) != current.get(field):
+                    return {"ok": False, "reason": f"immutable_field:{field}"}
+            try:
+                retry_error = _validate_retry_transition(
+                    current=current,
+                    updates=updates,
+                    allow_terminal_retry=allow_terminal_retry,
+                    next_status=next_status,
+                )
+            except (TypeError, ValueError):
+                retry_error = "retry_metadata_invalid"
+            if retry_error:
+                return {"ok": False, "reason": retry_error}
+            merged = dict(current)
+            merged.update(dict(updates))
+            merged.pop("_store_integrity_valid", None)
+            merged.pop("_store_revision", None)
+            merged["record_revision"] = revision + 1
+            history = list(current.get("transition_history") or ())
+            previous_receipt_id = str(history[-1].get("receipt_id") or "") if history else ""
+            transition_receipt = {
+                "schema_version": "reddog_resident_cycle_transition.v1",
+                "intent_id": intent_id,
+                "cycle_id": str(merged.get("cycle_id") or ""),
+                "from_status": status,
+                "to_status": next_status,
+                "from_revision": revision,
+                "to_revision": revision + 1,
+                "updates_digest": _digest(dict(updates)),
+                "previous_receipt_id": previous_receipt_id,
+                "transitioned_at": _now_iso(),
+                "authority": "observational_internal_integrity_only",
+            }
+            state_for_digest = dict(merged)
+            state_for_digest.pop("transition_history", None)
+            transition_receipt["result_state_digest"] = _digest(state_for_digest)
+            transition_receipt["receipt_id"] = _digest(transition_receipt)
+            merged["transition_history"] = [*history, transition_receipt]
+            payload = _canonical_json(merged)
+            cursor = conn.execute(
+                """
+                UPDATE reddog_resident_architect_cycles
+                SET cycle_id = ?, status = ?, snapshot_id = ?, determination_id = ?,
+                    revision = ?, cycle_json = ?, updated_at = ?
+                WHERE intent_id = ? AND revision = ?
+                """,
+                (
+                    merged.get("cycle_id"),
+                    merged.get("status"),
+                    merged.get("snapshot_id"),
+                    merged.get("determination_id"),
+                    revision + 1,
+                    payload,
+                    _now_iso(),
+                    intent_id,
+                    revision,
+                ),
+            )
+        if cursor.rowcount != 1:
+            return {"ok": False, "reason": "revision_conflict"}
+        return {"ok": True, "stored": True, "record": merged}
+
+    def upsert_cycle(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        """Compatibility seam: create only; existing rows require explicit CAS."""
+        return self.create_cycle(record)
 
     def update_cycle(self, intent_id: str, updates: Mapping[str, Any]) -> Mapping[str, Any]:
-        current = self.load_cycle_by_intent(intent_id)
-        if current is None:
-            return {"ok": False, "reason": "missing_cycle"}
-        merged = dict(current)
-        merged.update(dict(updates))
-        return self.upsert_cycle(merged)
+        del intent_id, updates
+        return {"ok": False, "reason": "cas_required"}
 
     def load_task_ids(self, determination_id: str) -> tuple[str, ...]:
         if not determination_id:
@@ -289,11 +527,23 @@ class AgentDbResidentArchitectCycleStore:
                     status TEXT NOT NULL,
                     snapshot_id TEXT,
                     determination_id TEXT,
+                    revision INTEGER NOT NULL DEFAULT 0,
                     cycle_json TEXT NOT NULL,
                     updated_at TEXT NOT NULL
                 )
                 """
             )
+            columns = {
+                str(row["name"] if isinstance(row, Mapping) else row[1])
+                for row in conn.execute(
+                    "PRAGMA table_info(reddog_resident_architect_cycles)"
+                ).fetchall()
+            }
+            if "revision" not in columns:
+                conn.execute(
+                    "ALTER TABLE reddog_resident_architect_cycles "
+                    "ADD COLUMN revision INTEGER NOT NULL DEFAULT 0"
+                )
             conn.execute(
                 """
                 CREATE INDEX IF NOT EXISTS idx_reddog_resident_architect_cycles_status
@@ -344,47 +594,121 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
     store = cycle_store or AgentDbResidentArchitectCycleStore(agent_db_factory=agent_db_factory)
     reasons = _validate_intent(red_dog_intent)
     intent_id = str(red_dog_intent.get("intent_id") or "").strip()
-    existing = store.load_cycle_by_intent(intent_id) if intent_id and not reasons else None
+    existing = store.load_cycle_by_intent(intent_id) if intent_id else None
+    submitted_intent_digest = resident_intent_digest(red_dog_intent)
 
     if cancel_requested:
-        if existing is not None and str(existing.get("status")) not in TERMINAL_STATUSES:
-            store.update_cycle(intent_id, {"status": STATUS_CANCELLED, "cancelled_at": _now_iso()})
+        if existing is None:
+            if reasons:
+                return _reject(red_dog_intent, reasons)
+            synthetic = _new_record(red_dog_intent, retry_count=0)
+            synthetic.update(
+                {
+                    "status": STATUS_CANCELLED,
+                    "cancelled_at": _now_iso(),
+                    "rejection_reasons": [ResidentCycleReason.CANCELLED],
+                }
+            )
+            return _result_from_record(
+                record=synthetic,
+                accepted=False,
+                rejection_reasons=(ResidentCycleReason.CANCELLED,),
+            )
+        if not _record_matches_cancel_request(existing, submitted_intent_digest):
+            return _result_from_record(
+                record=existing,
+                accepted=False,
+                rejection_reasons=(ResidentCycleReason.INTENT_CONFLICT,),
+            )
+        existing, cancelled = _cancel_cycle_with_retry(store, existing)
         return _result_from_record(
-            record=store.load_cycle_by_intent(intent_id) or existing or _new_record(red_dog_intent, retry_count=0),
+            record=existing,
             accepted=False,
-            rejection_reasons=(ResidentCycleReason.CANCELLED,),
+            rejection_reasons=(
+                ResidentCycleReason.CANCELLED if cancelled else ResidentCycleReason.CANCELLATION_CONFLICT,
+            ),
         )
 
+    if existing is not None and (
+        existing.get("_store_integrity_valid") is not True
+        or str(existing.get("intent_digest") or "") != submitted_intent_digest
+        or any(existing.get(field) is not True for field in RUNTIME_BOUNDARY_FIELDS)
+    ):
+        return _result_from_record(
+            record=existing,
+            accepted=False,
+            rejection_reasons=(ResidentCycleReason.INTENT_CONFLICT,),
+        )
+
+    retry_source: Mapping[str, Any] | None = None
     if existing is not None and retry_requested:
         status = str(existing.get("status") or "")
-        if status not in {STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED}:
+        if status not in {STATUS_FAILED, STATUS_TIMED_OUT}:
             return _result_from_record(
                 record=existing,
                 accepted=False,
                 rejection_reasons=(ResidentCycleReason.RETRY_NOT_ALLOWED,),
             )
         old_tasks = tuple(str(task_id) for task_id in existing.get("task_ids", ()) if str(task_id))
+        retry_source = existing
+        retry_count = int(existing.get("retry_count", 0)) + 1
+        retried = _new_record(red_dog_intent, retry_count=retry_count)
+        retried["created_at"] = existing.get("created_at")
+        retried["genesis_state_digest"] = existing.get("genesis_state_digest")
+        retried["attempt_history"] = [
+            *list(existing.get("attempt_history") or ()),
+            _attempt_history_entry(existing),
+        ]
+        transitioned = _transition_record(
+            store,
+            existing,
+            expected_statuses=(STATUS_FAILED, STATUS_TIMED_OUT, STATUS_CANCELLED),
+            updates=retried,
+            allow_terminal_retry=True,
+        )
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
         store.delete_cycle_tasks(old_tasks)
         existing = None
 
     if existing is not None and str(existing.get("status")) == STATUS_DETERMINED:
         return _result_from_record(record=existing, accepted=True, duplicate_intent_reused=True)
 
+    if existing is not None:
+        return _result_from_record(
+            record=existing,
+            accepted=False,
+            rejection_reasons=(ResidentCycleReason.ACTIVE_INTENT,),
+            recovered_existing_cycle=True,
+        )
+
     if reasons:
         return _reject(red_dog_intent, reasons)
     if external_research_retriever is None:
         external_research_retriever = NoopExternalResearchRetriever()
 
-    if retry_requested:
-        retry_count = int(existing.get("retry_count", 0)) + 1 if existing else 1
-    elif existing:
-        retry_count = int(existing.get("retry_count", 0))
-    else:
-        retry_count = 0
-    record = dict(existing) if existing is not None else _new_record(red_dog_intent, retry_count=retry_count)
-    recovered = existing is not None
+    retry_count = int(retry_source.get("retry_count", 0)) + 1 if retry_source else 0
+    record = (
+        dict(store.load_cycle_by_intent(intent_id) or {})
+        if retry_source is not None
+        else _new_record(red_dog_intent, retry_count=retry_count)
+    )
+    recovered = retry_source is not None
 
-    if existing is None:
+    if retry_source is None:
+        created = store.create_cycle(record)
+        if not created.get("ok"):
+            latest = store.load_cycle_by_intent(intent_id)
+            if isinstance(latest, Mapping) and str(latest.get("intent_digest") or "") != submitted_intent_digest:
+                return _result_from_record(
+                    record=latest,
+                    accepted=False,
+                    rejection_reasons=(ResidentCycleReason.INTENT_CONFLICT,),
+                )
+            return _transition_conflict_result(store, intent_id)
+        record = dict(created.get("record") or record)
+
+    if str(record.get("status") or "") == STATUS_SUBMITTED:
         initial = run_reddog_main_readonly_operational_bootstrap(
             repo_root=root,
             work_state_path=work_state_path,
@@ -412,30 +736,50 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             grounding_work_focus=str(red_dog_intent.get("work_focus") or prompt_text),
         )
         if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
-            record.update(
-                _failure_updates(
+            transitioned = _transition_record(
+                store,
+                record,
+                expected_statuses=(STATUS_SUBMITTED,),
+                updates=_failure_updates(
                     STATUS_FAILED,
                     (ResidentCycleReason.BOOTSTRAP_REJECTED, *initial.rejection_reasons),
-                )
+                ),
             )
-            store.upsert_cycle(record)
+            if transitioned is None:
+                return _transition_conflict_result(store, intent_id)
+            record = transitioned
             return _result_from_record(record=record, accepted=False)
         if not initial.enqueue_attempted or initial.enqueue_task_count <= 0 or initial.enqueue_rejection_reasons:
-            record.update(
-                _failure_updates(
+            transitioned = _transition_record(
+                store,
+                record,
+                expected_statuses=(STATUS_SUBMITTED,),
+                updates=_failure_updates(
                     STATUS_FAILED,
                     (ResidentCycleReason.TASK_ENQUEUE_REJECTED, *initial.enqueue_rejection_reasons),
-                )
+                ),
             )
-            store.upsert_cycle(record)
+            if transitioned is None:
+                return _transition_conflict_result(store, intent_id)
+            record = transitioned
             return _result_from_record(record=record, accepted=False)
         task_ids = store.load_task_ids(str(initial.determination_id or ""))
         if not task_ids:
-            record.update(_failure_updates(STATUS_FAILED, (ResidentCycleReason.NO_TASK_IDS,)))
-            store.upsert_cycle(record)
+            transitioned = _transition_record(
+                store,
+                record,
+                expected_statuses=(STATUS_SUBMITTED,),
+                updates=_failure_updates(STATUS_FAILED, (ResidentCycleReason.NO_TASK_IDS,)),
+            )
+            if transitioned is None:
+                return _transition_conflict_result(store, intent_id)
+            record = transitioned
             return _result_from_record(record=record, accepted=False)
-        record.update(
-            {
+        transitioned = _transition_record(
+            store,
+            record,
+            expected_statuses=(STATUS_SUBMITTED,),
+            updates={
                 "status": STATUS_ENQUEUED,
                 "snapshot_id": initial.snapshot_receipt_id,
                 "determination_id": initial.determination_id,
@@ -444,14 +788,31 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
                 "task_status_counts": dict(store.load_task_status_counts(task_ids)),
                 "initial_bootstrap": initial.to_dict(),
                 "updated_at": _now_iso(),
-            }
+            },
         )
-        store.upsert_cycle(record)
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
+        record = transitioned
+
+    if str(record.get("status") or "") == STATUS_ENQUEUED:
+        transitioned = _transition_record(
+            store,
+            record,
+            expected_statuses=(STATUS_ENQUEUED,),
+            updates={"status": STATUS_RUNNING, "updated_at": _now_iso()},
+        )
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
+        record = transitioned
 
     task_ids = tuple(str(task_id) for task_id in record.get("task_ids", ()) if str(task_id))
     claims: list[Mapping[str, Any]] = []
     claim_runner = openclaw_claim_runner or claim_reddog_readonly_audit_task_once
     for _ in range(max(0, int(max_claims))):
+        checkpoint = _checkpoint_record(store, record)
+        if checkpoint is None or str(checkpoint.get("status") or "") == STATUS_CANCELLED:
+            return _transition_conflict_result(store, intent_id)
+        record = checkpoint
         counts = dict(store.load_task_status_counts(task_ids))
         if task_ids and counts.get("completed", 0) == len(task_ids):
             break
@@ -468,27 +829,61 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             )
         )
         claims.append(claim)
+        transitioned = _transition_record(
+            store,
+            record,
+            expected_statuses=(STATUS_RUNNING,),
+            updates={
+                "openclaw_claims": [dict(item) for item in claims],
+                "task_status_counts": dict(store.load_task_status_counts(task_ids)),
+                "updated_at": _now_iso(),
+            },
+        )
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
+        record = transitioned
         if claim.get("status") == READONLY_AUDIT_OPENCLAW_CLAIM_IDLE:
             break
         if claim.get("status") != READONLY_AUDIT_OPENCLAW_CLAIM_ACCEPT:
-            record.update(
-                _failure_updates(
+            updates = _failure_updates(
                     STATUS_FAILED,
                     (ResidentCycleReason.OPENCLAW_CLAIM_REJECTED, *claim.get("rejection_reasons", ())),
                 )
+            updates["openclaw_claims"] = [dict(item) for item in claims]
+            updates["task_status_counts"] = dict(store.load_task_status_counts(task_ids))
+            transitioned = _transition_record(
+                store,
+                record,
+                expected_statuses=(STATUS_RUNNING,),
+                updates=updates,
             )
-            record["openclaw_claims"] = [dict(item) for item in claims]
-            record["task_status_counts"] = dict(store.load_task_status_counts(task_ids))
-            store.upsert_cycle(record)
+            if transitioned is None:
+                return _transition_conflict_result(store, intent_id)
+            record = transitioned
             return _result_from_record(record=record, accepted=False, recovered_existing_cycle=recovered)
 
     counts = dict(store.load_task_status_counts(task_ids))
     record["task_status_counts"] = counts
     record["openclaw_claims"] = [dict(item) for item in claims]
     if not task_ids or counts.get("completed", 0) != len(task_ids):
-        record.update(_failure_updates(STATUS_TIMED_OUT, (ResidentCycleReason.TIMEOUT,)))
-        store.upsert_cycle(record)
+        updates = _failure_updates(STATUS_TIMED_OUT, (ResidentCycleReason.TIMEOUT,))
+        updates["task_status_counts"] = counts
+        updates["openclaw_claims"] = [dict(item) for item in claims]
+        transitioned = _transition_record(
+            store,
+            record,
+            expected_statuses=(STATUS_RUNNING,),
+            updates=updates,
+        )
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
+        record = transitioned
         return _result_from_record(record=record, accepted=False, recovered_existing_cycle=recovered)
+
+    checkpoint = _checkpoint_record(store, record)
+    if checkpoint is None or str(checkpoint.get("status") or "") == STATUS_CANCELLED:
+        return _transition_conflict_result(store, intent_id)
+    record = checkpoint
 
     final = run_reddog_main_readonly_operational_bootstrap(
         repo_root=root,
@@ -518,14 +913,20 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
         architect_determination_store=architect_determination_store,
     )
     if not final.ready:
-        record.update(
-            _failure_updates(
+        updates = _failure_updates(
                 STATUS_FAILED,
                 (ResidentCycleReason.FINAL_BOOTSTRAP_REJECTED, *final.rejection_reasons),
             )
+        updates["final_bootstrap"] = final.to_dict()
+        transitioned = _transition_record(
+            store,
+            record,
+            expected_statuses=(STATUS_RUNNING,),
+            updates=updates,
         )
-        record["final_bootstrap"] = final.to_dict()
-        store.upsert_cycle(record)
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
+        record = transitioned
         return _result_from_record(
             record=record,
             accepted=False,
@@ -533,9 +934,20 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             recovered_existing_cycle=recovered,
         )
     if not final.backend_architect_determination_id:
-        record.update(_failure_updates(STATUS_FAILED, (ResidentCycleReason.ARCHITECT_DETERMINATION_MISSING,)))
-        record["final_bootstrap"] = final.to_dict()
-        store.upsert_cycle(record)
+        updates = _failure_updates(
+            STATUS_FAILED,
+            (ResidentCycleReason.ARCHITECT_DETERMINATION_MISSING,),
+        )
+        updates["final_bootstrap"] = final.to_dict()
+        transitioned = _transition_record(
+            store,
+            record,
+            expected_statuses=(STATUS_RUNNING,),
+            updates=updates,
+        )
+        if transitioned is None:
+            return _transition_conflict_result(store, intent_id)
+        record = transitioned
         return _result_from_record(
             record=record,
             accepted=False,
@@ -543,8 +955,11 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             recovered_existing_cycle=recovered,
         )
 
-    record.update(
-        {
+    transitioned = _transition_record(
+        store,
+        record,
+        expected_statuses=(STATUS_RUNNING,),
+        updates={
             "status": STATUS_DETERMINED,
             "rejection_reasons": [],
             "final_bootstrap": final.to_dict(),
@@ -553,17 +968,20 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             "architect_determination_id": final.backend_architect_determination_id,
             "queue_candidate_count": final.backend_architect_determination_queue_candidate_count,
             "updated_at": _now_iso(),
-        }
+        },
     )
-    store.upsert_cycle(record)
+    if transitioned is None:
+        return _transition_conflict_result(store, intent_id)
+    record = transitioned
     return _result_from_record(record=record, accepted=True, final_bootstrap=final, recovered_existing_cycle=recovered)
 
 
 def _new_record(intent: Mapping[str, Any], *, retry_count: int) -> dict[str, Any]:
     intent_id = str(intent.get("intent_id") or "").strip()
-    return {
-        "schema_version": "reddog_resident_architect_cycle.v1",
+    record = {
+        "schema_version": "reddog_resident_architect_cycle.v2",
         "intent_id": intent_id,
+        "intent_digest": resident_intent_digest(intent),
         "cycle_id": _digest({"intent_id": intent_id, "retry_count": retry_count, "slice": "resident_agentdb_cycle"}),
         "status": STATUS_SUBMITTED,
         "intent": dict(intent),
@@ -574,11 +992,16 @@ def _new_record(intent: Mapping[str, Any], *, retry_count: int) -> dict[str, Any
         "task_status_counts": {},
         "openclaw_claims": [],
         "retry_count": retry_count,
+        "record_revision": 0,
+        "attempt_history": [],
+        "transition_history": [],
         "created_at": _now_iso(),
         "updated_at": _now_iso(),
         "rejection_reasons": [],
-        "read_only_authority_only": True,
     }
+    record.update({field: True for field in RUNTIME_BOUNDARY_FIELDS})
+    record["genesis_state_digest"] = _genesis_state_digest(record)
+    return record
 
 
 def _validate_intent(intent: Mapping[str, Any]) -> tuple[str, ...]:
@@ -649,6 +1072,256 @@ def _failure_updates(status: str, reasons: Sequence[str]) -> dict[str, Any]:
     }
 
 
+def resident_intent_digest(intent: Mapping[str, Any]) -> str:
+    return _digest({"schema_version": "reddog_resident_intent_binding.v1", "intent": dict(intent)})
+
+
+def _attempt_history_entry(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "cycle_id": str(record.get("cycle_id") or ""),
+        "status": str(record.get("status") or ""),
+        "record_revision": int(record.get("record_revision") or 0),
+        "retry_count": int(record.get("retry_count") or 0),
+        "task_ids": [str(task_id) for task_id in record.get("task_ids", ()) if str(task_id)],
+        "closed_at": _now_iso(),
+    }
+
+
+def _validate_retry_transition(
+    *,
+    current: Mapping[str, Any],
+    updates: Mapping[str, Any],
+    allow_terminal_retry: bool,
+    next_status: str,
+) -> str:
+    current_retry = int(current.get("retry_count") or 0)
+    current_history = list(current.get("attempt_history") or ())
+    is_retry = bool(allow_terminal_retry and next_status == STATUS_SUBMITTED)
+    if not is_retry:
+        if "retry_count" in updates and int(updates.get("retry_count") or 0) != current_retry:
+            return "retry_count_not_monotonic"
+        if "attempt_history" in updates and list(updates.get("attempt_history") or ()) != current_history:
+            return "attempt_history_not_monotonic"
+        return ""
+
+    expected_retry = current_retry + 1
+    if int(updates.get("retry_count") or -1) != expected_retry:
+        return "retry_count_not_monotonic"
+    history = list(updates.get("attempt_history") or ())
+    if len(history) != len(current_history) + 1 or history[:-1] != current_history:
+        return "attempt_history_not_monotonic"
+    entry = history[-1] if isinstance(history[-1], Mapping) else {}
+    expected_entry = {
+        "cycle_id": str(current.get("cycle_id") or ""),
+        "status": str(current.get("status") or ""),
+        "record_revision": int(current.get("record_revision") or 0),
+        "retry_count": current_retry,
+        "task_ids": [str(task_id) for task_id in current.get("task_ids", ()) if str(task_id)],
+    }
+    if any(entry.get(key) != value for key, value in expected_entry.items()) or not str(
+        entry.get("closed_at") or ""
+    ):
+        return "attempt_history_not_monotonic"
+    expected_cycle_id = _digest(
+        {
+            "intent_id": str(current.get("intent_id") or ""),
+            "retry_count": expected_retry,
+            "slice": "resident_agentdb_cycle",
+        }
+    )
+    if str(updates.get("cycle_id") or "") != expected_cycle_id:
+        return "retry_cycle_id_invalid"
+    return ""
+
+
+def _transition_history_is_valid(record: Mapping[str, Any], *, revision: int) -> bool:
+    history = record.get("transition_history")
+    if not isinstance(history, list) or len(history) != revision:
+        return False
+    intent_id = str(record.get("intent_id") or "")
+    retry_count = _parse_nonnegative_int(record.get("retry_count"))
+    if retry_count is None:
+        return False
+    if not history:
+        return bool(
+            revision == 0
+            and frozenset(key for key in record if not str(key).startswith("_store_"))
+            == GENESIS_RECORD_FIELDS
+            and str(record.get("status") or "") == STATUS_SUBMITTED
+            and retry_count == 0
+            and record.get("attempt_history") == []
+            and str(record.get("cycle_id") or "")
+            == _digest({"intent_id": intent_id, "retry_count": 0, "slice": "resident_agentdb_cycle"})
+            and str(record.get("genesis_state_digest") or "") == _genesis_state_digest(record)
+        )
+    previous_receipt_id = ""
+    previous_status = ""
+    retry_edges = 0
+    for index, raw_entry in enumerate(history):
+        if not isinstance(raw_entry, Mapping):
+            return False
+        entry = dict(raw_entry)
+        receipt_id = str(entry.pop("receipt_id", ""))
+        from_revision = _parse_nonnegative_int(entry.get("from_revision"))
+        to_revision = _parse_nonnegative_int(entry.get("to_revision"))
+        if (
+            entry.get("schema_version") != "reddog_resident_cycle_transition.v1"
+            or str(entry.get("intent_id") or "") != str(record.get("intent_id") or "")
+            or from_revision != index
+            or to_revision != index + 1
+            or str(entry.get("previous_receipt_id") or "") != previous_receipt_id
+            or entry.get("authority") != "observational_internal_integrity_only"
+            or receipt_id != _digest(entry)
+        ):
+            return False
+        from_status = str(entry.get("from_status") or "")
+        to_status = str(entry.get("to_status") or "")
+        if index == 0 and from_status != STATUS_SUBMITTED:
+            return False
+        if index and from_status != previous_status:
+            return False
+        if from_status in {STATUS_FAILED, STATUS_TIMED_OUT} and to_status == STATUS_SUBMITTED:
+            retry_edges += 1
+        elif from_status in TERMINAL_STATUSES:
+            return False
+        elif to_status not in ALLOWED_STATUS_TRANSITIONS.get(from_status, ()):
+            return False
+        previous_status = to_status
+        previous_receipt_id = receipt_id
+    state_for_digest = dict(record)
+    state_for_digest.pop("transition_history", None)
+    state_for_digest.pop("_store_integrity_valid", None)
+    state_for_digest.pop("_store_revision", None)
+    final_state_digest = str(history[-1].get("result_state_digest") or "")
+    return (
+        previous_status == str(record.get("status") or "")
+        and retry_edges == retry_count
+        and len(record.get("attempt_history") or ()) == retry_edges
+        and final_state_digest == _digest(state_for_digest)
+    )
+
+
+def _record_matches_cancel_request(record: Mapping[str, Any], submitted_intent_digest: str) -> bool:
+    if (
+        record.get("_store_integrity_valid") is True
+        and str(record.get("intent_digest") or "") == submitted_intent_digest
+        and all(record.get(field) is True for field in RUNTIME_BOUNDARY_FIELDS)
+    ):
+        return True
+    intent = record.get("intent")
+    return bool(
+        (
+            str(record.get("status") or "") not in TERMINAL_STATUSES
+            or str(record.get("status") or "") == STATUS_CANCELLED
+        )
+        and not str(record.get("intent_digest") or "")
+        and isinstance(intent, Mapping)
+        and resident_intent_digest(intent) == submitted_intent_digest
+    )
+
+
+def _parse_nonnegative_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _genesis_state_digest(record: Mapping[str, Any]) -> str:
+    value = {
+        str(key): item
+        for key, item in record.items()
+        if key != "genesis_state_digest" and not str(key).startswith("_store_")
+    }
+    return _digest({"schema_version": "reddog_resident_cycle_genesis.v1", "record": value})
+
+
+def _cancel_cycle_with_retry(
+    store: ResidentArchitectCycleStore,
+    existing: Mapping[str, Any],
+    *,
+    max_attempts: int = 3,
+) -> tuple[dict[str, Any], bool]:
+    intent_id = str(existing.get("intent_id") or "")
+    current = dict(existing)
+    for _ in range(max(1, int(max_attempts))):
+        status = str(current.get("status") or "")
+        if status == STATUS_CANCELLED:
+            return current, True
+        if status in TERMINAL_STATUSES:
+            return current, False
+        transitioned = _transition_record(
+            store,
+            current,
+            expected_statuses=(STATUS_SUBMITTED, STATUS_ENQUEUED, STATUS_RUNNING),
+            updates={
+                "status": STATUS_CANCELLED,
+                "cancelled_at": _now_iso(),
+                "rejection_reasons": [ResidentCycleReason.CANCELLED],
+                "updated_at": _now_iso(),
+            },
+        )
+        if transitioned is not None:
+            return transitioned, True
+        latest = store.load_cycle_by_intent(intent_id)
+        if not isinstance(latest, Mapping):
+            break
+        current = dict(latest)
+    return current, str(current.get("status") or "") == STATUS_CANCELLED
+
+
+def _transition_record(
+    store: ResidentArchitectCycleStore,
+    record: Mapping[str, Any],
+    *,
+    expected_statuses: Sequence[str],
+    updates: Mapping[str, Any],
+    allow_terminal_retry: bool = False,
+) -> Optional[dict[str, Any]]:
+    transition = getattr(store, "transition_cycle", None)
+    if not callable(transition):
+        return None
+    result = transition(
+        str(record.get("intent_id") or ""),
+        expected_revision=int(record.get("record_revision", record.get("_store_revision", -1))),
+        expected_statuses=tuple(expected_statuses),
+        updates=dict(updates),
+        allow_terminal_retry=allow_terminal_retry,
+    )
+    if not isinstance(result, Mapping):
+        return None
+    value = result.get("record")
+    return dict(value) if result.get("ok") and isinstance(value, Mapping) else None
+
+
+def _checkpoint_record(
+    store: ResidentArchitectCycleStore,
+    record: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    latest = store.load_cycle_by_intent(str(record.get("intent_id") or ""))
+    if not isinstance(latest, Mapping):
+        return None
+    if latest.get("_store_integrity_valid") is not True:
+        return None
+    if int(latest.get("record_revision", -1)) != int(record.get("record_revision", -2)):
+        return dict(latest) if str(latest.get("status") or "") == STATUS_CANCELLED else None
+    return dict(latest)
+
+
+def _transition_conflict_result(
+    store: ResidentArchitectCycleStore,
+    intent_id: str,
+) -> RedDogResidentArchitectCycleResult:
+    latest = store.load_cycle_by_intent(intent_id)
+    record = dict(latest) if isinstance(latest, Mapping) else _new_record({"intent_id": intent_id}, retry_count=0)
+    if str(record.get("status") or "") == STATUS_CANCELLED:
+        reasons = (ResidentCycleReason.CANCELLED,)
+    else:
+        reasons = (ResidentCycleReason.TRANSITION_CONFLICT,)
+    return _result_from_record(record=record, accepted=False, rejection_reasons=reasons)
+
+
 def _reject(intent: Mapping[str, Any], reasons: Sequence[str]) -> RedDogResidentArchitectCycleResult:
     record = _new_record(intent if isinstance(intent, Mapping) else {}, retry_count=0)
     record.update(_failure_updates(STATUS_FAILED, reasons))
@@ -686,7 +1359,13 @@ def _result_from_record(
         duplicate_intent_reused=duplicate_intent_reused,
         recovered_existing_cycle=recovered_existing_cycle,
         retry_count=int(record.get("retry_count") or 0),
+        record_revision=int(record.get("record_revision") or 0),
+        intent_digest=str(record.get("intent_digest") or ""),
         rejection_reasons=tuple(dict.fromkeys(str(reason) for reason in reasons if str(reason).strip())),
+        **{
+            field: record.get(field) is True
+            for field in RUNTIME_BOUNDARY_FIELDS
+        },
     )
 
 
@@ -714,6 +1393,7 @@ __all__ = [
     "REDDOG_RESIDENT_CYCLE_REJECT",
     "RedDogResidentArchitectCycleResult",
     "ResidentCycleReason",
+    "RUNTIME_BOUNDARY_FIELDS",
     "STATUS_CANCELLED",
     "STATUS_DETERMINED",
     "STATUS_ENQUEUED",
@@ -721,5 +1401,6 @@ __all__ = [
     "STATUS_RUNNING",
     "STATUS_SUBMITTED",
     "STATUS_TIMED_OUT",
+    "resident_intent_digest",
     "run_reddog_resident_architect_durable_agentdb_cycle",
 ]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_client.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_client.py
@@ -13,6 +13,9 @@ from modules.communication.moltbot_bridge.src.reddog_resident_architect_client i
     RedDogResidentArchitectClient,
     ResidentClientReason,
 )
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    resident_intent_digest,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -86,7 +89,10 @@ class _Store:
         self.records = {}
 
     def load_cycle_by_intent(self, intent_id):
-        return self.records.get(intent_id)
+        record = self.records.get(intent_id)
+        if record is None:
+            return None
+        return {**record, "_store_integrity_valid": True}
 
     def upsert_cycle(self, record):
         self.records[str(record["intent_id"])] = dict(record)
@@ -128,6 +134,7 @@ class _Runner:
             "task_status_counts": {"completed": 5},
             "rejection_reasons": ["REJECT_RESIDENT_CYCLE_CANCELLED"] if status == "CANCELLED" else [],
             "intent": intent,
+            "intent_digest": resident_intent_digest(intent),
             "read_only_authority_only": True,
             "no_shell_command_executed": True,
             "no_repo_mutation_performed": True,
@@ -195,7 +202,7 @@ def test_cancel_and_failed_resume_use_persisted_intent_only() -> None:
 
     assert cancelled.status == "CANCELLED"
     assert runner.calls[-2]["cancel_requested"] is True
-    assert runner.calls[-1]["retry_requested"] is True
+    assert runner.calls[-1]["retry_requested"] is False
     assert resumed.status == "DETERMINED"
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -25,13 +25,23 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_
     RepoAuditModelResult,
 )
 import modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime as readonly_worker_runtime
+import modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle as resident_cycle_runtime
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    AgentDbResidentArchitectCycleStore,
     REDDOG_RESIDENT_CYCLE_ACCEPT,
+    RUNTIME_BOUNDARY_FIELDS,
+    STATUS_CANCELLED,
     STATUS_DETERMINED,
+    STATUS_FAILED,
+    STATUS_RUNNING,
     STATUS_TIMED_OUT,
     NoopExternalResearchRetriever,
     ResidentCycleReason,
+    resident_intent_digest,
     run_reddog_resident_architect_durable_agentdb_cycle,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
+    RedDogResidentArchitectClient,
 )
 from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
     build_fresh_holoindex_receipt,
@@ -120,6 +130,8 @@ def _intent() -> dict[str, object]:
         "intent_id": "sha256:intent-resident-cycle",
         "origin": "extension",
         "principal_ref": "012",
+        "foundup_id": "foundups_agent",
+        "source_surface": "editor_thin_client",
         "work_focus": WORK_FOCUS,
         "grounding_receipt": _grounding_receipt(),
         "submits_executable_authority": False,
@@ -296,6 +308,73 @@ def _runtime_kwargs(**overrides):
     return kwargs
 
 
+def _stored_cycle_record(*, status: str, retry_count: int = 0) -> dict[str, object]:
+    record = resident_cycle_runtime._new_record(_intent(), retry_count=retry_count)
+    record["status"] = status
+    record["created_at"] = NOW
+    record["updated_at"] = NOW
+    record["genesis_state_digest"] = resident_cycle_runtime._genesis_state_digest(record)
+    return record
+
+
+def _seed_cycle_status(
+    store,
+    *,
+    status: str,
+    retry_count: int = 0,
+) -> dict[str, object]:
+    record = _stored_cycle_record(status="SUBMITTED", retry_count=0)
+    assert store.create_cycle(record)["ok"]
+    current = dict(store.load_cycle_by_intent(str(record["intent_id"])))
+    for attempt in range(retry_count + 1):
+        if status == "SUBMITTED" and attempt == retry_count:
+            return current
+        enqueued = store.transition_cycle(
+            str(record["intent_id"]),
+            expected_revision=int(current["record_revision"]),
+            expected_statuses=("SUBMITTED",),
+            updates={"status": "ENQUEUED"},
+        )
+        assert enqueued["ok"]
+        running = store.transition_cycle(
+            str(record["intent_id"]),
+            expected_revision=int(enqueued["record"]["record_revision"]),
+            expected_statuses=("ENQUEUED",),
+            updates={"status": STATUS_RUNNING},
+        )
+        assert running["ok"]
+        current = dict(running["record"])
+        if status == STATUS_RUNNING and attempt == retry_count:
+            return current
+        timed_out = store.transition_cycle(
+            str(record["intent_id"]),
+            expected_revision=int(current["record_revision"]),
+            expected_statuses=(STATUS_RUNNING,),
+            updates={"status": STATUS_TIMED_OUT},
+        )
+        assert timed_out["ok"]
+        current = dict(timed_out["record"])
+        if attempt == retry_count:
+            return current
+        retried = resident_cycle_runtime._new_record(_intent(), retry_count=attempt + 1)
+        retried["created_at"] = current["created_at"]
+        retried["genesis_state_digest"] = current["genesis_state_digest"]
+        retried["attempt_history"] = [
+            *list(current.get("attempt_history") or ()),
+            resident_cycle_runtime._attempt_history_entry(current),
+        ]
+        retry_result = store.transition_cycle(
+            str(record["intent_id"]),
+            expected_revision=int(current["record_revision"]),
+            expected_statuses=(STATUS_TIMED_OUT,),
+            updates=retried,
+            allow_terminal_retry=True,
+        )
+        assert retry_result["ok"]
+        current = dict(retry_result["record"])
+    raise AssertionError("unreachable cycle seed")
+
+
 def test_durable_cycle_submits_agentdb_tasks_openclaw_claims_reports_and_determines() -> None:
     result = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
 
@@ -399,6 +478,427 @@ def test_duplicate_intent_reconnects_to_persisted_cycle_without_new_claims() -> 
         claim["task_id"] for claim in first.openclaw_claims
     )
     assert AgentDB().get_autonomous_tasks(status="completed", limit=20)
+
+
+def test_real_agentdb_cycle_reconnects_through_fresh_canonical_client() -> None:
+    first = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
+    assert first.accepted is True
+
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="editor",
+    )
+    status = client.status(first.intent_id)
+
+    assert status.accepted is True
+    assert status.status == STATUS_DETERMINED
+    assert status.intent_id == first.intent_id
+
+
+def test_reconnect_rejects_sql_revision_json_mismatch() -> None:
+    first = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
+    assert first.accepted is True
+    db = AgentDB()
+    with db.db.get_connection() as conn:
+        conn.execute(
+            """
+            UPDATE reddog_resident_architect_cycles
+            SET revision = revision + 1
+            WHERE intent_id = ?
+            """,
+            (first.intent_id,),
+        )
+
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="editor",
+    )
+    status = client.status(first.intent_id)
+
+    assert status.accepted is False
+    assert "REJECT_REDDOG_RESIDENT_CLIENT_RUNTIME_FAILED" in status.rejection_reasons
+
+
+@pytest.mark.parametrize(
+    "changed",
+    (
+        {"principal_ref": "attacker-principal"},
+        {"client_request_id": "different-payload"},
+    ),
+)
+def test_same_intent_id_rejects_changed_principal_or_payload(changed) -> None:
+    first = run_reddog_resident_architect_durable_agentdb_cycle(**_runtime_kwargs())
+    assert first.accepted is True
+    conflicting = dict(_intent())
+    conflicting.update(changed)
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(red_dog_intent=conflicting)
+    )
+
+    assert result.accepted is False
+    assert ResidentCycleReason.INTENT_CONFLICT in result.rejection_reasons
+
+
+def test_cycle_store_rejects_stale_revision_transition() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    record = _seed_cycle_status(store, status=STATUS_RUNNING)
+
+    first = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_RUNNING,),
+        updates={"task_status_counts": {"completed": 1}},
+    )
+    stale = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_RUNNING,),
+        updates={"status": STATUS_DETERMINED},
+    )
+
+    assert first["ok"] is True
+    assert first["record"]["record_revision"] == int(record["record_revision"]) + 1
+    assert len(first["record"]["transition_history"]) == int(first["record"]["record_revision"])
+    assert first["record"]["transition_history"][-1]["authority"] == "observational_internal_integrity_only"
+    assert stale == {"ok": False, "reason": "revision_conflict"}
+
+
+def test_cycle_store_rejects_status_jump_and_immutable_intent_change() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    record = _seed_cycle_status(store, status=STATUS_RUNNING)
+
+    status_jump = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_RUNNING,),
+        updates={"status": "SUBMITTED"},
+    )
+    intent_change = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_RUNNING,),
+        updates={"intent_digest": "sha256:forged"},
+    )
+
+    assert status_jump == {"ok": False, "reason": "invalid_status_transition"}
+    assert intent_change == {"ok": False, "reason": "immutable_field:intent_digest"}
+
+
+def test_cycle_store_rejects_fabricated_terminal_revision_zero_record() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    forged = _stored_cycle_record(status=STATUS_DETERMINED, retry_count=41)
+
+    created = store.create_cycle(forged)
+
+    assert created["ok"] is False
+    assert created["reason"] == "invalid_cycle_record"
+    assert store.load_cycle_by_intent(str(forged["intent_id"])) is None
+
+
+def test_reconnect_rejects_fabricated_revision_zero_decision_fields() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    record = _stored_cycle_record(status="SUBMITTED")
+    assert store.create_cycle(record)["ok"]
+    db = AgentDB()
+    with db.db.get_connection() as conn:
+        row = conn.execute(
+            "SELECT cycle_json FROM reddog_resident_architect_cycles WHERE intent_id = ?",
+            (record["intent_id"],),
+        ).fetchone()
+        stored = json.loads(row["cycle_json"])
+        stored["architect_action"] = "FIX"
+        stored["queue_candidate_count"] = 1
+        conn.execute(
+            "UPDATE reddog_resident_architect_cycles SET cycle_json = ? WHERE intent_id = ?",
+            (json.dumps(stored, sort_keys=True, separators=(",", ":")), record["intent_id"]),
+        )
+
+    loaded = store.load_cycle_by_intent(str(record["intent_id"]))
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="editor",
+    )
+    status = client.status(str(record["intent_id"]))
+
+    assert loaded is not None and loaded["_store_integrity_valid"] is False
+    assert status.accepted is False
+    assert "REJECT_REDDOG_RESIDENT_CLIENT_RUNTIME_FAILED" in status.rejection_reasons
+
+
+def test_cycle_store_rejects_retrying_completed_determination() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    record = _seed_cycle_status(store, status=STATUS_RUNNING)
+    determined = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_RUNNING,),
+        updates={"status": STATUS_DETERMINED},
+    )
+    assert determined["ok"]
+
+    retry = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(determined["record"]["record_revision"]),
+        expected_statuses=(STATUS_DETERMINED,),
+        updates={"status": "SUBMITTED", "retry_count": 1, "attempt_history": []},
+        allow_terminal_retry=True,
+    )
+
+    assert retry == {"ok": False, "reason": "terminal_status"}
+
+
+def test_cancellation_during_claim_remains_terminal() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    cancel_results = []
+
+    def cancelling_claim_runner(**kwargs):
+        cancel_results.append(
+            run_reddog_resident_architect_durable_agentdb_cycle(
+                repo_root=REPO_ROOT,
+                red_dog_intent=_intent(),
+                cycle_store=store,
+                cancel_requested=True,
+            )
+        )
+        return {"accepted": True, "status": "OPENCLAW_READONLY_AUDIT_CLAIM_ACCEPT"}
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cycle_store=store, openclaw_claim_runner=cancelling_claim_runner)
+    )
+    persisted = store.load_cycle_by_intent(str(_intent()["intent_id"]))
+
+    assert cancel_results and cancel_results[0].status == STATUS_CANCELLED
+    assert result.accepted is False
+    assert result.status == STATUS_CANCELLED
+    assert ResidentCycleReason.CANCELLED in result.rejection_reasons
+    assert persisted is not None and persisted["status"] == STATUS_CANCELLED
+
+
+class _CancellationConflictStore:
+    def __init__(self, *, failures: int) -> None:
+        self.inner = AgentDbResidentArchitectCycleStore()
+        self.failures = failures
+        self.cancel_attempts = 0
+
+    def __getattr__(self, name):
+        return getattr(self.inner, name)
+
+    def transition_cycle(self, intent_id, **kwargs):
+        if kwargs.get("updates", {}).get("status") == STATUS_CANCELLED:
+            self.cancel_attempts += 1
+            if self.cancel_attempts <= self.failures:
+                return {"ok": False, "reason": "revision_conflict"}
+        return self.inner.transition_cycle(intent_id, **kwargs)
+
+
+class _CheckpointIntegrityFailureStore:
+    def __init__(self) -> None:
+        self.inner = AgentDbResidentArchitectCycleStore()
+
+    def __getattr__(self, name):
+        return getattr(self.inner, name)
+
+    def load_cycle_by_intent(self, intent_id):
+        record = self.inner.load_cycle_by_intent(intent_id)
+        if isinstance(record, dict) and record.get("status") == STATUS_RUNNING:
+            return {**record, "_store_integrity_valid": False}
+        return record
+
+
+def test_integrity_invalid_checkpoint_blocks_worker_and_architect_model_calls() -> None:
+    store = _CheckpointIntegrityFailureStore()
+    claim_calls = []
+    architect = _ArchitectRunner()
+
+    def claim_runner(**kwargs):
+        claim_calls.append(kwargs)
+        return {"accepted": True, "status": "OPENCLAW_READONLY_AUDIT_CLAIM_ACCEPT"}
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(
+            cycle_store=store,
+            openclaw_claim_runner=claim_runner,
+            architect_model_runner=architect,
+        )
+    )
+
+    assert result.accepted is False
+    assert ResidentCycleReason.TRANSITION_CONFLICT in result.rejection_reasons
+    assert claim_calls == []
+    assert architect.calls == []
+
+
+def test_cancellation_retries_one_cas_conflict_and_proves_persisted_terminal_state() -> None:
+    store = _CancellationConflictStore(failures=1)
+    _seed_cycle_status(store, status=STATUS_RUNNING)
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cycle_store=store, cancel_requested=True)
+    )
+    persisted = store.load_cycle_by_intent(result.intent_id)
+
+    assert store.cancel_attempts == 2
+    assert result.status == STATUS_CANCELLED
+    assert result.rejection_reasons == (ResidentCycleReason.CANCELLED,)
+    assert persisted is not None and persisted["status"] == STATUS_CANCELLED
+
+
+def test_cancellation_conflict_never_reports_cancelled_when_persisted_state_is_running() -> None:
+    store = _CancellationConflictStore(failures=10)
+    _seed_cycle_status(store, status=STATUS_RUNNING)
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cycle_store=store, cancel_requested=True)
+    )
+    persisted = store.load_cycle_by_intent(result.intent_id)
+
+    assert store.cancel_attempts == 3
+    assert result.status == STATUS_RUNNING
+    assert result.rejection_reasons == (ResidentCycleReason.CANCELLATION_CONFLICT,)
+    assert persisted is not None and persisted["status"] == STATUS_RUNNING
+
+
+def test_legacy_active_cycle_is_cancel_only_and_cannot_resume() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    db = AgentDB()
+    store._ensure_table(db)
+    legacy = {
+        "schema_version": "reddog_resident_architect_cycle.v1",
+        "intent_id": _intent()["intent_id"],
+        "cycle_id": "sha256:legacy-cycle",
+        "status": STATUS_RUNNING,
+        "intent": _intent(),
+        "retry_count": 0,
+        "task_ids": [],
+        "created_at": NOW,
+        "updated_at": NOW,
+        "rejection_reasons": [],
+    }
+    with db.db.get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO reddog_resident_architect_cycles
+            (intent_id, cycle_id, status, snapshot_id, determination_id, revision, cycle_json, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                legacy["intent_id"],
+                legacy["cycle_id"],
+                legacy["status"],
+                None,
+                None,
+                0,
+                json.dumps(legacy, sort_keys=True, separators=(",", ":")),
+                NOW,
+            ),
+        )
+
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="editor",
+        cycle_store=store,
+    )
+    cancelled = client.cancel(str(legacy["intent_id"]))
+    cancelled_again = client.cancel(str(legacy["intent_id"]))
+    resumed = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cycle_store=store)
+    )
+
+    assert cancelled.status == STATUS_CANCELLED
+    assert cancelled.rejection_reasons == (ResidentCycleReason.CANCELLED,)
+    assert cancelled.canonical_resident_cycle_used is False
+    assert cancelled_again.status == STATUS_CANCELLED
+    assert cancelled_again.rejection_reasons == (ResidentCycleReason.CANCELLED,)
+    assert cancelled_again.canonical_resident_cycle_used is False
+    assert resumed.accepted is False
+    assert ResidentCycleReason.INTENT_CONFLICT in resumed.rejection_reasons
+
+
+def test_store_rejects_retry_count_rollback_and_attempt_history_erasure() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    record = _seed_cycle_status(store, status=STATUS_TIMED_OUT, retry_count=7)
+
+    rolled_back = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_TIMED_OUT,),
+        updates={"status": "SUBMITTED", "retry_count": 0, "attempt_history": []},
+        allow_terminal_retry=True,
+    )
+    history_erased = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_TIMED_OUT,),
+        updates={"status": "SUBMITTED", "retry_count": 8, "attempt_history": []},
+        allow_terminal_retry=True,
+    )
+
+    assert rolled_back == {"ok": False, "reason": "retry_count_not_monotonic"}
+    assert history_erased == {"ok": False, "reason": "attempt_history_not_monotonic"}
+
+
+def test_reconnect_rejects_tampered_transition_state_digest() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    record = _seed_cycle_status(store, status=STATUS_RUNNING)
+    transitioned = store.transition_cycle(
+        str(record["intent_id"]),
+        expected_revision=int(record["record_revision"]),
+        expected_statuses=(STATUS_RUNNING,),
+        updates={"task_status_counts": {"completed": 1}},
+    )
+    assert transitioned["ok"]
+    db = AgentDB()
+    with db.db.get_connection() as conn:
+        row = conn.execute(
+            "SELECT cycle_json FROM reddog_resident_architect_cycles WHERE intent_id = ?",
+            (record["intent_id"],),
+        ).fetchone()
+        stored = json.loads(row["cycle_json"])
+        stored["task_status_counts"] = {"completed": 99}
+        conn.execute(
+            "UPDATE reddog_resident_architect_cycles SET cycle_json = ? WHERE intent_id = ?",
+            (json.dumps(stored, sort_keys=True, separators=(",", ":")), record["intent_id"]),
+        )
+
+    loaded = store.load_cycle_by_intent(str(record["intent_id"]))
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="editor",
+    )
+    status = client.status(str(record["intent_id"]))
+
+    assert loaded is not None and loaded["_store_integrity_valid"] is False
+    assert status.accepted is False
+    assert "REJECT_REDDOG_RESIDENT_CLIENT_RUNTIME_FAILED" in status.rejection_reasons
+
+
+def test_retry_count_is_monotonic_from_seven_to_eight() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    _seed_cycle_status(store, status=STATUS_TIMED_OUT, retry_count=7)
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cycle_store=store, retry_requested=True, max_claims=0)
+    )
+
+    assert result.accepted is False
+    assert result.status == STATUS_TIMED_OUT
+    assert result.retry_count == 8
+    persisted = store.load_cycle_by_intent(result.intent_id)
+    assert persisted is not None
+    assert persisted["retry_count"] == 8
+    assert len(persisted["attempt_history"]) == 8
+    assert persisted["attempt_history"][-1]["retry_count"] == 7
 
 
 def test_missing_external_research_retriever_uses_noop_receipt_instead_of_blocking_cycle() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_session_bridge.py
@@ -61,40 +61,32 @@ def _grounding_receipt(work_focus: str) -> dict:
 
 
 def _accepted_result():
-    final = SimpleNamespace(
-        status="READY",
-        snapshot_receipt_id="sha256:final",
-        backend_architect_determination_action="FIX",
-        backend_architect_determination_next_slice="REDDOG_NEXT_PHASE1",
-        backend_architect_determination_id="sha256:architect",
-        backend_architect_determination_queue_candidate_count=1,
-    )
     return SimpleNamespace(
         accepted=True,
         status="DETERMINED",
+        canonical_resident_cycle_used=True,
         intent_id="sha256:intent",
         cycle_id="sha256:cycle",
         snapshot_id="sha256:snapshot",
         swarm_id="sha256:swarm",
         task_ids=("task-a", "task-b"),
         task_status_counts={"completed": 2},
-        openclaw_claims=({"accepted": True}, {"accepted": True}),
+        openclaw_claim_count=2,
         duplicate_intent_reused=False,
         recovered_existing_cycle=False,
-        final_bootstrap=final,
         architect_action="FIX",
         architect_next_slice="REDDOG_NEXT_PHASE1",
-        architect_determination_id="sha256:architect",
+        determination_id="sha256:architect",
         queue_candidate_count=1,
+        record_revision=7,
+        intent_digest="sha256:intent-digest",
         rejection_reasons=(),
-        no_shell_command_executed=True,
-        no_repo_mutation_performed=True,
-        no_holoindex_reindex_performed=True,
-        no_hermes_dispatch_performed=True,
-        no_worktree_operation_performed=True,
-        no_pr_created=True,
-        no_pattern_memory_promotion_performed=True,
-        no_live_foundup_enqueue_performed=True,
+        client_no_shell_command_executed=True,
+        client_no_repo_mutation_performed=True,
+        client_no_holoindex_reindex_performed=True,
+        client_no_hermes_execution_performed=True,
+        client_no_worktree_operation_performed=True,
+        client_no_pr_created=True,
     )
 
 
@@ -112,17 +104,27 @@ def test_resident_architect_session_summarizes_durable_cycle_runtime(monkeypatch
     calls = []
     grounding = _grounding_receipt("audit resident loop")
 
-    def fake_cycle(**kwargs):
-        calls.append(kwargs)
-        return _accepted_result()
+    class _Client:
+        def __init__(self, **kwargs):
+            calls.append({"init": kwargs})
 
-    monkeypatch.setattr(bridge, "run_reddog_resident_architect_durable_agentdb_cycle", fake_cycle)
+        def submit(self, intent):
+            calls.append({"intent": dict(intent)})
+            return _accepted_result()
+
+    monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-012")
+    monkeypatch.setenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", "foundups_agent")
+    monkeypatch.setattr(bridge, "RedDogResidentArchitectClient", _Client)
     result = bridge._result(
         {
             "explicit_resident_architect_session_requested": True,
             "red_dog_intent": {
                 "schema_version": "reddog_intent.v2",
                 "intent_id": "sha256:intent",
+                "origin": "extension",
+                "source_surface": "editor_thin_client",
+                "principal_ref": "principal-012",
+                "foundup_id": "foundups_agent",
                 "work_focus": "audit resident loop",
                 "grounding_receipt": grounding,
                 "submits_executable_authority": False,
@@ -145,14 +147,18 @@ def test_resident_architect_session_summarizes_durable_cycle_runtime(monkeypatch
         }
     )
 
-    assert calls and calls[0]["requested_operation"] == "extension_resident_architect_session"
-    assert calls[0]["red_dog_intent"]["intent_id"] == "sha256:intent"
-    assert calls[0]["prompt_text"] == "audit resident loop"
-    assert calls[0]["timeout_seconds"] == 13
-    assert calls[0]["breadcrumbs"] == ({"breadcrumb_id": "crumb-1"},)
-    assert calls[0]["brain_state"] == {"available": True, "signature_digest": "sha256:brain"}
-    assert calls[0]["workspace_memory_notes"] == ({"note_id": "note-1"},)
-    assert calls[0]["memex_snapshot_supply_config"]["foundup_id"] == "foundups_agent"
+    runtime = calls[0]["init"]["runtime_defaults"]
+    assert calls[0]["init"]["authenticated_principal_id"] == "principal-012"
+    assert calls[0]["init"]["authorized_foundup_ids"] == ("foundups_agent",)
+    assert calls[0]["init"]["transport"] == "editor"
+    assert calls[1]["intent"]["intent_id"] == "sha256:intent"
+    assert runtime["requested_operation"] == "extension_resident_architect_session"
+    assert runtime["prompt_text"] == "audit resident loop"
+    assert runtime["timeout_seconds"] == 13
+    assert runtime["breadcrumbs"] == ({"breadcrumb_id": "crumb-1"},)
+    assert runtime["brain_state"] == {"available": True, "signature_digest": "sha256:brain"}
+    assert runtime["workspace_memory_notes"] == ({"note_id": "note-1"},)
+    assert runtime["memex_snapshot_supply_config"]["foundup_id"] == "foundups_agent"
     assert result["decision"] == bridge.RESIDENT_ARCHITECT_SESSION_ACCEPT
     assert result["accepted"] is True
     assert result["resident_backend_invoked"] is True
@@ -172,10 +178,16 @@ def test_resident_architect_session_summarizes_durable_cycle_runtime(monkeypatch
 
 
 def test_resident_architect_session_bridge_failure_fails_closed(monkeypatch) -> None:
-    def fail_cycle(**kwargs):
-        raise RuntimeError("boom")
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
 
-    monkeypatch.setattr(bridge, "run_reddog_resident_architect_durable_agentdb_cycle", fail_cycle)
+        def submit(self, intent):
+            raise RuntimeError("boom")
+
+    monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-012")
+    monkeypatch.setenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", "foundups_agent")
+    monkeypatch.setattr(bridge, "RedDogResidentArchitectClient", _Client)
     grounding = _grounding_receipt("audit resident loop")
     result = bridge._result(
         {
@@ -183,6 +195,10 @@ def test_resident_architect_session_bridge_failure_fails_closed(monkeypatch) -> 
             "red_dog_intent": {
                 "schema_version": "reddog_intent.v2",
                 "intent_id": "sha256:intent",
+                "origin": "extension",
+                "source_surface": "editor_thin_client",
+                "principal_ref": "principal-012",
+                "foundup_id": "foundups_agent",
                 "work_focus": "audit resident loop",
                 "grounding_receipt": grounding,
                 "submits_executable_authority": False,
@@ -196,3 +212,32 @@ def test_resident_architect_session_bridge_failure_fails_closed(monkeypatch) -> 
     assert result["resident_backend_invoked"] is True
     assert result["no_repo_mutation_performed"] is True
     assert result["no_holoindex_reindex_performed"] is True
+
+
+def test_resident_architect_session_requires_host_authenticated_scope(monkeypatch) -> None:
+    monkeypatch.delenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", raising=False)
+    monkeypatch.delenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", raising=False)
+    grounding = _grounding_receipt("audit resident loop")
+
+    result = bridge._result(
+        {
+            "explicit_resident_architect_session_requested": True,
+            "red_dog_intent": {
+                "schema_version": "reddog_intent.v2",
+                "intent_id": "sha256:intent",
+                "origin": "extension",
+                "source_surface": "editor_thin_client",
+                "principal_ref": "principal-012",
+                "foundup_id": "foundups_agent",
+                "work_focus": "audit resident loop",
+                "grounding_receipt": grounding,
+                "submits_executable_authority": False,
+            },
+            "grounding_receipt_id": grounding["receipt_id"],
+            "work_focus": "audit resident loop",
+        }
+    )
+
+    assert result["accepted"] is False
+    assert result["resident_backend_invoked"] is False
+    assert result["rejection_reasons"] == ["resident_architect_authenticated_scope_missing"]

--- a/modules/foundups/agent/tests/test_hermes_reddog_resident_client_adapter.py
+++ b/modules/foundups/agent/tests/test_hermes_reddog_resident_client_adapter.py
@@ -12,6 +12,9 @@ from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
     RedDogResidentArchitectClient,
 )
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    resident_intent_digest,
+)
 from modules.foundups.agent.src.hermes_reddog_resident_client_adapter import (
     HERMES_REQUEST_SCHEMA,
     HERMES_TEXT_REQUEST_SCHEMA,
@@ -83,7 +86,10 @@ class _Store:
         self.records = {}
 
     def load_cycle_by_intent(self, intent_id):
-        return self.records.get(intent_id)
+        record = self.records.get(intent_id)
+        if record is None:
+            return None
+        return {**record, "_store_integrity_valid": True}
 
     def upsert_cycle(self, record):
         self.records[str(record["intent_id"])] = dict(record)
@@ -124,6 +130,7 @@ class _Runner:
             "task_status_counts": {"completed": 5},
             "rejection_reasons": [],
             "intent": intent,
+            "intent_digest": resident_intent_digest(intent),
             "read_only_authority_only": True,
             "no_shell_command_executed": True,
             "no_repo_mutation_performed": True,

--- a/scripts/reddog_resident_architect_session_once.py
+++ b/scripts/reddog_resident_architect_session_once.py
@@ -3,8 +3,9 @@
 Slice: REDDOG_EXTENSION_TO_RESIDENT_ARCHITECT_SESSION_RUNTIME_PHASE1
 
 The editor runtime may call this script only when the resident architect
-session is explicitly enabled. It delegates to the durable AgentDB resident
-cycle runtime and returns a bounded status packet. It does not perform source
+session is explicitly enabled. It delegates through the canonical
+host-authenticated resident client to the durable AgentDB cycle and returns a
+bounded status packet. It does not perform source
 mutation, shell work, worktree creation, PR creation, HoloIndex re-index,
 Hermes dispatch, live FoundUp enqueue, or direct inline task execution.
 """
@@ -21,8 +22,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (  # noqa: E402
-    run_reddog_resident_architect_durable_agentdb_cycle,
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (  # noqa: E402
+    RedDogResidentArchitectClient,
 )
 from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (  # noqa: E402
     validate_grounded_target_receipt,
@@ -128,8 +129,8 @@ def _sequence_of_mappings(value: Any) -> tuple[Mapping[str, Any], ...]:
 
 
 def _summarize_result(result: Any) -> Dict[str, Any]:
-    final = result.final_bootstrap
-    final_status = final.status if final else ""
+    task_ids = tuple(str(item) for item in result.task_ids if str(item))
+    completed = int(result.task_status_counts.get("completed", 0))
     return {
         "decision": RESIDENT_ARCHITECT_SESSION_ACCEPT if result.accepted else RESIDENT_ARCHITECT_SESSION_REJECT,
         "accepted": bool(result.accepted),
@@ -137,38 +138,38 @@ def _summarize_result(result: Any) -> Dict[str, Any]:
         "resident_backend_invoked": True,
         "red_dog_intent_submitted": True,
         "durable_agentdb_cycle": True,
+        "canonical_resident_client_used": bool(result.canonical_resident_cycle_used),
         "python_invocation_performed": True,
         "snapshot_id": _string(result.snapshot_id),
-        "final_snapshot_id": _string(getattr(final, "snapshot_receipt_id", "")) if final else "",
+        "final_snapshot_id": _string(result.snapshot_id),
         "swarm_id": _string(result.swarm_id),
         "cycle_id": _string(result.cycle_id),
         "intent_id": _string(result.intent_id),
         "initial_status": _string(result.status),
-        "final_status": final_status,
-        "task_count": len(result.task_ids),
+        "final_status": _string(result.status),
+        "task_count": len(task_ids),
         "task_status_counts": dict(result.task_status_counts),
-        "reports_persisted": int(result.task_status_counts.get("completed", 0)),
-        "readonly_audit_tasks_enqueued": bool(result.task_ids),
-        "readonly_audit_tasks_executed": (
-            int(result.task_status_counts.get("completed", 0)) == len(result.task_ids)
-            and bool(result.task_ids)
-        ),
-        "openclaw_claim_count": len(result.openclaw_claims),
+        "reports_persisted": completed,
+        "readonly_audit_tasks_enqueued": bool(task_ids),
+        "readonly_audit_tasks_executed": completed == len(task_ids) and bool(task_ids),
+        "openclaw_claim_count": int(result.openclaw_claim_count),
         "recovered_existing_cycle": bool(result.recovered_existing_cycle),
         "duplicate_intent_reused": bool(result.duplicate_intent_reused),
         "architect_action": _string(result.architect_action),
         "architect_next_slice": _string(result.architect_next_slice),
-        "architect_determination_id": _string(result.architect_determination_id),
+        "architect_determination_id": _string(result.determination_id),
         "queue_candidate_count": int(result.queue_candidate_count),
+        "record_revision": int(result.record_revision),
+        "intent_digest": _string(result.intent_digest),
         "rejection_reasons": list(result.rejection_reasons),
-        "no_shell_command_executed": bool(result.no_shell_command_executed),
-        "no_repo_mutation_performed": bool(result.no_repo_mutation_performed),
-        "no_holoindex_reindex_performed": bool(result.no_holoindex_reindex_performed),
-        "no_hermes_dispatch_performed": bool(result.no_hermes_dispatch_performed),
-        "no_worktree_operation_performed": bool(result.no_worktree_operation_performed),
-        "no_pr_created": bool(result.no_pr_created),
-        "no_pattern_memory_promotion_performed": bool(result.no_pattern_memory_promotion_performed),
-        "no_live_foundup_enqueue_performed": bool(result.no_live_foundup_enqueue_performed),
+        "no_shell_command_executed": bool(result.client_no_shell_command_executed),
+        "no_repo_mutation_performed": bool(result.client_no_repo_mutation_performed),
+        "no_holoindex_reindex_performed": bool(result.client_no_holoindex_reindex_performed),
+        "no_hermes_dispatch_performed": bool(result.client_no_hermes_execution_performed),
+        "no_worktree_operation_performed": bool(result.client_no_worktree_operation_performed),
+        "no_pr_created": bool(result.client_no_pr_created),
+        "no_pattern_memory_promotion_performed": True,
+        "no_live_foundup_enqueue_performed": True,
         "coding_worker_spawned": False,
     }
 
@@ -199,26 +200,41 @@ def _result(payload: Mapping[str, Any]) -> Dict[str, Any]:
 
     repo_root_text = payload.get("repo_root")
     repo_root = Path(str(repo_root_text)).resolve() if repo_root_text else REPO_ROOT
+    principal = str(os.getenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "")).strip()
+    authorized_foundups = tuple(
+        item.strip()
+        for item in str(os.getenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", "")).split(",")
+        if item.strip()
+    )
+    if not principal or not authorized_foundups:
+        return _reject("resident_architect_authenticated_scope_missing")
     try:
-        result = run_reddog_resident_architect_durable_agentdb_cycle(
+        client = RedDogResidentArchitectClient(
             repo_root=repo_root,
-            red_dog_intent=intent,
-            work_state_path=_string(
-                payload.get("work_state_path") or os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", "")
-            ),
-            holoindex_receipt_path=_string(
-                payload.get("holoindex_receipt_path") or os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")
-            ),
-            holoindex_ssd_path=_string(payload.get("holoindex_ssd_path") or os.getenv("HOLOINDEX_SSD_PATH", "")),
-            requested_operation="extension_resident_architect_session",
-            prompt_text=work_focus,
-            breadcrumbs=_sequence_of_mappings(payload.get("breadcrumbs")),
-            brain_state=_mapping(payload.get("brain_state")),
-            workspace_memory_notes=_sequence_of_mappings(payload.get("workspace_memory_notes")),
-            memex_snapshot_supply_config=_mapping(payload.get("memex_snapshot_supply")),
-            external_research_retriever=_external_retriever_from_env(),
-            timeout_seconds=_int(payload.get("timeout_seconds"), 60),
+            authenticated_principal_id=principal,
+            authorized_foundup_ids=authorized_foundups,
+            transport="editor",
+            runtime_defaults={
+                "work_state_path": _string(
+                    payload.get("work_state_path") or os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", "")
+                ),
+                "holoindex_receipt_path": _string(
+                    payload.get("holoindex_receipt_path") or os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")
+                ),
+                "holoindex_ssd_path": _string(
+                    payload.get("holoindex_ssd_path") or os.getenv("HOLOINDEX_SSD_PATH", "")
+                ),
+                "requested_operation": "extension_resident_architect_session",
+                "prompt_text": work_focus,
+                "breadcrumbs": _sequence_of_mappings(payload.get("breadcrumbs")),
+                "brain_state": _mapping(payload.get("brain_state")),
+                "workspace_memory_notes": _sequence_of_mappings(payload.get("workspace_memory_notes")),
+                "memex_snapshot_supply_config": _mapping(payload.get("memex_snapshot_supply")),
+                "external_research_retriever": _external_retriever_from_env(),
+                "timeout_seconds": _int(payload.get("timeout_seconds"), 60),
+            },
         )
+        result = client.submit(intent)
     except Exception as exc:
         output = _reject("resident_architect_session_bridge_failed", bridge_error_class=type(exc).__name__)
         output["resident_backend_invoked"] = True


### PR DESCRIPTION
## Summary
- bind resident cycles to canonical full intents and canonical genesis state
- enforce revision CAS, legal status transitions, terminal cancellation, and monotonic retries
- route editor resident sessions through the host-authenticated canonical client
- bump RedDog to 0.4.11

## WSP_97 evidence
- 77 focused resident/Hermes/main bootstrap tests passed
- RedDog extension contract passed
- two independent reviews returned GO
- git diff --check clean

## Truth boundary
Process-local no-effect fields and transition hashes are internal integrity controls only. This PR adds no signer, shell, repository write, worktree, PR, merge, HoloIndex re-index, Hermes execution, or live enqueue authority.

Worker-Lane: 0102-architect
Slice: REDDOG_RESIDENT_CYCLE_CAS_ATTESTATION_AND_INTENT_BINDING_PHASE1