### PR TITLE
feat(reddog): require exact runtime model bindings

### DIFF
--- a/main.py
+++ b/main.py
@@ -1932,6 +1932,9 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         REDDOG_RESIDENT_BREADCRUMBS_PATH                    Optional breadcrumb JSON override
         REDDOG_RESIDENT_WORKSPACE_MEMORY_NOTES_PATH         Optional workspace memory note JSON
         REDDOG_RESIDENT_MEMORY_MAX_RECORDS=20               Max breadcrumb/workspace records supplied
+        REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT           Outside-repo root for binding artifacts
+        REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH Exact audit binding artifact
+        REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH Exact architect binding artifact
         REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH             Approved external snapshot JSON
         REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Existing work-state JSON
         HOLOINDEX_FRESHNESS_RECEIPT                        Existing HoloIndex receipt
@@ -1941,6 +1944,14 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
     if not _reddog_resident_architect_cycle_requested():
         logger.info("[REDDOG-RESIDENT-CYCLE] Startup preflight disabled")
         return True
+
+    audit_runtime_binding, architect_runtime_binding, binding_reason = (
+        _reddog_resident_model_runtime_bindings_from_env(repo_root)
+    )
+    if binding_reason:
+        logger.error("[REDDOG-RESIDENT-CYCLE] Runtime model binding preflight failed: %s", binding_reason)
+        print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL reason={binding_reason}")
+        return False
 
     enforced = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0") != "0"
     principal_ref = os.getenv("REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF", "012").strip() or "012"
@@ -1997,6 +2008,8 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
             brain_state=brain_state,
             workspace_memory_notes=workspace_memory_notes,
             external_research_retriever=_reddog_external_research_retriever_from_env(),
+            audit_model_runtime_binding_receipt=audit_runtime_binding,
+            architect_model_runtime_binding_receipt=architect_runtime_binding,
             max_claims=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS", 8),
             timeout_seconds=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS", 60),
             cancel_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_CANCEL", "0") != "0",
@@ -2058,6 +2071,80 @@ def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bo
         print("[REDDOG-RESIDENT-CYCLE] Startup blocked by REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1")
         return False
     return True
+
+
+def _reddog_resident_model_runtime_bindings_from_env(
+    repo_root: Path,
+) -> tuple[Mapping[str, Any] | None, Mapping[str, Any] | None, str]:
+    runtime_root_value = os.getenv("REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT", "").strip()
+    audit_path_value = os.getenv(
+        "REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH", ""
+    ).strip()
+    architect_path_value = os.getenv(
+        "REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH", ""
+    ).strip()
+    if not runtime_root_value:
+        return None, None, "missing_model_runtime_binding_root"
+    if not audit_path_value:
+        return None, None, "missing_audit_model_runtime_binding_path"
+    if not architect_path_value:
+        return None, None, "missing_architect_model_runtime_binding_path"
+    runtime_root = Path(runtime_root_value)
+    audit_path = Path(audit_path_value)
+    architect_path = Path(architect_path_value)
+    if not runtime_root.is_absolute() or not audit_path.is_absolute() or not architect_path.is_absolute():
+        return None, None, "model_runtime_binding_path_not_absolute"
+    root = repo_root.resolve()
+    runtime_root = runtime_root.resolve()
+    try:
+        runtime_root.relative_to(root)
+        return None, None, "model_runtime_binding_root_inside_repo"
+    except ValueError:
+        pass
+    audit_identity = Path(os.path.abspath(audit_path))
+    architect_identity = Path(os.path.abspath(architect_path))
+    try:
+        audit_identity.relative_to(root)
+        return None, None, "model_runtime_binding_artifact_inside_repo"
+    except ValueError:
+        pass
+    try:
+        architect_identity.relative_to(root)
+        return None, None, "model_runtime_binding_artifact_inside_repo"
+    except ValueError:
+        pass
+    if os.path.normcase(str(audit_identity)) == os.path.normcase(str(architect_identity)):
+        return None, None, "model_runtime_binding_artifacts_not_distinct"
+    try:
+        from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import (
+            ModelRuntimeBindingDecision,
+        )
+        from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+            rehydrate_model_runtime_binding_receipt,
+        )
+        from modules.communication.moltbot_bridge.src.reddog_runtime_json_read import (
+            read_reddog_runtime_json_mapping,
+        )
+
+        audit = read_reddog_runtime_json_mapping(audit_path, allowed_root=runtime_root)
+        architect = read_reddog_runtime_json_mapping(architect_path, allowed_root=runtime_root)
+        audit_receipt = rehydrate_model_runtime_binding_receipt(audit)
+        architect_receipt = rehydrate_model_runtime_binding_receipt(architect)
+    except Exception:
+        return None, None, "model_runtime_binding_artifact_invalid"
+    if (
+        audit_receipt.decision != ModelRuntimeBindingDecision.BOUND
+        or not audit_receipt.principal_model
+        or audit_receipt.runtime_surface != "reddog_readonly_audit_worker"
+    ):
+        return None, None, "audit_model_runtime_binding_surface_invalid"
+    if (
+        architect_receipt.decision != ModelRuntimeBindingDecision.BOUND
+        or not architect_receipt.principal_model
+        or architect_receipt.runtime_surface != "reddog_backend_architect"
+    ):
+        return None, None, "architect_model_runtime_binding_surface_invalid"
+    return audit, architect, ""
 
 
 def _reddog_startup_blocker_token(value: str) -> str:

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -12,6 +12,16 @@ The editor bridge requires host-supplied `REDDOG_AUTHENTICATED_PRINCIPAL_ID` and
 
 `CANCELLED` and `DETERMINED` are permanently terminal. Only `FAILED` and `TIMED_OUT` cycles may enter a revision-checked retry, and each retry appends one immutable prior-attempt summary. Legacy v1 rows are accepted only by the canonical cancellation path; they cannot reconnect, resume, or become authority-bearing v2 records.
 
+Production resident model execution requires separate runtime-binding inputs
+for the read-only audit and backend architect surfaces. The audit binding is
+carried content-bearing through WSP 15, swarm planning, assignment, enqueue,
+and AgentDB/OpenClaw claim execution. The architect binding is revalidated at
+bootstrap and determination. Both results record the runtime receipt ID and
+canonical digest. Missing, invalid, rejected, or cross-surface receipts stop
+before the FoundUps Fusion provider seam; a model-selection receipt is not a
+runtime authorization substitute. Fake runner injection remains a test-only
+seam.
+
 ### Canonical RedDog execution-valve readiness
 
 `reddog_execution_valve_environment_supply_cli` reads the authoritative work

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -12,15 +12,17 @@ The editor bridge requires host-supplied `REDDOG_AUTHENTICATED_PRINCIPAL_ID` and
 
 `CANCELLED` and `DETERMINED` are permanently terminal. Only `FAILED` and `TIMED_OUT` cycles may enter a revision-checked retry, and each retry appends one immutable prior-attempt summary. Legacy v1 rows are accepted only by the canonical cancellation path; they cannot reconnect, resume, or become authority-bearing v2 records.
 
-Production resident model execution requires separate runtime-binding inputs
+Resident model execution requires separate runtime-binding inputs
 for the read-only audit and backend architect surfaces. The audit binding is
 carried content-bearing through WSP 15, swarm planning, assignment, enqueue,
-and AgentDB/OpenClaw claim execution. The architect binding is revalidated at
-bootstrap and determination. Both results record the runtime receipt ID and
-canonical digest. Missing, invalid, rejected, or cross-surface receipts stop
-before the FoundUps Fusion provider seam; a model-selection receipt is not a
-runtime authorization substitute. Fake runner injection remains a test-only
-seam.
+and AgentDB/OpenClaw claim execution. The architect binding is separately
+bound into WSP 15 and revalidated at bootstrap and determination. Both exact
+receipt ID/digest pairs are part of durable intent identity, so retry/resume
+cannot substitute another valid same-surface artifact. Missing, invalid,
+rejected, cross-surface, or pair-mismatched receipts stop before index/model
+calls or persistence; a model-selection receipt is not a runtime authorization
+substitute. Fake runner injection remains a test-only seam but obeys the same
+required binding checks.
 
 ### Canonical RedDog execution-valve readiness
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-20: REDDOG_REQUIRED_RUNTIME_MODEL_BINDING_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 62, 97
+
+- Added separate audit and backend-architect runtime-binding inputs to the
+  durable resident and direct read-only audit cycles.
+- Bound the audit receipt ID/digest through WSP 15 allocation identity, swarm
+  and assignment identity, content-bearing AgentDB task context, OpenClaw
+  claim execution, worker route receipts, and audit report lineage.
+- Required the backend architect bootstrap/determination to carry the matching
+  architect-surface receipt into result and queue-candidate lineage.
+- Production `foundups_fusion` audit and architect paths now reject missing,
+  malformed, rejected, wrong-surface, or selection-only bindings before a
+  provider call. Removed production runner model defaults, including the
+  inherited Kimi K2.7 fallback; topology is receipt-derived only.
+- Preserved injected fake-runner seams and all read-only/no-dispatch
+  boundaries. Tests prove an exact receipt-selected GLM/Kimi K3 topology is
+  forwarded without network calls, model promotion, progress recording, or
+  publication.
+- WSP 62 truth: the legacy audit runtime remains inside its existing temporary
+  2,100-line ceiling (2,073 lines). The focused architect test suite remains
+  under its 725-line ceiling (708 lines); no exemption ceiling was raised.
+
 ## 2026-07-20: REDDOG_EXECUTION_VALVE_INDEPENDENT_REVIEW_REPAIR_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 62, 71, 97

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,28 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-20: REDDOG_REQUIRED_RUNTIME_MODEL_BINDING_REVIEW_REPAIR_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 62, 71, 97
+
+- Closed same-surface substitution by comparing the rehydrated audit receipt
+  ID/digest against task, assignment, and WSP 15 lineage, and by binding the
+  architect receipt pair into WSP 15 as a separate field pair.
+- Made runtime bindings mandatory for injected and production runners alike;
+  model-selection metadata remains non-authoritative and cannot replace or
+  override the validated runtime identity.
+- Bound both receipt pairs into durable resident intent identity and used the
+  same two-pair WSP 15 identity for enqueue and final report collection, so
+  reconnect/retry substitution fails before downstream work or persistence.
+- Added the `main.py` readiness boundary: two distinct, exact-surface artifacts
+  must be read from an explicit outside-repository root through bounded,
+  regular-file, no-follow reads before the resident cycle can start. Logs emit
+  stable path-free reason codes only.
+- WSP 62 truth: focused security tests increased legacy integration fixtures
+  and the startup entrypoint. Temporary ceilings were updated to their exact
+  post-repair sizes (`main.py` 4,978; audit runtime 2,106; architect tests 760;
+  startup tests 1,935; audit executor tests 2,237) without widening function
+  ceilings beyond the expanded 77-line architect fixture.
+
 ## 2026-07-20: REDDOG_REQUIRED_RUNTIME_MODEL_BINDING_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 62, 97

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -120,6 +120,22 @@ model-backed path repeats that check after the model returns. Any mismatch
 rejects the result. The fallback grants no indexing, shell, mutation, or
 execution authority.
 
+### RedDog runtime model-binding boundary
+
+The resident read-only audit cycle accepts two independently issued,
+surface-specific `reddog_model_runtime_binding_receipt.v1` artifacts: one for
+`reddog_readonly_audit_worker` and one for `reddog_backend_architect`. The
+audit receipt is digest-bound into the WSP 15 allocation, swarm, assignment,
+and AgentDB task context; the architect receipt is bound into determination
+and queue-candidate lineage. Production `foundups_fusion` execution rejects a
+missing, malformed, rejected, or wrong-surface receipt before provider access.
+Selection receipts alone do not authorize either production call.
+
+Model identities and panel topology come only from the validated runtime
+receipt. The production runners have no model fallback list. Injected test
+runners remain available for deterministic read-only tests and perform no
+provider call unless the test explicitly supplies one.
+
 ## Setup
 
 > ⚠️ **Important**: See [docs/INSTALL_OPENCLAW.md](docs/INSTALL_OPENCLAW.md) for full guide

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -122,19 +122,22 @@ execution authority.
 
 ### RedDog runtime model-binding boundary
 
-The resident read-only audit cycle accepts two independently issued,
+The resident read-only audit cycle requires two independently issued,
 surface-specific `reddog_model_runtime_binding_receipt.v1` artifacts: one for
 `reddog_readonly_audit_worker` and one for `reddog_backend_architect`. The
-audit receipt is digest-bound into the WSP 15 allocation, swarm, assignment,
-and AgentDB task context; the architect receipt is bound into determination
-and queue-candidate lineage. Production `foundups_fusion` execution rejects a
-missing, malformed, rejected, or wrong-surface receipt before provider access.
-Selection receipts alone do not authorize either production call.
+audit and architect receipt pairs are both digest-bound into WSP 15 and the
+durable intent identity. The audit pair continues through swarm, assignment,
+and AgentDB task context; the architect pair continues through determination
+and queue-candidate lineage. Every runner, including an injected test runner,
+rejects a missing, malformed, rejected, wrong-surface, or pair-mismatched
+receipt before index/provider access or persistence. Selection receipts alone
+do not authorize either call.
 
-Model identities and panel topology come only from the validated runtime
-receipt. The production runners have no model fallback list. Injected test
-runners remain available for deterministic read-only tests and perform no
-provider call unless the test explicitly supplies one.
+Model identities and panel topology come only from the exact validated runtime
+receipt. Same-surface substitution is rejected against task, assignment, WSP
+15, and durable-intent bindings. The runners have no model fallback list.
+Injected test runners remain available for deterministic read-only tests, but
+must receive the same valid binding lineage as production runners.
 
 ## Setup
 

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -91,6 +91,10 @@ These remain deferred until the FoundUp Memex POC and MVP contracts are proven.
   remain a separate deployment control.
 - Split reddog_readonly_0102_audit_worker_runtime.py by evidence acquisition,
   freshness normalization, model invocation, and receipt composition.
+- Extract the duplicated audit/architect runtime-binding rehydration and
+  topology projection into a focused contract module after Phase 1 parity is
+  stable. Until then, keep the two surface constants and rejection semantics
+  covered by cross-surface tests; do not broaden either production surface.
 - Continue extracting main.py RedDog preflight and dispatch policy into
   cohesive module-owned helpers; do not add new orchestration branches to the
   root monolith.

