### PR TITLE
fix(ai-gateway): bind provider catalog publication identity

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -83,7 +83,15 @@ both attempt and candidate artifacts. Replacement is same-directory and atomic:
 the target is untouched until exact UTF-8 bytes have been flushed and fsynced
 to a validated exclusive temporary file. `AtomicArtifactOps` is injectable for
 offline failure tests; production uses ordinary writes, `os.fsync`, and
-`os.replace`.
+`os.replace`. Before replacement, the pathname must still be a single-link
+regular file matching the post-write descriptor device/inode where meaningful,
+exact size, and expected SHA-256 content digest. This is a trusted-runtime-root
+boundary, not a portable claim against an arbitrary concurrent directory
+writer. Parent-directory fsync is best-effort and may be unavailable on
+Windows.
+
+Redirect history with a non-3xx final response is represented by
+`redirect_history_rejected`; raw 3xx responses remain `redirect_rejected`.
 
 #### Model Intelligence Selection
 

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -82,13 +82,16 @@ scheduler.
 both attempt and candidate artifacts. Replacement is same-directory and atomic:
 the target is untouched until exact UTF-8 bytes have been flushed and fsynced
 to a validated exclusive temporary file. `AtomicArtifactOps` is injectable for
-offline failure tests; production uses ordinary writes, `os.fsync`, and
-`os.replace`. Before replacement, the pathname must still be a single-link
-regular file matching the post-write descriptor device/inode where meaningful,
-exact size, and expected SHA-256 content digest. This is a trusted-runtime-root
-boundary, not a portable claim against an arbitrary concurrent directory
-writer. Parent-directory fsync is best-effort and may be unavailable on
-Windows.
+offline failure tests and is a trusted seam. Before replacement, the pathname
+must still be a single-link regular file matching the post-write descriptor
+device/inode, exact size, and expected SHA-256 content digest; unavailable
+identity fails closed. Production retains that descriptor through publication.
+On Windows it renames the exact verified object by native handle and verifies
+the target before release. Detected publication mismatch restores the prior
+bytes/mode or absence, and cleanup does not unlink identity-ambiguous foreign
+substitutes. Non-Windows pathname publication requires an operator-controlled,
+non-shared runtime directory and makes no claim against an arbitrary
+concurrent directory writer. Parent-directory fsync is best-effort.
 
 Redirect history with a non-3xx final response is represented by
 `redirect_history_rejected`; raw 3xx responses remain `redirect_rejected`.

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -3,14 +3,14 @@
 ## [2026-07-24] - Provider Discovery Defensive Reliability Hotfix
 
 **Who/Type/Slice/WSP:** 0102 Codex / Defensive Reliability / DIRECT_PROVIDER_DEFENSIVE_RELIABILITY_20260723 / 15,22,50,62,97
-**What:** Added truthful non-3xx redirect-history receipts and bound artifact
-commit to post-write descriptor identity, exact size/content, regular-file
-type, and single-link pathname state.
-**Truth:** Path replacement and hard links fail closed; supported symlinks do
-too. A trusted runtime directory is required; arbitrary post-check writer
-races, parent-directory fsync, and Windows sync/mode behavior remain limited.
+**What:** Added truthful non-3xx redirect-history receipts; retained verified
+artifact identity through publication; added Windows exact-handle rename,
+identity-aware cleanup, and exact prior-target rollback on detected mismatch.
+**Truth:** Path replacement, hard links, and supported symlinks fail closed.
+Non-Windows publication requires a trusted non-shared runtime directory;
+parent-directory fsync and Windows sync/mode behavior remain limited.
 No live network/provider/runtime/Holo or authority mutations were performed.
-**Validation:** 91 passed / 1 Windows symlink skip focused; 332 passed / 1
+**Validation:** 98 passed / 1 Windows symlink skip focused; 339 passed / 1
 skip full ai_gateway.
 
 ## [2026-07-23] - Provider Catalog Atomic Artifact Repair

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,18 @@
 # AI Gateway Module Change Log
 
+## [2026-07-24] - Provider Discovery Defensive Reliability Hotfix
+
+**Who/Type/Slice/WSP:** 0102 Codex / Defensive Reliability / DIRECT_PROVIDER_DEFENSIVE_RELIABILITY_20260723 / 15,22,50,62,97
+**What:** Added truthful non-3xx redirect-history receipts and bound artifact
+commit to post-write descriptor identity, exact size/content, regular-file
+type, and single-link pathname state.
+**Truth:** Path replacement and hard links fail closed; supported symlinks do
+too. A trusted runtime directory is required; arbitrary post-check writer
+races, parent-directory fsync, and Windows sync/mode behavior remain limited.
+No live network/provider/runtime/Holo or authority mutations were performed.
+**Validation:** 91 passed / 1 Windows symlink skip focused; 332 passed / 1
+skip full ai_gateway.
+
 ## [2026-07-23] - Provider Catalog Atomic Artifact Repair
 
 **Who:** 0102 Codex worker, independent reviewer-driven repair

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -41,6 +41,18 @@ temporary write, fsync, or replacement removes the temporary file and leaves
 the previous target byte-identical. Low-level write and replace seams exist
 only for deterministic offline durability tests.
 
