### PR TITLE
test(holoindex): update maintenance receipt fixtures

### DIFF
--- a/modules/infrastructure/foundups_mcp_bridge/tests/TestModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/TestModLog.md
@@ -1,5 +1,28 @@
 # foundups_mcp_bridge TestModLog
 
+## [2026-07-20] Receipt-v2 maintenance fixture integrity repair
+
+**WSP Protocol:** WSP 00, 22, 50, 62, 97
+
+**Observed:** The second owner runbook group produced 3 failures and 61
+passes. Its maintenance fixture still declared receipt schema v1, used a
+literal generation, emitted only the seven query collections, and omitted the
+v2 source-policy and collection-snapshot proof digests. Production correctly
+treated the supposedly fresh fixture as stale and rejected refresh-published
+fixtures whose baseline proofs were incomplete.
+
+**Change:** Kept production validation unchanged. The maintenance fixture now
+emits all receipt-v2 collection entries, supplies format-valid policy and
+snapshot digests, computes the generation with the production helper, and
+self-checks with the production integrity validator. A blank legacy embedding
+fingerprint remains integrity-bound but semantically stale, so its test still
+proves that maintenance refreshes it.
+
+**Validation:** The exact second runbook group passes 64 tests. Adjacent
+freshness-receipt, maintenance-session, CLI-maintenance, and incremental-index
+suites pass 84 tests. The changed Python test module remains below the WSP 62
+800-line warning threshold; no exemption is required.
+
 ## [2026-07-20] Receipt-v2 owner fixture integrity repair
 
 **WSP Protocol:** WSP 00, 22, 50, 62, 97

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_reddog_holoindex_maintenance_handshake.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_reddog_holoindex_maintenance_handshake.py
@@ -8,9 +8,12 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from holo_index.freshness_receipt import (
-    BASELINE_QUERY_COLLECTIONS,
+    ALL_COLLECTIONS,
+    SCHEMA_VERSION,
     CollectionFreshness,
     HoloIndexFreshnessReceipt,
+    _receipt_generation_id,
+    freshness_receipt_integrity_ok,
     freshness_receipt_path,
     write_freshness_receipt,
 )
@@ -42,6 +45,8 @@ def _receipt(
     *,
     embedding_fingerprint: str = "sha256:" + ("1" * 64),
 ) -> HoloIndexFreshnessReceipt:
+    generated_at = "2026-07-18T00:00:00+00:00"
+    source = "cli"
     entries = [
         CollectionFreshness(
             name=name,
@@ -50,7 +55,7 @@ def _receipt(
             status="indexed",
             source="cli",
             repo_head_sha=HEAD,
-            last_indexed_at="2026-07-18T00:00:00+00:00",
+            last_indexed_at=generated_at,
             source_manifest_digest="sha256:" + ("b" * 64),
             indexed_paths_digest="sha256:" + ("c" * 64),
             removed_paths_digest="sha256:" + ("d" * 64),
@@ -59,19 +64,31 @@ def _receipt(
             embedding_space_fingerprint=embedding_fingerprint,
             verification="PASS",
             proof_kind="complete_source_manifest",
+            source_policy_digest="sha256:" + ("e" * 64),
+            collection_snapshot_digest="sha256:" + ("f" * 64),
         )
-        for name in sorted(BASELINE_QUERY_COLLECTIONS)
+        for name in sorted(ALL_COLLECTIONS)
     ]
-    return HoloIndexFreshnessReceipt(
-        schema_version="holoindex_freshness_receipt.v1",
-        generated_at="2026-07-18T00:00:00+00:00",
+    generation_id = _receipt_generation_id(
+        HEAD,
+        entries,
+        generated_at=generated_at,
+        repo_root=str(repo_root),
+        ssd_path=str(ssd_path),
+        source=source,
+    )
+    receipt = HoloIndexFreshnessReceipt(
+        schema_version=SCHEMA_VERSION,
+        generated_at=generated_at,
         repo_root=str(repo_root),
         repo_head_sha=HEAD,
         ssd_path=str(ssd_path),
-        source="cli",
-        generation_id="sha256:generation",
+        source=source,
+        generation_id=generation_id,
         collections=entries,
     )
+    assert freshness_receipt_integrity_ok(receipt)
+    return receipt
 
 
 def _publish(repo_root: Path, ssd_path: Path) -> None:
@@ -158,7 +175,7 @@ def test_fresh_exact_head_receipt_starts_owner_without_refresh(
     assert result.ready is True
     assert result.status == handshake.OPERATIONAL_READY
     assert result.refreshed is False
-    assert result.generation_id == "sha256:generation"
+    assert result.generation_id == _receipt(repo_root, ssd_path).generation_id
 
 
 def test_missing_receipt_runs_bounded_secret_free_refresh_and_restarts_owner(


### PR DESCRIPTION
## Summary
- migrate Holo maintenance-handshake fixtures to complete receipt-v2 envelopes
- include all nine collections and required proof digests
- generate fixture IDs with the production integrity algorithm
- preserve the legacy blank-fingerprint refresh case as integrity-valid but semantically stale

## Verification
- exact maintenance lifecycle runbook group: 64 passed
- adjacent maintenance/receipt suites: 148 passed (worker verification)
- WSP_62 and git diff checks passed
- production freshness and maintenance code unchanged