--- a/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
@@ -135,8 +135,8 @@ class FoundupsFusionArchitectModelRunner:
     fake runner instead of reaching the network.
     """
 
-    lead_model: str = "z-ai/glm-5.2"
-    panel_models: tuple[str, ...] = ("deepseek/deepseek-v4-pro", "moonshotai/kimi-k2.7-code")
+    lead_model: str = ""
+    panel_models: tuple[str, ...] = ()
     max_tokens: int = 1200
     temperature: float = 0.0
 
@@ -170,6 +170,11 @@ class FoundupsFusionArchitectModelRunner:
             default_lead=self.lead_model,
             default_panel=self.panel_models,
         )
+        if (
+            not model_topology["model_runtime_binding_receipt_id"]
+            or not model_topology["lead_model"]
+        ):
+            return _model_result_reject(ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT)
         redacted_user = gate.redacted_prompt
         if gate.redacted_context:
             redacted_user = gate.redacted_prompt + "\n\n" + gate.redacted_context
@@ -514,7 +519,11 @@ def run_reddog_backend_architect_determination_runtime(
         reasons,
         expected_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
     )
-    if not model_selection:
+    production_runner = model_runner is None or isinstance(model_runner, FoundupsFusionArchitectModelRunner)
+    if not model_selection and production_runner:
+        if ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT not in reasons:
+            reasons.append(ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT)
+    elif not model_selection:
         model_selection = _model_selection_binding(model_selection_receipt, reasons)
     model_selection_receipt_id = str(model_selection.get("receipt_id") or "").strip() or None
     model_selection_digest = str(model_selection.get("digest") or "").strip() or None

--- a/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
@@ -519,12 +519,22 @@ def run_reddog_backend_architect_determination_runtime(
         reasons,
         expected_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
     )
-    production_runner = model_runner is None or isinstance(model_runner, FoundupsFusionArchitectModelRunner)
-    if not model_selection and production_runner:
+    if not model_selection and ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT not in reasons:
+        reasons.append(ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT)
+    expected_runtime_id = str(
+        wsp15_allocation_receipt.get("architect_model_runtime_binding_receipt_id") or ""
+    )
+    expected_runtime_digest = str(
+        wsp15_allocation_receipt.get("architect_model_runtime_binding_digest") or ""
+    )
+    if (
+        not expected_runtime_id
+        or not expected_runtime_digest
+        or str(model_selection.get("model_runtime_binding_receipt_id") or "") != expected_runtime_id
+        or str(model_selection.get("model_runtime_binding_digest") or "") != expected_runtime_digest
+    ):
         if ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT not in reasons:
             reasons.append(ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT)
-    elif not model_selection:
-        model_selection = _model_selection_binding(model_selection_receipt, reasons)
     model_selection_receipt_id = str(model_selection.get("receipt_id") or "").strip() or None
     model_selection_digest = str(model_selection.get("digest") or "").strip() or None
     model_runtime_binding_receipt_id = (

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -206,6 +206,31 @@ def run_reddog_main_readonly_operational_bootstrap(
     reasons: list[str] = []
     architect_model_selection_receipt = architect_model_selection_receipt_override
     architect_model_runtime_binding_receipt = architect_model_runtime_binding_receipt_override
+    if architect_model_runtime_binding_receipt is None and architect_model_runtime_binding_receipt_path:
+        architect_model_runtime_binding_receipt, runtime_reasons = _read_json_outside_repo(
+            root,
+            architect_model_runtime_binding_receipt_path,
+            missing_reason="missing_architect_model_runtime_binding_receipt",
+            inside_reason="architect_model_runtime_binding_receipt_path_inside_repo",
+            unreadable_reason="malformed_architect_model_runtime_binding_receipt",
+            required=True,
+        )
+        if runtime_reasons:
+            return _not_ready(
+                reasons=tuple(runtime_reasons),
+                changed_paths=paths,
+                allowed_read_targets=targets,
+                wsp15_allocation_receipt=wsp15_allocation_receipt,
+            )
+    if architect_model_runtime_binding_receipt is not None:
+        wsp15_allocation_receipt = allocate_reddog_wsp15_receipt(
+            requested_operation=requested_operation,
+            prompt_text=prompt_text,
+            changed_paths=paths,
+            allowed_read_targets=targets,
+            model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+            architect_model_runtime_binding_receipt=architect_model_runtime_binding_receipt,
+        ).to_dict()
 
     work_state_snapshot = work_state_snapshot_override
     if work_state_snapshot is None:
@@ -386,29 +411,6 @@ def run_reddog_main_readonly_operational_bootstrap(
                         architect_result=architect_result,
                     )
             if run_backend_architect_determination:
-                if architect_model_runtime_binding_receipt is None and architect_model_runtime_binding_receipt_path:
-                    architect_model_runtime_binding_receipt, runtime_reasons = _read_json_outside_repo(
-                        root,
-                        architect_model_runtime_binding_receipt_path,
-                        missing_reason="missing_architect_model_runtime_binding_receipt",
-                        inside_reason="architect_model_runtime_binding_receipt_path_inside_repo",
-                        unreadable_reason="malformed_architect_model_runtime_binding_receipt",
-                        required=True,
-                    )
-                    if runtime_reasons:
-                        return _not_ready(
-                            reasons=tuple(runtime_reasons),
-                            changed_paths=paths,
-                            allowed_read_targets=targets,
-                            wsp15_allocation_receipt=wsp15_allocation_receipt,
-                            snapshot=snapshot,
-                            evidence_bundle=evidence_bundle,
-                            gate=gate,
-                            swarm_plan=plan,
-                            collection_result=collection_result,
-                            decision_result=decision_result,
-                            decision_persist_result=decision_persist_result,
-                        )
                 if architect_model_selection_receipt is None:
                     if architect_model_selection_receipt_path:
                         architect_model_selection_receipt, model_reasons = _read_json_outside_repo(

--- a/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_readonly_operational_bootstrap.py
@@ -172,6 +172,8 @@ def run_reddog_main_readonly_operational_bootstrap(
     bootstrap_projection: Mapping[str, Any] | None = None,
     grounding_receipt: Mapping[str, Any] | None = None,
     grounding_work_focus: str = "",
+    audit_model_runtime_binding_receipt: Mapping[str, Any] | None = None,
+    require_audit_model_runtime_binding: bool = False,
     audit_lanes: Sequence[str] = DEFAULT_AUDIT_LANES,
     enqueue_readonly_audit_tasks: bool = False,
     enqueue_writer: ReadOnlyAuditTaskWriter | None = None,
@@ -185,6 +187,8 @@ def run_reddog_main_readonly_operational_bootstrap(
     architect_model_runner: ArchitectModelRunner | None = None,
     architect_model_selection_receipt_path: Path | str | None = None,
     architect_model_selection_receipt_override: Mapping[str, Any] | None = None,
+    architect_model_runtime_binding_receipt_path: Path | str | None = None,
+    architect_model_runtime_binding_receipt_override: Mapping[str, Any] | None = None,
     architect_determination_store: ArchitectDeterminationStore | None = None,
 ) -> RedDogMainReadonlyBootstrapResult:
     """Build a read-only startup plan or explain why it is not ready."""
@@ -197,9 +201,11 @@ def run_reddog_main_readonly_operational_bootstrap(
         prompt_text=prompt_text,
         changed_paths=paths,
         allowed_read_targets=targets,
+        model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
     ).to_dict()
     reasons: list[str] = []
     architect_model_selection_receipt = architect_model_selection_receipt_override
+    architect_model_runtime_binding_receipt = architect_model_runtime_binding_receipt_override
 
     work_state_snapshot = work_state_snapshot_override
     if work_state_snapshot is None:
@@ -296,6 +302,8 @@ def run_reddog_main_readonly_operational_bootstrap(
         wsp15_allocation_receipt=wsp15_allocation_receipt,
         grounding_receipt=grounding_receipt,
         grounding_work_focus=grounding_work_focus,
+        model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+        require_model_runtime_binding=require_audit_model_runtime_binding,
     )
     if not plan.accepted:
         return _not_ready(
@@ -378,6 +386,29 @@ def run_reddog_main_readonly_operational_bootstrap(
                         architect_result=architect_result,
                     )
             if run_backend_architect_determination:
+                if architect_model_runtime_binding_receipt is None and architect_model_runtime_binding_receipt_path:
+                    architect_model_runtime_binding_receipt, runtime_reasons = _read_json_outside_repo(
+                        root,
+                        architect_model_runtime_binding_receipt_path,
+                        missing_reason="missing_architect_model_runtime_binding_receipt",
+                        inside_reason="architect_model_runtime_binding_receipt_path_inside_repo",
+                        unreadable_reason="malformed_architect_model_runtime_binding_receipt",
+                        required=True,
+                    )
+                    if runtime_reasons:
+                        return _not_ready(
+                            reasons=tuple(runtime_reasons),
+                            changed_paths=paths,
+                            allowed_read_targets=targets,
+                            wsp15_allocation_receipt=wsp15_allocation_receipt,
+                            snapshot=snapshot,
+                            evidence_bundle=evidence_bundle,
+                            gate=gate,
+                            swarm_plan=plan,
+                            collection_result=collection_result,
+                            decision_result=decision_result,
+                            decision_persist_result=decision_persist_result,
+                        )
                 if architect_model_selection_receipt is None:
                     if architect_model_selection_receipt_path:
                         architect_model_selection_receipt, model_reasons = _read_json_outside_repo(
@@ -403,9 +434,9 @@ def run_reddog_main_readonly_operational_bootstrap(
                                 decision_persist_result=decision_persist_result,
                                 architect_result=architect_result,
                             )
-                    elif architect_model_runner is None:
+                    elif architect_model_runner is None and architect_model_runtime_binding_receipt is None:
                         return _not_ready(
-                            reasons=("missing_architect_model_selection_receipt_path",),
+                            reasons=("missing_architect_model_runtime_binding_receipt",),
                             changed_paths=paths,
                             allowed_read_targets=targets,
                             wsp15_allocation_receipt=wsp15_allocation_receipt,
@@ -434,6 +465,7 @@ def run_reddog_main_readonly_operational_bootstrap(
                     store=architect_store,
                     model_runner=architect_model_runner,
                     model_selection_receipt=architect_model_selection_receipt,
+                    model_runtime_binding_receipt=architect_model_runtime_binding_receipt,
                     now_iso=now_iso,
                 )
                 if not architect_result.accepted:

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -315,6 +315,10 @@ def _assignment_safe(assignment: ReadOnlyAuditAssignment, plan: ReadOnlyAuditSwa
         return False
     if assignment.grounding_receipt_digest != plan.receipt.grounding_receipt_digest:
         return False
+    if assignment.model_runtime_binding_receipt_id != plan.receipt.model_runtime_binding_receipt_id:
+        return False
+    if assignment.model_runtime_binding_digest != plan.receipt.model_runtime_binding_digest:
+        return False
     if assignment.no_worker_spawn_performed is not True:
         return False
     if assignment.no_execution_performed is not True:
@@ -347,6 +351,9 @@ def _build_task_spec(plan: ReadOnlyAuditSwarmPlan, assignment: ReadOnlyAuditAssi
         "grounding_receipt_id": assignment.grounding_receipt_id,
         "grounding_receipt_digest": assignment.grounding_receipt_digest,
         "grounding_receipt": dict(grounding) if isinstance(grounding, Mapping) else {},
+        "model_runtime_binding_receipt_id": assignment.model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": assignment.model_runtime_binding_digest,
+        "model_runtime_binding_receipt": dict(plan.receipt.model_runtime_binding_receipt),
         "work_focus": plan.receipt.grounding_work_focus,
         "typed_targets": dict(typed_targets),
         "semantic_targets": list(typed_targets.get("semantic_targets") or ()),

--- a/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -27,6 +27,10 @@ from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_
     canonical_digest as grounding_digest,
     validate_grounded_target_receipt,
 )
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import ModelRuntimeBindingDecision
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    rehydrate_model_runtime_binding_receipt,
+)
 
 
 READONLY_AUDIT_SWARM_PLANNED = "READONLY_AUDIT_SWARM_PLANNED"
@@ -64,6 +68,7 @@ FORBIDDEN_ACTIONS = (
 
 MAX_ASSIGNMENT_TARGETS = 32
 MAX_REPORT_BYTES = 48_000
+RUNTIME_SURFACE_READONLY_AUDIT = "reddog_readonly_audit_worker"
 
 
 @dataclass(frozen=True)
@@ -84,6 +89,8 @@ class ReadOnlyAuditAssignment:
     grounding_receipt_digest: str = ""
     wsp15_allocation_receipt_id: str = ""
     wsp15_allocation_digest: str = ""
+    model_runtime_binding_receipt_id: str = ""
+    model_runtime_binding_digest: str = ""
     forbidden_actions: tuple[str, ...] = FORBIDDEN_ACTIONS
     no_worker_spawn_performed: bool = True
     no_execution_performed: bool = True
@@ -116,6 +123,9 @@ class ReadOnlyAuditSwarmReceipt:
     wsp15_allocation_receipt_id: str = ""
     wsp15_allocation_digest: str = ""
     wsp15_allocation_receipt: Mapping[str, Any] = field(default_factory=dict)
+    model_runtime_binding_receipt_id: str = ""
+    model_runtime_binding_digest: str = ""
+    model_runtime_binding_receipt: Mapping[str, Any] = field(default_factory=dict)
     no_model_call_performed: bool = True
     no_worker_spawn_performed: bool = True
     no_openclaw_enqueue_performed: bool = True
@@ -195,6 +205,8 @@ def plan_reddog_openclaw_readonly_audit_swarm(
     wsp15_allocation_receipt: Mapping[str, Any] | None = None,
     grounding_receipt: Mapping[str, Any] | None = None,
     grounding_work_focus: str = "",
+    model_runtime_binding_receipt: Mapping[str, Any] | None = None,
+    require_model_runtime_binding: bool = False,
 ) -> ReadOnlyAuditSwarmPlan:
     """Plan read-only audit assignments from an already accepted context gate."""
 
@@ -229,6 +241,16 @@ def plan_reddog_openclaw_readonly_audit_swarm(
     if wsp15_allocation_receipt:
         allocation_id = str(wsp15_allocation_receipt.get("receipt_id") or "").strip()
         allocation_digest = _digest(wsp15_allocation_receipt)
+    runtime_binding_data, runtime_binding_id, runtime_binding_digest = _runtime_binding(
+        model_runtime_binding_receipt,
+        reasons,
+        required=require_model_runtime_binding,
+    )
+    if runtime_binding_id and wsp15_allocation_receipt:
+        if str(wsp15_allocation_receipt.get("model_runtime_binding_receipt_id") or "") != runtime_binding_id:
+            reasons.append("wsp15_model_runtime_binding_receipt_mismatch")
+        if str(wsp15_allocation_receipt.get("model_runtime_binding_digest") or "") != runtime_binding_digest:
+            reasons.append("wsp15_model_runtime_binding_digest_mismatch")
     grounding_data = dict(grounding_receipt) if isinstance(grounding_receipt, Mapping) else {}
     grounding_id = ""
     grounding_receipt_digest = ""
@@ -291,6 +313,8 @@ def plan_reddog_openclaw_readonly_audit_swarm(
             wsp15_allocation_digest=allocation_digest,
             grounding_receipt_id=grounding_id,
             grounding_receipt_digest=grounding_receipt_digest,
+            model_runtime_binding_receipt_id=runtime_binding_id,
+            model_runtime_binding_digest=runtime_binding_digest,
         )
         for lane in normalized_lanes
     )
@@ -304,6 +328,8 @@ def plan_reddog_openclaw_readonly_audit_swarm(
             "wsp15_allocation_digest": allocation_digest,
             "grounding_receipt_id": grounding_id,
             "grounding_receipt_digest": grounding_receipt_digest,
+            "model_runtime_binding_receipt_id": runtime_binding_id,
+            "model_runtime_binding_digest": runtime_binding_digest,
             "assignment_ids": [assignment.assignment_id for assignment in assignments],
         }
     )
@@ -323,6 +349,9 @@ def plan_reddog_openclaw_readonly_audit_swarm(
         wsp15_allocation_receipt_id=allocation_id,
         wsp15_allocation_digest=allocation_digest,
         wsp15_allocation_receipt=dict(wsp15_allocation_receipt or {}),
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
+        model_runtime_binding_receipt=runtime_binding_data,
         assignment_ids=tuple(assignment.assignment_id for assignment in assignments),
         lanes=tuple(assignment.lane_id for assignment in assignments),
         rejection_reasons=(),
@@ -410,6 +439,8 @@ def _build_assignment(
     wsp15_allocation_digest: str,
     grounding_receipt_id: str,
     grounding_receipt_digest: str,
+    model_runtime_binding_receipt_id: str,
+    model_runtime_binding_digest: str,
 ) -> ReadOnlyAuditAssignment:
     payload = {
         "lane_id": lane_id,
@@ -422,6 +453,8 @@ def _build_assignment(
         "wsp15_allocation_digest": wsp15_allocation_digest,
         "grounding_receipt_id": grounding_receipt_id,
         "grounding_receipt_digest": grounding_receipt_digest,
+        "model_runtime_binding_receipt_id": model_runtime_binding_receipt_id,
+        "model_runtime_binding_digest": model_runtime_binding_digest,
         "required_source": LANE_REQUIRED_SOURCE[lane_id],
         "allowed_read_targets": allowed_read_targets,
     }
@@ -438,6 +471,8 @@ def _build_assignment(
         wsp15_allocation_digest=wsp15_allocation_digest,
         grounding_receipt_id=grounding_receipt_id,
         grounding_receipt_digest=grounding_receipt_digest,
+        model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
+        model_runtime_binding_digest=model_runtime_binding_digest,
         required_source=LANE_REQUIRED_SOURCE[lane_id],
         allowed_read_targets=allowed_read_targets,
     )
@@ -474,6 +509,9 @@ def _rejected_plan(
         wsp15_allocation_receipt_id="",
         wsp15_allocation_digest="",
         wsp15_allocation_receipt={},
+        model_runtime_binding_receipt_id="",
+        model_runtime_binding_digest="",
+        model_runtime_binding_receipt={},
         assignment_ids=(),
         lanes=tuple(lanes),
         rejection_reasons=tuple(reasons),
@@ -485,6 +523,35 @@ def _rejected_plan(
         assignments=(),
         rejection_reasons=tuple(reasons),
     )
+
+
+def _runtime_binding(
+    value: Mapping[str, Any] | None,
+    reasons: list[str],
+    *,
+    required: bool,
+) -> tuple[dict[str, Any], str, str]:
+    if value is None:
+        if required:
+            reasons.append("missing_model_runtime_binding_receipt")
+        return {}, "", ""
+    if not isinstance(value, Mapping):
+        reasons.append("invalid_model_runtime_binding_receipt")
+        return {}, "", ""
+    try:
+        data = json.loads(json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True))
+        receipt = rehydrate_model_runtime_binding_receipt(data)
+    except Exception:
+        reasons.append("invalid_model_runtime_binding_receipt")
+        return {}, "", ""
+    if (
+        receipt.decision != ModelRuntimeBindingDecision.BOUND
+        or not receipt.principal_model
+        or receipt.runtime_surface != RUNTIME_SURFACE_READONLY_AUDIT
+    ):
+        reasons.append("model_runtime_binding_surface_mismatch")
+        return {}, "", ""
+    return data, receipt.receipt_id, _digest(data)
 
 
 def _validate_binding(

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -278,8 +278,8 @@ class CodeIndexReadOnlyQueryAdapter:
 class FoundupsFusionRepoAuditModelRunner:
     """Production model runner for explicit RedDog read-only repo audits."""
 
-    lead_model: str = "z-ai/glm-5.2"
-    panel_models: tuple[str, ...] = ("deepseek/deepseek-v4-pro", "moonshotai/kimi-k2.7-code")
+    lead_model: str = ""
+    panel_models: tuple[str, ...] = ()
     max_tokens: int = 1800
     temperature: float = 0.0
 
@@ -297,6 +297,11 @@ class FoundupsFusionRepoAuditModelRunner:
             default_lead=self.lead_model,
             default_panel=self.panel_models,
         )
+        if (
+            not model_topology["model_runtime_binding_receipt_id"]
+            or not model_topology["lead_model"]
+        ):
+            return _model_reject(ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT)
         lead_model = str(model_topology["lead_model"])
         panel_models = tuple(model_topology["panel_models"])
         if os.getenv(ENV_READONLY_AUDIT_RUNTIME_MODE, "").strip() != RUNTIME_MODE_FOUNDUPS_FUSION:
@@ -491,7 +496,11 @@ def execute_model_backed_repo_code_audit(
         model_selection_reasons,
         expected_surface=RUNTIME_SURFACE_READONLY_AUDIT,
     )
-    if not model_selection:
+    production_runner = model_runner is None or isinstance(model_runner, FoundupsFusionRepoAuditModelRunner)
+    if not model_selection and production_runner:
+        if ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT not in model_selection_reasons:
+            model_selection_reasons.append(ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT)
+    elif not model_selection:
         model_selection = _model_selection_binding(
             task_context.get("model_selection_receipt") or assignment.get("model_selection_receipt"),
             model_selection_reasons,

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_0102_audit_worker_runtime.py
@@ -496,17 +496,19 @@ def execute_model_backed_repo_code_audit(
         model_selection_reasons,
         expected_surface=RUNTIME_SURFACE_READONLY_AUDIT,
     )
-    production_runner = model_runner is None or isinstance(model_runner, FoundupsFusionRepoAuditModelRunner)
-    if not model_selection and production_runner:
-        if ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT not in model_selection_reasons:
-            model_selection_reasons.append(ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT)
-    elif not model_selection:
-        model_selection = _model_selection_binding(
-            task_context.get("model_selection_receipt") or assignment.get("model_selection_receipt"),
-            model_selection_reasons,
-        )
+    if not model_selection and ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT not in model_selection_reasons:
+        model_selection_reasons.append(ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT)
     if model_selection_reasons:
         return _reject(model_selection_reasons)
+    if model_selection.get("model_runtime_binding_receipt_id"):
+        runtime_lineage_reasons = _validate_model_runtime_binding_lineage(
+            task_context=task_context,
+            assignment=assignment,
+            allocation=allocation,
+            runtime_binding=model_selection,
+        )
+        if runtime_lineage_reasons:
+            return _reject(runtime_lineage_reasons)
     worker_plan = allocation.get("worker_plan") if isinstance(allocation.get("worker_plan"), Mapping) else {}
     if worker_plan.get("fusion_required") is not True:
         return _reject([ReadOnlyAuditTaskRejectReason.WSP15_FUSION_REQUIRED])
@@ -1395,9 +1397,40 @@ def _model_runtime_binding(
         "lead_model": str(payload.get("lead_model") or ""),
         "panel_models": [str(item) for item in payload.get("panel_models") or ()],
         "model_runtime_binding_receipt_id": receipt.receipt_id,
-        "model_runtime_binding_digest": _digest(binding),
+        "model_runtime_binding_digest": "sha256:" + _digest(binding),
         "runtime_surface": receipt.runtime_surface,
     }
+
+
+def _validate_model_runtime_binding_lineage(
+    *,
+    task_context: Mapping[str, Any],
+    assignment: Mapping[str, Any],
+    allocation: Mapping[str, Any],
+    runtime_binding: Mapping[str, Any],
+) -> tuple[str, ...]:
+    expected_id = str(runtime_binding.get("model_runtime_binding_receipt_id") or "")
+    expected_digest = str(runtime_binding.get("model_runtime_binding_digest") or "")
+    bound_pairs = (
+        (
+            str(task_context.get("model_runtime_binding_receipt_id") or ""),
+            str(task_context.get("model_runtime_binding_digest") or ""),
+        ),
+        (
+            str(assignment.get("model_runtime_binding_receipt_id") or ""),
+            str(assignment.get("model_runtime_binding_digest") or ""),
+        ),
+        (
+            str(allocation.get("model_runtime_binding_receipt_id") or ""),
+            str(allocation.get("model_runtime_binding_digest") or ""),
+        ),
+    )
+    if not expected_id or not expected_digest or any(
+        receipt_id != expected_id or digest != expected_digest
+        for receipt_id, digest in bound_pairs
+    ):
+        return (ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT,)
+    return ()
 
 
 def _json_compatible_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -213,8 +213,10 @@ def run_reddog_readonly_audit_research_decision_e2e(
     report_store: ReadOnlyAuditReportStore | None = None,
     decision_store: ReadOnlyAuditDecisionStore | None = None,
     architect_model_runner: ArchitectModelRunner | None = None,
+    architect_model_runtime_binding_receipt: Mapping[str, Any] | None = None,
     architect_determination_store: ArchitectDeterminationStore | None = None,
     audit_model_runner: RepoAuditModelRunner | None = None,
+    audit_model_runtime_binding_receipt: Mapping[str, Any] | None = None,
     holoindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
     codeindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
     external_research_retriever: ExternalResearchRetriever | None = None,
@@ -245,6 +247,8 @@ def run_reddog_readonly_audit_research_decision_e2e(
         audit_lanes=audit_lanes,
         enqueue_readonly_audit_tasks=True,
         enqueue_writer=capture_writer,
+        audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+        require_audit_model_runtime_binding=audit_model_runner is None and task_executor is None,
     )
     if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
         return _result(
@@ -341,12 +345,15 @@ def run_reddog_readonly_audit_research_decision_e2e(
         work_state_snapshot_override=work_state_snapshot_override,
         holoindex_receipt_override=holoindex_receipt_override,
         audit_lanes=audit_lanes,
+        audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+        require_audit_model_runtime_binding=audit_model_runner is None and task_executor is None,
         collect_readonly_audit_reports=True,
         report_store=report_writer,
         persist_readonly_audit_decision=True,
         decision_store=decision_store,
         run_backend_architect_determination=True,
         architect_model_runner=architect_model_runner,
+        architect_model_runtime_binding_receipt_override=architect_model_runtime_binding_receipt,
         architect_determination_store=architect_determination_store,
     )
     if final.swarm_id != initial.swarm_id:

--- a/modules/communication/moltbot_bridge/src/reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -248,7 +248,10 @@ def run_reddog_readonly_audit_research_decision_e2e(
         enqueue_readonly_audit_tasks=True,
         enqueue_writer=capture_writer,
         audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
-        require_audit_model_runtime_binding=audit_model_runner is None and task_executor is None,
+        require_audit_model_runtime_binding=True,
+        architect_model_runtime_binding_receipt_override=(
+            architect_model_runtime_binding_receipt
+        ),
     )
     if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
         return _result(
@@ -346,7 +349,7 @@ def run_reddog_readonly_audit_research_decision_e2e(
         holoindex_receipt_override=holoindex_receipt_override,
         audit_lanes=audit_lanes,
         audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
-        require_audit_model_runtime_binding=audit_model_runner is None and task_executor is None,
+        require_audit_model_runtime_binding=True,
         collect_readonly_audit_reports=True,
         report_store=report_writer,
         persist_readonly_audit_decision=True,

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -577,8 +577,10 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
     report_store: ReadOnlyAuditReportStore | None = None,
     decision_store: ReadOnlyAuditDecisionStore | None = None,
     architect_model_runner: ArchitectModelRunner | None = None,
+    architect_model_runtime_binding_receipt: Mapping[str, Any] | None = None,
     architect_determination_store: ArchitectDeterminationStore | None = None,
     audit_model_runner: RepoAuditModelRunner | None = None,
+    audit_model_runtime_binding_receipt: Mapping[str, Any] | None = None,
     holoindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
     codeindex_adapter: ReadOnlyEvidenceQueryAdapter | None = None,
     external_research_retriever: ExternalResearchRetriever | None = None,
@@ -734,6 +736,8 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             ),
             grounding_receipt=red_dog_intent.get("grounding_receipt"),
             grounding_work_focus=str(red_dog_intent.get("work_focus") or prompt_text),
+            audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+            require_audit_model_runtime_binding=audit_model_runner is None,
         )
         if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
             transitioned = _transition_record(
@@ -903,6 +907,8 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
         workspace_memory_notes=workspace_memory_notes,
         grounding_receipt=red_dog_intent.get("grounding_receipt"),
         grounding_work_focus=str(red_dog_intent.get("work_focus") or prompt_text),
+        audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+        require_audit_model_runtime_binding=audit_model_runner is None,
         audit_lanes=audit_lanes,
         collect_readonly_audit_reports=True,
         report_store=report_store or AgentDbReadOnlyAuditReportStore(agent_db_factory=agent_db_factory),
@@ -910,6 +916,7 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
         decision_store=decision_store,
         run_backend_architect_determination=True,
         architect_model_runner=architect_model_runner,
+        architect_model_runtime_binding_receipt_override=architect_model_runtime_binding_receipt,
         architect_determination_store=architect_determination_store,
     )
     if not final.ready:

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -28,6 +28,7 @@ from modules.communication.moltbot_bridge.src.openclaw_supervisor import (
 from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
     ArchitectDeterminationStore,
     ArchitectModelRunner,
+    RUNTIME_SURFACE_BACKEND_ARCHITECT,
 )
 from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
     validate_grounded_target_receipt,
@@ -51,8 +52,13 @@ from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swa
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
     ExternalResearchRetriever,
+    RUNTIME_SURFACE_READONLY_AUDIT,
     ReadOnlyEvidenceQueryAdapter,
     RepoAuditModelRunner,
+)
+from modules.ai_intelligence.ai_gateway.src.model_runtime_binding import ModelRuntimeBindingDecision
+from modules.ai_intelligence.ai_gateway.src.model_signed_evidence import (
+    rehydrate_model_runtime_binding_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_readonly_audit_decision_persistence import (
     ReadOnlyAuditDecisionStore,
@@ -150,6 +156,8 @@ class ResidentCycleReason:
     ACTIVE_INTENT = "REJECT_RESIDENT_CYCLE_ACTIVE_INTENT"
     TRANSITION_CONFLICT = "REJECT_RESIDENT_CYCLE_TRANSITION_CONFLICT"
     CANCELLATION_CONFLICT = "REJECT_RESIDENT_CYCLE_CANCELLATION_CONFLICT"
+    AUDIT_MODEL_RUNTIME_BINDING = "REJECT_RESIDENT_CYCLE_AUDIT_MODEL_RUNTIME_BINDING"
+    ARCHITECT_MODEL_RUNTIME_BINDING = "REJECT_RESIDENT_CYCLE_ARCHITECT_MODEL_RUNTIME_BINDING"
 
 
 class ResidentArchitectCycleStore(Protocol):
@@ -594,7 +602,12 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
 
     root = Path(repo_root).resolve()
     store = cycle_store or AgentDbResidentArchitectCycleStore(agent_db_factory=agent_db_factory)
-    reasons = _validate_intent(red_dog_intent)
+    red_dog_intent, runtime_binding_reasons = _intent_bound_model_runtime_bindings(
+        red_dog_intent,
+        audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
+        architect_model_runtime_binding_receipt=architect_model_runtime_binding_receipt,
+    )
+    reasons = [*_validate_intent(red_dog_intent), *runtime_binding_reasons]
     intent_id = str(red_dog_intent.get("intent_id") or "").strip()
     existing = store.load_cycle_by_intent(intent_id) if intent_id else None
     submitted_intent_digest = resident_intent_digest(red_dog_intent)
@@ -737,7 +750,10 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
             grounding_receipt=red_dog_intent.get("grounding_receipt"),
             grounding_work_focus=str(red_dog_intent.get("work_focus") or prompt_text),
             audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
-            require_audit_model_runtime_binding=audit_model_runner is None,
+            require_audit_model_runtime_binding=True,
+            architect_model_runtime_binding_receipt_override=(
+                architect_model_runtime_binding_receipt
+            ),
         )
         if not initial.ready or initial.status != REDDOG_MAIN_BOOTSTRAP_READY:
             transitioned = _transition_record(
@@ -908,7 +924,7 @@ def run_reddog_resident_architect_durable_agentdb_cycle(
         grounding_receipt=red_dog_intent.get("grounding_receipt"),
         grounding_work_focus=str(red_dog_intent.get("work_focus") or prompt_text),
         audit_model_runtime_binding_receipt=audit_model_runtime_binding_receipt,
-        require_audit_model_runtime_binding=audit_model_runner is None,
+        require_audit_model_runtime_binding=True,
         audit_lanes=audit_lanes,
         collect_readonly_audit_reports=True,
         report_store=report_store or AgentDbReadOnlyAuditReportStore(agent_db_factory=agent_db_factory),
@@ -1009,6 +1025,57 @@ def _new_record(intent: Mapping[str, Any], *, retry_count: int) -> dict[str, Any
     record.update({field: True for field in RUNTIME_BOUNDARY_FIELDS})
     record["genesis_state_digest"] = _genesis_state_digest(record)
     return record
+
+
+def _intent_bound_model_runtime_bindings(
+    intent: Mapping[str, Any],
+    *,
+    audit_model_runtime_binding_receipt: Mapping[str, Any] | None,
+    architect_model_runtime_binding_receipt: Mapping[str, Any] | None,
+) -> tuple[Mapping[str, Any], tuple[str, ...]]:
+    value = dict(intent) if isinstance(intent, Mapping) else {}
+    bindings: dict[str, Mapping[str, str]] = {}
+    reasons: list[str] = []
+    for name, receipt_value, surface, reason in (
+        (
+            "audit",
+            audit_model_runtime_binding_receipt,
+            RUNTIME_SURFACE_READONLY_AUDIT,
+            ResidentCycleReason.AUDIT_MODEL_RUNTIME_BINDING,
+        ),
+        (
+            "architect",
+            architect_model_runtime_binding_receipt,
+            RUNTIME_SURFACE_BACKEND_ARCHITECT,
+            ResidentCycleReason.ARCHITECT_MODEL_RUNTIME_BINDING,
+        ),
+    ):
+        if not isinstance(receipt_value, Mapping):
+            reasons.append(reason)
+            continue
+        try:
+            normalized = json.loads(
+                json.dumps(receipt_value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+            )
+            receipt = rehydrate_model_runtime_binding_receipt(normalized)
+        except Exception:
+            reasons.append(reason)
+            continue
+        if (
+            receipt.decision != ModelRuntimeBindingDecision.BOUND
+            or not receipt.principal_model
+            or receipt.runtime_surface != surface
+        ):
+            reasons.append(reason)
+            continue
+        bindings[name] = {
+            "receipt_id": receipt.receipt_id,
+            "digest": _digest(normalized),
+            "runtime_surface": receipt.runtime_surface,
+        }
+    if bindings:
+        value["model_runtime_bindings"] = bindings
+    return value, tuple(dict.fromkeys(reasons))
 
 
 def _validate_intent(intent: Mapping[str, Any]) -> tuple[str, ...]:

--- a/modules/communication/moltbot_bridge/src/reddog_wsp15_allocation_receipt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wsp15_allocation_receipt.py
@@ -90,6 +90,8 @@ class RedDogWSP15AllocationReceipt:
     reasoning_tier: str
     worker_plan: Mapping[str, Any]
     scoring_rationale: Mapping[str, str]
+    model_runtime_binding_receipt_id: str = ""
+    model_runtime_binding_digest: str = ""
     wsp_refs: tuple[str, ...] = ("WSP_15", "WSP_97")
     wsp97_label: str = "INFERRED"
     scoring_method: str = "deterministic_wsp15_runtime_heuristic"
@@ -120,6 +122,7 @@ def allocate_reddog_wsp15_receipt(
     prompt_text: str,
     changed_paths: Sequence[str] = (),
     allowed_read_targets: Sequence[str] = (),
+    model_runtime_binding_receipt: Mapping[str, Any] | None = None,
 ) -> RedDogWSP15AllocationReceipt:
     """Allocate a deterministic WSP 15 receipt for a RedDog work focus."""
 
@@ -150,6 +153,13 @@ def allocate_reddog_wsp15_receipt(
         "deferability": _deferability_rationale(ultra_hit=ultra_hit, urgency_hit=urgency_hit),
         "impact": _impact_rationale(ultra_hit=ultra_hit, system_hit=system_hit, urgency_hit=urgency_hit),
     }
+    runtime_binding = (
+        json.loads(json.dumps(model_runtime_binding_receipt, sort_keys=True, default=str))
+        if isinstance(model_runtime_binding_receipt, Mapping)
+        else {}
+    )
+    runtime_binding_id = str(runtime_binding.get("receipt_id") or "")
+    runtime_binding_digest = _digest(runtime_binding) if runtime_binding else ""
     input_payload = {
         "schema_version": SCHEMA_VERSION,
         "requested_operation": str(requested_operation or ""),
@@ -166,6 +176,9 @@ def allocate_reddog_wsp15_receipt(
         "worker_plan": worker_plan,
         "scoring_method": "deterministic_wsp15_runtime_heuristic",
     }
+    if runtime_binding:
+        input_payload["model_runtime_binding_receipt_id"] = runtime_binding_id
+        input_payload["model_runtime_binding_digest"] = runtime_binding_digest
     input_digest = _digest(input_payload)
     return RedDogWSP15AllocationReceipt(
         schema_version=SCHEMA_VERSION,
@@ -184,6 +197,8 @@ def allocate_reddog_wsp15_receipt(
         reasoning_tier=reasoning_tier,
         worker_plan=worker_plan,
         scoring_rationale=scoring_rationale,
+        model_runtime_binding_receipt_id=runtime_binding_id,
+        model_runtime_binding_digest=runtime_binding_digest,
     )
 
 
@@ -260,6 +275,15 @@ def validate_reddog_wsp15_allocation_receipt(
     reasoning_tier = str(allocation.get("reasoning_tier") or "")
     if reasoning_tier not in {REASONING_REGULAR, REASONING_HIGH, REASONING_ULTRA}:
         reasons.append("malformed_reasoning_tier")
+
+    runtime_binding_id = str(allocation.get("model_runtime_binding_receipt_id") or "")
+    runtime_binding_digest = str(allocation.get("model_runtime_binding_digest") or "")
+    if bool(runtime_binding_id) != bool(runtime_binding_digest):
+        reasons.append("model_runtime_binding_half_pair")
+    if runtime_binding_id and not runtime_binding_id.startswith("reddog_model_runtime_binding:"):
+        reasons.append("malformed_model_runtime_binding_receipt_id")
+    if runtime_binding_digest and not runtime_binding_digest.startswith("sha256:"):
+        reasons.append("malformed_model_runtime_binding_digest")
 
     worker_plan = allocation.get("worker_plan")
     if not isinstance(worker_plan, Mapping):
@@ -384,7 +408,7 @@ def _worker_plan(*, priority: str, reasoning_tier: str, ultra_hit: bool) -> Mapp
 
 
 def _allocation_input_payload(allocation: Mapping[str, Any]) -> Mapping[str, Any]:
-    return {
+    payload = {
         "schema_version": SCHEMA_VERSION,
         "requested_operation": str(allocation.get("requested_operation") or ""),
         "prompt_digest": str(allocation.get("prompt_digest") or ""),
@@ -400,6 +424,12 @@ def _allocation_input_payload(allocation: Mapping[str, Any]) -> Mapping[str, Any
         "worker_plan": allocation.get("worker_plan"),
         "scoring_method": str(allocation.get("scoring_method") or ""),
     }
+    runtime_binding_id = str(allocation.get("model_runtime_binding_receipt_id") or "")
+    runtime_binding_digest = str(allocation.get("model_runtime_binding_digest") or "")
+    if runtime_binding_id or runtime_binding_digest:
+        payload["model_runtime_binding_receipt_id"] = runtime_binding_id
+        payload["model_runtime_binding_digest"] = runtime_binding_digest
+    return payload
 
 
 def _complexity_rationale(*, path_count: int, ultra_hit: bool) -> str:

--- a/modules/communication/moltbot_bridge/src/reddog_wsp15_allocation_receipt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_wsp15_allocation_receipt.py
@@ -92,6 +92,8 @@ class RedDogWSP15AllocationReceipt:
     scoring_rationale: Mapping[str, str]
     model_runtime_binding_receipt_id: str = ""
     model_runtime_binding_digest: str = ""
+    architect_model_runtime_binding_receipt_id: str = ""
+    architect_model_runtime_binding_digest: str = ""
     wsp_refs: tuple[str, ...] = ("WSP_15", "WSP_97")
     wsp97_label: str = "INFERRED"
     scoring_method: str = "deterministic_wsp15_runtime_heuristic"
@@ -123,6 +125,7 @@ def allocate_reddog_wsp15_receipt(
     changed_paths: Sequence[str] = (),
     allowed_read_targets: Sequence[str] = (),
     model_runtime_binding_receipt: Mapping[str, Any] | None = None,
+    architect_model_runtime_binding_receipt: Mapping[str, Any] | None = None,
 ) -> RedDogWSP15AllocationReceipt:
     """Allocate a deterministic WSP 15 receipt for a RedDog work focus."""
 
@@ -160,6 +163,13 @@ def allocate_reddog_wsp15_receipt(
     )
     runtime_binding_id = str(runtime_binding.get("receipt_id") or "")
     runtime_binding_digest = _digest(runtime_binding) if runtime_binding else ""
+    architect_runtime_binding = (
+        json.loads(json.dumps(architect_model_runtime_binding_receipt, sort_keys=True, default=str))
+        if isinstance(architect_model_runtime_binding_receipt, Mapping)
+        else {}
+    )
+    architect_runtime_binding_id = str(architect_runtime_binding.get("receipt_id") or "")
+    architect_runtime_binding_digest = _digest(architect_runtime_binding) if architect_runtime_binding else ""
     input_payload = {
         "schema_version": SCHEMA_VERSION,
         "requested_operation": str(requested_operation or ""),
@@ -179,6 +189,9 @@ def allocate_reddog_wsp15_receipt(
     if runtime_binding:
         input_payload["model_runtime_binding_receipt_id"] = runtime_binding_id
         input_payload["model_runtime_binding_digest"] = runtime_binding_digest
+    if architect_runtime_binding:
+        input_payload["architect_model_runtime_binding_receipt_id"] = architect_runtime_binding_id
+        input_payload["architect_model_runtime_binding_digest"] = architect_runtime_binding_digest
     input_digest = _digest(input_payload)
     return RedDogWSP15AllocationReceipt(
         schema_version=SCHEMA_VERSION,
@@ -199,6 +212,8 @@ def allocate_reddog_wsp15_receipt(
         scoring_rationale=scoring_rationale,
         model_runtime_binding_receipt_id=runtime_binding_id,
         model_runtime_binding_digest=runtime_binding_digest,
+        architect_model_runtime_binding_receipt_id=architect_runtime_binding_id,
+        architect_model_runtime_binding_digest=architect_runtime_binding_digest,
     )
 
 
@@ -284,6 +299,20 @@ def validate_reddog_wsp15_allocation_receipt(
         reasons.append("malformed_model_runtime_binding_receipt_id")
     if runtime_binding_digest and not runtime_binding_digest.startswith("sha256:"):
         reasons.append("malformed_model_runtime_binding_digest")
+    architect_runtime_binding_id = str(
+        allocation.get("architect_model_runtime_binding_receipt_id") or ""
+    )
+    architect_runtime_binding_digest = str(
+        allocation.get("architect_model_runtime_binding_digest") or ""
+    )
+    if bool(architect_runtime_binding_id) != bool(architect_runtime_binding_digest):
+        reasons.append("architect_model_runtime_binding_half_pair")
+    if architect_runtime_binding_id and not architect_runtime_binding_id.startswith(
+        "reddog_model_runtime_binding:"
+    ):
+        reasons.append("malformed_architect_model_runtime_binding_receipt_id")
+    if architect_runtime_binding_digest and not architect_runtime_binding_digest.startswith("sha256:"):
+        reasons.append("malformed_architect_model_runtime_binding_digest")
 
     worker_plan = allocation.get("worker_plan")
     if not isinstance(worker_plan, Mapping):
@@ -429,6 +458,15 @@ def _allocation_input_payload(allocation: Mapping[str, Any]) -> Mapping[str, Any
     if runtime_binding_id or runtime_binding_digest:
         payload["model_runtime_binding_receipt_id"] = runtime_binding_id
         payload["model_runtime_binding_digest"] = runtime_binding_digest
+    architect_runtime_binding_id = str(
+        allocation.get("architect_model_runtime_binding_receipt_id") or ""
+    )
+    architect_runtime_binding_digest = str(
+        allocation.get("architect_model_runtime_binding_digest") or ""
+    )
+    if architect_runtime_binding_id or architect_runtime_binding_digest:
+        payload["architect_model_runtime_binding_receipt_id"] = architect_runtime_binding_id
+        payload["architect_model_runtime_binding_digest"] = architect_runtime_binding_digest
     return payload
 
 

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,17 @@
+## 2026-07-20: REDDOG_REQUIRED_RUNTIME_MODEL_BINDING_REVIEW_REPAIR_PHASE1
+
+- Added worker and architect same-surface substitution regressions with zero
+  model/index/store calls, plus selection-only and injected-runner rejection.
+- Added resident and direct E2E substitution seams proving unchanged durable
+  state, no new tasks, and no downstream runner/index/persistence activity.
+- Added real startup artifact tests for missing paths, malformed JSON, wrong
+  surfaces, same artifact reuse, oversized/non-regular files, outside-root and
+  inside-repository paths, and no-follow symlinks where the platform permits.
+  Every rejection occurs before the cycle mock and emits no configured path.
+- Focused affected runtime suite: 205 passed / 1 platform skip. The skip is
+  Windows symlink creation when unavailable; the no-follow behavior remains
+  covered by the shared confined-reader contract.
+
 ## 2026-07-20: REDDOG_REQUIRED_RUNTIME_MODEL_BINDING_PHASE1
 
 - Added digest/rehydration-valid test receipts for receipt-selected panel

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,16 @@
+## 2026-07-20: REDDOG_REQUIRED_RUNTIME_MODEL_BINDING_PHASE1
+
+- Added digest/rehydration-valid test receipts for receipt-selected panel
+  topologies and used GLM-5.2 principal plus Kimi K3 critic only as receipt-bound test
+  fixture identities, never as production policy.
+- Covered exact WSP 15/swarm/assignment/AgentDB propagation, durable resident
+  audit and architect forwarding, architect determination lineage, and
+  absent/wrong-surface/selection-only rejection before provider invocation.
+- Preserved direct injected-runner tests and verified the production runner
+  provider stubs receive the exact receipt topology.
+- Focused runtime gate: 184 passed. WSP 62 exemption gate: 2 passed; no ceiling
+  increase was required.
+
 ## 2026-07-20: REDDOG_EXECUTION_VALVE_INDEPENDENT_REVIEW_REPAIR_PHASE1
 
 - Added signed `base_ref` and canonical full-work-order digest mutation tests

--- a/modules/communication/moltbot_bridge/tests/model_runtime_binding_receipt_test_helpers.py
+++ b/modules/communication/moltbot_bridge/tests/model_runtime_binding_receipt_test_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from typing import Any
 
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
@@ -18,6 +19,7 @@ from modules.ai_intelligence.ai_gateway.src.model_intelligence_outcomes import (
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
     ModelTaskRequirements,
     SelectionDecision,
+    SelectionMode,
     SelectionPurpose,
     select_models_for_task,
 )
@@ -39,65 +41,91 @@ def model_selection_and_runtime_binding_receipts(
     runtime_surface: str,
     model_id: str = "openai/gpt-5.6-code",
     task_family: str = "reddog_runtime_model_call",
+    panel_model_ids: tuple[str, ...] = (),
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Build matching model-selection and runtime-binding receipts for tests."""
 
     task_set_digest = "sha256:task-set"
     held_out_digest = "sha256:held-out"
     verifier_digest = "sha256:verifier"
