### PR TITLE
test(holoindex): bind owner fixtures to receipt v2

### DIFF
--- a/modules/infrastructure/foundups_mcp_bridge/tests/TestModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/TestModLog.md
@@ -1,5 +1,27 @@
 # foundups_mcp_bridge TestModLog
 
+## [2026-07-20] Receipt-v2 owner fixture integrity repair
+
+**WSP Protocol:** WSP 00, 22, 50, 62, 97
+
+**Observed:** The first owner runbook group produced 23 failures and 38 passes.
+The shared owner and HTTP fixtures still emitted the pre-v2 literal
+`generation-1`, only the seven query collections, and placeholder proof
+digests. Production correctly rejected those fixtures as
+`invalid_freshness_receipt_integrity` before reaching the semantic and timeout
+behaviors under test.
+
+**Change:** Kept production validation unchanged. The synthetic receipt helper
+now includes every v2 receipt collection, uses format-valid proof digests, and
+computes its generation with the production integrity algorithm after test
+repository/store identity normalization. The HTTP suite reuses that helper so
+the transport and core fixtures cannot drift independently.
+
+**Validation:** The exact first runbook group passes 61 tests. The adjacent
+embedding/generation and production freshness-receipt suites pass 39 tests.
+Changed Python test modules remain below the WSP 62 800-line warning threshold;
+no exemption is required.
+
 ## [2026-07-18] HoloIndex / RedDog Operational Truth Boundary POC
 
 **WSP Protocol:** WSP 05, 06, 15, 22, 50, 62, 87, 96, 97

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -9,7 +10,12 @@ from typing import Any, Mapping
 
 import pytest
 