+The store binds each commit to post-write descriptor evidence: device/inode
+identity when the host exposes it, exact size, SHA-256 digest, regular-file
+type, and a single-link pathname. A changed pathname or changed content fails
+before replacement and leaves the previous artifact intact. This boundary
+assumes the operator supplies a trusted runtime directory; it does not claim
+portable exclusion of an arbitrary writer racing after the final check.
+Parent-directory fsync remains best-effort, including on Windows.
+
+Transport responses that report redirect history with a non-3xx final status
+produce the content-free `redirect_history_rejected` terminal reason. Raw 3xx
+responses continue to use `redirect_rejected`.
+
 Example manual invocation:
 
 ```text

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -38,15 +38,21 @@ Both runtime artifacts use a module-local atomic store. It writes exact UTF-8
 to an exclusive same-directory temporary file, flushes and fsyncs it, then
 replaces the validated target while holding the existing runtime lock. A failed
 temporary write, fsync, or replacement removes the temporary file and leaves
-the previous target byte-identical. Low-level write and replace seams exist
-only for deterministic offline durability tests.
+the previous target byte-identical. A detected post-publication mismatch is
+rolled back to the prior bytes and mode, or to absence. Low-level write,
+precommit, and replace seams are trusted and exist only for deterministic
+offline durability tests.
 
 The store binds each commit to post-write descriptor evidence: device/inode
 identity when the host exposes it, exact size, SHA-256 digest, regular-file
-type, and a single-link pathname. A changed pathname or changed content fails
-before replacement and leaves the previous artifact intact. This boundary
-assumes the operator supplies a trusted runtime directory; it does not claim
-portable exclusion of an arbitrary writer racing after the final check.
+type, and a single-link pathname. It retains that descriptor through
+publication and verifies the published target before releasing it. Windows
+production publication renames the verified object by native handle, so a
+pathname substitution cannot select different bytes. Cleanup never unlinks a
+foreign or identity-ambiguous substitute. Other hosts require an
+operator-controlled, non-shared runtime directory because their standard
+pathname replace cannot exclude an arbitrary writer after the final check.
+Unavailable file identity fails closed.
 Parent-directory fsync remains best-effort, including on Windows.
 
 Transport responses that report redirect history with a non-3xx final status

--- a/modules/ai_intelligence/ai_gateway/ROADMAP.md
+++ b/modules/ai_intelligence/ai_gateway/ROADMAP.md
@@ -30,8 +30,13 @@
 - [x] Explicit bounded OpenRouter model-list discovery with injected offline
   transport tests, strict candidate normalization, durable attempt receipts,
   and outside-repository last-known-good persistence.
+- [x] Bound atomic candidate/attempt commits to post-write descriptor identity,
+  exact size/content, and single-link pathname validation.
 - [ ] Operator-owned scheduling integration. Phase 1 provides scheduled
   invocation admission fields but intentionally installs no scheduler.
+- [ ] Evaluate platform-specific handle-based publication and stronger
+  directory durability. The current portable boundary requires a trusted
+  runtime directory and uses best-effort parent-directory fsync.
 
 ## Phase 1: Enhanced Intelligence (Next)
 - **Cost optimization algorithms** - Auto-select cheapest provider

--- a/modules/ai_intelligence/ai_gateway/ROADMAP.md
+++ b/modules/ai_intelligence/ai_gateway/ROADMAP.md
@@ -32,11 +32,13 @@
   and outside-repository last-known-good persistence.
 - [x] Bound atomic candidate/attempt commits to post-write descriptor identity,
   exact size/content, and single-link pathname validation.
+- [x] Retain verified object identity through Windows publication and restore
+  exact prior target state after detected publication failure or mismatch.
 - [ ] Operator-owned scheduling integration. Phase 1 provides scheduled
   invocation admission fields but intentionally installs no scheduler.
-- [ ] Evaluate platform-specific handle-based publication and stronger
-  directory durability. The current portable boundary requires a trusted
-  runtime directory and uses best-effort parent-directory fsync.
+- [ ] Evaluate directory-handle publication on non-Windows hosts and stronger
+  directory durability. Their current boundary requires a trusted non-shared
+  runtime directory and all parent-directory fsync remains best-effort.
 
 ## Phase 1: Enhanced Intelligence (Next)
 - **Cost optimization algorithms** - Auto-select cheapest provider

--- a/modules/ai_intelligence/ai_gateway/src/model_openrouter_direct_discovery.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_openrouter_direct_discovery.py
@@ -284,7 +284,9 @@ def _response_rejection(response: HTTPResponse) -> tuple[str, str | None, int | 
     if size > MAX_RESPONSE_BYTES:
         return "body_too_large", None, None
     digest = sha256_bytes(response.body)
-    if response.redirected or 300 <= response.status < 400:
+    if response.redirected and not 300 <= response.status < 400:
+        return "redirect_history_rejected", digest, min(size, MAX_RESPONSE_BYTES)
+    if 300 <= response.status < 400:
         return "redirect_rejected", digest, min(size, MAX_RESPONSE_BYTES)
     if response.status != 200:
         return "http_status_rejected", digest, min(size, MAX_RESPONSE_BYTES)

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_artifact_store.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_artifact_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import stat
 import tempfile
@@ -29,6 +30,14 @@ class AtomicArtifactOps:
     writer: Callable[[BinaryIO, bytes], None] = _write_all
     fsync: Callable[[int], None] = os.fsync
     replacer: Callable[[Path, Path], None] = os.replace
+
+
+@dataclass(frozen=True)
+class _TempArtifactProof:
+    device: int
+    inode: int
+    size: int
+    digest: str
 
 
 @dataclass(frozen=True)
@@ -64,9 +73,11 @@ class ProviderCatalogArtifactStore:
                     prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
                 )
                 temporary = Path(raw_temp)
-                self._write_temp(descriptor, temporary, payload, mode)
+                proof = self._write_temp(descriptor, temporary, payload, mode)
                 target = self._target(target)
-                temporary = self._validated_temp(temporary, target.parent)
+                temporary = self._validated_temp(
+                    temporary, target.parent, proof, payload
+                )
                 self.ops.replacer(temporary, target)
                 temporary = None
                 _fsync_parent(target.parent, self.ops.fsync)
@@ -88,35 +99,80 @@ class ProviderCatalogArtifactStore:
 
     def _write_temp(
         self, descriptor: int, temporary: Path, payload: bytes, mode: int | None
-    ) -> None:
+    ) -> _TempArtifactProof:
+        proof: _TempArtifactProof | None = None
         try:
             opened, named = os.fstat(descriptor), os.lstat(temporary)
             if (
                 not stat.S_ISREG(opened.st_mode)
+                or opened.st_nlink != 1
                 or (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino)
             ):
                 raise ValueError("runtime_artifact_temp_descriptor_mismatch")
             if mode is not None and hasattr(os, "fchmod"):
                 os.fchmod(descriptor, mode)
-            with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            with os.fdopen(descriptor, "w+b", closefd=True) as stream:
                 descriptor = -1
                 self.ops.writer(stream, payload)
                 stream.flush()
-                if os.fstat(stream.fileno()).st_size != len(payload):
+                metadata = os.fstat(stream.fileno())
+                if metadata.st_size != len(payload) or metadata.st_nlink != 1:
                     raise OSError("runtime_artifact_temp_size_mismatch")
                 self.ops.fsync(stream.fileno())
+                stream.seek(0)
+                if stream.read(len(payload) + 1) != payload:
+                    raise OSError("runtime_artifact_temp_content_mismatch")
+                proof = _TempArtifactProof(
+                    metadata.st_dev,
+                    metadata.st_ino,
+                    metadata.st_size,
+                    hashlib.sha256(payload).hexdigest(),
+                )
         finally:
             if descriptor >= 0:
                 os.close(descriptor)
-        self._validated_temp(temporary, temporary.parent)
+        if proof is None:
+            raise OSError("runtime_artifact_temp_proof_missing")
+        return proof
 
-    def _validated_temp(self, temporary: Path, parent: Path) -> Path:
+    def _validated_temp(
+        self,
+        temporary: Path,
+        parent: Path,
+        proof: _TempArtifactProof,
+        payload: bytes,
+    ) -> Path:
         value = validate_runtime_artifact_path(
             temporary, repo_root=self.repo_root, allowed_root=self.runtime_root
         )
         metadata = os.lstat(value)
-        if value.parent != parent or not stat.S_ISREG(metadata.st_mode):
+        if (
+            value.parent != parent
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size != proof.size
+            or not _same_identity(metadata, proof)
+        ):
             raise ValueError("runtime_artifact_temp_invalid")
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(value, flags)
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_nlink != 1
+                or opened.st_size != proof.size
+                or not _same_identity(opened, proof)
+            ):
+                raise ValueError("runtime_artifact_temp_invalid")
+            with os.fdopen(descriptor, "rb", closefd=True) as stream:
+                descriptor = -1
+                content = stream.read(proof.size + 1)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        if content != payload or hashlib.sha256(content).hexdigest() != proof.digest:
+            raise ValueError("runtime_artifact_temp_content_mismatch")
         return value
 
     @staticmethod
@@ -128,6 +184,12 @@ class ProviderCatalogArtifactStore:
         if not stat.S_ISREG(metadata.st_mode):
             raise ValueError("runtime_artifact_target_not_regular")
         return stat.S_IMODE(metadata.st_mode)
+
+
+def _same_identity(metadata: os.stat_result, proof: _TempArtifactProof) -> bool:
+    if proof.inode > 0 and metadata.st_ino > 0:
+        return (metadata.st_dev, metadata.st_ino) == (proof.device, proof.inode)
+    return True
 
 
 def _remove_temp(path: Path | None) -> None:

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_artifact_store.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_artifact_store.py
@@ -8,36 +8,27 @@ import stat
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO, Callable
 
+from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_atomic_io import (
+    AtomicArtifactOps,
+    _TempArtifactProof,
+    _VerifiedTemp,
+    _cleanup_failed_publication,
+    _fsync_parent,
+    _open_verification_descriptor,
+    _publish_verified,
+    _release_native_publication,
+    _remove_owned_temp,
+    _restore_prior_target,
+    _snapshot_target,
+    _valid_metadata,
+    _verify_descriptor_content,
+)
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
     runtime_operation_lock,
     validate_runtime_artifact_path,
     validate_runtime_root_path,
 )
-
-
-def _write_all(stream: BinaryIO, payload: bytes) -> None:
-    written = stream.write(payload)
-    if written != len(payload):
-        raise OSError("runtime_artifact_temp_write_incomplete")
-
-
-@dataclass(frozen=True)
-class AtomicArtifactOps:
-    """Injectable low-level seams used by offline durability tests."""
-
-    writer: Callable[[BinaryIO, bytes], None] = _write_all
-    fsync: Callable[[int], None] = os.fsync
-    replacer: Callable[[Path, Path], None] = os.replace
-
-
-@dataclass(frozen=True)
-class _TempArtifactProof:
-    device: int
-    inode: int
-    size: int
-    digest: str
 
 
 @dataclass(frozen=True)
@@ -59,7 +50,6 @@ class ProviderCatalogArtifactStore:
 
     def replace_text(self, path: Path | str, text: str) -> Path:
         """Atomically replace one confined regular artifact with exact UTF-8."""
-
         if type(text) is not str:
             raise ValueError("runtime_artifact_text_invalid")
         target = self._target(path, create_parent=True)
@@ -67,7 +57,12 @@ class ProviderCatalogArtifactStore:
         with runtime_operation_lock(target):
             target = self._target(target)
             mode = self._existing_mode(target)
+            prior = _snapshot_target(target, mode)
             temporary: Path | None = None
+            verified: _VerifiedTemp | None = None
+            proof: _TempArtifactProof | None = None
+            publication_started = False
+            native_handle_published = False
             try:
                 descriptor, raw_temp = tempfile.mkstemp(
                     prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
@@ -75,15 +70,32 @@ class ProviderCatalogArtifactStore:
                 temporary = Path(raw_temp)
                 proof = self._write_temp(descriptor, temporary, payload, mode)
                 target = self._target(target)
-                temporary = self._validated_temp(
-                    temporary, target.parent, proof, payload
+                verified = self._validated_temp(temporary, target.parent, proof, payload)
+                self.ops.before_commit(verified.path)
+                self._verify_for_commit(verified, target.parent, payload)
+                publication_started = True
+                verified = _publish_verified(
+                    verified, target, self.ops.replacer, payload
                 )
-                self.ops.replacer(temporary, target)
+                native_handle_published = os.name == "nt" and self.ops.replacer is os.replace
+                self._verify_published_target(target, verified, payload)
+                _remove_owned_temp(temporary, proof)
                 temporary = None
                 _fsync_parent(target.parent, self.ops.fsync)
             except Exception:
-                _remove_temp(temporary)
+                verified = _release_native_publication(verified, native_handle_published)
+                try:
+                    if publication_started:
+                        _restore_prior_target(target, prior)
+                finally:
+                    failed_verified, verified = verified, None
+                    _cleanup_failed_publication(
+                        failed_verified, temporary, proof
+                    )
                 raise
+            finally:
+                if verified is not None:
+                    os.close(verified.descriptor)
         return target
 
     def _target(self, path: Path | str, *, create_parent: bool = False) -> Path:
@@ -141,39 +153,55 @@ class ProviderCatalogArtifactStore:
         parent: Path,
         proof: _TempArtifactProof,
         payload: bytes,
-    ) -> Path:
+    ) -> _VerifiedTemp:
         value = validate_runtime_artifact_path(
             temporary, repo_root=self.repo_root, allowed_root=self.runtime_root
         )
-        metadata = os.lstat(value)
-        if (
-            value.parent != parent
-            or not stat.S_ISREG(metadata.st_mode)
-            or metadata.st_nlink != 1
-            or metadata.st_size != proof.size
-            or not _same_identity(metadata, proof)
-        ):
+        if value.parent != parent or not _valid_metadata(os.lstat(value), proof):
             raise ValueError("runtime_artifact_temp_invalid")
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(value, flags)
+        descriptor = _open_verification_descriptor(value)
         try:
             opened = os.fstat(descriptor)
-            if (
-                not stat.S_ISREG(opened.st_mode)
-                or opened.st_nlink != 1
-                or opened.st_size != proof.size
-                or not _same_identity(opened, proof)
-            ):
+            if not _valid_metadata(opened, proof):
                 raise ValueError("runtime_artifact_temp_invalid")
-            with os.fdopen(descriptor, "rb", closefd=True) as stream:
-                descriptor = -1
-                content = stream.read(proof.size + 1)
+            _verify_descriptor_content(descriptor, proof, payload)
+            return _VerifiedTemp(value, descriptor, proof)
+        except Exception:
+            os.close(descriptor)
+            raise
+
+    def _verify_for_commit(
+        self, verified: _VerifiedTemp, parent: Path, payload: bytes
+    ) -> None:
+        value = validate_runtime_artifact_path(
+            verified.path,
+            repo_root=self.repo_root,
+            allowed_root=self.runtime_root,
+        )
+        if (
+            value.parent != parent
+            or not _valid_metadata(os.lstat(value), verified.proof)
+            or not _valid_metadata(os.fstat(verified.descriptor), verified.proof)
+        ):
+            raise ValueError("runtime_artifact_temp_changed_before_commit")
+        _verify_descriptor_content(verified.descriptor, verified.proof, payload)
+
+    @staticmethod
+    def _verify_published_target(
+        target: Path, verified: _VerifiedTemp, payload: bytes
+    ) -> None:
+        if (
+            not _valid_metadata(os.lstat(target), verified.proof)
+            or not _valid_metadata(os.fstat(verified.descriptor), verified.proof)
+        ):
+            raise ValueError("runtime_artifact_publication_identity_mismatch")
+        descriptor = _open_verification_descriptor(target)
+        try:
+            if not _valid_metadata(os.fstat(descriptor), verified.proof):
+                raise ValueError("runtime_artifact_publication_identity_mismatch")
+            _verify_descriptor_content(descriptor, verified.proof, payload)
         finally:
-            if descriptor >= 0:
-                os.close(descriptor)
-        if content != payload or hashlib.sha256(content).hexdigest() != proof.digest:
-            raise ValueError("runtime_artifact_temp_content_mismatch")
-        return value
+            os.close(descriptor)
 
     @staticmethod
     def _existing_mode(target: Path) -> int | None:
@@ -184,35 +212,5 @@ class ProviderCatalogArtifactStore:
         if not stat.S_ISREG(metadata.st_mode):
             raise ValueError("runtime_artifact_target_not_regular")
         return stat.S_IMODE(metadata.st_mode)
-
-
-def _same_identity(metadata: os.stat_result, proof: _TempArtifactProof) -> bool:
-    if proof.inode > 0 and metadata.st_ino > 0:
-        return (metadata.st_dev, metadata.st_ino) == (proof.device, proof.inode)
-    return True
-
-
-def _remove_temp(path: Path | None) -> None:
-    if path is None:
-        return
-    try:
-        path.unlink(missing_ok=True)
-    except OSError:
-        pass
-
-
-def _fsync_parent(parent: Path, fsync: Callable[[int], None]) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
-    try:
-        descriptor = os.open(parent, flags)
-    except (OSError, NotImplementedError):
-        return
-    try:
-        fsync(descriptor)
-    except (OSError, NotImplementedError):
-        pass
-    finally:
-        os.close(descriptor)
-
 
 __all__ = ["AtomicArtifactOps", "ProviderCatalogArtifactStore"]

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_atomic_io.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_atomic_io.py
@@ -1,0 +1,331 @@
+"""Low-level atomic I/O primitives for provider catalog artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Callable
+
+
+def _write_all(stream: BinaryIO, payload: bytes) -> None:
+    written = stream.write(payload)
+    if written != len(payload):
+        raise OSError("runtime_artifact_temp_write_incomplete")
+
+
+def _before_commit(_path: Path) -> None:
+    """Trusted no-op seam for deterministic publication failure tests."""
+
+
+@dataclass(frozen=True)
+class AtomicArtifactOps:
+    """Trusted low-level seams used only by offline durability tests."""
+
+    writer: Callable[[BinaryIO, bytes], None] = _write_all
+    fsync: Callable[[int], None] = os.fsync
+    replacer: Callable[[Path, Path], None] = os.replace
+    before_commit: Callable[[Path], None] = _before_commit
+
+
+@dataclass(frozen=True)
+class _TempArtifactProof:
+    device: int
+    inode: int
+    size: int
+    digest: str
+
+
+@dataclass(frozen=True)
+class _VerifiedTemp:
+    path: Path
+    descriptor: int
+    proof: _TempArtifactProof
+
+
+@dataclass(frozen=True)
+class _PriorTarget:
+    payload: bytes | None
+    mode: int | None
+
+
+def _same_identity(metadata: os.stat_result, proof: _TempArtifactProof) -> bool:
+    return (
+        proof.inode > 0
+        and metadata.st_ino > 0
+        and (metadata.st_dev, metadata.st_ino) == (proof.device, proof.inode)
+    )
+
+
+def _valid_metadata(metadata: os.stat_result, proof: _TempArtifactProof) -> bool:
+    return (
+        stat.S_ISREG(metadata.st_mode)
+        and metadata.st_nlink == 1
+        and metadata.st_size == proof.size
+        and _same_identity(metadata, proof)
+    )
+
+
+def _verify_descriptor_content(
+    descriptor: int, proof: _TempArtifactProof, payload: bytes
+) -> None:
+    content = _read_descriptor(descriptor, proof.size + 1)
+    if content != payload or hashlib.sha256(content).hexdigest() != proof.digest:
+        raise ValueError("runtime_artifact_temp_content_mismatch")
+
+
+def _read_descriptor(descriptor: int, limit: int) -> bytes:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks = []
+    remaining = limit
+    while remaining > 0:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _open_verification_descriptor(path: Path) -> int:
+    if os.name != "nt":
+        return os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    return _open_windows_descriptor(path, 0x80000000)
+
+
+def _open_windows_publication_descriptor(path: Path) -> int:
+    return _open_windows_descriptor(path, 0x80000000 | 0x00010000)
+
+
+def _open_windows_descriptor(path: Path, desired_access: int) -> int:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    handle = create_file(
+        str(path),
+        desired_access,
+        0x00000001 | 0x00000002 | 0x00000004,
+        None,
+        3,
+        0x00000080 | 0x00200000,
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        return msvcrt.open_osfhandle(
+            handle, os.O_RDONLY | getattr(os, "O_BINARY", 0)
+        )
+    except Exception:
+        close_handle(handle)
+        raise
+
+
+def _publish_verified(
+    verified: _VerifiedTemp,
+    target: Path,
+    replacer: Callable[[Path, Path], None],
+    payload: bytes,
+) -> _VerifiedTemp:
+    if os.name == "nt" and replacer is os.replace:
+        descriptor = _open_windows_publication_descriptor(verified.path)
+        replacement = _VerifiedTemp(verified.path, descriptor, verified.proof)
+        try:
+            if not _valid_metadata(os.fstat(descriptor), verified.proof):
+                raise ValueError("runtime_artifact_temp_changed_before_commit")
+            _verify_descriptor_content(descriptor, verified.proof, payload)
+            _rename_windows_descriptor(descriptor, target)
+        except Exception:
+            os.close(descriptor)
+            raise
+        os.close(verified.descriptor)
+        return replacement
+    replacer(verified.path, target)
+    return verified
+
+
+def _rename_windows_descriptor(descriptor: int, target: Path) -> None:
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    class _FileRenameInfoHead(ctypes.Structure):
+        _fields_ = [
+            ("replace", wintypes.BOOLEAN),
+            ("root", wintypes.HANDLE),
+            ("name_len", wintypes.DWORD),
+        ]
+
+    nt_path = _windows_nt_path(target)
+    raw_name = nt_path.encode("utf-16-le")
+    name_offset = _FileRenameInfoHead.name_len.offset + ctypes.sizeof(
+        wintypes.DWORD
+    )
+    size = ctypes.sizeof(_FileRenameInfoHead) + len(raw_name)
+    buffer = ctypes.create_string_buffer(size)
+    header = _FileRenameInfoHead.from_buffer(buffer)
+    header.replace, header.root, header.name_len = 1, None, len(raw_name)
+    ctypes.memmove(ctypes.addressof(buffer) + name_offset, raw_name, len(raw_name))
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    rename = kernel32.SetFileInformationByHandle
+    rename.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    rename.restype = wintypes.BOOL
+    if not rename(msvcrt.get_osfhandle(descriptor), 3, buffer, size):
+        raise ctypes.WinError(ctypes.get_last_error())
+
+
+def _windows_nt_path(path: Path) -> str:
+    resolved = str(path.resolve())
+    if resolved.startswith("\\\\"):
+        return "\\??\\UNC\\" + resolved.lstrip("\\")
+    return "\\??\\" + resolved
+
+
+def _snapshot_target(target: Path, mode: int | None) -> _PriorTarget:
+    if mode is None:
+        return _PriorTarget(None, None)
+    named = os.lstat(target)
+    descriptor = _open_verification_descriptor(target)
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_ino <= 0
+            or named.st_ino <= 0
+            or opened.st_size != named.st_size
+            or (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino)
+        ):
+            raise ValueError("runtime_artifact_target_changed")
+        return _PriorTarget(_read_descriptor(descriptor, opened.st_size), mode)
+    finally:
+        os.close(descriptor)
+
+
+def _restore_prior_target(target: Path, prior: _PriorTarget) -> None:
+    if prior.payload is None:
+        target.unlink(missing_ok=True)
+        _fsync_parent(target.parent, os.fsync)
+        return
+    if _target_matches_prior(target, prior):
+        return
+    descriptor, raw_temp = tempfile.mkstemp(
+        prefix=f".{target.name}.restore.", suffix=".tmp", dir=target.parent
+    )
+    temporary: Path | None = Path(raw_temp)
+    try:
+        with os.fdopen(descriptor, "w+b", closefd=True) as stream:
+            _write_all(stream, prior.payload)
+            stream.flush()
+            if prior.mode is not None and hasattr(os, "fchmod"):
+                os.fchmod(stream.fileno(), prior.mode)
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+        temporary = None
+        if not _target_matches_prior(target, prior):
+            raise OSError("runtime_artifact_prior_target_restore_mismatch")
+        _fsync_parent(target.parent, os.fsync)
+    finally:
+        _remove_temp(temporary)
+
+
+def _target_matches_prior(target: Path, prior: _PriorTarget) -> bool:
+    try:
+        named = os.lstat(target)
+        descriptor = os.open(
+            target, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        )
+    except (OSError, ValueError):
+        return False
+    try:
+        opened = os.fstat(descriptor)
+        return (
+            prior.payload is not None
+            and stat.S_ISREG(opened.st_mode)
+            and (opened.st_dev, opened.st_ino) == (named.st_dev, named.st_ino)
+            and stat.S_IMODE(opened.st_mode) == prior.mode
+            and _read_descriptor(descriptor, opened.st_size + 1) == prior.payload
+        )
+    finally:
+        os.close(descriptor)
+
+
+def _remove_temp(path: Path | None) -> None:
+    if path is None:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _remove_owned_temp(
+    path: Path | None, proof: _TempArtifactProof | None
+) -> None:
+    if path is None:
+        return
+    if proof is None:
+        _remove_temp(path)
+        return
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return
+    if _valid_metadata(metadata, proof):
+        _remove_temp(path)
+
+
+def _cleanup_failed_publication(
+    verified: _VerifiedTemp | None,
+    temporary: Path | None,
+    proof: _TempArtifactProof | None,
+) -> None:
+    if verified is not None:
+        os.close(verified.descriptor)
+    _remove_owned_temp(temporary, proof)
+
+
+def _release_native_publication(
+    verified: _VerifiedTemp | None, native_handle_published: bool
+) -> _VerifiedTemp | None:
+    if native_handle_published and verified is not None:
+        os.close(verified.descriptor)
+        return None
+    return verified
+
+
+def _fsync_parent(parent: Path, fsync: Callable[[int], None]) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(parent, flags)
+    except (OSError, NotImplementedError):
+        return
+    try:
+        fsync(descriptor)
+    except (OSError, NotImplementedError):
+        pass
+    finally:
+        os.close(descriptor)

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_snapshot.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_snapshot.py
@@ -23,7 +23,7 @@ _SECRET = re.compile(r"(?i)(?:bearer\s+\S+|(?:api[_-]?key|token|secret)\s*[:=]|"
                      r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.)")
 _REASONS = frozenset("""completed precall_intent transport_pending invocation_invalid scheduled_invocation_not_due
 scheduled_invocation_expired output_path_invalid precall_write_failed transport_timeout transport_failed
-redirect_rejected http_status_rejected content_type_rejected body_too_large json_invalid top_level_invalid
+redirect_rejected redirect_history_rejected http_status_rejected content_type_rejected body_too_large json_invalid top_level_invalid
 record_limit_exceeded no_acceptable_records candidate_write_failed terminal_receipt_write_failed""".split())
 _OUTCOMES = frozenset("BLOCKED_PRECALL INDETERMINATE COMPLETED FAILED".split())
 _INVOCATION_KEYS = frozenset("schema_version invocation_id mode schedule_id scheduled_for_ms expires_at_ms".split())
@@ -418,8 +418,8 @@ def _validate_receipt_state(
             and (reason == "terminal_receipt_write_failed" or evidence_empty))
     else:
         has_body = digest is not None and size is not None
-        if reason == "redirect_rejected":
-            evidence = has_body and status is not None and 300 <= status < 400
+        if reason in {"redirect_rejected", "redirect_history_rejected"}:
+            evidence = has_body and status is not None and ((300 <= status < 400) == (reason == "redirect_rejected"))
         elif reason == "http_status_rejected":
             evidence = has_body and status is not None and status != 200 and not 300 <= status < 400
         elif reason in {"content_type_rejected", "json_invalid", "top_level_invalid", "record_limit_exceeded", "no_acceptable_records"}:

--- a/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
+++ b/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
@@ -1,5 +1,24 @@
 # AI Gateway TestModLog
 
+## 2026-07-24 - Provider discovery defensive reliability hotfix
+
+Scope: offline-only regressions for redirect-history receipt coherence and
+post-write/precommit artifact pathname integrity.
+
+- `test_redirected_200_emits_truthful_terminal_receipt_and_preserves_lkg`
+  requires a canonical `FAILED/redirect_history_rejected` receipt, exact final
+  HTTP status, rehydration, and unchanged last-known-good candidate.
+- `test_precommit_path_attack_never_publishes_substituted_bytes` covers
+  pathname replacement, hard-link creation, and file-symlink substitution.
+  Unsupported unprivileged Windows symlink creation is reported as one
+  platform skip; pathname replacement and hard-link cases still run.
+- Receipt-unit cases require redirect-history evidence with a non-3xx final
+  status and keep raw 3xx evidence bound to `redirect_rejected`.
+- WSP 62 AST enforcement remains green for every touched production function.
+
+Hotfix focused gate (the five provider/catalog files): `91 passed, 1 skipped`.
+Full `modules/ai_intelligence/ai_gateway/tests`: `332 passed, 1 skipped`.
+
 ## 2026-07-23 - Direct provider catalog durability and WSP62 repair
 
 Scope: offline-only verification for the bounded OpenRouter catalog discovery

--- a/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
+++ b/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
@@ -2,8 +2,8 @@
 
 ## 2026-07-24 - Provider discovery defensive reliability hotfix
 
-Scope: offline-only regressions for redirect-history receipt coherence and
-post-write/precommit artifact pathname integrity.
+Scope: offline-only regressions for redirect-history receipt coherence,
+retained-handle publication, rollback, and pathname integrity.
 
 - `test_redirected_200_emits_truthful_terminal_receipt_and_preserves_lkg`
   requires a canonical `FAILED/redirect_history_rejected` receipt, exact final
@@ -11,13 +11,17 @@ post-write/precommit artifact pathname integrity.
 - `test_precommit_path_attack_never_publishes_substituted_bytes` covers
   pathname replacement, hard-link creation, and file-symlink substitution.
   Unsupported unprivileged Windows symlink creation is reported as one
-  platform skip; pathname replacement and hard-link cases still run.
+  platform skip; ambiguous foreign substitutes are preserved, never unlinked.
+- Post-validation and Windows final-check substitution cases prove that no
+  substituted bytes become the candidate; Windows publishes the exact verified
+  handle object. Wrong-publication and held-target failures restore exact prior
+  bytes/mode or absence and clean only identity-owned temporary files.
 - Receipt-unit cases require redirect-history evidence with a non-3xx final
   status and keep raw 3xx evidence bound to `redirect_rejected`.
 - WSP 62 AST enforcement remains green for every touched production function.
 
-Hotfix focused gate (the five provider/catalog files): `91 passed, 1 skipped`.
-Full `modules/ai_intelligence/ai_gateway/tests`: `332 passed, 1 skipped`.
+Hotfix focused gate (the five provider/catalog files): `98 passed, 1 skipped`.
+Full `modules/ai_intelligence/ai_gateway/tests`: `339 passed, 1 skipped`.
 
 ## 2026-07-23 - Direct provider catalog durability and WSP62 repair
 

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_direct_discovery.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_direct_discovery.py
@@ -130,6 +130,31 @@ def test_failed_refresh_preserves_lkg_and_emits_content_free_terminal_reason(
     assert "sensitive provider detail" not in json.dumps(persisted)
 
 
+def test_redirected_200_emits_truthful_terminal_receipt_and_preserves_lkg(
+    tmp_path: Path,
+) -> None:
+    old = b'{"existing":"last-known-good"}\n'
+    candidate = tmp_path / "candidate.json"
+    candidate.write_bytes(old)
+    response = HTTPResponse(
+        200,
+        {"Content-Type": "application/json"},
+        (FIXTURES / "openrouter_models_success.json").read_bytes(),
+        redirected=True,
+    )
+
+    result = _run(tmp_path, _FakeTransport(response))
+
+    assert (result.receipt.outcome, result.receipt.reason) == (
+        "FAILED",
+        "redirect_history_rejected",
+    )
+    assert result.receipt.http_status == 200
+    assert candidate.read_bytes() == old
+    persisted = json.loads((tmp_path / "attempt.json").read_text(encoding="utf-8"))
+    assert rehydrate_discovery_receipt(persisted) == result.receipt
+
+
 def test_oversized_response_is_rejected_without_hashing_or_lkg_replacement(
     tmp_path: Path,
 ) -> None:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_artifact_store.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_artifact_store.py
@@ -241,10 +241,11 @@ def test_postvalidation_substitution_preserves_lkg_before_default_replace(
         store.replace_text(target, "trusted-new-value")
 
     assert attempted is True
-    assert substituted is (os.name != "nt")
     assert target.read_bytes() == old
     assert b"attacker-controlled" not in target.read_bytes()
-    assert _temps(tmp_path) == []
+    remaining_payloads = sorted(path.read_bytes() for path in _temps(tmp_path))
+    expected_payloads = [b"attacker-controlled"] if substituted else []
+    assert remaining_payloads == expected_payloads
 
 
 @pytest.mark.parametrize("prior_exists", [True, False])

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_artifact_store.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_artifact_store.py
@@ -153,3 +153,56 @@ def test_successful_atomic_replace_is_exact_and_preserves_mode(tmp_path: Path) -
     assert target.read_bytes() == "exact-\u03c9\n".encode("utf-8")
     assert stat.S_IMODE(os.lstat(target).st_mode) == before_mode
     assert _temps(tmp_path) == []
+
+
+@pytest.mark.parametrize("attack", ["pathname_replacement", "hard_link", "symlink"])
+def test_precommit_path_attack_never_publishes_substituted_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    attack: str,
+) -> None:
+    target = tmp_path / "candidate.json"
+    old = b"last-known-good"
+    target.write_bytes(old)
+    original = ProviderCatalogArtifactStore._validated_temp
+    attacked = False
+
+    def attack_then_validate(self, *args):
+        nonlocal attacked
+        temporary = next(
+            value
+            for value in args
+            if isinstance(value, Path) and value.suffix == ".tmp"
+        )
+        if not attacked:
+            attacked = True
+            substitute = tmp_path / f"{attack}.substitute"
+            if attack == "hard_link":
+                os.link(temporary, substitute)
+            else:
+                substitute.write_bytes(b"attacker-controlled")
+                if attack == "pathname_replacement":
+                    os.replace(substitute, temporary)
+                else:
+                    temporary.unlink()
+                    try:
+                        temporary.symlink_to(substitute)
+                    except OSError as error:
+                        pytest.skip(f"file symlink unavailable: {error}")
+        return original(self, *args)
+
+    monkeypatch.setattr(
+        ProviderCatalogArtifactStore,
+        "_validated_temp",
+        attack_then_validate,
+    )
+    store = ProviderCatalogArtifactStore.create(
+        repo_root=Path.cwd(), runtime_root=tmp_path
+    )
+
+    with pytest.raises((OSError, ValueError)):
+        store.replace_text(target, "trusted-new-value")
+
+    assert attacked is True
+    assert target.read_bytes() == old
+    assert b"attacker-controlled" not in target.read_bytes()

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_artifact_store.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_artifact_store.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from modules.ai_intelligence.ai_gateway.src import model_provider_catalog_atomic_io
 from modules.ai_intelligence.ai_gateway.src.model_openrouter_direct_discovery import (
     HTTPResponse,
     discover_openrouter_model_catalog,
@@ -17,6 +18,10 @@ from modules.ai_intelligence.ai_gateway.src.model_openrouter_direct_discovery im
 from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_artifact_store import (
     AtomicArtifactOps,
     ProviderCatalogArtifactStore,
+)
+from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_atomic_io import (
+    _open_windows_publication_descriptor,
+    _rename_windows_descriptor,
 )
 from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_snapshot import (
     build_discovery_invocation,
@@ -206,3 +211,171 @@ def test_precommit_path_attack_never_publishes_substituted_bytes(
     assert attacked is True
     assert target.read_bytes() == old
     assert b"attacker-controlled" not in target.read_bytes()
+    assert _temps(tmp_path) != []
+
+
+def test_postvalidation_substitution_preserves_lkg_before_default_replace(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "candidate.json"
+    old = b"last-known-good"
+    target.write_bytes(old)
+    attempted = False
+    substituted = False
+
+    def substitute_after_validation(temporary: Path) -> None:
+        nonlocal attempted, substituted
+        attempted = True
+        replacement = tmp_path / "postvalidation.substitute"
+        replacement.write_bytes(b"attacker-controlled")
+        os.replace(replacement, temporary)
+        substituted = True
+
+    store = ProviderCatalogArtifactStore.create(
+        repo_root=Path.cwd(),
+        runtime_root=tmp_path,
+        ops=AtomicArtifactOps(before_commit=substitute_after_validation),
+    )
+
+    with pytest.raises((OSError, ValueError)):
+        store.replace_text(target, "trusted-new-value")
+
+    assert attempted is True
+    assert substituted is (os.name != "nt")
+    assert target.read_bytes() == old
+    assert b"attacker-controlled" not in target.read_bytes()
+    assert _temps(tmp_path) == []
+
+
+@pytest.mark.parametrize("prior_exists", [True, False])
+def test_wrong_publication_restores_exact_prior_target(
+    tmp_path: Path, prior_exists: bool
+) -> None:
+    target = tmp_path / "candidate.json"
+    old = b"last-known-good-byte-for-byte"
+    if prior_exists:
+        target.write_bytes(old)
+        target.chmod(0o640)
+        old_mode = stat.S_IMODE(os.lstat(target).st_mode)
+    else:
+        old_mode = None
+
+    def publish_wrong_bytes(_source: Path, destination: Path) -> None:
+        replacement = tmp_path / "wrong-publication"
+        replacement.write_bytes(b"attacker-controlled")
+        os.replace(replacement, destination)
+
+    store = ProviderCatalogArtifactStore.create(
+        repo_root=Path.cwd(),
+        runtime_root=tmp_path,
+        ops=AtomicArtifactOps(replacer=publish_wrong_bytes),
+    )
+
+    with pytest.raises(ValueError, match="publication_identity_mismatch"):
+        store.replace_text(target, "trusted-new-value")
+
+    assert target.exists() is prior_exists
+    if prior_exists:
+        assert target.read_bytes() == old
+        assert stat.S_IMODE(os.lstat(target).st_mode) == old_mode
+    assert _temps(tmp_path) == []
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows exact-handle backend")
+def test_windows_publish_uses_verified_object_after_final_path_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "candidate.json"
+    target.write_bytes(b"last-known-good")
+    real_rename = _rename_windows_descriptor
+    swapped = False
+
+    def swap_after_final_check(descriptor: int, destination: Path) -> None:
+        nonlocal swapped
+        source = next(iter(_temps(tmp_path)))
+        second = _open_windows_publication_descriptor(source)
+        displaced = tmp_path / "verified-object-displaced"
+        try:
+            real_rename(second, displaced)
+        finally:
+            os.close(second)
+        source.write_bytes(b"attacker-controlled")
+        swapped = True
+        real_rename(descriptor, destination)
+
+    monkeypatch.setattr(
+        model_provider_catalog_atomic_io,
+        "_rename_windows_descriptor",
+        swap_after_final_check,
+    )
+    store = ProviderCatalogArtifactStore.create(
+        repo_root=Path.cwd(), runtime_root=tmp_path
+    )
+
+    store.replace_text(target, "trusted-new-value")
+
+    assert swapped is True
+    assert target.read_bytes() == b"trusted-new-value"
+    assert b"attacker-controlled" not in target.read_bytes()
+    assert any(
+        path.read_bytes() == b"attacker-controlled" for path in _temps(tmp_path)
+    )
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows exact-handle backend")
+def test_windows_native_rename_failure_preserves_exact_lkg(tmp_path: Path) -> None:
+    target = tmp_path / "candidate.json"
+    old = b"last-known-good-byte-for-byte"
+    target.write_bytes(old)
+    blockers = []
+
+    def block_target_delete(_temporary: Path) -> None:
+        blockers.append(os.open(target, os.O_RDONLY))
+
+    store = ProviderCatalogArtifactStore.create(
+        repo_root=Path.cwd(),
+        runtime_root=tmp_path,
+        ops=AtomicArtifactOps(before_commit=block_target_delete),
+    )
+    try:
+        with pytest.raises(OSError):
+            store.replace_text(target, "trusted-new-value")
+    finally:
+        for descriptor in blockers:
+            os.close(descriptor)
+
+    assert target.read_bytes() == old
+    assert _temps(tmp_path) == []
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows exact-handle backend")
+@pytest.mark.parametrize("prior_exists", [True, False])
+def test_windows_detected_postpublication_mismatch_restores_prior(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    prior_exists: bool,
+) -> None:
+    target = tmp_path / "candidate.json"
+    old = b"last-known-good-byte-for-byte"
+    if prior_exists:
+        target.write_bytes(old)
+
+    def force_mismatch(_target, _verified, _payload) -> None:
+        raise ValueError("forced_publication_mismatch")
+
+    monkeypatch.setattr(
+        ProviderCatalogArtifactStore,
+        "_verify_published_target",
+        staticmethod(force_mismatch),
+    )
+    store = ProviderCatalogArtifactStore.create(
+        repo_root=Path.cwd(), runtime_root=tmp_path
+    )
+
+    with pytest.raises(ValueError, match="forced_publication_mismatch"):
+        store.replace_text(target, "trusted-new-value")
+
+    assert target.exists() is prior_exists
+    if prior_exists:
+        assert target.read_bytes() == old
+    assert _temps(tmp_path) == []

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
@@ -16,6 +16,7 @@ NEW_MODULE_NAMES = {
 FUNCTION_LIMIT_MODULES = (
     "model_intelligence_catalog.py",
     "model_openrouter_direct_discovery.py",
+    "model_provider_catalog_atomic_io.py",
     "model_provider_catalog_artifact_store.py",
     "model_provider_catalog_snapshot.py",
 )
@@ -74,6 +75,11 @@ def test_new_surfaces_stay_below_phase_one_size_limits() -> None:
     ) < 450
     assert len(
         (MODULE / "src/model_openrouter_direct_discovery.py").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ) < 400
+    assert len(
+        (MODULE / "src/model_provider_catalog_atomic_io.py").read_text(
             encoding="utf-8"
         ).splitlines()
     ) < 400

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_snapshot.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_snapshot.py
@@ -257,6 +257,8 @@ def test_noncompleted_receipts_reject_incoherent_state(
     [
         ("redirect_rejected", {"http_status": 200, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
         ("redirect_rejected", {"http_status": 302}),
+        ("redirect_history_rejected", {"http_status": 302, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
+        ("redirect_history_rejected", {"http_status": 200}),
         ("http_status_rejected", {"http_status": 200, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
         ("http_status_rejected", {"http_status": 302, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
         ("content_type_rejected", {"http_status": 415, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
@@ -287,6 +289,7 @@ def test_failed_receipt_reason_requires_coherent_transport_evidence(
     "reason,details",
     [
         ("redirect_rejected", {"http_status": 302, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
+        ("redirect_history_rejected", {"http_status": 200, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
         ("http_status_rejected", {"http_status": 503, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
         ("content_type_rejected", {"http_status": 200, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),
         ("json_invalid", {"http_status": 200, "response_body_digest": sha256_bytes(b"x"), "response_byte_count": 1}),


### PR DESCRIPTION
## Summary
- emit a durable `redirect_history_rejected` terminal receipt for redirected non-3xx responses
- bind Windows provider-catalog publication to the exact verified file handle
- fail closed on unavailable file identity and restore the exact prior target on detected publication mismatch
- preserve foreign pathname replacements while cleaning only identity-proven owned temporary artifacts
- document the owner-controlled non-shared runtime-directory boundary for non-Windows publication

## WSP_97 contradiction evidence
- parent commit reproduced redirected-200 receipt failure and stranded `transport_pending`
- parent commit reproduced pathname/hard-link substitution publishing different bytes
- the first repair was independently rejected because its verification handle closed before publication
- the final repair passed exact-handle substitution, native failure, rollback, inode-zero, and identity-aware cleanup probes

## Validation
- focused AI gateway: 98 passed, 1 skipped (unprivileged Windows symlink creation)
- full AI gateway: 339 passed, 1 skipped
- protected/WSP gates: green; touched functions <= 50 lines
- Ruff, compile, diff/show checks: green
- independent final review: GO at `17106384dbea33c283934c16d232ad3f79d80a43`

## Boundaries
- no live provider, runtime, scheduler, HoloIndex, or model calls
- no model selection/promotion/runtime-binding authority changes
- POSIX publication requires an owner-controlled runtime directory without untrusted peer writers; the cooperative operation lock is not a security boundary
- parent-directory fsync remains best-effort where unsupported