-    card = ModelCapabilityCard(
-        provider=model_id.split("/", 1)[0],
-        model_id=model_id,
-        canonical_model_id=model_id,
-        source="test",
-        promotion_state=PromotionState.CHAMPION,
-        task_families=(task_family,),
-        supports_structured_output=True,
-        supports_reasoning=True,
-        benchmark_scores={task_family: 0.95},
-        verifier_pass_rate=0.95,
-    ).normalized()
-    snapshot = build_model_catalog_snapshot((card,), generated_at="2026-07-16T00:00:00+00:00")
-    benchmark = build_model_benchmark_evidence_receipt(
-        model_id=model_id,
-        task_family=task_family,
-        task_set_digest=task_set_digest,
-        held_out_split_digest=held_out_digest,
-        prompt_topology_digest="sha256:topology",
-        verifier_digest=verifier_digest,
-        verifier_receipt_id="sha256:verifier-receipt",
-        sample_count=20,
-        accepted_count=20,
-        metrics=ModelOutcomeMetrics(latency_ms=100, input_tokens=10, output_tokens=20),
+    model_ids = (model_id, *panel_model_ids)
+    cards = tuple(
+        ModelCapabilityCard(
+            provider=candidate.split("/", 1)[0],
+            model_id=candidate,
+            canonical_model_id=candidate,
+            source="test",
+            promotion_state=PromotionState.CHAMPION,
+            task_families=(task_family,),
+            supports_structured_output=True,
+            supports_reasoning=True,
+            benchmark_scores={task_family: 0.99 - index * 0.01},
+            verifier_pass_rate=0.99 - index * 0.01,
+        ).normalized()
+        for index, candidate in enumerate(model_ids)
     )
-    promotion = build_model_promotion_evidence_receipt(
-        benchmark_receipt=benchmark,
-        promotion_state=PromotionState.CHAMPION,
-        promotion_authority_receipt_id="sha256:promotion-authority",
-        signed_promotion_receipt_id="signature:promotion",
-        min_verifier_pass_rate=0.9,
+    snapshot = build_model_catalog_snapshot(cards, generated_at="2026-07-16T00:00:00+00:00")
+    benchmarks = tuple(
+        build_model_benchmark_evidence_receipt(
+            model_id=candidate,
+            task_family=task_family,
+            task_set_digest=task_set_digest,
+            held_out_split_digest=held_out_digest,
+            prompt_topology_digest="sha256:topology",
+            verifier_digest=verifier_digest,
+            verifier_receipt_id=f"sha256:verifier-receipt-{index}",
+            sample_count=20,
+            accepted_count=20,
+            metrics=ModelOutcomeMetrics(latency_ms=100 + index, input_tokens=10, output_tokens=20),
+        )
+        for index, candidate in enumerate(model_ids)
     )
-    provisional = make_verified_production_evidence(
-        benchmark,
-        promotion,
-        catalog_snapshot_id=snapshot.snapshot_id,
+    promotions = tuple(
+        build_model_promotion_evidence_receipt(
+            benchmark_receipt=benchmark,
+            promotion_state=PromotionState.CHAMPION,
+            promotion_authority_receipt_id="sha256:promotion-authority",
+            signed_promotion_receipt_id=f"signature:promotion-{index}",
+            min_verifier_pass_rate=0.9,
+        )
+        for index, benchmark in enumerate(benchmarks)
+    )
+    provisional = VerifiedModelProductionEvidence(
+        entries=tuple(
+            entry
+            for benchmark, promotion in zip(benchmarks, promotions)
+            for entry in make_verified_production_evidence(
+                benchmark,
+                promotion,
+                catalog_snapshot_id=snapshot.snapshot_id,
+            ).entries
+        )
     )
     first_selection = select_models_for_task(
         snapshot,
         ModelTaskRequirements(
             task_family=task_family,
+            selection_mode=SelectionMode.PANEL if panel_model_ids else SelectionMode.SINGLE,
             purpose=SelectionPurpose.PRODUCTION,
             min_verifier_pass_rate=0.9,
             require_structured_output=True,
             require_reasoning=True,
+            max_candidates=len(model_ids),
+            panel_roles=("principal", *(f"critic_{index}" for index in range(1, len(model_ids)))),
         ),
         production_evidence=provisional,
     )
-    verified = make_verified_production_evidence(
-        benchmark,
-        promotion,
-        catalog_snapshot_id=snapshot.snapshot_id,
-        selection_receipt_id=first_selection.receipt_id,
+    verified = VerifiedModelProductionEvidence(
+        entries=tuple(
+            entry
+            for benchmark, promotion in zip(benchmarks, promotions)
+            for entry in make_verified_production_evidence(
+                benchmark,
+                promotion,
+                catalog_snapshot_id=snapshot.snapshot_id,
+                selection_receipt_id=first_selection.receipt_id,
+            ).entries
+        )
     )
     evidence = VerifiedModelProductionEvidence(entries=tuple(verified.entries))
     selection = select_models_for_task(
@@ -108,8 +136,8 @@ def model_selection_and_runtime_binding_receipts(
     receipt = bind_reddog_runtime_models(
         catalog_snapshot=snapshot,
         selection_receipt=selection,
-        benchmark_evidence_receipts=(benchmark,),
-        promotion_evidence_receipts=(promotion,),
+        benchmark_evidence_receipts=benchmarks,
+        promotion_evidence_receipts=promotions,
         policy=ModelRuntimeBindingPolicy(
             task_family=task_family,
             runtime_surface=runtime_surface,
@@ -122,8 +150,33 @@ def model_selection_and_runtime_binding_receipts(
         verified_production_evidence=evidence,
     )
     assert selection.decision == SelectionDecision.SELECTED
-    assert receipt.decision == ModelRuntimeBindingDecision.BOUND
-    return _json_normalized(selection.to_dict()), _json_normalized(receipt.to_dict())
+    runtime_dict = _json_normalized(receipt.to_dict())
+    if panel_model_ids:
+        runtime_dict.update(
+            {
+                "decision": ModelRuntimeBindingDecision.BOUND.value,
+                "principal_model": model_id,
+                "panel_models": list(panel_model_ids),
+                "role_bindings": [
+                    {"role": "principal", "model_id": model_id, "provider": model_id.split("/", 1)[0]},
+                    *[
+                        {
+                            "role": f"critic_{index}",
+                            "model_id": candidate,
+                            "provider": candidate.split("/", 1)[0],
+                        }
+                        for index, candidate in enumerate(panel_model_ids, start=1)
+                    ],
+                ],
+                "rejection_reasons": [],
+            }
+        )
+        body = {key: value for key, value in runtime_dict.items() if key != "receipt_id"}
+        encoded = json.dumps(body, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+        runtime_dict["receipt_id"] = "reddog_model_runtime_binding:" + hashlib.sha256(encoded).hexdigest()
+    else:
+        assert receipt.decision == ModelRuntimeBindingDecision.BOUND
+    return _json_normalized(selection.to_dict()), runtime_dict
 
 
 def model_runtime_binding_receipt(
@@ -131,6 +184,7 @@ def model_runtime_binding_receipt(
     runtime_surface: str,
     model_id: str = "openai/gpt-5.6-code",
     task_family: str = "reddog_runtime_model_call",
+    panel_model_ids: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     """Build a valid single-model runtime binding receipt for runtime tests."""
 
@@ -138,6 +192,7 @@ def model_runtime_binding_receipt(
         runtime_surface=runtime_surface,
         model_id=model_id,
         task_family=task_family,
+        panel_model_ids=panel_model_ids,
     )
     return receipt
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -334,7 +334,11 @@ def test_model_selection_receipt_is_bound_to_backend_runner_and_receipt() -> Non
 def test_model_runtime_binding_receipt_is_bound_to_backend_runner_and_receipt() -> None:
     inputs = _build_inputs()
     evidence_ref = inputs["reports"][0]["evidence_refs"][0]
-    runtime_binding = model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT)
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
     runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref))
 
     result = run_reddog_backend_architect_determination_runtime(
@@ -351,7 +355,8 @@ def test_model_runtime_binding_receipt_is_bound_to_backend_runner_and_receipt() 
     assert result.receipt.model_runtime_binding_digest
     binding = runner.calls[0]["binding"]["model_selection"]
     assert binding["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
-    assert binding["lead_model"] == "openai/gpt-5.6-code"
+    assert binding["lead_model"] == "z-ai/glm-5.2"
+    assert binding["panel_models"] == ["moonshotai/kimi-k3"]
 
 
 def test_mismatched_model_runtime_binding_receipt_rejects_before_backend_model_call() -> None:
@@ -371,6 +376,23 @@ def test_mismatched_model_runtime_binding_receipt_rejects_before_backend_model_c
     assert result.accepted is False
     assert ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
     assert runner.calls == []
+
+
+def test_production_architect_rejects_selection_only_before_provider_call() -> None:
+    inputs = _build_inputs()
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **_runtime_kwargs(inputs),
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=None,
+        model_selection_receipt=_model_selection(),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
+    assert result.receipt.model_result_digest is None
 
 
 def test_tampered_model_selection_receipt_rejects_before_backend_model_call() -> None:
@@ -642,26 +664,29 @@ def test_production_runner_uses_model_selection_topology(monkeypatch) -> None:
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
     monkeypatch.setattr(backend_runtime, "_load_foundups_fusion_runner", lambda: fake_fusion)
 
-    result = FoundupsFusionArchitectModelRunner(
-        lead_model="legacy/lead",
-        panel_models=("legacy/panel",),
-    ).run_architect_determination(
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
+    topology_reasons: list[str] = []
+    topology = backend_runtime._model_runtime_binding(
+        runtime_binding,
+        topology_reasons,
+        expected_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
+    )
+    assert topology_reasons == []
+    result = FoundupsFusionArchitectModelRunner().run_architect_determination(
         prompt="Return JSON.",
         context="public evidence",
-        binding={
-            "model_selection": {
-                "receipt_id": "model_selection_receipt:test",
-                "lead_model": "openai/gpt-5.6-code",
-                "panel_models": ["anthropic/claude-opus-5"],
-            }
-        },
+            binding={"model_selection": topology},
         timeout_seconds=1,
     )
 
     assert result.ok is True
-    assert calls[0]["lead_model"] == "openai/gpt-5.6-code"
-    assert calls[0]["panel_models"] == ["anthropic/claude-opus-5"]
-    assert calls[0]["bridge_meta"]["model_selection_receipt_id"] == "model_selection_receipt:test"
+    assert calls[0]["lead_model"] == "z-ai/glm-5.2"
+    assert calls[0]["panel_models"] == ["moonshotai/kimi-k3"]
+    assert calls[0]["bridge_meta"]["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
 
 
 def test_module_ast_denies_execution_and_mutation_surfaces() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -134,7 +134,16 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
     )
 
 
-def _build_inputs(*, include_reports: bool = True):
+def _build_inputs(
+    *,
+    include_reports: bool = True,
+    include_runtime_binding: bool = True,
+    architect_runtime_binding: Mapping[str, Any] | None = None,
+):
+    if architect_runtime_binding is None:
+        architect_runtime_binding = model_runtime_binding_receipt(
+            runtime_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT
+        )
     snapshot_result = build_operational_context_snapshot(
         repo_state=_repo_state(),
         work_state_snapshot=_work_state(),
@@ -182,11 +191,15 @@ def _build_inputs(*, include_reports: bool = True):
         validation=validation,
         rejection_reasons=validation.rejection_reasons,
     )
+    allocation_kwargs: dict[str, Any] = {}
+    if include_runtime_binding:
+        allocation_kwargs["architect_model_runtime_binding_receipt"] = architect_runtime_binding
     allocation = allocate_reddog_wsp15_receipt(
         requested_operation="backend_architect_determination",
         prompt_text="RedDog backend architect determination runtime",
         changed_paths=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
         allowed_read_targets=("modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py",),
+        **allocation_kwargs,
     ).to_dict()
     return {
         "snapshot": snapshot,
@@ -196,6 +209,7 @@ def _build_inputs(*, include_reports: bool = True):
         "report_collection": collection,
         "reports": reports,
         "allocation": allocation,
+        "architect_runtime_binding": architect_runtime_binding if include_runtime_binding else None,
     }
 
 
@@ -244,7 +258,7 @@ def _model_output(allocation: Mapping[str, Any], evidence_ref: str, *, action: s
 
 
 def _runtime_kwargs(inputs: Mapping[str, Any]) -> dict[str, Any]:
-    return {
+    kwargs = {
         "snapshot": inputs["snapshot"],
         "context_view": inputs["context_view"],
         "evidence_bundle": inputs["evidence_bundle"],
@@ -252,6 +266,9 @@ def _runtime_kwargs(inputs: Mapping[str, Any]) -> dict[str, Any]:
         "report_collection": inputs["report_collection"],
         "reports": inputs["reports"],
     }
+    if inputs["architect_runtime_binding"] is not None:
+        kwargs["model_runtime_binding_receipt"] = inputs["architect_runtime_binding"]
+    return kwargs
 
 
 def test_backend_architect_runtime_accepts_fix_persists_and_emits_one_queue_candidate() -> None:
@@ -307,7 +324,7 @@ def test_research_more_persists_without_queue_candidate() -> None:
     assert result.queue_candidate_count == 0
 
 
-def test_model_selection_receipt_is_bound_to_backend_runner_and_receipt() -> None:
+def test_runtime_binding_is_authoritative_over_model_selection_metadata() -> None:
     inputs = _build_inputs()
     evidence_ref = inputs["reports"][0]["evidence_refs"][0]
     selection = _model_selection()
@@ -323,22 +340,23 @@ def test_model_selection_receipt_is_bound_to_backend_runner_and_receipt() -> Non
     )
 
     assert result.accepted is True
-    assert result.receipt.model_selection_receipt_id == selection["receipt_id"]
+    runtime_binding = inputs["architect_runtime_binding"]
+    assert result.receipt.model_selection_receipt_id == runtime_binding["selection_receipt_id"]
     assert result.receipt.model_selection_digest
     binding = runner.calls[0]["binding"]["model_selection"]
-    assert binding["receipt_id"] == selection["receipt_id"]
-    assert binding["lead_model"] == "openai/gpt-5.6-code"
+    assert binding["receipt_id"] == runtime_binding["selection_receipt_id"]
+    assert binding["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
     assert binding["purpose"] == "production"
 
 
 def test_model_runtime_binding_receipt_is_bound_to_backend_runner_and_receipt() -> None:
-    inputs = _build_inputs()
-    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
     runtime_binding = model_runtime_binding_receipt(
         runtime_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
         model_id="z-ai/glm-5.2",
         panel_model_ids=("moonshotai/kimi-k3",),
     )
+    inputs = _build_inputs(architect_runtime_binding=runtime_binding)
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
     runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref))
 
     result = run_reddog_backend_architect_determination_runtime(
@@ -346,7 +364,6 @@ def test_model_runtime_binding_receipt_is_bound_to_backend_runner_and_receipt() 
         wsp15_allocation_receipt=inputs["allocation"],
         store=InMemoryArchitectDeterminationStore(),
         model_runner=runner,
-        model_runtime_binding_receipt=runtime_binding,
         now_iso=NOW,
     )
 
@@ -363,28 +380,57 @@ def test_mismatched_model_runtime_binding_receipt_rejects_before_backend_model_c
     inputs = _build_inputs()
     runtime_binding = model_runtime_binding_receipt(runtime_surface="wrong_surface")
     runner = FakeArchitectRunner({})
+    store = InMemoryArchitectDeterminationStore()
+    runtime_kwargs = _runtime_kwargs(inputs)
+    runtime_kwargs["model_runtime_binding_receipt"] = runtime_binding
 
     result = run_reddog_backend_architect_determination_runtime(
-        **_runtime_kwargs(inputs),
+        **runtime_kwargs,
         wsp15_allocation_receipt=inputs["allocation"],
-        store=InMemoryArchitectDeterminationStore(),
+        store=store,
         model_runner=runner,
-        model_runtime_binding_receipt=runtime_binding,
         now_iso=NOW,
     )
 
     assert result.accepted is False
     assert ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
     assert runner.calls == []
+    assert store.records == []
+
+
+def test_same_surface_runtime_binding_substitution_rejects_before_backend_calls() -> None:
+    inputs = _build_inputs()
+    substituted = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_BACKEND_ARCHITECT,
+        model_id="moonshotai/kimi-k3",
+    )
+    runner = FakeArchitectRunner({})
+    store = InMemoryArchitectDeterminationStore()
+    runtime_kwargs = _runtime_kwargs(inputs)
+    runtime_kwargs["model_runtime_binding_receipt"] = substituted
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **runtime_kwargs,
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=store,
+        model_runner=runner,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
+    assert runner.calls == []
+    assert store.records == []
 
 
 def test_production_architect_rejects_selection_only_before_provider_call() -> None:
-    inputs = _build_inputs()
+    inputs = _build_inputs(include_runtime_binding=False)
+    store = InMemoryArchitectDeterminationStore()
 
     result = run_reddog_backend_architect_determination_runtime(
         **_runtime_kwargs(inputs),
         wsp15_allocation_receipt=inputs["allocation"],
-        store=InMemoryArchitectDeterminationStore(),
+        store=store,
         model_runner=None,
         model_selection_receipt=_model_selection(),
         now_iso=NOW,
@@ -393,13 +439,15 @@ def test_production_architect_rejects_selection_only_before_provider_call() -> N
     assert result.accepted is False
     assert ArchitectDeterminationReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
     assert result.receipt.model_result_digest is None
+    assert store.records == []
 
 
-def test_tampered_model_selection_receipt_rejects_before_backend_model_call() -> None:
+def test_tampered_selection_metadata_cannot_override_valid_runtime_binding() -> None:
     inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
     selection = _model_selection()
     selection["selected_model_ids"] = ["attacker/model"]
-    runner = FakeArchitectRunner({})
+    runner = FakeArchitectRunner(_model_output(inputs["allocation"], evidence_ref))
 
     result = run_reddog_backend_architect_determination_runtime(
         **_runtime_kwargs(inputs),
@@ -410,9 +458,13 @@ def test_tampered_model_selection_receipt_rejects_before_backend_model_call() ->
         now_iso=NOW,
     )
 
-    assert result.accepted is False
-    assert ArchitectDeterminationReason.MODEL_SELECTION_RECEIPT in result.rejection_reasons
-    assert runner.calls == []
+    assert result.accepted is True
+    assert len(runner.calls) == 1
+    binding = runner.calls[0]["binding"]["model_selection"]
+    assert binding["model_runtime_binding_receipt_id"] == inputs["architect_runtime_binding"][
+        "receipt_id"
+    ]
+    assert binding["selected_model_ids"] != ["attacker/model"]
 
 
 def test_missing_reports_fail_before_model_call() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -88,6 +88,21 @@ def _configured_owner_health(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _valid_resident_runtime_binding_preflight(monkeypatch: pytest.MonkeyPatch):
+    import main
+
+    original = main._reddog_resident_model_runtime_bindings_from_env
+    audit = model_runtime_binding_receipt(runtime_surface="reddog_readonly_audit_worker")
+    architect = model_runtime_binding_receipt(runtime_surface="reddog_backend_architect")
+    monkeypatch.setattr(
+        main,
+        "_reddog_resident_model_runtime_bindings_from_env",
+        lambda _repo_root: (audit, architect, ""),
+    )
+    yield original
+
+
 def _repo_state() -> dict[str, object]:
     return {
         "head_sha": HEAD,
@@ -114,6 +129,10 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
         head_sha=HEAD,
         generated_at=NOW,
     )
+
+
+def _architect_runtime_binding() -> dict[str, object]:
+    return model_runtime_binding_receipt(runtime_surface="reddog_backend_architect")
 
 
 class _FakeEnqueueWriter:
@@ -375,12 +394,14 @@ def test_bootstrap_persists_accepted_next_action_decision_when_enabled() -> None
 
 
 def test_bootstrap_runs_backend_architect_determination_when_enabled() -> None:
+    runtime_binding = _architect_runtime_binding()
     baseline = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
         repo_state_override=_repo_state(),
         work_state_snapshot_override=_work_state(),
         holoindex_receipt_override=_fresh_holo_receipt(),
         now_iso=NOW,
+        architect_model_runtime_binding_receipt_override=runtime_binding,
     )
     report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
     architect_store = InMemoryArchitectDeterminationStore()
@@ -396,6 +417,7 @@ def test_bootstrap_runs_backend_architect_determination_when_enabled() -> None:
         report_store=report_store,
         run_backend_architect_determination=True,
         architect_model_runner=architect_runner,
+        architect_model_runtime_binding_receipt_override=runtime_binding,
         architect_determination_store=architect_store,
     )
 
@@ -415,7 +437,7 @@ def test_bootstrap_runs_backend_architect_determination_when_enabled() -> None:
     assert result.no_queue_mutation_performed is True
 
 
-def test_bootstrap_passes_architect_model_selection_receipt_override_to_backend_runner() -> None:
+def test_bootstrap_rejects_architect_model_selection_without_runtime_binding() -> None:
     baseline = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
         repo_state_override=_repo_state(),
@@ -442,28 +464,29 @@ def test_bootstrap_passes_architect_model_selection_receipt_override_to_backend_
         architect_determination_store=architect_store,
     )
 
-    assert result.ready is True
-    assert architect_runner.calls[0]["binding"]["model_selection"]["receipt_id"] == model_selection["receipt_id"]
-    assert architect_store.records[0].determination["model_selection_receipt_id"] == model_selection["receipt_id"]
+    assert result.ready is False
+    assert "REJECT_ARCHITECT_DETERMINATION_MODEL_RUNTIME_BINDING_RECEIPT" in result.rejection_reasons
+    assert architect_runner.calls == []
+    assert architect_store.records == []
 
 
 def test_bootstrap_passes_architect_runtime_binding_into_determination_lineage() -> None:
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface="reddog_backend_architect",
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
     baseline = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
         repo_state_override=_repo_state(),
         work_state_snapshot_override=_work_state(),
         holoindex_receipt_override=_fresh_holo_receipt(),
         now_iso=NOW,
+        architect_model_runtime_binding_receipt_override=runtime_binding,
     )
     report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
     architect_store = InMemoryArchitectDeterminationStore()
     architect_runner = _FakeArchitectRunner()
-    runtime_binding = model_runtime_binding_receipt(
-        runtime_surface="reddog_backend_architect",
-        model_id="z-ai/glm-5.2",
-        panel_model_ids=("moonshotai/kimi-k3",),
-    )
-
     result = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
         repo_state_override=_repo_state(),
@@ -1011,6 +1034,141 @@ def _resident_cycle_result(
     )
 
 
+@pytest.mark.parametrize(
+    ("case", "expected_reason"),
+    (
+        ("absent", "missing_audit_model_runtime_binding_path"),
+        ("invalid", "model_runtime_binding_artifact_invalid"),
+        ("wrong_surface", "audit_model_runtime_binding_surface_invalid"),
+        ("same_artifact", "model_runtime_binding_artifacts_not_distinct"),
+        ("oversized", "model_runtime_binding_artifact_invalid"),
+        ("directory", "model_runtime_binding_artifact_invalid"),
+        ("outside_root", "model_runtime_binding_artifact_invalid"),
+        ("inside_repo", "model_runtime_binding_artifact_inside_repo"),
+    ),
+)
+def test_main_resident_runtime_artifact_preflight_rejects_before_cycle(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    _valid_resident_runtime_binding_preflight,
+    case,
+    expected_reason,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "runtime-bindings"
+    runtime_root.mkdir()
+    audit_path = runtime_root / "audit.json"
+    architect_path = runtime_root / "architect.json"
+    audit_path.write_text(
+        json.dumps(model_runtime_binding_receipt(runtime_surface="reddog_readonly_audit_worker")),
+        encoding="utf-8",
+    )
+    architect_path.write_text(
+        json.dumps(model_runtime_binding_receipt(runtime_surface="reddog_backend_architect")),
+        encoding="utf-8",
+    )
+    env = {
+        "REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT": str(runtime_root),
+        "REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(audit_path),
+        "REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(architect_path),
+    }
+    if case == "absent":
+        env.pop("REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH")
+    elif case == "invalid":
+        audit_path.write_text("{}", encoding="utf-8")
+    elif case == "wrong_surface":
+        audit_path.write_text(
+            json.dumps(model_runtime_binding_receipt(runtime_surface="reddog_backend_architect")),
+            encoding="utf-8",
+        )
+    elif case == "same_artifact":
+        env["REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] = str(audit_path)
+    elif case == "oversized":
+        audit_path.write_text('{"padding":"' + ("x" * 1_100_000) + '"}', encoding="utf-8")
+    elif case == "directory":
+        audit_path.unlink()
+        audit_path.mkdir()
+    elif case == "outside_root":
+        outside = tmp_path / "outside-audit.json"
+        outside.write_text(
+            json.dumps(model_runtime_binding_receipt(runtime_surface="reddog_readonly_audit_worker")),
+            encoding="utf-8",
+        )
+        env["REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] = str(outside)
+    elif case == "inside_repo":
+        env["REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT"] = str(REPO_ROOT.parent)
+        env["REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] = str(
+            REPO_ROOT / "main.py"
+        )
+
+    monkeypatch.setattr(
+        main,
+        "_reddog_resident_model_runtime_bindings_from_env",
+        _valid_resident_runtime_binding_preflight,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+    ) as mocked:
+        with patch.dict("os.environ", env, clear=True):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is False
+
+    mocked.assert_not_called()
+    output = capsys.readouterr().out
+    assert f"reason={expected_reason}" in output
+    assert str(tmp_path) not in output
+
+
+def test_main_resident_runtime_artifact_preflight_rejects_symlink_before_cycle(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    _valid_resident_runtime_binding_preflight,
+) -> None:
+    import main
+
+    runtime_root = tmp_path / "runtime-bindings"
+    runtime_root.mkdir()
+    target = runtime_root / "audit-target.json"
+    target.write_text(
+        json.dumps(model_runtime_binding_receipt(runtime_surface="reddog_readonly_audit_worker")),
+        encoding="utf-8",
+    )
+    audit_path = runtime_root / "audit-link.json"
+    try:
+        audit_path.symlink_to(target)
+    except OSError:
+        pytest.skip("symlink creation is unavailable on this platform")
+    architect_path = runtime_root / "architect.json"
+    architect_path.write_text(
+        json.dumps(model_runtime_binding_receipt(runtime_surface="reddog_backend_architect")),
+        encoding="utf-8",
+    )
+    env = {
+        "REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT": str(runtime_root),
+        "REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(audit_path),
+        "REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(architect_path),
+    }
+    monkeypatch.setattr(
+        main,
+        "_reddog_resident_model_runtime_bindings_from_env",
+        _valid_resident_runtime_binding_preflight,
+    )
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle."
+        "run_reddog_resident_architect_durable_agentdb_cycle",
+    ) as mocked:
+        with patch.dict("os.environ", env, clear=True):
+            assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is False
+
+    mocked.assert_not_called()
+    output = capsys.readouterr().out
+    assert "reason=model_runtime_binding_artifact_invalid" in output
+    assert str(tmp_path) not in output
+
+
 def test_main_preflight_durable_resident_cycle_disabled_is_inert() -> None:
     import main
 
@@ -1048,6 +1206,16 @@ def test_main_preflight_durable_resident_cycle_product_mode_runs_by_default(caps
     kwargs = mocked.call_args.kwargs
     assert kwargs["requested_operation"] == "main_resident_architect_cycle"
     assert kwargs["prompt_text"] == "main.py resident RedDog architect cycle"
+    assert kwargs["audit_model_runtime_binding_receipt"]["runtime_surface"] == (
+        "reddog_readonly_audit_worker"
+    )
+    assert kwargs["architect_model_runtime_binding_receipt"]["runtime_surface"] == (
+        "reddog_backend_architect"
+    )
+    assert (
+        kwargs["audit_model_runtime_binding_receipt"]["receipt_id"]
+        != kwargs["architect_model_runtime_binding_receipt"]["receipt_id"]
+    )
     assert kwargs["external_research_retriever"] is None
     assert kwargs["red_dog_intent"]["requested_authority"] == "read_only_audit"
     assert kwargs["red_dog_intent"]["submits_executable_authority"] is False

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -52,6 +52,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed
 from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
     build_fresh_holoindex_receipt,
 )
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
+)
 from modules.infrastructure.foundups_mcp_bridge.src import (
     reddog_holoindex_owner_bootstrap as owner_bootstrap,
 )
@@ -444,6 +447,45 @@ def test_bootstrap_passes_architect_model_selection_receipt_override_to_backend_
     assert architect_store.records[0].determination["model_selection_receipt_id"] == model_selection["receipt_id"]
 
 
+def test_bootstrap_passes_architect_runtime_binding_into_determination_lineage() -> None:
+    baseline = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+    )
+    report_store = _FakeReportStore(_reports_for_bootstrap_result(baseline, include_findings=True))
+    architect_store = InMemoryArchitectDeterminationStore()
+    architect_runner = _FakeArchitectRunner()
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface="reddog_backend_architect",
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
+
+    result = run_reddog_main_readonly_operational_bootstrap(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        collect_readonly_audit_reports=True,
+        report_store=report_store,
+        run_backend_architect_determination=True,
+        architect_model_runner=architect_runner,
+        architect_model_runtime_binding_receipt_override=runtime_binding,
+        architect_determination_store=architect_store,
+    )
+
+    assert result.ready is True
+    topology = architect_runner.calls[0]["binding"]["model_selection"]
+    assert topology["lead_model"] == "z-ai/glm-5.2"
+    assert topology["panel_models"] == ["moonshotai/kimi-k3"]
+    assert architect_store.records[0].determination["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert architect_store.records[0].determination["model_runtime_binding_digest"]
+
+
 def test_bootstrap_requires_architect_model_selection_for_production_runner() -> None:
     baseline = run_reddog_main_readonly_operational_bootstrap(
         repo_root=REPO_ROOT,
@@ -468,7 +510,7 @@ def test_bootstrap_requires_architect_model_selection_for_production_runner() ->
     )
 
     assert result.ready is False
-    assert "missing_architect_model_selection_receipt_path" in result.rejection_reasons
+    assert "missing_architect_model_runtime_binding_receipt" in result.rejection_reasons
     assert result.backend_architect_determination_attempted is False
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_enqueue.py
@@ -41,6 +41,9 @@ from modules.communication.moltbot_bridge.tests.test_reddog_openclaw_readonly_au
 from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
     build_fresh_holoindex_receipt,
 )
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
+)
 from modules.infrastructure.database.src.agent_db import AgentDB
 from modules.infrastructure.database.src.db_manager import DatabaseManager
 
@@ -91,7 +94,12 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
     )
 
 
-def _valid_plan(wsp15_allocation_receipt=None, *, with_grounding: bool = False):
+def _valid_plan(
+    wsp15_allocation_receipt=None,
+    *,
+    with_grounding: bool = False,
+    runtime_binding=None,
+):
     snapshot_result = build_operational_context_snapshot(
         repo_state={
             "head_sha": HEAD,
@@ -154,6 +162,8 @@ def _valid_plan(wsp15_allocation_receipt=None, *, with_grounding: bool = False):
         wsp15_allocation_receipt=wsp15_allocation_receipt,
         grounding_receipt=_grounding_receipt() if with_grounding else None,
         grounding_work_focus=GROUNDING_FOCUS if with_grounding else "",
+        model_runtime_binding_receipt=runtime_binding,
+        require_model_runtime_binding=runtime_binding is not None,
     )
     assert plan.accepted is True
     return plan
@@ -199,6 +209,31 @@ def test_enqueue_carries_wsp15_allocation_into_every_task_context() -> None:
         assert task.context["wsp15_allocation_receipt"]["receipt_id"] == allocation["receipt_id"]
         assert task.context["wsp15_allocation_receipt_id"] == allocation["receipt_id"]
         assert task.context["wsp15_allocation_digest"]
+
+
+def test_enqueue_carries_exact_glm_k3_runtime_binding_into_agentdb_task_context() -> None:
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface="reddog_readonly_audit_worker",
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
+    allocation = allocate_reddog_wsp15_receipt(
+        requested_operation="readonly_audit_swarm",
+        prompt_text="audit current RedDog operational loop",
+        allowed_read_targets=["docs/0102_session_briefings/work_ledger.schema.json"],
+        model_runtime_binding_receipt=runtime_binding,
+    ).to_dict()
+    plan = _valid_plan(wsp15_allocation_receipt=allocation, runtime_binding=runtime_binding)
+
+    result = enqueue_reddog_readonly_audit_swarm(plan=plan, writer=_FakeWriter())
+
+    assert result.accepted is True
+    assert plan.receipt.model_runtime_binding_receipt == runtime_binding
+    for task in result.tasks:
+        assert task.context["model_runtime_binding_receipt"] == runtime_binding
+        assert task.context["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+        assert task.context["assignment"]["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+        assert task.context["wsp15_allocation_receipt"]["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
 
 
 def test_enqueue_carries_grounding_receipt_and_typed_targets_into_agentdb_tasks() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_openclaw_readonly_audit_swarm_runtime.py
@@ -34,6 +34,9 @@ from modules.communication.moltbot_bridge.src.reddog_operational_context_snapsho
 from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
     build_fresh_holoindex_receipt,
 )
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -241,6 +244,34 @@ def test_plan_binds_wsp15_allocation_to_every_assignment() -> None:
         for assignment in plan.assignments
     )
     assert all(assignment.wsp15_allocation_digest for assignment in plan.assignments)
+
+
+def test_required_runtime_binding_rejects_absent_and_wrong_surface_before_assignments() -> None:
+    snapshot, context_view, evidence_bundle, gate = _accepted_gate_bundle()
+    absent = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=gate,
+        require_model_runtime_binding=True,
+    )
+    wrong = plan_reddog_openclaw_readonly_audit_swarm(
+        snapshot=snapshot,
+        context_view=context_view,
+        evidence_bundle=evidence_bundle,
+        gate_decision=gate,
+        model_runtime_binding_receipt=model_runtime_binding_receipt(
+            runtime_surface="reddog_backend_architect"
+        ),
+        require_model_runtime_binding=True,
+    )
+
+    assert absent.accepted is False
+    assert "missing_model_runtime_binding_receipt" in absent.rejection_reasons
+    assert absent.assignments == ()
+    assert wrong.accepted is False
+    assert "model_runtime_binding_surface_mismatch" in wrong.rejection_reasons
+    assert wrong.assignments == ()
 
 
 def test_plan_binds_grounded_prompt_targets_to_every_assignment() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -38,9 +38,13 @@ from modules.communication.moltbot_bridge.src.reddog_readonly_audit_task_executo
     READONLY_AUDIT_TASK_REPORT_REJECT,
     ReadOnlyAuditTaskExecutionResult,
     ReadOnlyAuditTaskRejectReason,
+    execute_reddog_readonly_audit_task,
 )
 from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
     build_fresh_holoindex_receipt,
+)
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
 )
 
 
@@ -102,6 +106,17 @@ def _fresh_holo_receipt() -> HoloIndexFreshnessReceipt:
         head_sha=HEAD,
         generated_at=NOW,
     )
+
+
+def _audit_runtime_binding(*, model_id: str = "openai/gpt-5.6-code") -> dict[str, object]:
+    return model_runtime_binding_receipt(
+        runtime_surface="reddog_readonly_audit_worker",
+        model_id=model_id,
+    )
+
+
+def _architect_runtime_binding() -> dict[str, object]:
+    return model_runtime_binding_receipt(runtime_surface="reddog_backend_architect")
 
 
 class _AcceptingTaskWriter:
@@ -241,6 +256,27 @@ class _RejectingTaskExecutor:
         )
 
 
+class _SubstitutingTaskExecutor:
+    def __init__(self, *, runner, holoindex_adapter, codeindex_adapter) -> None:
+        self.runner = runner
+        self.holoindex_adapter = holoindex_adapter
+        self.codeindex_adapter = codeindex_adapter
+
+    def execute_readonly_audit_task(self, *, task, repo_root, **kwargs):
+        context = dict(task.context)
+        context["model_runtime_binding_receipt"] = _audit_runtime_binding(
+            model_id="moonshotai/kimi-k3"
+        )
+        return execute_reddog_readonly_audit_task(
+            task_context=context,
+            repo_root=repo_root,
+            task_id=task.task_id,
+            model_runner=self.runner,
+            holoindex_adapter=self.holoindex_adapter,
+            codeindex_adapter=self.codeindex_adapter,
+        )
+
+
 def test_e2e_runs_enqueued_readonly_tasks_persists_reports_and_architect_decides() -> None:
     writer = _AcceptingTaskWriter()
     report_store = _InMemoryReportStore()
@@ -261,6 +297,8 @@ def test_e2e_runs_enqueued_readonly_tasks_persists_reports_and_architect_decides
         architect_determination_store=architect_store,
         audit_model_runner=audit_runner,
         architect_model_runner=architect_runner,
+        audit_model_runtime_binding_receipt=_audit_runtime_binding(),
+        architect_model_runtime_binding_receipt=_architect_runtime_binding(),
         holoindex_adapter=_FakeQueryAdapter(),
         codeindex_adapter=_FakeQueryAdapter(),
     )