-from holo_index.freshness_receipt import SCHEMA_VERSION as FRESHNESS_SCHEMA_VERSION
+from holo_index.freshness_receipt import (
+    ALL_COLLECTIONS,
+    CollectionFreshness,
+    SCHEMA_VERSION as FRESHNESS_SCHEMA_VERSION,
+    _receipt_generation_id,
+)
 from holo_index.source_scope import canonical_source_scope_id
 from modules.infrastructure.foundups_mcp_bridge.src.holo_query_service import (
     BASELINE_COLLECTIONS,
@@ -25,9 +31,36 @@ SHA = "a" * 40
 SPACE_FINGERPRINT = "sha256:" + ("1" * 64)
 
 
-def _receipt(*, sha: str = SHA, generation: str = "generation-1", omit: str = "") -> Mapping[str, Any]:
+def _test_digest(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _bind_receipt_generation(receipt: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Bind a synthetic receipt with the production v2 integrity algorithm."""
+    value = dict(receipt)
+    entries = [CollectionFreshness(**entry) for entry in value["collections"]]
+    value["generation_id"] = _receipt_generation_id(
+        str(value["repo_head_sha"]),
+        entries,
+        generated_at=str(value["generated_at"]),
+        base_generation_id=str(value["base_generation_id"]),
+        repo_root=str(value["repo_root"]),
+        ssd_path=str(value["ssd_path"]),
+        source=str(value["source"]),
+    )
+    return value
+
+
+def _receipt(
+    *,
+    sha: str = SHA,
+    generation: str = "generation-1",
+    omit: str = "",
+    repo_root: Path | str = "O:/Foundups-Agent",
+    ssd_path: Path | str = "E:/HoloIndex",
+) -> Mapping[str, Any]:
     collections = []
-    for name in sorted(BASELINE_COLLECTIONS):
+    for name in sorted(ALL_COLLECTIONS):
         if name == omit:
             continue
         collections.append(
@@ -38,28 +71,31 @@ def _receipt(*, sha: str = SHA, generation: str = "generation-1", omit: str = ""
                 "source": "test",
                 "repo_head_sha": sha,
                 "last_indexed_at": "2026-07-18T00:00:00+00:00",
-                "source_manifest_digest": f"sha256:manifest-{name}",
-                "indexed_paths_digest": f"sha256:paths-{name}",
-                "removed_paths_digest": "sha256:removed",
+                "source_manifest_digest": _test_digest(f"manifest:{name}"),
+                "indexed_paths_digest": _test_digest(f"paths:{name}"),
+                "removed_paths_digest": _test_digest(f"removed:{name}"),
                 "embedding_backend": "sentence_transformers",
                 "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
                 "embedding_space_fingerprint": SPACE_FINGERPRINT,
                 "verification": "PASS",
                 "proof_kind": "complete_source_manifest",
                 "source_scope_id": canonical_source_scope_id(name),
+                "source_policy_digest": _test_digest(f"policy:{name}"),
+                "collection_snapshot_digest": _test_digest(f"snapshot:{name}"),
             }
         )
-    return {
+    receipt = {
         "schema_version": FRESHNESS_SCHEMA_VERSION,
         "generated_at": "2026-07-18T00:00:00+00:00",
-        "repo_root": "O:/Foundups-Agent",
+        "repo_root": str(repo_root),
         "repo_head_sha": sha,
-        "ssd_path": "E:/HoloIndex",
-        "source": "test",
-        "generation_id": generation,
+        "ssd_path": str(ssd_path),
+        "source": f"test:{generation}" if generation else "test",
+        "generation_id": "",
         "base_generation_id": "",
         "collections": collections,
     }
+    return _bind_receipt_generation(receipt) if generation else receipt
 
 
 def _raw_result(*, mode: str = "semantic", error: str = "") -> Mapping[str, Any]:
@@ -139,7 +175,11 @@ def _service(
         normalized = dict(receipt)
         normalized["repo_root"] = str(tmp_path)
         normalized["ssd_path"] = str(tmp_path / "holo-store")
-        return normalized
+        return (
+            _bind_receipt_generation(normalized)
+            if normalized.get("generation_id")
+            else normalized
+        )
     kwargs.setdefault(
         "repository_state_reader",
         lambda _root: SimpleNamespace(
@@ -442,7 +482,10 @@ def test_stable_semantic_generation_preserves_complete_raw_wsp_and_knowledge(
         assert result["ok"] is True
         assert result["freshness"] == "CURRENT"
         assert result["retrieval_mode"] == "semantic"
-        assert result["freshness_generation_id"] == "generation-1"
+        assert result["freshness_generation_id"] == _receipt(
+            repo_root=tmp_path,
+            ssd_path=tmp_path / "holo-store",
+        )["generation_id"]
         assert result["repo_head_sha"] == SHA
         assert result["raw_result"] == raw
         assert result["raw_result"]["wsp_hits"] == raw["wsp_hits"]

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_http.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_http.py
@@ -11,8 +11,6 @@ from typing import Any, Mapping
 
 import pytest
 
-from holo_index.freshness_receipt import SCHEMA_VERSION
-from holo_index.source_scope import canonical_source_scope_id
 from modules.communication.moltbot_bridge.src import (
     reddog_holoindex_owner_query_client as owner_client,
 )
@@ -28,6 +26,9 @@ from modules.infrastructure.foundups_mcp_bridge.src.holo_query_service import (
     HoloIndexQueryOwnerService,
     main,
 )
+from modules.infrastructure.foundups_mcp_bridge.tests.test_holo_query_service import (
+    _receipt as _service_receipt,
+)
 
 
 TOKEN = "stdlib-owner-service-token-with-strong-length"
@@ -36,36 +37,10 @@ SPACE_FINGERPRINT = "sha256:" + ("1" * 64)
 
 
 def _receipt(repo_root: Path, ssd_path: Path) -> Mapping[str, Any]:
-    return {
-        "schema_version": SCHEMA_VERSION,
-        "generated_at": "2026-07-18T00:00:00+00:00",
-        "repo_root": str(repo_root.resolve(strict=False)),
-        "repo_head_sha": SHA,
-        "ssd_path": str(ssd_path.resolve(strict=False)),
-        "source": "test",
-        "generation_id": "generation-1",
-        "base_generation_id": "",
-        "collections": [
-            {
-                "name": name,
-                "count": 1,
-                "status": "indexed",
-                "source": "test",
-                "repo_head_sha": SHA,
-                "last_indexed_at": "2026-07-18T00:00:00+00:00",
-                "source_manifest_digest": f"sha256:manifest-{name}",
-                "indexed_paths_digest": f"sha256:paths-{name}",
-                "removed_paths_digest": "sha256:removed",
-                "embedding_backend": "sentence_transformers",
-                "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
-                "embedding_space_fingerprint": SPACE_FINGERPRINT,
-                "verification": "PASS",
-                "proof_kind": "complete_source_manifest",
-                "source_scope_id": canonical_source_scope_id(name),
-            }
-            for name in sorted(BASELINE_COLLECTIONS)
-        ],
-    }
+    return _service_receipt(
+        repo_root=repo_root.resolve(strict=False),
+        ssd_path=ssd_path.resolve(strict=False),
+    )
 
 
 class _Backend:
@@ -201,7 +176,10 @@ def test_reddog_adapter_queries_live_owner_without_opening_local_chroma(
         assert result["freshness"] == "CURRENT"
         assert result["retrieval_mode"] == "semantic"
         assert result["repo_head_sha"] == SHA
-        assert result["freshness_generation_id"] == "generation-1"
+        assert result["freshness_generation_id"] == _receipt(
+            tmp_path,
+            tmp_path / "holo-store",
+        )["generation_id"]
         assert {hit["path"] for hit in result["hits"]} == {
             "WSP_framework/src/WSP_97.md",
             "WSP_knowledge/docs/Papers/example.md",


### PR DESCRIPTION
## Summary
- rebuild Holo owner-service fixtures as complete receipt-v2 envelopes
- bind synthetic generations with the production integrity algorithm
- reuse the canonical fixture in HTTP owner tests
- leave production freshness validation unchanged

## WSP_97 evidence
Receipt-v2 hardening correctly rejected legacy seven-collection fixtures before semantic branches. This updates only test fixtures and TestModLog; production remains fail closed.

## Verification
- exact owner-service runbook group: 61 passed
- adjacent owner/generation/receipt suites: 100 passed (worker verification)
- WSP_62 audit passed
- git diff --check passed