### PR TITLE
feat(reddog): ground scoped audits with safe repo fallback

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -5,6 +5,9 @@
 - Added read-only `repo_audit_grounding.v1` generation after the existing bundle retrieval path. Generation-bound semantic ownership is unchanged; the structured bundle supplies only bounded candidate/direct-read evidence.
 - Strong coverage requires successfully secure-read implementation source plus independent test/contract evidence. Missing, stale, or denied candidates activate deterministic discovery and merged/deduplicated selection.
 - Final evidence is capped at 12 paths, 12KB per file, and 96KB total; candidate scans are separately capped at 4KB per file and 512KB total. Fixed private/tool-state roots, unsafe paths, secrets, binaries, oversize files, links/reparse points, and identity races fail closed.
+- Exposed deterministic path-category and path/entity classification helpers so
+  transport receipts and consuming validators recompute discovery claims from
+  the same fixed policy instead of trusting serialized category labels.
 - Added focused offline tests; no semantic model call, network access, re-index, or write authority is introduced.
 
 ## [2026-07-19] HOLOINDEX_VERIFIED_UNCHANGED_COLLECTION_CARRY_FORWARD_PHASE1

--- a/holo_index/cli/repo_audit_discovery.py
+++ b/holo_index/cli/repo_audit_discovery.py
@@ -266,7 +266,8 @@ def secure_read_repo_file(
         os.close(fd)
 
 
-def _category(rel_path: str) -> str:
+def repo_audit_category(rel_path: str) -> str:
+    """Derive the evidence category from a repository-relative path."""
     parts = rel_path.casefold().split("/")
     name = parts[-1]
     if "tests" in parts or name.startswith("test_") or name.endswith(".test.js"):
@@ -282,6 +283,12 @@ def _category(rel_path: str) -> str:
     if Path(name).suffix.casefold() in {".py", ".js", ".ts", ".tsx", ".jsx", ".sol", ".go", ".rs", ".java", ".c", ".h"}:
         return "implementation_source"
     return "documentation"
+
+
+def repo_audit_path_supports_entity(rel_path: str, entity: str) -> bool:
+    """Return whether a path itself binds evidence to the canonical entity."""
+    score, _reasons = _path_match_score(rel_path, entity)
+    return score > 0
 
 
 def _path_match_score(rel_path: str, entity: str) -> Tuple[int, List[str]]:
@@ -312,7 +319,7 @@ def _candidate(rel_path: str, entity: str, source: str, content_match: bool = Fa
         reasons.append("bounded_content_match")
     if score <= 0:
         return None
-    category = _category(rel_path)
+    category = repo_audit_category(rel_path)
     if category == "implementation_source":
         score += 25
     elif category in {"test", "contract"}:

--- a/holo_index/tests/TESTModLog.md
+++ b/holo_index/tests/TESTModLog.md
@@ -1,5 +1,11 @@
 ﻿# HoloIndex Test Suite TESTModLog
 
+## [2026-07-20] RedDog Repository-Audit Consumer Binding Repair
+
+- Added `.worktrees` pruning coverage alongside vendor/generated roots.
+- Retained confined-reader traversal, link/reparse, final-handle, identity-race,
+  byte-budget, deterministic-ordering, and source-plus-test coverage tests.
+
 ## [2026-07-18] HoloIndex / RedDog Operational Truth Boundary POC
 
 **WSP Protocol**: WSP 05, 06, 15, 22, 50, 62, 87, 97

--- a/holo_index/tests/test_repo_audit_discovery.py
+++ b/holo_index/tests/test_repo_audit_discovery.py
@@ -214,16 +214,16 @@ def test_secure_reader_fails_closed_when_final_handle_path_is_unavailable(tmp_pa
 
 def test_discovery_prunes_secret_vendor_generated_and_reparse(tmp_path):
     _seed_pfmall(tmp_path)
-    for folder in ("vendor", "generated"):
+    for folder in ("vendor", "generated", ".worktrees"):
         path = tmp_path / folder
         path.mkdir()
         (path / "pfmall.py").write_text("pfmall", encoding="utf-8")
     (tmp_path / "pfmall_secret.py").write_text("pfmall", encoding="utf-8")
     receipt = discovery.build_repo_audit_grounding(tmp_path, "audit pfmall codebase", {})["receipt"]
     selected = {item["path"] for item in receipt["selected"]}
-    assert not any(path.startswith(("vendor/", "generated/")) for path in selected)
+    assert not any(path.startswith(("vendor/", "generated/", ".worktrees/")) for path in selected)
     assert "pfmall_secret.py" not in selected
-    assert receipt["exclusion_counts"]["pruned"] >= 2
+    assert receipt["exclusion_counts"]["pruned"] >= 3
 
 
 def test_discovery_never_enters_reads_or_selects_private_tool_state_roots(tmp_path, monkeypatch):

--- a/holo_index/wsp_62_exemptions.yaml
+++ b/holo_index/wsp_62_exemptions.yaml
@@ -117,7 +117,7 @@ exemptions:
     reason: >-
       Legacy HoloIndex WSP_22 reverse-chronological journal. This focused slice
       appends current evidence without rewriting historical module traceability.
-    threshold_override: 8700
+    threshold_override: 8800
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -516,11 +516,16 @@ Transport-neutral grounding additionally supports a fail-closed repository
 audit fallback for entity-scoped audits (including `pfmall`, `p.fMALL`,
 `p-fmall`, and `PFMALL`). The owner query runs first. Only when that evidence is
 unavailable, stale, or insufficient does the service use the shared bounded
-repository discovery reader. Acceptance requires a stable repository HEAD,
-one implementation-source read, and one independent test/contract read. The
-resulting `reddog_repo_audit_fallback.v1` is nested in and digest-bound by the
-canonical `reddog_grounded_target_receipt.v1`; selected paths replace the
-unresolved semantic target for downstream direct-read audit execution.
+repository discovery reader. Acceptance requires entity-bound paths, exact
+fixed-policy limits, one implementation-source read, and one independent
+test/contract read. The resulting `reddog_repo_audit_fallback.v1` records the
+creation-time HEAD and evidence digests and is nested in the canonical
+`reddog_grounded_target_receipt.v1`. At consumption, both deterministic and
+model-backed audit executors reopen every selected path with the confined
+reader and match path, digest, bytes, and truncation; the model-backed executor
+checks again after the model returns. Thus an unstaged content change rejects
+even when HEAD is unchanged. Selected paths replace the unresolved semantic
+target only after these checks.
 
 ### OpenClaw Supervisor Contract
 

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -512,6 +512,16 @@ Resident RedDog live-canary contract:
 - `READY_FOR_EXECUTION` does not claim that a live canary ran. Missing authority artifacts, signer socket, Git/GitHub readiness, or OpenRouter key presence returns `BLOCKED` without exposing values.
 - The surface has no signer launch, secret resolution, PR-ready, merge, reward, or HoloIndex re-index authority.
 
+Transport-neutral grounding additionally supports a fail-closed repository
+audit fallback for entity-scoped audits (including `pfmall`, `p.fMALL`,
+`p-fmall`, and `PFMALL`). The owner query runs first. Only when that evidence is
+unavailable, stale, or insufficient does the service use the shared bounded
+repository discovery reader. Acceptance requires a stable repository HEAD,
+one implementation-source read, and one independent test/contract read. The
+resulting `reddog_repo_audit_fallback.v1` is nested in and digest-bound by the
+canonical `reddog_grounded_target_receipt.v1`; selected paths replace the
+unresolved semantic target for downstream direct-read audit execution.
+
 ### OpenClaw Supervisor Contract
 
 Canonical 0102 lifecycle owner:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -11,6 +11,24 @@
 - Required canonical revision-zero genesis state and routed the editor session bridge through `RedDogResidentArchitectClient` with host principal and FoundUp scope.
 - Added production AgentDB reconnect, stale-writer, cancellation-race, immutable-field, and `7 -> 8` retry regressions without adding execution authority.
 
+## 2026-07-20: REDDOG_TRANSPORT_NEUTRAL_REPO_AUDIT_FALLBACK_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 62, 71, 84, 97
+
+- Reused the reviewed bounded repository-audit discovery reader after an
+  owner-first HoloIndex attempt cannot ground an entity-scoped audit.
+- Bound safe implementation plus independent test/contract reads to a stable
+  repository HEAD and nested the proof in the canonical grounding receipt.
+- Rejected incomplete coverage, repository-state races, private/tool/generated
+  roots, traversal, link/reparse escapes, and receipt substitution before any
+  model, shell, repository mutation, or HoloIndex re-index path.
+- Added p.fMALL alias coverage and preserved CURRENT sufficient HoloIndex
+  evidence as the preferred path with no fallback scan.
+- The post-edit non-mutating HoloIndex probe ran in offline lexical mode and did
+  not surface the new transport fallback. Recorded
+  `HOLOINDEX_REDDOG_TRANSPORT_REPO_AUDIT_FALLBACK_INDEX_GAP_PHASE1`; no runtime
+  re-index was performed.
+
 ## 2026-07-20: REDDOG_FUSION_PROGRESS_AND_OPENROUTER_USAGE_RECEIPTS_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 50, 71, 91, 97

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -28,6 +28,15 @@
   not surface the new transport fallback. Recorded
   `HOLOINDEX_REDDOG_TRANSPORT_REPO_AUDIT_FALLBACK_INDEX_GAP_PHASE1`; no runtime
   re-index was performed.
+- Independent review exposed that a fully rehashed unrelated-path substitution
+  and an unstaged post-receipt content change were not rejected. The repaired
+  validator now derives the expected entity from the original focus, recomputes
+  path categories, and enforces the exact discovery policy, limits, coverage,
+  and no-action attestations.
+- Both deterministic and model-backed audit consumers now reopen selected
+  evidence with the confined reader and require exact path/digest/bytes/truncated
+  equality. The model-backed path repeats the check after model return, so a
+  clean or unchanged HEAD cannot mask working-tree evidence drift.
 
 ## 2026-07-20: REDDOG_FUSION_PROGRESS_AND_OPENROUTER_USAGE_RECEIPTS_PHASE1
 

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -85,6 +85,17 @@ audit-enqueue, and configured auto-task consumers. The legacy
 foundups_mcp_bridge `holo_tools.py` path remains a direct-store consumer and is
 not covered by an all-consumers migration claim.
 
+For an entity-scoped repository/module audit, an unavailable, stale, or
+insufficient owner result may enter the deterministic repository-audit fallback.
+HoloIndex is always queried first. The fallback securely re-reads candidate
+files under fixed path, file-count, and byte budgets; prunes private tool state,
+generated/vendor roots, secrets, traversal, and links/reparse points; and accepts
+only implementation source plus an independent test or contract. Its immutable
+receipt binds the selected content digests to a stable local Git HEAD. Failure
+to establish either evidence class or stable repository state rejects before a
+model call. The fallback grants no indexing, shell, mutation, or execution
+authority.
+
 ## Setup
 
 > ⚠️ **Important**: See [docs/INSTALL_OPENCLAW.md](docs/INSTALL_OPENCLAW.md) for full guide

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -90,11 +90,15 @@ insufficient owner result may enter the deterministic repository-audit fallback.
 HoloIndex is always queried first. The fallback securely re-reads candidate
 files under fixed path, file-count, and byte budgets; prunes private tool state,
 generated/vendor roots, secrets, traversal, and links/reparse points; and accepts
-only implementation source plus an independent test or contract. Its immutable
-receipt binds the selected content digests to a stable local Git HEAD. Failure
-to establish either evidence class or stable repository state rejects before a
-model call. The fallback grants no indexing, shell, mutation, or execution
-authority.
+only implementation source plus an independent test or contract whose paths
+bind to the requested entity. The creation-time receipt records the fixed
+policy, selected content digests, and local Git HEAD; it does not claim that
+HEAD alone proves later working-tree content. Each read-only executor reopens
+every selected file through the confined reader and requires exact path,
+digest, byte-count, and truncation equality before consuming it. The
+model-backed path repeats that check after the model returns. Any mismatch
+rejects the result. The fallback grants no indexing, shell, mutation, or
+execution authority.
 
 ## Setup
 

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -85,6 +85,10 @@ These remain deferred until the FoundUp Memex POC and MVP contracts are proven.
 - Migrate or explicitly retire the legacy foundups_mcp_bridge `holo_tools.py`
   direct-store consumer; Phase 1 covers only the wired RedDog operational
   consumers.
+- Decompose `ground_transport_work_focus` into request validation, target
+  classification, owner preflight, and receipt composition after the bounded
+  repository-audit fallback stabilizes; the temporary WSP_62 exemption records
+  this integration debt without expanding the runtime's authority.
 
 These items are an explicit WSP_62 remediation register; no global compliance
 claim is made while historical monolith debt remains.

--- a/modules/communication/moltbot_bridge/src/reddog_grounded_target_assignment_continuity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_grounded_target_assignment_continuity.py
@@ -16,6 +16,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from holo_index.cli.repo_audit_discovery import (
+    canonicalize_entity,
+    detect_repo_audit_intent,
+    repo_audit_category,
+    repo_audit_path_supports_entity,
+)
+from modules.communication.moltbot_bridge.src.reddog_repo_audit_fallback_grounding import (
+    NO_ACTION_FIELDS,
+    REPO_AUDIT_POLICY,
+)
 
 SCHEMA_VERSION = "reddog_grounded_target_receipt.v1"
 SOURCE_SURFACES = frozenset({"editor_thin_client", "hermes_thin_client", "api_thin_client"})
@@ -23,6 +33,7 @@ SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 REPO_AUDIT_PRUNED_SEGMENTS = frozenset({
     ".agent", ".agents", ".cache", ".chroma", ".claude", ".codex", ".cursor",
     ".git", ".idea", ".m2m", ".memory", ".venv", ".vscode", ".windsurf",
+    ".worktrees",
     "__pycache__", "archive", "archives", "build", "cache", "chroma", "dist",
     "generated", "log", "logs", "memory", "node_modules", "temp", "tmp",
     "vector", "vectors", "vendor", "venv",
@@ -125,7 +136,7 @@ def validate_grounded_target_receipt(
     if data.get("grounding_target_universe_required") is True and not any(targets):
         reasons.append(GroundingReason.TARGET_UNIVERSE)
     _validate_semantic(data, targets[1], reasons)
-    _validate_repo(data, targets[0], reasons)
+    _validate_repo(data, targets[0], str(work_focus or ""), reasons)
     reasons = list(dict.fromkeys(reasons))
     if reasons:
         return GroundedTargetReceiptValidation(False, None, tuple(reasons))
@@ -187,7 +198,9 @@ def _validate_semantic(data: Mapping[str, Any], targets: Sequence[str], reasons:
         reasons.append(GroundingReason.SEMANTIC_GENERATION)
 
 
-def _validate_repo(data: Mapping[str, Any], targets: Sequence[str], reasons: list[str]) -> None:
+def _validate_repo(
+    data: Mapping[str, Any], targets: Sequence[str], work_focus: str, reasons: list[str]
+) -> None:
     if not targets:
         return
     if data.get("target_recall_ok") is not True or _strings(data.get("required_targets_missing")):
@@ -200,12 +213,15 @@ def _validate_repo(data: Mapping[str, Any], targets: Sequence[str], reasons: lis
     if not isinstance(fallback, Mapping):
         reasons.append(GroundingReason.REPO_AUDIT)
         return
-    if not _valid_repo_audit_fallback(data, fallback, targets):
+    if not _valid_repo_audit_fallback(data, fallback, targets, work_focus):
         reasons.append(GroundingReason.REPO_AUDIT)
 
 
 def _valid_repo_audit_fallback(
-    data: Mapping[str, Any], fallback: Mapping[str, Any], targets: Sequence[str]
+    data: Mapping[str, Any],
+    fallback: Mapping[str, Any],
+    targets: Sequence[str],
+    work_focus: str,
 ) -> bool:
     audit = fallback.get("repo_audit_grounding")
     audit_mapping = dict(audit) if isinstance(audit, Mapping) else {}
@@ -215,7 +231,9 @@ def _valid_repo_audit_fallback(
         if _sequence(selected)
         else []
     )
-    categories = {str(item.get("category") or "") for item in records}
+    intent = detect_repo_audit_intent(work_focus)
+    expected_entity = str(intent.get("entity") or "")
+    categories = {repo_audit_category(str(item.get("path") or "")) for item in records}
     paths = tuple(str(item.get("path") or "") for item in records)
     coverage = (
         audit_mapping.get("coverage")
@@ -225,35 +243,104 @@ def _valid_repo_audit_fallback(
     state = {
         "repo_head_sha": str(fallback.get("repo_head_sha") or ""),
         "evidence_digest": str(fallback.get("selected_evidence_digest") or ""),
-        "entity": str(audit_mapping.get("entity") or ""),
+        "expected_entity": expected_entity,
         "search_mode": str(audit_mapping.get("search_mode") or ""),
+        "work_focus_digest": canonical_digest({"work_focus": work_focus}),
+        "policy_digest": canonical_digest(REPO_AUDIT_POLICY),
     }
-    required = (
+    aliases = _strings(audit_mapping.get("aliases"))
+    expected_search_mode = (
+        "holo_evidence_only"
+        if audit_mapping.get("holo_evidence_sufficient") is True
+        else "holo_then_deterministic"
+    )
+    deterministic = audit_mapping.get("deterministic_candidates")
+    deterministic_records = list(deterministic) if _sequence(deterministic) else []
+    total_bytes = sum(_integer(item.get("bytes")) for item in records)
+    return all((
+        _valid_fallback_metadata(
+            fallback, audit_mapping, intent, aliases, expected_entity, expected_search_mode
+        ),
+        _valid_fallback_evidence(
+            records, categories, coverage, deterministic_records, total_bytes, expected_entity
+        ),
+        _valid_fallback_bindings(data, fallback, audit_mapping, records, paths, targets, state),
+    ))
+
+
+def _valid_fallback_metadata(
+    fallback: Mapping[str, Any],
+    audit: Mapping[str, Any],
+    intent: Mapping[str, Any],
+    aliases: Sequence[str],
+    expected_entity: str,
+    expected_search_mode: str,
+) -> bool:
+    return all((
         fallback.get("schema_version") == "reddog_repo_audit_fallback.v1",
         fallback.get("applied") is True,
         fallback.get("accepted") is True,
         fallback.get("holo_owner_attempted_first") is True,
         fallback.get("holo_owner_evidence_usable") is False,
+        fallback.get("expected_entity") == expected_entity,
+        fallback.get("fixed_policy") == REPO_AUDIT_POLICY,
+        fallback.get("fixed_policy_digest") == canonical_digest(REPO_AUDIT_POLICY),
+        all(fallback.get(field_name) is True for field_name in NO_ACTION_FIELDS),
         not _strings(fallback.get("rejection_reasons")),
-        audit_mapping.get("schema_version") == "repo_audit_grounding.v1",
-        audit_mapping.get("applied") is True,
-        audit_mapping.get("holo_first") is True,
+        audit.get("schema_version") == "repo_audit_grounding.v1",
+        audit.get("applied") is True,
+        audit.get("audit_intent") is True,
+        audit.get("holo_first") is True,
+        intent.get("audit_intent") is True,
+        audit.get("entity") == expected_entity,
+        bool(aliases) and all(canonicalize_entity(alias) == expected_entity for alias in aliases),
+        audit.get("search_mode") == expected_search_mode,
+    ))
+
+
+def _valid_fallback_evidence(
+    records: Sequence[Mapping[str, Any]],
+    categories: set[str],
+    coverage: Mapping[str, Any],
+    deterministic_records: Sequence[Any],
+    total_bytes: int,
+    expected_entity: str,
+) -> bool:
+    return all((
+        len(deterministic_records) <= int(REPO_AUDIT_POLICY["max_selected_paths"]) * 3,
         coverage.get("verdict") == "PASS",
+        _strings(coverage.get("reasons")) == (),
         "implementation_source" in categories,
         bool(categories.intersection({"test", "contract"})),
-        bool(records) and all(_valid_repo_audit_record(item) for item in records),
+        0 < len(records) <= int(REPO_AUDIT_POLICY["max_selected_paths"]),
+        len({str(item.get("path") or "").casefold() for item in records}) == len(records),
+        0 < total_bytes <= int(REPO_AUDIT_POLICY["total_read_budget_bytes"]),
+        all(_valid_repo_audit_record(item, expected_entity) for item in records),
+    ))
+
+
+def _valid_fallback_bindings(
+    data: Mapping[str, Any],
+    fallback: Mapping[str, Any],
+    audit: Mapping[str, Any],
+    records: Sequence[Mapping[str, Any]],
+    paths: Sequence[str],
+    targets: Sequence[str],
+    state: Mapping[str, Any],
+) -> bool:
+    return all((
+        fallback.get("work_focus_digest") == state["work_focus_digest"],
         tuple(targets) == paths,
         data.get("repo_audit_fallback_digest") == canonical_digest(fallback),
-        fallback.get("repo_audit_grounding_digest") == canonical_digest(audit_mapping),
+        fallback.get("repo_audit_grounding_digest") == canonical_digest(audit),
         fallback.get("selected_evidence_digest") == canonical_digest({"selected": records}),
         fallback.get("repository_state_digest") == canonical_digest(state),
         data.get("repo_state_head_sha") == fallback.get("repo_head_sha"),
         re.fullmatch(r"[0-9a-f]{40}(?:[0-9a-f]{24})?", state["repo_head_sha"]) is not None,
-    )
-    return all(required)
+    ))
 
 
-def _valid_repo_audit_record(record: Mapping[str, Any]) -> bool:
+def _valid_repo_audit_record(record: Mapping[str, Any], expected_entity: str) -> bool:
     path = str(record.get("path") or "").replace("\\", "/")
     parts = path.split("/")
     lowered = [part.casefold() for part in parts]
@@ -271,8 +358,10 @@ def _valid_repo_audit_record(record: Mapping[str, Any]) -> bool:
         and not any(marker in part for part in lowered for marker in REPO_AUDIT_SECRET_MARKERS)
         and not lowered[-1].endswith(REPO_AUDIT_SECRET_SUFFIXES)
         and Path(lowered[-1]).suffix in REPO_AUDIT_ALLOWED_SUFFIXES
+        and repo_audit_path_supports_entity(path, expected_entity)
+        and record.get("category") == repo_audit_category(path)
         and SHA256_RE.fullmatch(str(record.get("digest") or "")) is not None
-        and 0 < size <= 12_000
+        and 0 < size <= int(REPO_AUDIT_POLICY["per_file_read_bytes"])
         and isinstance(record.get("truncated"), bool)
     )
 

--- a/modules/communication/moltbot_bridge/src/reddog_grounded_target_assignment_continuity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_grounded_target_assignment_continuity.py
@@ -13,12 +13,28 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 
 SCHEMA_VERSION = "reddog_grounded_target_receipt.v1"
 SOURCE_SURFACES = frozenset({"editor_thin_client", "hermes_thin_client", "api_thin_client"})
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+REPO_AUDIT_PRUNED_SEGMENTS = frozenset({
+    ".agent", ".agents", ".cache", ".chroma", ".claude", ".codex", ".cursor",
+    ".git", ".idea", ".m2m", ".memory", ".venv", ".vscode", ".windsurf",
+    "__pycache__", "archive", "archives", "build", "cache", "chroma", "dist",
+    "generated", "log", "logs", "memory", "node_modules", "temp", "tmp",
+    "vector", "vectors", "vendor", "venv",
+})
+REPO_AUDIT_SECRET_MARKERS = ("secret", "credential", "token", "private_key", "apikey", "api_key")
+REPO_AUDIT_SECRET_NAMES = frozenset({".env", "id_rsa", "id_ed25519"})
+REPO_AUDIT_SECRET_SUFFIXES = (".pem", ".key", ".p12", ".pfx", ".keystore", ".vsix")
+REPO_AUDIT_ALLOWED_SUFFIXES = frozenset({
+    ".py", ".js", ".ts", ".tsx", ".jsx", ".md", ".rst", ".txt", ".json",
+    ".yaml", ".yml", ".toml", ".html", ".css", ".sol", ".go", ".rs",
+    ".java", ".c", ".h",
+})
 
 
 class GroundingReason:
@@ -33,6 +49,7 @@ class GroundingReason:
     SEMANTIC_COVERAGE = "grounding_semantic_coverage_invalid"
     SEMANTIC_GENERATION = "grounding_semantic_generation_invalid"
     REPO_RECALL = "grounding_repo_recall_invalid"
+    REPO_AUDIT = "grounding_repo_audit_receipt_invalid"
     COUNTS = "grounding_target_counts_invalid"
 
 
@@ -175,6 +192,89 @@ def _validate_repo(data: Mapping[str, Any], targets: Sequence[str], reasons: lis
         return
     if data.get("target_recall_ok") is not True or _strings(data.get("required_targets_missing")):
         reasons.append(GroundingReason.REPO_RECALL)
+    if data.get("repo_audit_fallback_used") is not True:
+        return
+    if tuple(targets) != _strings(data.get("direct_read_paths")):
+        reasons.append(GroundingReason.REPO_RECALL)
+    fallback = data.get("repo_audit_fallback")
+    if not isinstance(fallback, Mapping):
+        reasons.append(GroundingReason.REPO_AUDIT)
+        return
+    if not _valid_repo_audit_fallback(data, fallback, targets):
+        reasons.append(GroundingReason.REPO_AUDIT)
+
+
+def _valid_repo_audit_fallback(
+    data: Mapping[str, Any], fallback: Mapping[str, Any], targets: Sequence[str]
+) -> bool:
+    audit = fallback.get("repo_audit_grounding")
+    audit_mapping = dict(audit) if isinstance(audit, Mapping) else {}
+    selected = audit_mapping.get("selected")
+    records = (
+        [dict(item) for item in selected if isinstance(item, Mapping)]
+        if _sequence(selected)
+        else []
+    )
+    categories = {str(item.get("category") or "") for item in records}
+    paths = tuple(str(item.get("path") or "") for item in records)
+    coverage = (
+        audit_mapping.get("coverage")
+        if isinstance(audit_mapping.get("coverage"), Mapping)
+        else {}
+    )
+    state = {
+        "repo_head_sha": str(fallback.get("repo_head_sha") or ""),
+        "evidence_digest": str(fallback.get("selected_evidence_digest") or ""),
+        "entity": str(audit_mapping.get("entity") or ""),
+        "search_mode": str(audit_mapping.get("search_mode") or ""),
+    }
+    required = (
+        fallback.get("schema_version") == "reddog_repo_audit_fallback.v1",
+        fallback.get("applied") is True,
+        fallback.get("accepted") is True,
+        fallback.get("holo_owner_attempted_first") is True,
+        fallback.get("holo_owner_evidence_usable") is False,
+        not _strings(fallback.get("rejection_reasons")),
+        audit_mapping.get("schema_version") == "repo_audit_grounding.v1",
+        audit_mapping.get("applied") is True,
+        audit_mapping.get("holo_first") is True,
+        coverage.get("verdict") == "PASS",
+        "implementation_source" in categories,
+        bool(categories.intersection({"test", "contract"})),
+        bool(records) and all(_valid_repo_audit_record(item) for item in records),
+        tuple(targets) == paths,
+        data.get("repo_audit_fallback_digest") == canonical_digest(fallback),
+        fallback.get("repo_audit_grounding_digest") == canonical_digest(audit_mapping),
+        fallback.get("selected_evidence_digest") == canonical_digest({"selected": records}),
+        fallback.get("repository_state_digest") == canonical_digest(state),
+        data.get("repo_state_head_sha") == fallback.get("repo_head_sha"),
+        re.fullmatch(r"[0-9a-f]{40}(?:[0-9a-f]{24})?", state["repo_head_sha"]) is not None,
+    )
+    return all(required)
+
+
+def _valid_repo_audit_record(record: Mapping[str, Any]) -> bool:
+    path = str(record.get("path") or "").replace("\\", "/")
+    parts = path.split("/")
+    lowered = [part.casefold() for part in parts]
+    try:
+        size = int(record.get("bytes"))
+    except (TypeError, ValueError):
+        return False
+    return (
+        bool(path)
+        and not path.startswith("/")
+        and not (len(path) > 1 and path[1] == ":")
+        and all(part not in ("", ".", "..") for part in parts)
+        and not any(part in REPO_AUDIT_PRUNED_SEGMENTS for part in lowered)
+        and not any(part in REPO_AUDIT_SECRET_NAMES for part in lowered)
+        and not any(marker in part for part in lowered for marker in REPO_AUDIT_SECRET_MARKERS)
+        and not lowered[-1].endswith(REPO_AUDIT_SECRET_SUFFIXES)
+        and Path(lowered[-1]).suffix in REPO_AUDIT_ALLOWED_SUFFIXES
+        and SHA256_RE.fullmatch(str(record.get("digest") or "")) is not None
+        and 0 < size <= 12_000
+        and isinstance(record.get("truncated"), bool)
+    )
 
 
 def _strings(value: Any) -> tuple[str, ...]:

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -27,6 +27,7 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executo
     READONLY_AUDIT_TASK_REPORT_ACCEPT,
     ReadOnlyAuditTaskExecutionResult,
     ReadOnlyAuditTaskRejectReason,
+    _bound_fallback_snapshots,
     _ReadOnlyTargetSnapshot,
     _digest,
     _evidence_ref,
@@ -54,7 +55,6 @@ from modules.communication.moltbot_bridge.src.reddog_memex_snapshot_projection_s
 )
 from modules.communication.moltbot_bridge.src.reddog_holoindex_query_adapter import (
     HoloIndexReadOnlyQueryAdapter,
-    holoindex_hits as _holoindex_hits,
     path_is_allowed,
     paths_from_query_receipt,
 )
@@ -461,6 +461,13 @@ def execute_model_backed_repo_code_audit(
     grounding, grounding_reasons = _validated_task_grounding(task_context, assignment)
     if grounding_reasons:
         return _reject(grounding_reasons)
+    bound_snapshots, bound_reject = _bound_fallback_snapshots(
+        task_context=task_context,
+        assignment=assignment,
+        repo_root=repo_root,
+    )
+    if bound_reject:
+        return _reject([bound_reject])
     allocation = task_context.get("wsp15_allocation_receipt") or assignment.get("wsp15_allocation_receipt")
     validation = validate_reddog_wsp15_allocation_receipt(allocation if isinstance(allocation, Mapping) else None)
     if validation.rejection_reasons == ("missing_wsp15_allocation",):
@@ -517,7 +524,10 @@ def execute_model_backed_repo_code_audit(
         return _reject([holo_reject])
 
     candidate_paths = _candidate_paths(
-        seed_targets=seed_targets,
+        seed_targets=(
+            *tuple(item.evidence.path for item in (bound_snapshots or ())),
+            *tuple(seed_targets),
+        ),
         discovered_paths=paths_from_query_receipt(holo_receipt),
     )
     if not candidate_paths:
@@ -527,6 +537,7 @@ def execute_model_backed_repo_code_audit(
         seed_targets=seed_targets,
         candidate_paths=candidate_paths,
         allowed_targets=discovery_targets,
+        bound_snapshots=bound_snapshots or (),
     )
     if read_reject:
         return _reject([read_reject])
@@ -653,6 +664,13 @@ def execute_model_backed_repo_code_audit(
     )
     if final_repository_state is None:
         return _reject([ReadOnlyAuditTaskRejectReason.REPOSITORY_STATE_CHANGED])
+    _final_bound, final_bound_reject = _bound_fallback_snapshots(
+        task_context=task_context,
+        assignment=assignment,
+        repo_root=repo_root,
+    )
+    if final_bound_reject:
+        return _reject([final_bound_reject])
 
     report = _build_model_report(
         assignment=assignment,
@@ -1171,13 +1189,18 @@ def _read_candidate_snapshots(
     seed_targets: Sequence[str],
     candidate_paths: Sequence[str],
     allowed_targets: Sequence[str],
+    bound_snapshots: Sequence[_ReadOnlyTargetSnapshot] = (),
 ) -> tuple[tuple[_ReadOnlyTargetSnapshot, ...], str]:
     seed_set = {str(item).replace("\\", "/").strip() for item in seed_targets}
+    bound_by_path = {item.evidence.path: item for item in bound_snapshots}
     snapshots: list[_ReadOnlyTargetSnapshot] = []
     for path in candidate_paths:
         if not path_is_allowed(path, allowed_targets):
             if path in seed_set:
                 return (), ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET
+            continue
+        if path in bound_by_path:
+            snapshots.append(bound_by_path[path])
             continue
         safe_path = _resolve_safe_target(repo_root, path)
         if safe_path is None:

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_task_executor.py
@@ -20,11 +20,19 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
+from holo_index.cli.repo_audit_discovery import secure_read_repo_file
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    canonical_digest as grounding_digest,
+    validate_grounded_target_receipt,
+)
 from modules.communication.moltbot_bridge.src.reddog_lane_state_reconciler import (
     reconcile_active_and_json_ledgers,
 )
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
     READONLY_AUDIT_TASK_SOURCE,
+)
+from modules.communication.moltbot_bridge.src.reddog_repo_audit_fallback_grounding import (
+    reread_bound_repo_audit_evidence,
 )
 
 
@@ -57,6 +65,8 @@ class ReadOnlyAuditTaskRejectReason:
     INDEX_QUERY_STALE = "REJECT_INDEX_QUERY_STALE"
     INDEX_QUERY_NO_CANDIDATES = "REJECT_INDEX_QUERY_NO_CANDIDATES"
     REPOSITORY_STATE_CHANGED = "REJECT_REPOSITORY_STATE_CHANGED"
+    GROUNDING_EVIDENCE_CHANGED = "REJECT_GROUNDING_EVIDENCE_CHANGED"
+    GROUNDING_RECEIPT_INVALID = "REJECT_GROUNDING_RECEIPT_INVALID"
     MODEL_FAILURE = "REJECT_MODEL_FAILURE"
     MODEL_TIMEOUT = "REJECT_MODEL_TIMEOUT"
     MODEL_SELECTION_RECEIPT = "REJECT_MODEL_SELECTION_RECEIPT"
@@ -151,7 +161,13 @@ def execute_reddog_readonly_audit_task(
         return _reject([ReadOnlyAuditTaskRejectReason.TOO_MANY_TARGETS])
 
     root = Path(repo_root).resolve()
-    lane_id = str(assignment.get("lane_id") or "")
+    bound_snapshots, bound_reject = _bound_fallback_snapshots(
+        task_context=task_context,
+        assignment=assignment,
+        repo_root=root,
+    )
+    if bound_reject:
+        return _reject([bound_reject])
     if task_context.get("worker_mode") == "model_backed_0102":
         from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
             execute_model_backed_repo_code_audit,
@@ -170,8 +186,15 @@ def execute_reddog_readonly_audit_task(
             timeout_seconds=timeout_seconds,
         )
 
+    bound_by_path = {
+        item.evidence.path: item for item in (bound_snapshots or ())
+    }
     snapshots: list[_ReadOnlyTargetSnapshot] = []
     for target in targets:
+        normalized = str(target).replace("\\", "/").strip()
+        if normalized in bound_by_path:
+            snapshots.append(bound_by_path[normalized])
+            continue
         safe_path = _resolve_safe_target(root, target)
         if safe_path is None:
             return _reject([ReadOnlyAuditTaskRejectReason.UNSAFE_TARGET])
@@ -215,25 +238,66 @@ def _resolve_safe_target(root: Path, target: str) -> Optional[Path]:
 
 
 def _read_target_snapshot(root: Path, path: Path) -> _ReadOnlyTargetSnapshot:
-    raw = path.read_bytes()
-    truncated = len(raw) > MAX_READ_BYTES_PER_TARGET
-    payload = raw[:MAX_READ_BYTES_PER_TARGET]
-    digest = "sha256:" + hashlib.sha256(payload).hexdigest()
-    try:
-        text = payload.decode("utf-8")
-    except UnicodeDecodeError:
-        text = payload.decode("utf-8", errors="replace")
     relative = path.relative_to(root).as_posix()
+    read = secure_read_repo_file(
+        root,
+        relative,
+        byte_cap=MAX_READ_BYTES_PER_TARGET,
+        remaining_budget=MAX_READ_BYTES_PER_TARGET,
+    )
+    if read.get("ok") is not True:
+        raise OSError(str(read.get("reason") or "secure_read_rejected"))
+    return _snapshot_from_secure_read(read)
+
+
+def _snapshot_from_secure_read(read: Mapping[str, Any]) -> _ReadOnlyTargetSnapshot:
+    text = str(read.get("content") or "")
     return _ReadOnlyTargetSnapshot(
         evidence=ReadOnlyTargetEvidence(
-            path=relative,
-            digest=digest,
-            bytes_read=len(payload),
+            path=str(read.get("path") or ""),
+            digest=str(read.get("digest") or ""),
+            bytes_read=int(read.get("bytes") or 0),
             line_count=text.count("\n") + (1 if text else 0),
-            truncated=truncated,
+            truncated=bool(read.get("truncated")),
         ),
         text=text,
     )
+
+
+def _bound_fallback_snapshots(
+    *,
+    task_context: Mapping[str, Any],
+    assignment: Mapping[str, Any],
+    repo_root: Path,
+) -> tuple[tuple[_ReadOnlyTargetSnapshot, ...] | None, str]:
+    receipt = task_context.get("grounding_receipt")
+    if not isinstance(receipt, Mapping) or receipt.get("repo_audit_fallback_used") is not True:
+        return None, ""
+    validation = validate_grounded_target_receipt(
+        receipt,
+        work_focus=str(task_context.get("work_focus") or ""),
+    )
+    if not validation.accepted or validation.verified is None:
+        return None, ReadOnlyAuditTaskRejectReason.GROUNDING_RECEIPT_INVALID
+    verified = validation.verified
+    receipt_digest = grounding_digest(verified.receipt)
+    bindings = (
+        (task_context.get("grounding_receipt_id"), verified.receipt_id),
+        (assignment.get("grounding_receipt_id"), verified.receipt_id),
+        (task_context.get("grounding_receipt_digest"), receipt_digest),
+        (assignment.get("grounding_receipt_digest"), receipt_digest),
+        (grounding_digest(task_context.get("typed_targets")), verified.typed_targets_digest),
+    )
+    if any(str(value or "") != expected for value, expected in bindings):
+        return None, ReadOnlyAuditTaskRejectReason.GROUNDING_RECEIPT_INVALID
+    allowed = {str(item).replace("\\", "/").strip() for item in assignment.get("allowed_read_targets", ())}
+    if not set(verified.repo_file_targets).issubset(allowed):
+        return None, ReadOnlyAuditTaskRejectReason.GROUNDING_RECEIPT_INVALID
+    fallback = receipt.get("repo_audit_fallback")
+    reads, reasons = reread_bound_repo_audit_evidence(repo_root, fallback)
+    if reasons:
+        return None, ReadOnlyAuditTaskRejectReason.GROUNDING_EVIDENCE_CHANGED
+    return tuple(_snapshot_from_secure_read(item) for item in reads), ""
 
 
 def _build_report(

--- a/modules/communication/moltbot_bridge/src/reddog_repo_audit_fallback_grounding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_repo_audit_fallback_grounding.py
@@ -2,23 +2,51 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from holo_index.cli.repo_audit_discovery import (
+    MAX_CONTENT_SCAN_BYTES,
+    MAX_CONTENT_SCAN_TOTAL_BYTES,
+    MAX_DISCOVERY_ENTRIES,
+    MAX_FILE_SIZE_BYTES,
+    MAX_SELECTED_PATHS,
+    PER_FILE_READ_BYTES,
+    TOTAL_READ_BUDGET_BYTES,
     build_repo_audit_grounding,
     detect_repo_audit_intent,
+    repo_audit_category,
+    repo_audit_path_supports_entity,
+    secure_read_repo_file,
 )
 from holo_index.freshness_receipt import read_git_head_sha
-from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
-    canonical_digest,
-)
 
 
 SCHEMA_VERSION = "reddog_repo_audit_fallback.v1"
 GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+REPO_AUDIT_POLICY = {
+    "schema_version": "repo_audit_fixed_policy.v1",
+    "max_selected_paths": MAX_SELECTED_PATHS,
+    "total_read_budget_bytes": TOTAL_READ_BUDGET_BYTES,
+    "per_file_read_bytes": PER_FILE_READ_BYTES,
+    "max_file_size_bytes": MAX_FILE_SIZE_BYTES,
+    "max_discovery_entries": MAX_DISCOVERY_ENTRIES,
+    "max_content_scan_bytes": MAX_CONTENT_SCAN_BYTES,
+    "max_content_scan_total_bytes": MAX_CONTENT_SCAN_TOTAL_BYTES,
+    "path_policy": "repo_audit_discovery_pruned_confined.v1",
+}
+NO_ACTION_FIELDS = (
+    "no_model_call_performed",
+    "no_shell_command_executed",
+    "no_holoindex_reindex_performed",
+    "no_repo_mutation_performed",
+    "no_external_research_performed",
+    "no_execution_authority_granted",
+)
 
 
 class RepoAuditFallbackReason:
@@ -57,8 +85,10 @@ def build_bound_repo_audit_fallback(
     after_head = read_git_head_sha(repo_root)
     audit = result.get("receipt") if isinstance(result.get("receipt"), Mapping) else {}
     selected = _selected_records(audit)
-    reasons = _fallback_reasons(before_head, after_head, audit, selected)
+    reasons = _fallback_reasons(before_head, after_head, intent, audit, selected)
     receipt = _build_receipt(
+        work_focus=work_focus,
+        expected_entity=str(intent.get("entity") or ""),
         audit=audit,
         selected=selected,
         repo_head_sha=after_head,
@@ -91,18 +121,26 @@ def _selected_records(audit: Mapping[str, Any]) -> list[Mapping[str, Any]]:
 def _fallback_reasons(
     before_head: str,
     after_head: str,
+    intent: Mapping[str, Any],
     audit: Mapping[str, Any],
     selected: Sequence[Mapping[str, Any]],
 ) -> list[str]:
     reasons: list[str] = []
     if not GIT_SHA_RE.fullmatch(before_head) or before_head != after_head:
         reasons.append(RepoAuditFallbackReason.REPO_STATE)
-    categories = {str(item.get("category") or "") for item in selected}
+    entity = str(intent.get("entity") or "")
+    categories = {repo_audit_category(str(item.get("path") or "")) for item in selected}
     coverage = audit.get("coverage") if isinstance(audit.get("coverage"), Mapping) else {}
     if (
         audit.get("schema_version") != "repo_audit_grounding.v1"
         or audit.get("applied") is not True
         or audit.get("holo_first") is not True
+        or audit.get("audit_intent") is not True
+        or str(audit.get("entity") or "") != entity
+        or len(selected) > MAX_SELECTED_PATHS
+        or sum(int(item.get("bytes") or 0) for item in selected) > TOTAL_READ_BUDGET_BYTES
+        or any(str(item.get("category") or "") != repo_audit_category(str(item.get("path") or "")) for item in selected)
+        or any(not repo_audit_path_supports_entity(str(item.get("path") or ""), entity) for item in selected)
         or coverage.get("verdict") != "PASS"
         or "implementation_source" not in categories
         or not categories.intersection({"test", "contract"})
@@ -113,6 +151,8 @@ def _fallback_reasons(
 
 def _build_receipt(
     *,
+    work_focus: str,
+    expected_entity: str,
     audit: Mapping[str, Any],
     selected: Sequence[Mapping[str, Any]],
     repo_head_sha: str,
@@ -121,11 +161,15 @@ def _build_receipt(
 ) -> Mapping[str, Any]:
     audit_value = dict(audit)
     evidence_digest = canonical_digest({"selected": list(selected)})
+    focus_digest = canonical_digest({"work_focus": work_focus})
+    policy_digest = canonical_digest(REPO_AUDIT_POLICY)
     state = {
         "repo_head_sha": repo_head_sha,
         "evidence_digest": evidence_digest,
-        "entity": str(audit_value.get("entity") or ""),
+        "expected_entity": expected_entity,
         "search_mode": str(audit_value.get("search_mode") or ""),
+        "work_focus_digest": focus_digest,
+        "policy_digest": policy_digest,
     }
     return {
         "schema_version": SCHEMA_VERSION,
@@ -133,6 +177,10 @@ def _build_receipt(
         "accepted": not rejection_reasons,
         "holo_owner_attempted_first": bool(owner_results),
         "holo_owner_evidence_usable": False,
+        "work_focus_digest": focus_digest,
+        "expected_entity": expected_entity,
+        "fixed_policy": dict(REPO_AUDIT_POLICY),
+        "fixed_policy_digest": policy_digest,
         "repo_head_sha": repo_head_sha,
         "repo_audit_grounding": audit_value,
         "repo_audit_grounding_digest": canonical_digest(audit_value),
@@ -143,12 +191,62 @@ def _build_receipt(
         "no_shell_command_executed": True,
         "no_holoindex_reindex_performed": True,
         "no_repo_mutation_performed": True,
+        "no_external_research_performed": True,
+        "no_execution_authority_granted": True,
     }
+
+
+def reread_bound_repo_audit_evidence(
+    repo_root: Path,
+    fallback: Mapping[str, Any],
+) -> tuple[tuple[Mapping[str, Any], ...], tuple[str, ...]]:
+    """Confined re-read requiring exact equality with every selected record."""
+    audit = fallback.get("repo_audit_grounding")
+    audit_mapping = dict(audit) if isinstance(audit, Mapping) else {}
+    selected = _selected_records(audit_mapping)
+    if not selected or len(selected) > MAX_SELECTED_PATHS:
+        return (), (RepoAuditFallbackReason.EVIDENCE,)
+    reads: list[Mapping[str, Any]] = []
+    remaining = TOTAL_READ_BUDGET_BYTES
+    for expected in selected:
+        path = str(expected.get("path") or "")
+        read = secure_read_repo_file(
+            repo_root,
+            path,
+            byte_cap=PER_FILE_READ_BYTES,
+            remaining_budget=remaining,
+        )
+        if not read.get("ok") or not _read_matches_selected(read, expected):
+            return (), ("repo_audit_selected_evidence_changed",)
+        remaining -= int(read["bytes"])
+        reads.append(read)
+    return tuple(reads), ()
+
+
+def _read_matches_selected(read: Mapping[str, Any], expected: Mapping[str, Any]) -> bool:
+    return all((
+        str(read.get("path") or "") == str(expected.get("path") or ""),
+        str(read.get("digest") or "") == str(expected.get("digest") or ""),
+        int(read.get("bytes") or -1) == int(expected.get("bytes") or -2),
+        bool(read.get("truncated")) is bool(expected.get("truncated")),
+        str(expected.get("category") or "") == repo_audit_category(str(read.get("path") or "")),
+    ))
+
+
+def canonical_digest(payload: Any) -> str:
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
 __all__ = [
     "RepoAuditFallbackReason",
     "RepoAuditFallbackResult",
+    "NO_ACTION_FIELDS",
+    "REPO_AUDIT_POLICY",
     "SCHEMA_VERSION",
     "build_bound_repo_audit_fallback",
+    "canonical_digest",
+    "reread_bound_repo_audit_evidence",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_repo_audit_fallback_grounding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_repo_audit_fallback_grounding.py
@@ -1,0 +1,154 @@
+"""Bind deterministic repository-audit evidence after HoloIndex cannot ground it."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from holo_index.cli.repo_audit_discovery import (
+    build_repo_audit_grounding,
+    detect_repo_audit_intent,
+)
+from holo_index.freshness_receipt import read_git_head_sha
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    canonical_digest,
+)
+
+
+SCHEMA_VERSION = "reddog_repo_audit_fallback.v1"
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+
+
+class RepoAuditFallbackReason:
+    EVIDENCE = "repo_audit_source_and_independent_verification_required"
+    REPO_STATE = "repo_audit_repository_state_unavailable_or_changed"
+
+
+@dataclass(frozen=True)
+class RepoAuditFallbackResult:
+    applied: bool
+    accepted: bool
+    repo_file_targets: tuple[str, ...] = ()
+    receipt: Mapping[str, Any] = field(default_factory=dict)
+    rejection_reasons: tuple[str, ...] = ()
+
+
+def build_bound_repo_audit_fallback(
+    *,
+    repo_root: Path,
+    work_focus: str,
+    owner_results: Sequence[Mapping[str, Any]],
+) -> RepoAuditFallbackResult:
+    """Read bounded local evidence only for a detected entity-scoped audit."""
+    intent = detect_repo_audit_intent(work_focus)
+    if intent.get("audit_intent") is not True:
+        return RepoAuditFallbackResult(applied=False, accepted=False)
+    before_head = read_git_head_sha(repo_root)
+    try:
+        result = build_repo_audit_grounding(
+            repo_root,
+            work_focus,
+            _owner_search_payload(owner_results),
+        )
+    except Exception:
+        result = {}
+    after_head = read_git_head_sha(repo_root)
+    audit = result.get("receipt") if isinstance(result.get("receipt"), Mapping) else {}
+    selected = _selected_records(audit)
+    reasons = _fallback_reasons(before_head, after_head, audit, selected)
+    receipt = _build_receipt(
+        audit=audit,
+        selected=selected,
+        repo_head_sha=after_head,
+        owner_results=owner_results,
+        rejection_reasons=reasons,
+    )
+    return RepoAuditFallbackResult(
+        applied=True,
+        accepted=not reasons,
+        repo_file_targets=tuple(str(item["path"]) for item in selected) if not reasons else (),
+        receipt=receipt,
+        rejection_reasons=tuple(reasons),
+    )
+
+
+def _owner_search_payload(owner_results: Sequence[Mapping[str, Any]]) -> Mapping[str, Any]:
+    if len(owner_results) != 1:
+        return {}
+    raw = owner_results[0].get("raw_result")
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _selected_records(audit: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    selected = audit.get("selected")
+    if not isinstance(selected, Sequence) or isinstance(selected, (str, bytes)):
+        return []
+    return [dict(item) for item in selected if isinstance(item, Mapping)]
+
+
+def _fallback_reasons(
+    before_head: str,
+    after_head: str,
+    audit: Mapping[str, Any],
+    selected: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    reasons: list[str] = []
+    if not GIT_SHA_RE.fullmatch(before_head) or before_head != after_head:
+        reasons.append(RepoAuditFallbackReason.REPO_STATE)
+    categories = {str(item.get("category") or "") for item in selected}
+    coverage = audit.get("coverage") if isinstance(audit.get("coverage"), Mapping) else {}
+    if (
+        audit.get("schema_version") != "repo_audit_grounding.v1"
+        or audit.get("applied") is not True
+        or audit.get("holo_first") is not True
+        or coverage.get("verdict") != "PASS"
+        or "implementation_source" not in categories
+        or not categories.intersection({"test", "contract"})
+    ):
+        reasons.append(RepoAuditFallbackReason.EVIDENCE)
+    return reasons
+
+
+def _build_receipt(
+    *,
+    audit: Mapping[str, Any],
+    selected: Sequence[Mapping[str, Any]],
+    repo_head_sha: str,
+    owner_results: Sequence[Mapping[str, Any]],
+    rejection_reasons: Sequence[str],
+) -> Mapping[str, Any]:
+    audit_value = dict(audit)
+    evidence_digest = canonical_digest({"selected": list(selected)})
+    state = {
+        "repo_head_sha": repo_head_sha,
+        "evidence_digest": evidence_digest,
+        "entity": str(audit_value.get("entity") or ""),
+        "search_mode": str(audit_value.get("search_mode") or ""),
+    }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "applied": True,
+        "accepted": not rejection_reasons,
+        "holo_owner_attempted_first": bool(owner_results),
+        "holo_owner_evidence_usable": False,
+        "repo_head_sha": repo_head_sha,
+        "repo_audit_grounding": audit_value,
+        "repo_audit_grounding_digest": canonical_digest(audit_value),
+        "selected_evidence_digest": evidence_digest,
+        "repository_state_digest": canonical_digest(state),
+        "rejection_reasons": list(rejection_reasons),
+        "no_model_call_performed": True,
+        "no_shell_command_executed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+
+
+__all__ = [
+    "RepoAuditFallbackReason",
+    "RepoAuditFallbackResult",
+    "SCHEMA_VERSION",
+    "build_bound_repo_audit_fallback",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_transport_neutral_grounding_service.py
+++ b/modules/communication/moltbot_bridge/src/reddog_transport_neutral_grounding_service.py
@@ -6,8 +6,9 @@ The service converts host-authenticated work focus into the same immutable
 ``reddog_intent.v2`` consumed by the canonical AgentDB resident cycle. It is a
 read-only evidence router: repository targets are containment-checked and
 semantic targets require a current generation-bound HoloIndex owner response.
-Quoted blocks remain data, external research fails closed until an approved
-retriever is supplied, and no model, shell, indexing, or execution path exists.
+Entity-scoped audits may use bounded local source plus test/contract reads only
+after owner evidence fails. Quoted blocks remain data, external research fails
+closed, and no model, shell, indexing, or execution path exists.
 """
 
 from __future__ import annotations
@@ -31,6 +32,10 @@ from modules.communication.moltbot_bridge.src.reddog_holoindex_query_adapter imp
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executor import (
     _resolve_safe_target,
+)
+from modules.communication.moltbot_bridge.src.reddog_repo_audit_fallback_grounding import (
+    RepoAuditFallbackReason,
+    build_bound_repo_audit_fallback,
 )
 
 
@@ -94,6 +99,8 @@ class GroundingServiceReason:
     HOLOINDEX_FAILED = "grounding_holoindex_owner_query_failed"
     HOLOINDEX_STALE = "grounding_holoindex_generation_not_current"
     SEMANTIC_EVIDENCE = "grounding_semantic_evidence_insufficient"
+    REPO_AUDIT_EVIDENCE = "grounding_repo_audit_evidence_incomplete"
+    REPO_STATE = "grounding_repo_state_unavailable_or_changed"
     EXTERNAL_RESEARCH = "grounding_external_research_adapter_required"
     RECEIPT_INVALID = "grounding_receipt_self_validation_failed"
 
@@ -194,6 +201,7 @@ def ground_transport_work_focus(
 
     semantic_coverage: list[Mapping[str, Any]] = []
     owner_results: list[Mapping[str, Any]] = []
+    repo_audit_fallback: Mapping[str, Any] = {}
     if semantic_targets:
         query = owner_query or _owner_query(
             repo_root=root,
@@ -222,6 +230,39 @@ def ground_transport_work_focus(
         if not _consistent_owner_bindings(owner_results):
             reasons.append(GroundingServiceReason.HOLOINDEX_STALE)
 
+    owner_failure_reasons = {
+        GroundingServiceReason.HOLOINDEX_FAILED,
+        GroundingServiceReason.HOLOINDEX_STALE,
+        GroundingServiceReason.SEMANTIC_EVIDENCE,
+    }
+    if (
+        len(semantic_targets) == 1
+        and not repo_targets
+        and any(reason in owner_failure_reasons for reason in reasons)
+    ):
+        fallback = build_bound_repo_audit_fallback(
+            repo_root=root,
+            work_focus=focus,
+            owner_results=owner_results,
+        )
+        if fallback.applied:
+            repo_audit_fallback = fallback.receipt
+            if fallback.accepted:
+                typed = {
+                    **typed,
+                    "repo_file_targets": list(fallback.repo_file_targets),
+                    "semantic_targets": [],
+                }
+                repo_targets = list(fallback.repo_file_targets)
+                direct_paths = list(fallback.repo_file_targets)
+                semantic_coverage = []
+                reasons = [reason for reason in reasons if reason not in owner_failure_reasons]
+            else:
+                if RepoAuditFallbackReason.REPO_STATE in fallback.rejection_reasons:
+                    reasons.append(GroundingServiceReason.REPO_STATE)
+                if RepoAuditFallbackReason.EVIDENCE in fallback.rejection_reasons:
+                    reasons.append(GroundingServiceReason.REPO_AUDIT_EVIDENCE)
+
     if external_targets:
         reasons.append(GroundingServiceReason.EXTERNAL_RESEARCH)
 
@@ -236,6 +277,7 @@ def ground_transport_work_focus(
         missing_paths=missing_paths,
         substantive=substantive,
         rejection_reasons=reasons,
+        repo_audit_fallback=repo_audit_fallback,
     )
     if reasons:
         return _reject(reasons, typed=typed, receipt=receipt)
@@ -435,6 +477,7 @@ def _build_grounding_receipt(
     missing_paths: Sequence[str],
     substantive: bool,
     rejection_reasons: Sequence[str],
+    repo_audit_fallback: Mapping[str, Any],
 ) -> Mapping[str, Any]:
     owner = owner_results[0] if owner_results else {}
     repo_targets = list(typed.get("repo_file_targets") or ())
@@ -461,6 +504,10 @@ def _build_grounding_receipt(
         "target_recall_ok": (not missing_paths) if repo_targets else None,
         "required_targets_missing": list(missing_paths),
         "direct_read_paths": list(direct_paths),
+        "repo_audit_fallback_used": bool(repo_audit_fallback),
+        "repo_audit_fallback": dict(repo_audit_fallback),
+        "repo_audit_fallback_digest": canonical_digest(repo_audit_fallback) if repo_audit_fallback else "",
+        "repo_state_head_sha": str(repo_audit_fallback.get("repo_head_sha") or ""),
         "holoindex_owner_query_ok": bool(owner_results) and all(item.get("ok") is True for item in owner_results),
         "holoindex_freshness": str(owner.get("freshness") or "UNKNOWN"),
         "holoindex_generation_id": str(owner.get("freshness_generation_id") or ""),

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -7,6 +7,12 @@
 - Added nested receipt tamper and fully rehashed private/traversal path
   substitution regressions; retained the shared discovery suite for link,
   reparse, identity-race, bounded-read, and deterministic ordering coverage.
+- Added independent-review reproductions for fully rehashed safe unrelated
+  source/test substitution, category/search/audit/coverage/policy/no-action
+  changes, selected-count and aggregate-byte overruns, and `.worktrees` paths.
+- Added deterministic and model-backed consuming-read regressions for exact
+  path/digest/bytes/truncated equality, including unstaged changes before the
+  worker and during model execution while HEAD remains unchanged.
 
 ## 2026-07-19: REDDOG_HOLOINDEX_V2_RUNTIME_FIXTURE_MIGRATION_PHASE1
 

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,13 @@
+## 2026-07-20: REDDOG_TRANSPORT_NEUTRAL_REPO_AUDIT_FALLBACK_PHASE1
+
+- Covered `pfmall`, `p.fMALL`, `p-fmall`, and `PFMALL` owner-unavailable audits.
+- Proved owner-first ordering, CURRENT-owner short circuiting, stable-HEAD
+  binding, source-plus-test enforcement, private/generated-root pruning, and
+  no-model/no-shell fail-closed behavior.
+- Added nested receipt tamper and fully rehashed private/traversal path
+  substitution regressions; retained the shared discovery suite for link,
+  reparse, identity-race, bounded-read, and deterministic ordering coverage.
+
 ## 2026-07-19: REDDOG_HOLOINDEX_V2_RUNTIME_FIXTURE_MIGRATION_PHASE1
 
 - Replaced stale positive HoloIndex v1 receipt fixtures with one canonical v2 helper that builds complete source-manifest, scope, policy, and collection-snapshot proofs.

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -39,6 +39,9 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executo
     ReadOnlyAuditTaskRejectReason,
     execute_reddog_readonly_audit_task,
 )
+from modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service import (
+    ground_transport_work_focus,
+)
 from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
     allocate_reddog_wsp15_receipt,
     canonical_reddog_wsp15_allocation_digest,
@@ -309,6 +312,97 @@ def _context() -> dict:
     }
 
 
+def _fallback_grounding_context(root: Path, *, model_backed: bool) -> dict:
+    source = root / "modules" / "foundups" / "pfmall" / "src" / "pfmall_runtime.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("def run_pfmall():\n    return 'current'\n", encoding="utf-8")
+    test = root / "modules" / "foundups" / "pfmall" / "tests" / "test_pfmall_runtime.py"
+    test.parent.mkdir(parents=True, exist_ok=True)
+    test.write_text("def test_pfmall():\n    assert True\n", encoding="utf-8")
+    ref = root / ".git" / "refs" / "heads" / "main"
+    ref.parent.mkdir(parents=True, exist_ok=True)
+    (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    ref.write_text("a" * 40 + "\n", encoding="utf-8")
+    focus = "Audit p.fMALL codebase and recommend defensive improvements."
+    grounding = ground_transport_work_focus(
+        repo_root=root,
+        work_focus=focus,
+        foundup_id="foundups_agent",
+        authenticated_principal_id="principal-012",
+        source_surface="hermes_thin_client",
+        client_request_id="executor-fallback-1",
+        owner_query=lambda query: {
+            "ok": False,
+            "query": query,
+            "freshness": "STALE",
+            "raw_result": {},
+            "index_gap_detected": True,
+            "no_holoindex_reindex_performed": True,
+        },
+    )
+    assert grounding.accepted is True
+    targets = tuple(grounding.typed_targets["repo_file_targets"])
+    context = (
+        _model_context(allowed_read_targets=targets)
+        if model_backed
+        else _context()
+    )
+    context["assignment"] = dict(context["assignment"])
+    context["assignment"]["allowed_read_targets"] = list(targets)
+    receipt = dict(grounding.grounding_receipt)
+    receipt_digest = grounding_digest(receipt)
+    context.update({
+        "grounding_receipt": receipt,
+        "grounding_receipt_id": receipt["receipt_id"],
+        "grounding_receipt_digest": receipt_digest,
+        "work_focus": focus,
+        "typed_targets": dict(grounding.typed_targets),
+    })
+    context["assignment"]["grounding_receipt_id"] = receipt["receipt_id"]
+    context["assignment"]["grounding_receipt_digest"] = receipt_digest
+    return context
+
+
+def _fallback_source_path(root: Path, context: dict) -> Path:
+    selected = context["grounding_receipt"]["repo_audit_fallback"]["repo_audit_grounding"]["selected"]
+    record = next(item for item in selected if item["category"] == "implementation_source")
+    return root / record["path"]
+
+
+def _rehash_fallback_context(context: dict) -> None:
+    receipt = context["grounding_receipt"]
+    fallback = receipt["repo_audit_fallback"]
+    audit = fallback["repo_audit_grounding"]
+    selected = audit["selected"]
+    paths = [item["path"] for item in selected]
+    receipt["typed_targets"]["repo_file_targets"] = paths
+    receipt["direct_read_paths"] = paths
+    receipt["repo_file_targets_count"] = len(paths)
+    receipt["typed_targets_digest"] = grounding_digest(receipt["typed_targets"])
+    fallback["repo_audit_grounding_digest"] = grounding_digest(audit)
+    fallback["selected_evidence_digest"] = grounding_digest({"selected": selected})
+    state = {
+        "repo_head_sha": fallback["repo_head_sha"],
+        "evidence_digest": fallback["selected_evidence_digest"],
+        "expected_entity": fallback["expected_entity"],
+        "search_mode": audit["search_mode"],
+        "work_focus_digest": fallback["work_focus_digest"],
+        "policy_digest": fallback["fixed_policy_digest"],
+    }
+    fallback["repository_state_digest"] = grounding_digest(state)
+    receipt["repo_audit_fallback_digest"] = grounding_digest(fallback)
+    receipt["receipt_id"] = grounding_digest(
+        {key: value for key, value in receipt.items() if key != "receipt_id"}
+    )
+    context["typed_targets"] = dict(receipt["typed_targets"])
+    context["assignment"]["allowed_read_targets"] = paths
+    context["grounding_receipt_id"] = receipt["receipt_id"]
+    context["assignment"]["grounding_receipt_id"] = receipt["receipt_id"]
+    digest = grounding_digest(receipt)
+    context["grounding_receipt_digest"] = digest
+    context["assignment"]["grounding_receipt_digest"] = digest
+
+
 def _model_context(
     *,
     allowed_read_targets: tuple[str, ...] | None = None,
@@ -498,6 +592,96 @@ def test_readonly_audit_executor_reads_only_allowlisted_targets(tmp_path: Path) 
     assert finding["recommended_action"] == "FIX"
     assert finding["next_slice_name"] == READONLY_AUDIT_LANE_ANALYZER_SLICE
     assert set(finding["evidence_refs"]) == set(result.report["evidence_refs"])
+
+
+def test_deterministic_fallback_rejects_unstaged_content_change_at_consuming_read(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    context = _fallback_grounding_context(root, model_backed=False)
+    _fallback_source_path(root, context).write_text("CHANGED = True\n", encoding="utf-8")
+
+    result = execute_reddog_readonly_audit_task(task_context=context, repo_root=root)
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.GROUNDING_EVIDENCE_CHANGED in result.rejection_reasons
+    assert result.no_model_call_performed is True
+
+
+@pytest.mark.parametrize("field", ["path", "digest", "bytes", "truncated"])
+def test_deterministic_consumer_requires_exact_selected_read_receipt(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    root = _repo(tmp_path)
+    context = _fallback_grounding_context(root, model_backed=False)
+    selected = context["grounding_receipt"]["repo_audit_fallback"]["repo_audit_grounding"]["selected"]
+    record = next(item for item in selected if item["category"] == "implementation_source")
+    if field == "path":
+        record[field] = "modules/foundups/pfmall/src/pfmall_missing.py"
+    elif field == "digest":
+        record[field] = "sha256:" + "0" * 64
+    elif field == "bytes":
+        record[field] += 1
+    else:
+        record[field] = not record[field]
+    _rehash_fallback_context(context)
+
+    result = execute_reddog_readonly_audit_task(task_context=context, repo_root=root)
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.GROUNDING_EVIDENCE_CHANGED in result.rejection_reasons
+
+
+def test_model_fallback_rejects_changed_content_before_index_or_model(tmp_path: Path) -> None:
+    root = _repo(tmp_path)
+    context = _fallback_grounding_context(root, model_backed=True)
+    _fallback_source_path(root, context).write_text("CHANGED = True\n", encoding="utf-8")
+    runner = _EchoEvidenceModelRunner()
+    holo = _FakeQueryAdapter()
+    code = _FakeQueryAdapter()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        model_runner=runner,
+        holoindex_adapter=holo,
+        codeindex_adapter=code,
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.GROUNDING_EVIDENCE_CHANGED in result.rejection_reasons
+    assert runner.calls == []
+    assert holo.calls == []
+    assert code.calls == []
+
+
+def test_model_fallback_rechecks_content_after_model_even_when_head_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    context = _fallback_grounding_context(root, model_backed=True)
+    source = _fallback_source_path(root, context)
+
+    class _MutatingRunner(_EchoEvidenceModelRunner):
+        def run_repo_code_audit(self, **kwargs):
+            result = super().run_repo_code_audit(**kwargs)
+            source.write_text("CHANGED_DURING_MODEL = True\n", encoding="utf-8")
+            return result
+
+    runner = _MutatingRunner()
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        model_runner=runner,
+        holoindex_adapter=_FakeQueryAdapter(),
+        codeindex_adapter=_FakeQueryAdapter(),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.GROUNDING_EVIDENCE_CHANGED in result.rejection_reasons
+    assert runner.calls
+    assert context["grounding_receipt"]["repo_state_head_sha"] == "a" * 40
 
 
 def test_model_backed_repo_code_audit_accepts_strict_evidence_bound_report(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_transport_neutral_grounding_service.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_transport_neutral_grounding_service.py
@@ -3,11 +3,21 @@
 from __future__ import annotations
 
 import ast
+from copy import deepcopy
 import json
 from pathlib import Path
 import subprocess
 
+import pytest
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_repo_audit_fallback_grounding as repo_audit_fallback,
+)
+from modules.communication.moltbot_bridge.src import (
+    reddog_transport_neutral_grounding_service as grounding_service,
+)
 from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    canonical_digest,
     validate_grounded_target_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service import (
@@ -25,6 +35,7 @@ MODULE_PATH = (
     / "src"
     / "reddog_transport_neutral_grounding_service.py"
 )
+FALLBACK_MODULE_PATH = MODULE_PATH.with_name("reddog_repo_audit_fallback_grounding.py")
 GENERATION = "sha256:" + "1" * 64
 FRESHNESS_RECEIPT = "sha256:" + "2" * 64
 
@@ -69,6 +80,38 @@ def _ground(work_focus: str, **kwargs):
         client_request_id="request-1",
         owner_query=kwargs.pop("owner_query", lambda query: _owner_result(query=query)),
         **kwargs,
+    )
+
+
+def _seed_repo_audit_fixture(root: Path, *, include_test: bool = True) -> None:
+    source = root / "modules" / "foundups" / "pfmall" / "src" / "pfmall_runtime.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("def build_pfmall():\n    return 'bounded source'\n", encoding="utf-8")
+    if include_test:
+        test = root / "modules" / "foundups" / "pfmall" / "tests" / "test_pfmall_runtime.py"
+        test.parent.mkdir(parents=True)
+        test.write_text("def test_pfmall_runtime():\n    assert True\n", encoding="utf-8")
+    private = root / ".memory" / "pfmall" / "test_pfmall_private.py"
+    private.parent.mkdir(parents=True)
+    private.write_text("PRIVATE_TOOL_STATE = True\n", encoding="utf-8")
+    generated = root / "build" / "pfmall_generated.py"
+    generated.parent.mkdir(parents=True)
+    generated.write_text("GENERATED = True\n", encoding="utf-8")
+    ref = root / ".git" / "refs" / "heads" / "main"
+    ref.parent.mkdir(parents=True)
+    (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+    ref.write_text("a" * 40 + "\n", encoding="utf-8")
+
+
+def _ground_at(repo_root: Path, work_focus: str, owner_query):
+    return ground_transport_work_focus(
+        repo_root=repo_root,
+        work_focus=work_focus,
+        foundup_id="foundups_agent",
+        authenticated_principal_id="principal-012",
+        source_surface="hermes_thin_client",
+        client_request_id="request-fallback-1",
+        owner_query=owner_query,
     )
 
 
@@ -146,6 +189,147 @@ def test_single_decoy_hit_cannot_ground_broad_audit() -> None:
 
     assert result.accepted is False
     assert GroundingServiceReason.SEMANTIC_EVIDENCE in result.rejection_reasons
+
+
+@pytest.mark.parametrize("alias", ["pfmall", "p.fMALL", "p-fmall", "PFMALL"])
+def test_owner_unavailable_scoped_audit_uses_bounded_repo_evidence(
+    tmp_path: Path, monkeypatch, alias: str
+) -> None:
+    _seed_repo_audit_fixture(tmp_path)
+    order = []
+    real_fallback = grounding_service.build_bound_repo_audit_fallback
+
+    def owner(query):
+        order.append("owner")
+        return _owner_result(query=query, current=False, hits=[])
+
+    def fallback(**kwargs):
+        order.append("fallback")
+        return real_fallback(**kwargs)
+
+    monkeypatch.setattr(grounding_service, "build_bound_repo_audit_fallback", fallback)
+    result = _ground_at(tmp_path, f"Audit {alias} codebase and recommend work.", owner)
+
+    assert result.accepted is True
+    assert order == ["owner", "fallback"]
+    assert result.typed_targets["semantic_targets"] == []
+    paths = result.typed_targets["repo_file_targets"]
+    assert any(path.endswith("pfmall_runtime.py") and "/src/" in path for path in paths)
+    assert any("/tests/" in path for path in paths)
+    assert all(not path.startswith((".memory/", "build/")) for path in paths)
+    fallback_receipt = result.grounding_receipt["repo_audit_fallback"]
+    assert fallback_receipt["holo_owner_attempted_first"] is True
+    assert fallback_receipt["repo_head_sha"] == "a" * 40
+    assert fallback_receipt["repo_audit_grounding"]["coverage"]["verdict"] == "PASS"
+    assert validate_grounded_target_receipt(
+        result.grounding_receipt,
+        work_focus=f"Audit {alias} codebase and recommend work.",
+    ).accepted is True
+
+
+def test_sufficient_current_owner_evidence_does_not_run_repo_fallback(monkeypatch) -> None:
+    def forbidden_fallback(**_kwargs):
+        raise AssertionError("repo fallback must not run after sufficient CURRENT owner evidence")
+
+    monkeypatch.setattr(
+        grounding_service,
+        "build_bound_repo_audit_fallback",
+        forbidden_fallback,
+    )
+    hits = [
+        {"path": "modules/foundups/pfmall/api.py", "title": "p.fMALL codebase implementation"},
+        {"path": "modules/foundups/pfmall/tests/test_http_api.py", "title": "p.fMALL codebase tests"},
+    ]
+    result = _ground(
+        "Audit p.fMALL codebase.",
+        owner_query=lambda query: _owner_result(query=query, hits=hits),
+    )
+
+    assert result.accepted is True
+    assert result.grounding_receipt["repo_audit_fallback_used"] is False
+    assert result.typed_targets["semantic_targets"] == ["Audit p.fMALL codebase."]
+
+
+def test_repo_fallback_without_independent_verification_fails_before_model(tmp_path: Path) -> None:
+    _seed_repo_audit_fixture(tmp_path, include_test=False)
+    result = _ground_at(
+        tmp_path,
+        "Audit p.fMALL codebase.",
+        lambda query: _owner_result(query=query, current=False, hits=[]),
+    )
+
+    assert result.accepted is False
+    assert GroundingServiceReason.REPO_AUDIT_EVIDENCE in result.rejection_reasons
+    assert result.no_model_call_performed is True
+    assert result.no_shell_command_executed is True
+
+
+def test_repo_fallback_rejects_head_change_during_bounded_reads(tmp_path: Path, monkeypatch) -> None:
+    _seed_repo_audit_fixture(tmp_path)
+    heads = iter(("a" * 40, "b" * 40))
+    monkeypatch.setattr(repo_audit_fallback, "read_git_head_sha", lambda _root: next(heads))
+    result = _ground_at(
+        tmp_path,
+        "Audit p.fMALL module.",
+        lambda query: _owner_result(query=query, current=False, hits=[]),
+    )
+
+    assert result.accepted is False
+    assert GroundingServiceReason.REPO_STATE in result.rejection_reasons
+
+
+def test_repo_fallback_nested_receipt_tampering_fails_continuity(tmp_path: Path) -> None:
+    _seed_repo_audit_fixture(tmp_path)
+    focus = "Audit p.fMALL repository."
+    result = _ground_at(
+        tmp_path,
+        focus,
+        lambda query: _owner_result(query=query, current=False, hits=[]),
+    )
+    receipt = deepcopy(result.grounding_receipt)
+    receipt["repo_audit_fallback"]["repo_head_sha"] = "b" * 40
+    receipt["receipt_id"] = canonical_digest(
+        {key: value for key, value in receipt.items() if key != "receipt_id"}
+    )
+
+    validation = validate_grounded_target_receipt(receipt, work_focus=focus)
+    assert validation.accepted is False
+    assert "grounding_repo_audit_receipt_invalid" in validation.rejection_reasons
+
+
+def test_rehashed_repo_fallback_cannot_bind_private_or_traversal_path(tmp_path: Path) -> None:
+    _seed_repo_audit_fixture(tmp_path)
+    focus = "Audit p.fMALL repository."
+    result = _ground_at(
+        tmp_path,
+        focus,
+        lambda query: _owner_result(query=query, current=False, hits=[]),
+    )
+    receipt = deepcopy(result.grounding_receipt)
+    fallback = receipt["repo_audit_fallback"]
+    fallback["repo_audit_grounding"]["selected"][0]["path"] = ".memory/../pfmall.py"
+    fallback["repo_audit_grounding_digest"] = canonical_digest(fallback["repo_audit_grounding"])
+    fallback["selected_evidence_digest"] = canonical_digest(
+        {"selected": fallback["repo_audit_grounding"]["selected"]}
+    )
+    state = {
+        "repo_head_sha": fallback["repo_head_sha"],
+        "evidence_digest": fallback["selected_evidence_digest"],
+        "entity": fallback["repo_audit_grounding"]["entity"],
+        "search_mode": fallback["repo_audit_grounding"]["search_mode"],
+    }
+    fallback["repository_state_digest"] = canonical_digest(state)
+    receipt["typed_targets"]["repo_file_targets"][0] = ".memory/../pfmall.py"
+    receipt["direct_read_paths"][0] = ".memory/../pfmall.py"
+    receipt["typed_targets_digest"] = canonical_digest(receipt["typed_targets"])
+    receipt["repo_audit_fallback_digest"] = canonical_digest(fallback)
+    receipt["receipt_id"] = canonical_digest(
+        {key: value for key, value in receipt.items() if key != "receipt_id"}
+    )
+
+    validation = validate_grounded_target_receipt(receipt, work_focus=focus)
+    assert validation.accepted is False
+    assert "grounding_repo_audit_receipt_invalid" in validation.rejection_reasons
 
 
 def test_two_category_decoys_still_cannot_ground_unrelated_claim() -> None:
@@ -272,26 +456,27 @@ def test_malformed_foundup_request_or_principal_identifiers_fail_closed() -> Non
 
 
 def test_grounding_service_has_no_model_shell_index_or_write_surface() -> None:
-    source = MODULE_PATH.read_text(encoding="utf-8")
-    tree = ast.parse(source)
-    imported = {
-        alias.name
-        for node in ast.walk(tree)
-        if isinstance(node, (ast.Import, ast.ImportFrom))
-        for alias in node.names
-    }
-    assert "subprocess" not in imported
-    assert "os" not in imported
-    for forbidden in (
-        "FoundupsFusionRepoAuditModelRunner",
-        "index_all",
-        "incremental_index",
-        "write_text(",
-        "git push",
-        "gh pr",
-        "HermesFoundUpBuilder",
-    ):
-        assert forbidden not in source
+    for module_path in (MODULE_PATH, FALLBACK_MODULE_PATH):
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        assert "subprocess" not in imported
+        assert "os" not in imported
+        for forbidden in (
+            "FoundupsFusionRepoAuditModelRunner",
+            "index_all",
+            "incremental_index",
+            "write_text(",
+            "git push",
+            "gh pr",
+            "HermesFoundUpBuilder",
+        ):
+            assert forbidden not in source
 
 
 def test_backend_target_classes_match_editor_extractor_on_shared_fixtures() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_transport_neutral_grounding_service.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_transport_neutral_grounding_service.py
@@ -115,6 +115,33 @@ def _ground_at(repo_root: Path, work_focus: str, owner_query):
     )
 
 
+def _rehash_fallback_receipt(receipt: dict) -> None:
+    fallback = receipt["repo_audit_fallback"]
+    audit = fallback["repo_audit_grounding"]
+    selected = audit["selected"]
+    paths = [item["path"] for item in selected]
+    receipt["typed_targets"]["repo_file_targets"] = paths
+    receipt["direct_read_paths"] = paths
+    receipt["repo_file_targets_count"] = len(paths)
+    receipt["typed_targets_digest"] = canonical_digest(receipt["typed_targets"])
+    fallback["repo_audit_grounding_digest"] = canonical_digest(audit)
+    fallback["selected_evidence_digest"] = canonical_digest({"selected": selected})
+    fallback["fixed_policy_digest"] = canonical_digest(fallback["fixed_policy"])
+    state = {
+        "repo_head_sha": fallback["repo_head_sha"],
+        "evidence_digest": fallback["selected_evidence_digest"],
+        "expected_entity": fallback["expected_entity"],
+        "search_mode": audit["search_mode"],
+        "work_focus_digest": fallback["work_focus_digest"],
+        "policy_digest": fallback["fixed_policy_digest"],
+    }
+    fallback["repository_state_digest"] = canonical_digest(state)
+    receipt["repo_audit_fallback_digest"] = canonical_digest(fallback)
+    receipt["receipt_id"] = canonical_digest(
+        {key: value for key, value in receipt.items() if key != "receipt_id"}
+    )
+
+
 def test_repo_path_is_verified_and_bound_into_v2_intent() -> None:
     focus = (
         "Audit modules/communication/moltbot_bridge/src/"
@@ -330,6 +357,110 @@ def test_rehashed_repo_fallback_cannot_bind_private_or_traversal_path(tmp_path: 
     validation = validate_grounded_target_receipt(receipt, work_focus=focus)
     assert validation.accepted is False
     assert "grounding_repo_audit_receipt_invalid" in validation.rejection_reasons
+
+
+def test_fully_rehashed_safe_unrelated_evidence_cannot_replace_requested_entity(
+    tmp_path: Path,
+) -> None:
+    _seed_repo_audit_fixture(tmp_path)
+    focus = "Audit p.fMALL repository."
+    result = _ground_at(
+        tmp_path,
+        focus,
+        lambda query: _owner_result(query=query, current=False, hits=[]),
+    )
+    receipt = deepcopy(result.grounding_receipt)
+    selected = receipt["repo_audit_fallback"]["repo_audit_grounding"]["selected"]
+    selected[0]["path"] = "modules/unrelated/safe_runtime.py"
+    selected[0]["category"] = "implementation_source"
+    selected[1]["path"] = "modules/unrelated/tests/test_safe_runtime.py"
+    selected[1]["category"] = "test"
+    _rehash_fallback_receipt(receipt)
+
+    validation = validate_grounded_target_receipt(receipt, work_focus=focus)
+    assert validation.accepted is False
+    assert "grounding_repo_audit_receipt_invalid" in validation.rejection_reasons
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "category",
+        "search_mode",
+        "audit_intent",
+        "coverage",
+        "fixed_policy",
+        "no_action",
+        "worktrees_path",
+        "selected_limit",
+        "aggregate_budget",
+    ],
+)
+def test_fully_rehashed_fallback_policy_substitution_fails_closed(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    _seed_repo_audit_fixture(tmp_path)
+    focus = "Audit p.fMALL repository."
+    result = _ground_at(
+        tmp_path,
+        focus,
+        lambda query: _owner_result(query=query, current=False, hits=[]),
+    )
+    receipt = deepcopy(result.grounding_receipt)
+    fallback = receipt["repo_audit_fallback"]
+    _mutate_fallback_policy(fallback, mutation)
+    _rehash_fallback_receipt(receipt)
+
+    validation = validate_grounded_target_receipt(receipt, work_focus=focus)
+    assert validation.accepted is False
+    assert "grounding_repo_audit_receipt_invalid" in validation.rejection_reasons
+
+
+def _mutate_fallback_policy(fallback: dict, mutation: str) -> None:
+    audit = fallback["repo_audit_grounding"]
+    selected = audit["selected"]
+    if mutation == "category":
+        selected[0]["category"] = "test"
+    elif mutation == "search_mode":
+        audit["search_mode"] = "model_selected"
+    elif mutation == "audit_intent":
+        audit["audit_intent"] = False
+    elif mutation == "coverage":
+        audit["coverage"] = {"verdict": "PASS", "reasons": ["missing_test"]}
+    elif mutation == "fixed_policy":
+        fallback["fixed_policy"]["max_selected_paths"] = 99
+    elif mutation == "no_action":
+        fallback["no_shell_command_executed"] = False
+    elif mutation == "worktrees_path":
+        selected[0]["path"] = ".worktrees/pfmall/pfmall_runtime.py"
+    elif mutation == "selected_limit":
+        selected[:] = [
+            {
+                **selected[index % len(selected)],
+                "path": (
+                    f"modules/foundups/pfmall/tests/test_pfmall_{index}.py"
+                    if index == 0
+                    else f"modules/foundups/pfmall/src/pfmall_{index}.py"
+                ),
+                "category": "implementation_source" if index else "test",
+            }
+            for index in range(13)
+        ]
+    else:
+        selected[:] = [
+            {
+                **selected[index % len(selected)],
+                "path": (
+                    f"modules/foundups/pfmall/tests/test_pfmall_{index}.py"
+                    if index == 0
+                    else f"modules/foundups/pfmall/src/pfmall_{index}.py"
+                ),
+                "category": "test" if index == 0 else "implementation_source",
+                "bytes": 12_000,
+            }
+            for index in range(9)
+        ]
 
 
 def test_two_category_decoys_still_cannot_ground_unrelated_claim() -> None:

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -1,4 +1,30 @@
 exemptions:
+  - file: "INTERFACE.md"
+    reason: >-
+      Legacy module interface registry. This slice adds one bounded transport
+      contract beside its canonical resident-client boundary; splitting the
+      historical registry is separate documentation-maintenance work.
+    threshold_override: 1100
+    temporary: true
+    review_date: "2026-Q3"
+    reviewer: "0102 Technical Architect"
+    remediation: "modules/communication/moltbot_bridge/ROADMAP.md#2026-07-18-reddog--holoindex-truth-boundary-follow-ups"
+
+  - file: "src/reddog_transport_neutral_grounding_service.py"
+    reason: >-
+      Existing transport integration boundary spanning request validation,
+      target classification, owner preflight, bounded repository-audit
+      fallback, and canonical receipt composition. The fallback implementation
+      itself is isolated in a compliant module; broad decomposition is tracked
+      separately to avoid mixing architecture churn into this safety slice.
+    threshold_override: 600
+    function_threshold_override: 180
+    functions: ["ground_transport_work_focus"]
+    temporary: true
+    review_date: "2026-Q3"
+    reviewer: "0102 Technical Architect"
+    remediation: "modules/communication/moltbot_bridge/ROADMAP.md#2026-07-18-reddog--holoindex-truth-boundary-follow-ups"
+
   - file: "scripts/run_task.py"
     reason: >-
       Legacy multi-family task dispatcher. The newly added HoloIndex startup
@@ -115,7 +141,7 @@ exemptions:
     reason: >-
       Legacy WSP_22 test journal. Current entries record focused validation;
       historical test evidence is not split during a runtime-security slice.
-    threshold_override: 1400
+    threshold_override: 1500
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -43,8 +43,8 @@ exemptions:
       Legacy audit-worker integration boundary spanning evidence acquisition,
       model invocation, and receipt composition. This POC preserves its
       reviewed repository and HoloIndex truth checks without a broad rewrite.
-    threshold_override: 2000
-    function_threshold_override: 240
+    threshold_override: 2100
+    function_threshold_override: 270
     functions:
       - "execute_model_backed_repo_code_audit"
       - "_optional_memex_query_artifacts"
@@ -58,11 +58,11 @@ exemptions:
 
   - file: "src/reddog_readonly_audit_task_executor.py"
     reason: >-
-      Existing task-execution transaction boundary; the exact-HEAD pre/post
-      repository proofs must remain adjacent until a dedicated transaction
-      object is introduced with parity tests.
+      Existing task-execution transaction boundary; repository-state and exact
+      selected-evidence consuming reads remain adjacent until a dedicated
+      transaction object is introduced with parity tests.
     threshold_override: 675
-    function_threshold_override: 75
+    function_threshold_override: 90
     functions: ["execute_reddog_readonly_audit_task"]
     temporary: true
     review_date: "2026-Q3"
@@ -118,7 +118,7 @@ exemptions:
     reason: >-
       Legacy executor regression matrix. Repository-state truth-boundary cases
       were added without mixing production refactoring into the security fix.
-    threshold_override: 1800
+    threshold_override: 2100
     function_threshold_override: 60
     temporary: true
     review_date: "2026-Q3"
@@ -129,7 +129,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 8500
+    threshold_override: 9000
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"


### PR DESCRIPTION
## Summary
- keep generation-bound Holo owner evidence first for transport-neutral RedDog grounding
- add bounded deterministic repository discovery for one entity-scoped codebase audit when owner evidence is unavailable or stale
- require implementation source plus independent test/contract evidence before models
- bind fallback receipts to original work focus, path-derived categories, fixed limits, and exact confined content rereads
- reject file drift before deterministic/model consumption and recheck after model return

## WSP_97 truth
This is read-only grounding continuity. It grants no execution authority, runs no shell, performs no reindex, and fails closed when evidence or repository content changes.

## Verification
- complete dependent scope: 192 passed, 1 platform skip
- explicit file-drift regressions: 3 passed
- repaired focused rerun: 132 passed, 1 platform skip
- Ruff, Python compile, YAML, git diff, WSP_00 and focused WSP_62 gates passed
- independent review: GO at 843351f57