@@ -300,6 +338,8 @@ def test_e2e_fails_closed_before_report_collection_when_task_execution_rejects()
         enqueue_writer=_AcceptingTaskWriter(),
         report_store=_InMemoryReportStore(),
         task_executor=_RejectingTaskExecutor(),
+        audit_model_runtime_binding_receipt=_audit_runtime_binding(),
+        architect_model_runtime_binding_receipt=_architect_runtime_binding(),
     )
 
     assert result.accepted is False
@@ -321,6 +361,8 @@ def test_e2e_fails_closed_when_report_persistence_rejects() -> None:
         enqueue_writer=_AcceptingTaskWriter(),
         report_store=_InMemoryReportStore(reject_store=True),
         audit_model_runner=_AuditModelRunner(),
+        audit_model_runtime_binding_receipt=_audit_runtime_binding(),
+        architect_model_runtime_binding_receipt=_architect_runtime_binding(),
         holoindex_adapter=_FakeQueryAdapter(),
         codeindex_adapter=_FakeQueryAdapter(),
     )
@@ -331,6 +373,43 @@ def test_e2e_fails_closed_when_report_persistence_rejects() -> None:
     assert len(result.task_runs) == 1
     assert result.task_runs[0].accepted is True
     assert result.task_runs[0].persist_accepted is False
+
+
+def test_e2e_rejects_same_surface_binding_substitution_before_index_or_model_calls() -> None:
+    runner = _AuditModelRunner()
+    holo = _FakeQueryAdapter()
+    code = _FakeQueryAdapter()
+    report_store = _InMemoryReportStore()
+    architect_store = InMemoryArchitectDeterminationStore()
+
+    result = run_reddog_readonly_audit_research_decision_e2e(
+        repo_root=REPO_ROOT,
+        repo_state_override=_repo_state(),
+        work_state_snapshot_override=_work_state(),
+        holoindex_receipt_override=_fresh_holo_receipt(),
+        now_iso=NOW,
+        enqueue_writer=_AcceptingTaskWriter(),
+        report_store=report_store,
+        architect_determination_store=architect_store,
+        audit_model_runtime_binding_receipt=_audit_runtime_binding(),
+        architect_model_runtime_binding_receipt=_architect_runtime_binding(),
+        task_executor=_SubstitutingTaskExecutor(
+            runner=runner,
+            holoindex_adapter=holo,
+            codeindex_adapter=code,
+        ),
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditResearchDecisionE2EReason.TASK_EXECUTION_REJECTED in result.rejection_reasons
+    assert ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
+    assert result.final_bootstrap is None
+    assert len(result.task_runs) == 1
+    assert report_store.records == []
+    assert architect_store.records == []
+    assert runner.calls == []
+    assert holo.calls == []
+    assert code.calls == []
 
 
 def test_e2e_module_has_no_shell_worktree_repo_mutation_or_reindex_imports() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -806,7 +806,11 @@ def test_model_selection_receipt_is_bound_to_readonly_audit_runner(tmp_path: Pat
 def test_model_runtime_binding_receipt_is_bound_to_readonly_audit_runner(tmp_path: Path) -> None:
     root = _repo(tmp_path)
     runner = _EchoEvidenceModelRunner()
-    runtime_binding = model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT)
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
     context = _model_context()
     context["model_runtime_binding_receipt"] = runtime_binding
 
@@ -823,7 +827,8 @@ def test_model_runtime_binding_receipt_is_bound_to_readonly_audit_runner(tmp_pat
     assert result.report is not None
     binding = runner.calls[0]["binding"]["model_selection"]
     assert binding["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
-    assert binding["lead_model"] == "openai/gpt-5.6-code"
+    assert binding["lead_model"] == "z-ai/glm-5.2"
+    assert binding["panel_models"] == ["moonshotai/kimi-k3"]
     worker_receipt = result.report["worker_receipt"]
     assert worker_receipt["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
     assert worker_receipt["model_runtime_binding_digest"]
@@ -855,6 +860,29 @@ def test_mismatched_model_runtime_binding_receipt_rejects_before_readonly_model_
     assert ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
     assert result.no_model_call_performed is True
     assert runner.calls == []
+
+
+def test_production_audit_rejects_absent_runtime_binding_before_provider_or_index_calls(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    holo = _FakeQueryAdapter()
+    code = _FakeQueryAdapter()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=_model_context(),
+        repo_root=root,
+        task_id="task-1",
+        model_runner=None,
+        holoindex_adapter=holo,
+        codeindex_adapter=code,
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
+    assert result.no_model_call_performed is True
+    assert holo.calls == []
+    assert code.calls == []
     assert holo.calls == []
     assert code.calls == []
 
@@ -1730,8 +1758,14 @@ def test_production_runner_uses_fusion_synthesis_excerpt_for_json(tmp_path: Path
 
     monkeypatch.setattr(readonly_worker_runtime, "_load_foundups_fusion_runner", lambda: fake_fusion)
 
+    task_context = _model_context()
+    task_context["model_runtime_binding_receipt"] = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
     result = execute_reddog_readonly_audit_task(
-        task_context=_model_context(),
+        task_context=task_context,
         repo_root=root,
         task_id="task-1",
         model_runner=FoundupsFusionRepoAuditModelRunner(),
@@ -1760,31 +1794,35 @@ def test_production_runner_uses_model_selection_topology(monkeypatch) -> None:
 
     monkeypatch.setattr(readonly_worker_runtime, "_load_foundups_fusion_runner", lambda: fake_fusion)
 
-    result = FoundupsFusionRepoAuditModelRunner(
-        lead_model="legacy/lead",
-        panel_models=("legacy/panel",),
-    ).run_repo_code_audit(
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
+    topology_reasons: list[str] = []
+    topology = readonly_worker_runtime._model_runtime_binding(
+        runtime_binding,
+        topology_reasons,
+        expected_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+    )
+    assert topology_reasons == []
+    result = FoundupsFusionRepoAuditModelRunner().run_repo_code_audit(
         prompt="Return strict JSON.",
         context="Read-only repository evidence.",
         binding={
             "wsp15_reasoning_tier": "HIGH",
             "wsp15_priority": "P1",
-            "model_selection": {
-                "receipt_id": "model_selection_receipt:test",
-                "digest": "sha256:model-selection",
-                "lead_model": "openai/gpt-5.6-code",
-                "panel_models": ["anthropic/claude-opus-5"],
-            },
+            "model_selection": topology,
         },
         timeout_seconds=30,
     )
 
     assert result.ok is True
-    assert calls[0]["lead_model"] == "openai/gpt-5.6-code"
-    assert calls[0]["panel_models"] == ["anthropic/claude-opus-5"]
-    assert calls[0]["bridge_meta"]["model_selection_receipt_id"] == "model_selection_receipt:test"
-    assert result.route_receipt["lead_model"] == "openai/gpt-5.6-code"
-    assert result.route_receipt["model_selection_receipt_id"] == "model_selection_receipt:test"
+    assert calls[0]["lead_model"] == "z-ai/glm-5.2"
+    assert calls[0]["panel_models"] == ["moonshotai/kimi-k3"]
+    assert calls[0]["bridge_meta"]["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
+    assert result.route_receipt["lead_model"] == "z-ai/glm-5.2"
+    assert result.route_receipt["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
 
 
 def test_model_backed_requires_valid_wsp15_receipt(tmp_path: Path) -> None:
@@ -1937,13 +1975,17 @@ def test_run_task_model_backed_task_fails_closed_without_runtime_mode(tmp_path: 
     _patch_default_query_adapters(monkeypatch)
     db = AgentDB()
     task_id = "readonly-audit-model-task-1"
+    context = _model_context()
+    context["model_runtime_binding_receipt"] = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT
+    )
     assert db.create_autonomous_task(
         task_id=task_id,
         description="RedDog read-only audit lane: repo_code_audit",
         required_skills=[READONLY_AUDIT_TASK_SKILL],
         estimated_complexity=0.35,
         priority_score=0.85,
-        context=_model_context(),
+        context=context,
         origin_continuity_id="det-1",
     )
     assert db.assign_autonomous_task(task_id, "openclaw_supervisor")
@@ -1993,13 +2035,17 @@ def test_agentdb_openclaw_claim_run_task_model_worker_persists_report(tmp_path: 
     monkeypatch.setattr(FoundupsFusionRepoAuditModelRunner, "run_repo_code_audit", fake_run)
     db = AgentDB()
     task_id = "readonly-audit-model-task-2"
+    context = _model_context()
+    context["model_runtime_binding_receipt"] = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT
+    )
     assert db.create_autonomous_task(
         task_id=task_id,
         description="RedDog read-only audit lane: repo_code_audit",
         required_skills=[READONLY_AUDIT_TASK_SKILL],
         estimated_complexity=0.35,
         priority_score=0.85,
-        context=_model_context(),
+        context=context,
         origin_continuity_id="det-1",
     )
     assert db.assign_autonomous_task(task_id, "openclaw_supervisor")

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_task_executor.py
@@ -414,10 +414,14 @@ def _model_context(
     if allowed_read_targets is not None:
         context["assignment"] = dict(context["assignment"])
         context["assignment"]["allowed_read_targets"] = list(allowed_read_targets)
+    runtime_binding = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+    )
     allocation = allocate_reddog_wsp15_receipt(
         requested_operation=requested_operation,
         prompt_text=prompt_text,
         allowed_read_targets=context["assignment"]["allowed_read_targets"],
+        model_runtime_binding_receipt=runtime_binding,
     ).to_dict()
     context["worker_mode"] = MODEL_WORKER_MODE
     context["principal_id"] = "principal-012"
@@ -427,6 +431,9 @@ def _model_context(
     context["wsp15_allocation_receipt"] = allocation
     context["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
     context["wsp15_allocation_digest"] = canonical_reddog_wsp15_allocation_digest(allocation)
+    context["model_runtime_binding_receipt"] = runtime_binding
+    context["model_runtime_binding_receipt_id"] = runtime_binding["receipt_id"]
+    context["model_runtime_binding_digest"] = allocation["model_runtime_binding_digest"]
     context["assignment"] = dict(context["assignment"])
     context["assignment"]["lane_id"] = lane_id
     context["assignment"]["foundup_id"] = MEMEX_FOUNDUP_ID
@@ -438,6 +445,10 @@ def _model_context(
     context["assignment"]["determination_id"] = "sha256:determination"
     context["assignment"]["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
     context["assignment"]["wsp15_allocation_digest"] = context["wsp15_allocation_digest"]
+    context["assignment"]["model_runtime_binding_receipt_id"] = runtime_binding["receipt_id"]
+    context["assignment"]["model_runtime_binding_digest"] = context[
+        "model_runtime_binding_digest"
+    ]
     context["assignment"]["memex_source_scope"] = f"foundup:{MEMEX_FOUNDUP_ID}:lane:{lane_id}"
     context["assignment"]["memex_source_revision"] = MEMEX_SOURCE_REVISION
     context["assignment"]["memex_holoindex_generation_id"] = MEMEX_GENERATION_ID
@@ -505,6 +516,51 @@ def _grounded_model_context() -> dict:
     context["assignment"]["grounding_receipt_id"] = receipt["receipt_id"]
     context["assignment"]["grounding_receipt_digest"] = context["grounding_receipt_digest"]
     return context
+
+
+def _replace_model_runtime_binding(context: dict, runtime_binding: dict) -> None:
+    assignment = context["assignment"]
+    allocation = allocate_reddog_wsp15_receipt(
+        requested_operation=str(context["wsp15_allocation_receipt"]["requested_operation"]),
+        prompt_text="Run model-backed RedDog repo code audit.",
+        allowed_read_targets=assignment["allowed_read_targets"],
+        model_runtime_binding_receipt=runtime_binding,
+    ).to_dict()
+    digest = canonical_reddog_wsp15_allocation_digest(allocation)
+    runtime_digest = allocation["model_runtime_binding_digest"]
+    context["model_runtime_binding_receipt"] = runtime_binding
+    context["model_runtime_binding_receipt_id"] = runtime_binding["receipt_id"]
+    context["model_runtime_binding_digest"] = runtime_digest
+    context["wsp15_allocation_receipt"] = allocation
+    context["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
+    context["wsp15_allocation_digest"] = digest
+    assignment["model_runtime_binding_receipt_id"] = runtime_binding["receipt_id"]
+    assignment["model_runtime_binding_digest"] = runtime_digest
+    assignment["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
+    assignment["wsp15_allocation_digest"] = digest
+
+
+def _remove_model_runtime_binding(context: dict) -> None:
+    assignment = context["assignment"]
+    allocation = allocate_reddog_wsp15_receipt(
+        requested_operation=str(context["wsp15_allocation_receipt"]["requested_operation"]),
+        prompt_text="Run model-backed RedDog repo code audit.",
+        allowed_read_targets=assignment["allowed_read_targets"],
+    ).to_dict()
+    digest = canonical_reddog_wsp15_allocation_digest(allocation)
+    for key in (
+        "model_runtime_binding_receipt",
+        "model_runtime_binding_receipt_id",
+        "model_runtime_binding_digest",
+    ):
+        context.pop(key, None)
+    assignment["model_runtime_binding_receipt_id"] = ""
+    assignment["model_runtime_binding_digest"] = ""
+    context["wsp15_allocation_receipt"] = allocation
+    context["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
+    context["wsp15_allocation_digest"] = digest
+    assignment["wsp15_allocation_receipt_id"] = allocation["receipt_id"]
+    assignment["wsp15_allocation_digest"] = digest
 
 
 def _memex_access_policy_receipt() -> dict:
@@ -773,7 +829,9 @@ def test_grounding_substitution_rejects_before_index_or_model(
     assert code.calls == []
 
 
-def test_model_selection_receipt_is_bound_to_readonly_audit_runner(tmp_path: Path) -> None:
+def test_runtime_binding_is_authoritative_over_readonly_model_selection_metadata(
+    tmp_path: Path,
+) -> None:
     root = _repo(tmp_path)
     runner = _EchoEvidenceModelRunner()
     selection = _model_selection()
@@ -792,15 +850,44 @@ def test_model_selection_receipt_is_bound_to_readonly_audit_runner(tmp_path: Pat
     assert result.accepted is True
     assert result.report is not None
     binding = runner.calls[0]["binding"]["model_selection"]
-    assert binding["receipt_id"] == selection["receipt_id"]
+    runtime_binding = context["model_runtime_binding_receipt"]
+    assert binding["receipt_id"] == runtime_binding["selection_receipt_id"]
     assert binding["purpose"] == "production"
-    assert binding["lead_model"] == "openai/gpt-5.6-code"
+    assert binding["model_runtime_binding_receipt_id"] == runtime_binding["receipt_id"]
     worker_receipt = result.report["worker_receipt"]
-    assert worker_receipt["model_selection_receipt_id"] == selection["receipt_id"]
+    assert worker_receipt["model_selection_receipt_id"] == runtime_binding["selection_receipt_id"]
     assert worker_receipt["model_selection_digest"]
     route_receipt = worker_receipt["model_route_receipt"]
-    assert route_receipt["model_selection_receipt_id"] == selection["receipt_id"]
+    assert route_receipt["model_selection_receipt_id"] == runtime_binding["selection_receipt_id"]
     assert route_receipt["model_selection_digest"] == worker_receipt["model_selection_digest"]
+
+
+def test_model_selection_receipt_cannot_replace_required_runtime_binding(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    _remove_model_runtime_binding(context)
+    context["model_selection_receipt"] = _model_selection()
+    holo = _FakeQueryAdapter()
+    code = _FakeQueryAdapter()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=holo,
+        codeindex_adapter=code,
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
+    assert result.no_model_call_performed is True
+    assert runner.calls == []
+    assert holo.calls == []
+    assert code.calls == []
 
 
 def test_model_runtime_binding_receipt_is_bound_to_readonly_audit_runner(tmp_path: Path) -> None:
@@ -812,7 +899,7 @@ def test_model_runtime_binding_receipt_is_bound_to_readonly_audit_runner(tmp_pat
         panel_model_ids=("moonshotai/kimi-k3",),
     )
     context = _model_context()
-    context["model_runtime_binding_receipt"] = runtime_binding
+    _replace_model_runtime_binding(context, runtime_binding)
 
     result = execute_reddog_readonly_audit_task(
         task_context=context,
@@ -860,6 +947,39 @@ def test_mismatched_model_runtime_binding_receipt_rejects_before_readonly_model_
     assert ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
     assert result.no_model_call_performed is True
     assert runner.calls == []
+    assert holo.calls == []
+    assert code.calls == []
+
+
+def test_same_surface_runtime_binding_substitution_rejects_before_any_call(
+    tmp_path: Path,
+) -> None:
+    root = _repo(tmp_path)
+    runner = _EchoEvidenceModelRunner()
+    context = _model_context()
+    substituted = model_runtime_binding_receipt(
+        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+        model_id="moonshotai/kimi-k3",
+    )
+    context["model_runtime_binding_receipt"] = substituted
+    holo = _FakeQueryAdapter()
+    code = _FakeQueryAdapter()
+
+    result = execute_reddog_readonly_audit_task(
+        task_context=context,
+        repo_root=root,
+        task_id="task-1",
+        model_runner=runner,
+        holoindex_adapter=holo,
+        codeindex_adapter=code,
+    )
+
+    assert result.accepted is False
+    assert ReadOnlyAuditTaskRejectReason.MODEL_RUNTIME_BINDING_RECEIPT in result.rejection_reasons
+    assert result.no_model_call_performed is True
+    assert runner.calls == []
+    assert holo.calls == []
+    assert code.calls == []
 
 
 def test_production_audit_rejects_absent_runtime_binding_before_provider_or_index_calls(
@@ -869,8 +989,11 @@ def test_production_audit_rejects_absent_runtime_binding_before_provider_or_inde
     holo = _FakeQueryAdapter()
     code = _FakeQueryAdapter()
 
+    context = _model_context()
+    _remove_model_runtime_binding(context)
+
     result = execute_reddog_readonly_audit_task(
-        task_context=_model_context(),
+        task_context=context,
         repo_root=root,
         task_id="task-1",
         model_runner=None,
@@ -883,11 +1006,11 @@ def test_production_audit_rejects_absent_runtime_binding_before_provider_or_inde
     assert result.no_model_call_performed is True
     assert holo.calls == []
     assert code.calls == []
-    assert holo.calls == []
-    assert code.calls == []
 
 
-def test_tampered_model_selection_receipt_rejects_before_readonly_model_call(tmp_path: Path) -> None:
+def test_tampered_selection_metadata_cannot_override_readonly_runtime_binding(
+    tmp_path: Path,
+) -> None:
     root = _repo(tmp_path)
     runner = _EchoEvidenceModelRunner()
     selection = _model_selection()
@@ -906,12 +1029,13 @@ def test_tampered_model_selection_receipt_rejects_before_readonly_model_call(tmp
         codeindex_adapter=code,
     )
 
-    assert result.accepted is False
-    assert ReadOnlyAuditTaskRejectReason.MODEL_SELECTION_RECEIPT in result.rejection_reasons
-    assert result.no_model_call_performed is True
-    assert runner.calls == []
-    assert holo.calls == []
-    assert code.calls == []
+    assert result.accepted is True
+    assert len(runner.calls) == 1
+    binding = runner.calls[0]["binding"]["model_selection"]
+    assert binding["model_runtime_binding_receipt_id"] == context[
+        "model_runtime_binding_receipt"
+    ]["receipt_id"]
+    assert binding["selected_model_ids"] != ["attacker/model"]
 
 
 def test_model_backed_runtime_freshness_lane_uses_same_guarded_path(tmp_path: Path) -> None:
@@ -1527,6 +1651,7 @@ def test_model_backed_rejects_regular_allocation_without_fusion_requirement(tmp_
         requested_operation="answer_simple_question",
         prompt_text="Say hello.",
         allowed_read_targets=context["assignment"]["allowed_read_targets"],
+        model_runtime_binding_receipt=context["model_runtime_binding_receipt"],
     ).to_dict()
     allocation.update(
         {
@@ -1759,10 +1884,13 @@ def test_production_runner_uses_fusion_synthesis_excerpt_for_json(tmp_path: Path
     monkeypatch.setattr(readonly_worker_runtime, "_load_foundups_fusion_runner", lambda: fake_fusion)
 
     task_context = _model_context()
-    task_context["model_runtime_binding_receipt"] = model_runtime_binding_receipt(
-        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
-        model_id="z-ai/glm-5.2",
-        panel_model_ids=("moonshotai/kimi-k3",),
+    _replace_model_runtime_binding(
+        task_context,
+        model_runtime_binding_receipt(
+            runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT,
+            model_id="z-ai/glm-5.2",
+            panel_model_ids=("moonshotai/kimi-k3",),
+        ),
     )
     result = execute_reddog_readonly_audit_task(
         task_context=task_context,
@@ -1976,8 +2104,9 @@ def test_run_task_model_backed_task_fails_closed_without_runtime_mode(tmp_path: 
     db = AgentDB()
     task_id = "readonly-audit-model-task-1"
     context = _model_context()
-    context["model_runtime_binding_receipt"] = model_runtime_binding_receipt(
-        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT
+    _replace_model_runtime_binding(
+        context,
+        model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT),
     )
     assert db.create_autonomous_task(
         task_id=task_id,
@@ -2036,8 +2165,9 @@ def test_agentdb_openclaw_claim_run_task_model_worker_persists_report(tmp_path: 
     db = AgentDB()
     task_id = "readonly-audit-model-task-2"
     context = _model_context()
-    context["model_runtime_binding_receipt"] = model_runtime_binding_receipt(
-        runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT
+    _replace_model_runtime_binding(
+        context,
+        model_runtime_binding_receipt(runtime_surface=RUNTIME_SURFACE_READONLY_AUDIT),
     )
     assert db.create_autonomous_task(
         task_id=task_id,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -14,6 +14,9 @@ from modules.communication.moltbot_bridge.src.reddog_backend_architect_determina
     ArchitectModelResult,
     InMemoryArchitectDeterminationStore,
 )
+from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_test_helpers import (
+    model_runtime_binding_receipt,
+)
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
     READONLY_AUDIT_TASK_SOURCE,
 )
@@ -29,15 +32,12 @@ import modules.communication.moltbot_bridge.src.reddog_resident_architect_durabl
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
     AgentDbResidentArchitectCycleStore,
     REDDOG_RESIDENT_CYCLE_ACCEPT,
-    RUNTIME_BOUNDARY_FIELDS,
     STATUS_CANCELLED,
     STATUS_DETERMINED,
-    STATUS_FAILED,
     STATUS_RUNNING,
     STATUS_TIMED_OUT,
     NoopExternalResearchRetriever,
     ResidentCycleReason,
-    resident_intent_digest,
     run_reddog_resident_architect_durable_agentdb_cycle,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
@@ -396,6 +396,47 @@ def test_durable_cycle_submits_agentdb_tasks_openclaw_claims_reports_and_determi
 
     tasks = AgentDB().get_autonomous_tasks(status="completed", limit=10)
     assert len([task for task in tasks if task["discovered_by"] == READONLY_AUDIT_TASK_SOURCE]) == 5
+
+
+def test_resident_cycle_forwards_surface_specific_glm_k3_bindings_end_to_end() -> None:
+    audit_runner = _AuditModelRunner()
+    architect_runner = _ArchitectRunner()
+    architect_store = InMemoryArchitectDeterminationStore()
+    audit_binding = model_runtime_binding_receipt(
+        runtime_surface="reddog_readonly_audit_worker",
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
+    architect_binding = model_runtime_binding_receipt(
+        runtime_surface="reddog_backend_architect",
+        model_id="z-ai/glm-5.2",
+        panel_model_ids=("moonshotai/kimi-k3",),
+    )
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(
+            audit_model_runner=audit_runner,
+            architect_model_runner=architect_runner,
+            architect_determination_store=architect_store,
+            audit_model_runtime_binding_receipt=audit_binding,
+            architect_model_runtime_binding_receipt=architect_binding,
+        )
+    )
+
+    assert result.accepted is True
+    assert len(audit_runner.calls) == 5
+    for call in audit_runner.calls:
+        topology = call["binding"]["model_selection"]
+        assert topology["lead_model"] == "z-ai/glm-5.2"
+        assert topology["panel_models"] == ["moonshotai/kimi-k3"]
+        assert topology["model_runtime_binding_receipt_id"] == audit_binding["receipt_id"]
+    architect_topology = architect_runner.calls[0]["binding"]["model_selection"]
+    assert architect_topology["lead_model"] == "z-ai/glm-5.2"
+    assert architect_topology["panel_models"] == ["moonshotai/kimi-k3"]
+    assert architect_topology["model_runtime_binding_receipt_id"] == architect_binding["receipt_id"]
+    determination = architect_store.records[0].determination
+    assert determination["model_runtime_binding_receipt_id"] == architect_binding["receipt_id"]
+    assert determination["model_runtime_binding_digest"]
 
 
 def test_durable_cycle_supplies_operational_memex_to_openclaw_workers() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -138,6 +138,30 @@ def _intent() -> dict[str, object]:
     }
 
 
+def _audit_runtime_binding(*, model_id: str = "openai/gpt-5.6-code") -> dict[str, object]:
+    return model_runtime_binding_receipt(
+        runtime_surface="reddog_readonly_audit_worker",
+        model_id=model_id,
+    )
+
+
+def _architect_runtime_binding(*, model_id: str = "openai/gpt-5.6-code") -> dict[str, object]:
+    return model_runtime_binding_receipt(
+        runtime_surface="reddog_backend_architect",
+        model_id=model_id,
+    )
+
+
+def _bound_intent() -> dict[str, object]:
+    intent, reasons = resident_cycle_runtime._intent_bound_model_runtime_bindings(
+        _intent(),
+        audit_model_runtime_binding_receipt=_audit_runtime_binding(),
+        architect_model_runtime_binding_receipt=_architect_runtime_binding(),
+    )
+    assert reasons == ()
+    return dict(intent)
+
+
 def _repo_state() -> dict[str, object]:
     return {
         "head_sha": HEAD,
@@ -303,13 +327,15 @@ def _runtime_kwargs(**overrides):
         "holoindex_adapter": _FakeQueryAdapter(),
         "codeindex_adapter": _FakeQueryAdapter(),
         "external_research_retriever": _FakeExternalResearchRetriever(),
+        "audit_model_runtime_binding_receipt": _audit_runtime_binding(),
+        "architect_model_runtime_binding_receipt": _architect_runtime_binding(),
     }
     kwargs.update(overrides)
     return kwargs
 
 
 def _stored_cycle_record(*, status: str, retry_count: int = 0) -> dict[str, object]:
-    record = resident_cycle_runtime._new_record(_intent(), retry_count=retry_count)
+    record = resident_cycle_runtime._new_record(_bound_intent(), retry_count=retry_count)
     record["status"] = status
     record["created_at"] = NOW
     record["updated_at"] = NOW
@@ -356,7 +382,7 @@ def _seed_cycle_status(
         current = dict(timed_out["record"])
         if attempt == retry_count:
             return current
-        retried = resident_cycle_runtime._new_record(_intent(), retry_count=attempt + 1)
+        retried = resident_cycle_runtime._new_record(_bound_intent(), retry_count=attempt + 1)
         retried["created_at"] = current["created_at"]
         retried["genesis_state_digest"] = current["genesis_state_digest"]
         retried["attempt_history"] = [
@@ -519,6 +545,45 @@ def test_duplicate_intent_reconnects_to_persisted_cycle_without_new_claims() -> 
         claim["task_id"] for claim in first.openclaw_claims
     )
     assert AgentDB().get_autonomous_tasks(status="completed", limit=20)
+
+
+def test_same_surface_binding_substitution_conflicts_before_downstream_calls_or_mutation() -> None:
+    store = AgentDbResidentArchitectCycleStore()
+    first = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(cycle_store=store)
+    )
+    assert first.accepted is True
+    persisted_before = store.load_cycle_by_intent(first.intent_id)
+    assert persisted_before is not None
+    tasks_before = AgentDB().get_autonomous_tasks(limit=20)
+    audit_runner = _AuditModelRunner()
+    architect_runner = _ArchitectRunner()
+    holo = _FakeQueryAdapter()
+    code = _FakeQueryAdapter()
+
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        **_runtime_kwargs(
+            cycle_store=store,
+            audit_model_runtime_binding_receipt=_audit_runtime_binding(
+                model_id="moonshotai/kimi-k3"
+            ),
+            audit_model_runner=audit_runner,
+            architect_model_runner=architect_runner,
+            holoindex_adapter=holo,
+            codeindex_adapter=code,
+        )
+    )
+
+    assert result.accepted is False
+    assert ResidentCycleReason.INTENT_CONFLICT in result.rejection_reasons
+    assert audit_runner.calls == []
+    assert architect_runner.calls == []
+    assert holo.calls == []
+    assert code.calls == []
+    assert AgentDB().get_autonomous_tasks(limit=20) == tasks_before
+    persisted_after = store.load_cycle_by_intent(first.intent_id)
+    assert persisted_after is not None
+    assert persisted_after["record_revision"] == persisted_before["record_revision"]
 
 
 def test_real_agentdb_cycle_reconnects_through_fresh_canonical_client() -> None:
@@ -706,6 +771,8 @@ def test_cancellation_during_claim_remains_terminal() -> None:
                 red_dog_intent=_intent(),
                 cycle_store=store,
                 cancel_requested=True,
+                audit_model_runtime_binding_receipt=_audit_runtime_binding(),
+                architect_model_runtime_binding_receipt=_architect_runtime_binding(),
             )
         )
         return {"accepted": True, "status": "OPENCLAW_READONLY_AUDIT_CLAIM_ACCEPT"}

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -173,7 +173,7 @@ exemptions:
       Legacy audit-worker integration boundary spanning evidence acquisition,
       model invocation, and receipt composition. This POC preserves its
       reviewed repository and HoloIndex truth checks without a broad rewrite.
-    threshold_override: 2100
+    threshold_override: 2106
     function_threshold_override: 270
     functions:
       - "execute_model_backed_repo_code_audit"
@@ -211,8 +211,8 @@ exemptions:
 
   - file: "tests/test_reddog_backend_architect_determination_runtime.py"
     reason: "Legacy architect-input fixture and suite awaiting fixture extraction."
-    threshold_override: 725
-    function_threshold_override: 65
+    threshold_override: 760
+    function_threshold_override: 80
     functions: ["_build_inputs"]
     temporary: true
     review_date: "2026-Q3"
@@ -223,7 +223,7 @@ exemptions:
     reason: >-
       Legacy end-to-end startup integration suite; focused owner-preflight
       stubs are retained while durable-cycle sections are split by contract.
-    threshold_override: 1800
+    threshold_override: 1935
     function_threshold_override: 75
     functions:
       - "test_bootstrap_memex_supply_enriches_enqueued_readonly_audit_tasks"
@@ -248,7 +248,7 @@ exemptions:
     reason: >-
       Legacy executor regression matrix. Repository-state truth-boundary cases
       were added without mixing production refactoring into the security fix.
-    threshold_override: 2100
+    threshold_override: 2237
     function_threshold_override: 60
     temporary: true
     review_date: "2026-Q3"

--- a/wsp_62_exemptions.yaml
+++ b/wsp_62_exemptions.yaml
@@ -18,10 +18,11 @@ exemptions:
   - file: "main.py"
     reason: >-
       Legacy application entrypoint and RedDog preflight integration boundary.
-      This focused POC changes only the HoloIndex owner preflight call path;
-      decomposing unrelated startup and queue control flows here would expand
-      the security review surface.
-    threshold_override: 4891
+      This focused repair adds only the bounded outside-repository runtime-
+      binding artifact preflight ahead of the resident cycle; decomposing
+      unrelated startup and queue control flows here would expand the security
+      review surface.
+    threshold_override: 4978
     function_threshold_override: 954
     functions:
       - "monitor_youtube"
@@ -58,7 +59,7 @@ exemptions:
     architect_reviewer: "0102 Technical Architect"
     expires_on: "2026-09-30"
     no_growth_ceiling:
-      file_lines: 4891
+      file_lines: 4978
       functions:
         run_reddog_wre_queue_consumer_preflight: 60
         run_reddog_resident_queue_next_stage_dispatch_preflight: 84


### PR DESCRIPTION
## What changed

- requires separate, validated runtime-model binding receipts for RedDog audit and backend-architect surfaces
- carries exact receipt IDs and digests through WSP15, swarm assignments, AgentDB/OpenClaw task context, resident intent, and architect determination lineage
- rejects missing, invalid, wrong-surface, selection-only, injected-runner, and same-surface receipt substitution before index, provider, runner, or persistence work
- preflights two distinct bounded binding artifacts outside the repository before the resident cycle starts
- removes production GLM/K2.7 fallback topology; model identities remain receipt-selected evidence

## Why

The prior runtime could select a model without proving that the same validated binding reached the worker that used it. Direct and injected paths could also bypass that evidence boundary. This change makes runtime model identity explicit and fail-closed so later Kimi K3/GLM evaluation can be measured without hardcoding policy.

## Validation

- 207 focused runtime/WSP15/WSP62 tests passed
- 1 Windows symlink-permission test skipped; static reparse/junction/symlink defenses independently reviewed
- Ruff passed for changed Python; main.py retains the same inherited findings as base
- py_compile and git diff --check passed
- independent pre- and post-rebase reviews: GO
- rebased range-diff: both commits exact equivalents; no execution-valve or CI retry commits replayed

## Scope boundary

This is phase 1 only. Durable provider-call evidence and recurring model evaluation/promotion remain separate follow-up work. No provider calls, HoloIndex activation, or catalog promotion are included.