### PR TITLE
fix(idle-automation): add durable schedule claim leases

### DIFF
--- a/modules/infrastructure/idle_automation/INTERFACE.md
+++ b/modules/infrastructure/idle_automation/INTERFACE.md
@@ -136,6 +136,8 @@ if result["overall_success"]:
 | `AUTO_LINKEDIN_POST` | bool | `true` | Enable LinkedIn posting |
 | `IDLE_TASK_TIMEOUT` | int | `300` | Maximum execution time (seconds) |
 | `MAX_DAILY_EXECUTIONS` | int | `3` | Maximum executions per day |
+| `AUTO_SCHEDULED_ROUTINES` | bool | `true` | Enable scheduled routine claims and dispatch |
+| `IDLE_AUTOMATION_RUNTIME_ROOT` | path | `~/.foundups-agent/idle_automation` | Trusted private claim-state root outside the repository |
 
 ### Safety Controls
 
@@ -231,6 +233,36 @@ All external dependencies can be mocked for testing:
 - Network checks via connectivity mocking
 - LinkedIn API via bridge mocking
 - WRE integration via mock objects
+
+## Scheduled Claim Interface
+
+### `ScheduleEvaluator.claim_schedule(spec, *, now=None)`
+
+Computes the canonical cadence window and asks `ScheduleClaimStore` to publish
+one durable claim. It returns `ScheduleClaim` only after the fixed
+`schedule_claim_state.json` artifact is atomically published under the trusted
+runtime root. Disabled, unknown, out-of-window, completed, actively leased, and
+backoff-blocked schedules return `None`.
+
+### `ScheduleEvaluator.finalize_claim(token, *, success, outcome_code, now=None)`
+
+Performs exact-token compare-and-set finalization. A token that expired may
+finalize only while it remains current; recovery immediately makes the old
+token stale. Outcome state stores only bounded codes or a digest, never raw
+dispatcher text.
+
+### Durability Contract
+
+- Maximum claim lease: 3900 seconds, exceeding the 3600-second bounded routine
+  timeout plus margin.
+- Retry policy: 60 seconds, then 300 seconds; maximum three attempts.
+- Lease recovery: at most one expired-claim recovery per window.
+- Publication: same-directory temp, fsync, replace, post-replace byte proof,
+  and exact last-known-good restoration on uncertain replacer behavior.
+- Malformed, partial, duplicate-key, oversized, or noncanonical state fails
+  closed before dispatch.
+- Claims provide cooperative single ownership, not exactly-once side effects;
+  registered routines must be repeat-safe or independently fenced.
 
 ## WSP Compliance Matrix
 

--- a/modules/infrastructure/idle_automation/INTERFACE.md
+++ b/modules/infrastructure/idle_automation/INTERFACE.md
@@ -261,6 +261,9 @@ dispatcher text.
   and exact last-known-good restoration on uncertain replacer behavior.
 - Malformed, partial, duplicate-key, oversized, or noncanonical state fails
   closed before dispatch.
+- A legacy `last_run` suppresses a window only when `last_result` has the
+  canonical `success:` prefix. Failed or unknown legacy results remain due and
+  enter durable claim/retry control.
 - Claims provide cooperative single ownership, not exactly-once side effects;
   registered routines must be repeat-safe or independently fenced.
 

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,49 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-07-24 - Durable Schedule Claim Lease Phase 1
+
+**WSP Protocol**: WSP 15, WSP 22, WSP 62, WSP 97
+**Phase**: P0 autonomous scheduling correctness
+**Agent**: 0102
+
+#### Problem
+
+Scheduled dispatch used a non-atomic `get_due -> await dispatch ->
+record_execution` sequence. Independent workers could observe the same due
+schedule and both execute it; crashes also left no authoritative retry or
+completion boundary.
+
+#### Solution
+
+- Kept `ScheduleEvaluator` as the single cadence/window owner.
+- Added canonical full SHA-256 window execution IDs.
+- Added trusted outside-repository `schedule_claim_state.json`.
+- Added one-window durable leases with opaque exact-token finalization.
+- Added restart idempotency, one lease recovery, three attempts, and 60/300
+  second backoff.
+- Added strict malformed/partial/duplicate/cap validation, bounded retention,
+  content-free outcomes, atomic publication proof, and exact LKG restoration.
+- Changed DAE ordering to claim immediately before dispatch and finalize before
+  recording successful legacy `last_run`; failed attempts no longer suppress
+  their bounded retry.
+
+#### Safety Boundary
+
+Lease recovery is at-least-once and therefore permits only repeat-safe or
+independently fenced routines. The Windows `Local\` mutex coordinates the same
+logon session, not cross-session services.
+
+#### Tests
+
+- 83 focused claim/evaluator/DAE tests pass.
+- Full module run: 117 passed; one unrelated pre-existing startup HoloIndex
+  mock-target mismatch remains outside this lane.
+- Neighbor runtime safety: 11 passed, 1 skipped.
+- Adversarial coverage includes concurrency, stale tokens, expiry recovery,
+  retry cap, malformed state, exact LKG preservation, path confinement,
+  retention, disabled zero-dispatch, and completion-unknown finalization.
+
 ### 2026-03-27 - Cross-Surface Continuity Wiring (triggering_session)
 
 **WSP Protocol**: WSP 22, WSP 54 (Multi-Agent Coordination)

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,18 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-07-24 - Legacy Failed-Row Durable Retry Migration
+
+**WSP Protocol**: WSP 22, WSP 62, WSP 97
+
+- Corrected legacy migration so a current-window `last_run` suppresses work
+  only when `last_result` is explicit canonical `success:...`.
+- Failed or unknown legacy results now remain due and enter durable claim
+  control instead of being silently skipped.
+- `record_execution()` advances `last_run` only for successful executions.
+- Added persisted failed-row, unknown-result fail-safe, canonical-success, and
+  failed-record timestamp regressions.
+
 ### 2026-07-24 - Durable Schedule Claim Lease Phase 1
 
 **WSP Protocol**: WSP 15, WSP 22, WSP 62, WSP 97

--- a/modules/infrastructure/idle_automation/README.md
+++ b/modules/infrastructure/idle_automation/README.md
@@ -42,6 +42,16 @@ The Idle Automation module provides autonomous background tasks that execute whe
 - Prevents duplicate executions
 - Telemetry collection for optimization
 
+### Durable Scheduled-Routine Claims
+- `ScheduleEvaluator` remains the sole cadence/window owner.
+- Each due window receives a canonical SHA-256 execution ID.
+- The DAE durably claims exactly one window immediately before dispatch.
+- Exact opaque tokens finalize success or bounded retry state.
+- Completed windows remain idempotent across process restarts.
+- One expired-lease recovery and three total attempts are permitted.
+- Claim control state is stored under a trusted, private runtime root outside
+  the repository; schedule phrases cannot select its path.
+
 ### Safety & Controls
 - Opt-in configuration via environment variables
 - Network availability checks
@@ -75,6 +85,8 @@ wre_integration.record_idle_execution(
 - `AUTO_GIT_PUSH=true`: Enable automatic Git operations
 - `AUTO_LINKEDIN_POST=true`: Enable LinkedIn posting
 - `IDLE_TASK_TIMEOUT=300`: Maximum execution time per idle task
+- `AUTO_SCHEDULED_ROUTINES=true`: Enable scheduled safe-routine dispatch
+- `IDLE_AUTOMATION_RUNTIME_ROOT=...`: Trusted outside-repository claim-state root
 
 ### Safety Controls
 - `--no-auto-push` CLI flag to disable during testing
@@ -92,6 +104,9 @@ idle_automation/
 +-- __init__.py          # Module exports
 +-- src/
 [U+2502]   +-- idle_automation_dae.py    # Main DAE implementation
+[U+2502]   +-- schedule_evaluator.py     # Cadence/window ownership
+[U+2502]   +-- schedule_claim_state.py   # Claim lease state machine
+[U+2502]   +-- schedule_claim_codec.py   # Strict codec + atomic publication
 [U+2502]   +-- git_automation.py         # Git operations
 [U+2502]   +-- social_media_integration.py # Social media posting
 +-- tests/
@@ -132,3 +147,15 @@ print(f"Last execution: {status['last_run']}")
 ---
 
 *This module transforms idle time into productive autonomous operations per WSP 35 Module Execution Automation.*
+
+## Claim Safety Boundary
+
+The lease prevents concurrent cooperative workers from owning the same logical
+window. Recovery is intentionally at-least-once: after a wedged lease expires,
+an earlier worker may still finish while the recovery owner runs. Only
+repeat-safe or independently fenced routines may be added to scheduled
+dispatch.
+
+The runtime directory must be private and non-shared. On Windows, the reused
+`Local\` named-mutex boundary coordinates processes in the same logon session;
+it is not a cross-session service lock.

--- a/modules/infrastructure/idle_automation/ROADMAP.md
+++ b/modules/infrastructure/idle_automation/ROADMAP.md
@@ -23,6 +23,9 @@ wsp_cycle(input="idle_automation", log=True)
 - **LinkedIn Integration**: Social media posting with duplicate prevention
 - **Safety Controls**: Network checks, daily limits, environment opt-in
 - **YouTube DAE Integration**: Hook system for idle task execution
+- **Durable Schedule Claims (Phase 1)**: Canonical windows, one-owner leases,
+  exact-token finalization, restart idempotency, bounded retry/recovery, and
+  fail-closed atomic outside-repository state
 
 ## Development Phases
 
@@ -46,6 +49,8 @@ wsp_cycle(input="idle_automation", log=True)
 - **Performance Analytics**: Detailed execution metrics and optimization
 - **Multi-Platform Support**: Support for additional social media platforms
 - **Advanced Scheduling**: Time-based and event-based task triggers
+- **Schedule Fencing Phase 2**: Add side-effect fencing before allowing
+  non-repeat-safe routines or cross-logon-session Windows workers
 
 #### WSP Enhancements
 - **WSP 70 Status Reporting**: Enhanced status reporting capabilities

--- a/modules/infrastructure/idle_automation/src/idle_automation_dae.py
+++ b/modules/infrastructure/idle_automation/src/idle_automation_dae.py
@@ -792,31 +792,13 @@ class IdleAutomationDAE:
         return result
 
     async def _execute_scheduled_routines(self) -> Dict[str, Any]:
-        """
-        Execute scheduled OpenClaw routines based on natural-language schedules.
-
-        Evaluates due schedules and dispatches to existing native paths.
-        Prevents duplicate immediate reruns by tracking last execution.
-        """
-        result = {
-            "task": "scheduled_routines",
-            "success": False,
-            "due_count": 0,
-            "executed_count": 0,
-            "skipped_count": 0,
-            "executed_routines": [],
-            "duration": 0,
-        }
-
+        """Claim each due window durably before dispatching its safe routine."""
+        result = self._scheduled_routines_result()
         start_time = datetime.now()
-
         try:
-            # Check if scheduled routines are enabled
-            scheduled_enabled = self._parse_bool_env("AUTO_SCHEDULED_ROUTINES", True)
-            if not scheduled_enabled:
+            if not self._parse_bool_env("AUTO_SCHEDULED_ROUTINES", True):
                 result["error"] = "Scheduled routines disabled"
                 return result
-
             from modules.infrastructure.idle_automation.src.schedule_evaluator import (
                 ScheduleEvaluator,
             )
@@ -824,53 +806,111 @@ class IdleAutomationDAE:
             evaluator = ScheduleEvaluator()
             due_schedules = evaluator.get_due_schedules()
             result["due_count"] = len(due_schedules)
-
             if not due_schedules:
                 result["success"] = True
                 result["error"] = "No schedules due"
                 return result
-
-            failed_count = 0
             for spec in due_schedules:
-                routine_result = await self._dispatch_scheduled_routine(spec.routine)
-                success = routine_result.get("success", False)
-                summary = routine_result.get("summary", "completed" if success else "failed")
-
-                evaluator.record_execution(spec.id, success, summary)
-
-                if success:
-                    result["executed_count"] += 1
-                    result["executed_routines"].append({
-                        "id": spec.id,
-                        "routine": spec.routine,
-                        "cadence": spec.cadence,
-                        "success": True,
-                    })
-                else:
-                    failed_count += 1
-                    result["skipped_count"] += 1
-                    result["executed_routines"].append({
-                        "id": spec.id,
-                        "routine": spec.routine,
-                        "cadence": spec.cadence,
-                        "success": False,
-                        "error": routine_result.get("error"),
-                    })
-
-            # Only report success if all due routines succeeded
-            result["success"] = failed_count == 0
-            result["failed_count"] = failed_count
+                if not await self._claim_and_dispatch(evaluator, spec, result):
+                    break
+            result["success"] = (
+                result["failed_count"] == 0
+                and result["finalization_failed_count"] == 0
+            )
             self.idle_state["last_scheduled_routines"] = datetime.now().isoformat()
-
         except ImportError:
             result["error"] = "Schedule evaluator not available"
         except Exception as e:
-            result["error"] = f"Scheduled routines failed: {e}"
-            logger.warning(f"Scheduled routines error: {e}")
+            result["error"] = "Scheduled claim state unavailable"
+            logger.warning(
+                "Scheduled routines stopped on %s", type(e).__name__
+            )
         finally:
             result["duration"] = (datetime.now() - start_time).total_seconds()
-
         return result
+
+    async def _claim_and_dispatch(self, evaluator, spec, result) -> bool:
+        """Claim one window, dispatch it, then exact-token finalize."""
+        try:
+            claim = evaluator.claim_schedule(spec)
+        except Exception as exc:
+            result["error"] = "Scheduled claim state unavailable"
+            logger.warning("Schedule claim failed on %s", type(exc).__name__)
+            result["failed_count"] += 1
+            return False
+        if claim is None:
+            result["skipped_count"] += 1
+            result["lease_conflict_count"] += 1
+            return True
+        dispatch = await self._dispatch_claimed_routine(claim.routine)
+        outcome = "success" if dispatch["success"] else dispatch["outcome"]
+        try:
+            finalized = evaluator.finalize_claim(
+                claim.token,
+                success=dispatch["success"],
+                outcome_code=outcome,
+            )
+        except Exception as exc:
+            finalized = False
+            logger.warning("Schedule finalize failed on %s", type(exc).__name__)
+        self._record_claim_result(evaluator, spec, dispatch, finalized, result)
+        return finalized
+
+    async def _dispatch_claimed_routine(self, routine: str) -> Dict[str, Any]:
+        """Convert dispatcher exceptions to a bounded durable outcome code."""
+        try:
+            response = await self._dispatch_scheduled_routine(routine)
+            return {
+                "success": bool(response.get("success", False)),
+                "outcome": "routine_failed",
+                "error": response.get("error"),
+            }
+        except Exception as exc:
+            logger.warning("Scheduled dispatch failed on %s", type(exc).__name__)
+            return {
+                "success": False,
+                "outcome": "dispatch_error",
+                "error": "Scheduled routine dispatch failed",
+            }
+
+    def _record_claim_result(
+        self, evaluator, spec, dispatch, finalized, result
+    ) -> None:
+        """Update reporting and legacy last-run only after durable completion."""
+        entry = {
+            "id": spec.id,
+            "routine": spec.routine,
+            "cadence": spec.cadence,
+            "success": dispatch["success"] and finalized,
+        }
+        if not finalized:
+            result["finalization_failed_count"] += 1
+            result["failed_count"] += 1
+            entry["error"] = "Scheduled claim finalization failed"
+        elif dispatch["success"]:
+            result["executed_count"] += 1
+            evaluator.record_execution(spec.id, True, "durable claim completed")
+        else:
+            result["failed_count"] += 1
+            result["skipped_count"] += 1
+            entry["error"] = dispatch.get("error")
+        result["executed_routines"].append(entry)
+
+    @staticmethod
+    def _scheduled_routines_result() -> Dict[str, Any]:
+        """Return stable scheduled-routine reporting fields."""
+        return {
+            "task": "scheduled_routines",
+            "success": False,
+            "due_count": 0,
+            "executed_count": 0,
+            "skipped_count": 0,
+            "failed_count": 0,
+            "lease_conflict_count": 0,
+            "finalization_failed_count": 0,
+            "executed_routines": [],
+            "duration": 0,
+        }
 
     async def _dispatch_scheduled_routine(self, routine: str) -> Dict[str, Any]:
         """

--- a/modules/infrastructure/idle_automation/src/schedule_claim_codec.py
+++ b/modules/infrastructure/idle_automation/src/schedule_claim_codec.py
@@ -1,0 +1,433 @@
+"""Strict codec and atomic publication for idle schedule claim state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import stat
+import tempfile
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import BinaryIO, Callable
+
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    validate_runtime_artifact_path,
+)
+
+STATE_SCHEMA = "idle_automation_schedule_claim_state.v1"
+MAX_STATE_BYTES = 2 * 1024 * 1024
+MAX_EXECUTION_RECORDS = 4096
+MAX_ATTEMPTS = 3
+MAX_LEASE_RECOVERIES = 1
+
+
+class ScheduleStateError(ValueError):
+    """The durable claim state could not be trusted."""
+
+
+def _write_all(stream: BinaryIO, payload: bytes) -> None:
+    if stream.write(payload) != len(payload):
+        raise OSError("schedule_claim_state_write_incomplete")
+
+
+@dataclass(frozen=True)
+class ScheduleClaimOps:
+    """Trusted low-level seams for deterministic offline durability tests."""
+
+    writer: Callable[[BinaryIO, bytes], None] = _write_all
+    fsync: Callable[[int], None] = os.fsync
+    replacer: Callable[[Path, Path], None] = os.replace
+
+
+def build_execution_id(
+    schedule_id: str,
+    routine: str,
+    cadence: str,
+    window_start: str,
+    window_end: str,
+) -> str:
+    """Return the canonical digest for one immutable schedule window."""
+    fields = [schedule_id, routine, cadence, window_start, window_end]
+    if any(not isinstance(item, str) or not item for item in fields):
+        raise ScheduleStateError("schedule_claim_window_text_invalid")
+    canonical = json.dumps(
+        fields, ensure_ascii=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def normalized_utc(value: datetime) -> datetime:
+    """Normalize an aware or legacy-naive timestamp to UTC."""
+    if not isinstance(value, datetime):
+        raise ScheduleStateError("schedule_claim_time_invalid")
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def parse_time(value: object) -> datetime:
+    """Parse a required ISO timestamp or fail closed."""
+    if not isinstance(value, str) or not value:
+        raise ScheduleStateError("schedule_claim_timestamp_invalid")
+    try:
+        return normalized_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+    except ValueError as error:
+        raise ScheduleStateError("schedule_claim_timestamp_invalid") from error
+
+
+def iso_time(value: datetime) -> str:
+    """Serialize a normalized UTC timestamp."""
+    return normalized_utc(value).isoformat()
+
+
+def empty_state() -> dict:
+    """Return a canonical empty state document."""
+    return {
+        "schema_version": STATE_SCHEMA,
+        "updated_at": iso_time(datetime(1970, 1, 1, tzinfo=UTC)),
+        "executions": {},
+    }
+
+
+def load_claim_state(
+    path: Path, *, repo_root: Path, runtime_root: Path
+) -> dict:
+    """Read and validate state from the trusted fixed artifact path."""
+    target = validate_runtime_artifact_path(
+        path,
+        repo_root=repo_root,
+        allowed_root=runtime_root,
+    )
+    if not target.exists():
+        return empty_state()
+    metadata = os.lstat(target)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+        or metadata.st_size > MAX_STATE_BYTES
+    ):
+        raise ScheduleStateError("schedule_claim_state_file_invalid")
+    try:
+        state = json.loads(
+            target.read_text(encoding="utf-8"),
+            object_pairs_hook=_unique_object,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ScheduleStateError("schedule_claim_state_malformed") from error
+    validate_state(state)
+    return state
+
+
+def save_claim_state(
+    state: dict,
+    now: datetime,
+    *,
+    path: Path,
+    runtime_root: Path,
+    ops: ScheduleClaimOps,
+) -> None:
+    """Atomically publish validated state or restore exact prior bytes."""
+    state["updated_at"] = iso_time(now)
+    validate_state(state)
+    payload = (
+        json.dumps(state, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    if len(payload) > MAX_STATE_BYTES:
+        raise ScheduleStateError("schedule_claim_state_capacity_exhausted")
+    prior = path.read_bytes() if path.exists() else None
+    descriptor, raw_path = tempfile.mkstemp(
+        prefix=".schedule-claims.", suffix=".tmp", dir=runtime_root
+    )
+    temporary: Path | None = Path(raw_path)
+    try:
+        owned_descriptor = descriptor
+        descriptor = -1
+        _write_temporary(owned_descriptor, payload, ops)
+        try:
+            ops.replacer(temporary, path)
+            temporary = None
+            if path.read_bytes() != payload:
+                raise OSError("schedule_claim_state_post_replace_mismatch")
+        except Exception:
+            _restore_lkg(runtime_root, path, prior)
+            raise
+        _fsync_parent(runtime_root)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _write_temporary(
+    descriptor: int,
+    payload: bytes,
+    ops: ScheduleClaimOps,
+) -> None:
+    owned_descriptor = descriptor
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(owned_descriptor, 0o600)
+        with os.fdopen(owned_descriptor, "w+b", closefd=True) as stream:
+            owned_descriptor = -1
+            ops.writer(stream, payload)
+            stream.flush()
+            if os.fstat(stream.fileno()).st_size != len(payload):
+                raise OSError("schedule_claim_state_size_mismatch")
+            ops.fsync(stream.fileno())
+            stream.seek(0)
+            if stream.read(len(payload) + 1) != payload:
+                raise OSError("schedule_claim_state_content_mismatch")
+    finally:
+        if owned_descriptor >= 0:
+            os.close(owned_descriptor)
+
+
+def validate_state(state: object) -> None:
+    """Validate exact top-level and record schemas."""
+    if not isinstance(state, dict) or set(state) != {
+        "schema_version",
+        "updated_at",
+        "executions",
+    }:
+        raise ScheduleStateError("schedule_claim_state_shape_invalid")
+    if state["schema_version"] != STATE_SCHEMA:
+        raise ScheduleStateError("schedule_claim_state_schema_invalid")
+    parse_time(state["updated_at"])
+    records = state["executions"]
+    if not isinstance(records, dict) or len(records) > MAX_EXECUTION_RECORDS:
+        raise ScheduleStateError("schedule_claim_state_records_invalid")
+    for execution_id, record in records.items():
+        _validate_record(execution_id, record)
+
+
+def _validate_record(execution_id: str, record: object) -> None:
+    required = _record_keys()
+    if not isinstance(record, dict) or set(record) != required:
+        raise ScheduleStateError("schedule_claim_record_shape_invalid")
+    text_fields = (
+        "execution_id",
+        "schedule_id",
+        "routine",
+        "cadence",
+        "window_start",
+        "window_end",
+        "status",
+    )
+    if any(
+        not isinstance(record[field], str) or not record[field]
+        for field in text_fields
+    ):
+        raise ScheduleStateError("schedule_claim_record_text_invalid")
+    _validate_record_identity(execution_id, record)
+    if record["status"] not in {
+        "claimed",
+        "retry_wait",
+        "completed",
+        "exhausted",
+    }:
+        raise ScheduleStateError("schedule_claim_record_status_invalid")
+    if type(record["attempt"]) is not int or not 1 <= record["attempt"] <= MAX_ATTEMPTS:
+        raise ScheduleStateError("schedule_claim_record_attempt_invalid")
+    if (
+        type(record["lease_recoveries"]) is not int
+        or not 0 <= record["lease_recoveries"] <= MAX_LEASE_RECOVERIES
+    ):
+        raise ScheduleStateError("schedule_claim_record_recovery_invalid")
+    _validate_status_fields(record)
+
+
+def _validate_record_identity(execution_id: str, record: dict) -> None:
+    if record["execution_id"] != execution_id:
+        raise ScheduleStateError("schedule_claim_record_id_invalid")
+    expected = build_execution_id(
+        record["schedule_id"],
+        record["routine"],
+        record["cadence"],
+        record["window_start"],
+        record["window_end"],
+    )
+    if not secrets.compare_digest(execution_id, expected):
+        raise ScheduleStateError("schedule_claim_record_id_invalid")
+    if parse_time(record["window_start"]) >= parse_time(record["window_end"]):
+        raise ScheduleStateError("schedule_claim_record_window_invalid")
+    claimed_at = record["claimed_at"]
+    if claimed_at is not None and not (
+        parse_time(record["window_start"])
+        <= parse_time(claimed_at)
+        < parse_time(record["window_end"])
+    ):
+        raise ScheduleStateError("schedule_claim_record_claim_time_invalid")
+
+
+def _validate_status_fields(record: dict) -> None:
+    nullable = (
+        "token",
+        "claimant_id",
+        "claimed_at",
+        "lease_expires_at",
+        "next_attempt_at",
+        "completed_at",
+        "terminal_at",
+        "last_outcome",
+    )
+    values = (record[key] for key in nullable)
+    if any(value is not None and not isinstance(value, str) for value in values):
+        raise ScheduleStateError("schedule_claim_record_optional_invalid")
+    status = record["status"]
+    if status == "claimed":
+        _validate_claimed(record)
+    elif status == "retry_wait":
+        _validate_retry(record)
+    elif status == "completed":
+        _validate_completed(record)
+    else:
+        _validate_exhausted(record)
+
+
+def _validate_claimed(record: dict) -> None:
+    owner_fields = ("token", "claimant_id", "claimed_at", "lease_expires_at")
+    if not all(record[key] for key in owner_fields):
+        raise ScheduleStateError("schedule_claim_record_lease_invalid")
+    if not _valid_opaque(record["token"]) or not _valid_opaque(record["claimant_id"]):
+        raise ScheduleStateError("schedule_claim_record_owner_invalid")
+    claimed_at = parse_time(record["claimed_at"])
+    if parse_time(record["lease_expires_at"]) <= claimed_at:
+        raise ScheduleStateError("schedule_claim_record_lease_order_invalid")
+
+
+def _validate_retry(record: dict) -> None:
+    if (
+        _has_owner(record)
+        or not record["claimed_at"]
+        or not record["next_attempt_at"]
+    ):
+        raise ScheduleStateError("schedule_claim_record_retry_invalid")
+    if parse_time(record["next_attempt_at"]) <= parse_time(record["claimed_at"]):
+        raise ScheduleStateError("schedule_claim_record_retry_order_invalid")
+
+
+def _validate_completed(record: dict) -> None:
+    if (
+        not record["completed_at"]
+        or not record["terminal_at"]
+        or not record["claimed_at"]
+        or _has_owner(record)
+        or record["next_attempt_at"] is not None
+    ):
+        raise ScheduleStateError("schedule_claim_record_completion_invalid")
+    claimed_at = parse_time(record["claimed_at"])
+    if parse_time(record["completed_at"]) < claimed_at:
+        raise ScheduleStateError("schedule_claim_record_completion_order_invalid")
+    if parse_time(record["terminal_at"]) < claimed_at:
+        raise ScheduleStateError("schedule_claim_record_terminal_order_invalid")
+
+
+def _validate_exhausted(record: dict) -> None:
+    if (
+        _has_owner(record)
+        or record["next_attempt_at"] is not None
+        or not record["claimed_at"]
+        or not record["terminal_at"]
+    ):
+        raise ScheduleStateError("schedule_claim_record_exhausted_invalid")
+    if parse_time(record["terminal_at"]) < parse_time(record["claimed_at"]):
+        raise ScheduleStateError("schedule_claim_record_terminal_order_invalid")
+
+
+def _record_keys() -> set[str]:
+    return {
+        "execution_id",
+        "schedule_id",
+        "routine",
+        "cadence",
+        "window_start",
+        "window_end",
+        "status",
+        "attempt",
+        "lease_recoveries",
+        "token",
+        "claimant_id",
+        "claimed_at",
+        "lease_expires_at",
+        "next_attempt_at",
+        "completed_at",
+        "terminal_at",
+        "last_outcome",
+    }
+
+
+def _valid_opaque(value: object) -> bool:
+    return isinstance(value, str) and 0 < len(value) <= 256
+
+
+def _has_owner(record: dict) -> bool:
+    return any(
+        record[key] is not None
+        for key in ("token", "claimant_id", "lease_expires_at")
+    )
+
+
+def _unique_object(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ScheduleStateError("schedule_claim_state_duplicate_key")
+        result[key] = value
+    return result
+
+
+def _restore_lkg(root: Path, target: Path, prior: bytes | None) -> None:
+    if prior is None:
+        target.unlink(missing_ok=True)
+        _fsync_parent(root)
+        return
+    descriptor, raw_path = tempfile.mkstemp(
+        prefix=".schedule-claims.restore.", suffix=".tmp", dir=root
+    )
+    temporary = Path(raw_path)
+    try:
+        with os.fdopen(descriptor, "w+b", closefd=True) as stream:
+            descriptor = -1
+            _write_all(stream, prior)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+        _fsync_parent(root)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def _fsync_parent(parent: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(parent, flags)
+    except (OSError, NotImplementedError):
+        return
+    try:
+        os.fsync(descriptor)
+    except (OSError, NotImplementedError):
+        pass
+    finally:
+        os.close(descriptor)
+
+
+__all__ = [
+    "MAX_ATTEMPTS",
+    "MAX_EXECUTION_RECORDS",
+    "MAX_LEASE_RECOVERIES",
+    "ScheduleClaimOps",
+    "ScheduleStateError",
+    "build_execution_id",
+    "empty_state",
+    "iso_time",
+    "load_claim_state",
+    "normalized_utc",
+    "parse_time",
+    "save_claim_state",
+]

--- a/modules/infrastructure/idle_automation/src/schedule_claim_state.py
+++ b/modules/infrastructure/idle_automation/src/schedule_claim_state.py
@@ -1,0 +1,371 @@
+"""Durable one-owner state machine for canonical idle schedule windows."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable
+
+from modules.infrastructure.idle_automation.src.schedule_claim_codec import (
+    MAX_ATTEMPTS,
+    MAX_EXECUTION_RECORDS,
+    MAX_LEASE_RECOVERIES,
+    ScheduleClaimOps,
+    ScheduleStateError,
+    build_execution_id,
+    iso_time,
+    load_claim_state,
+    normalized_utc,
+    parse_time,
+    save_claim_state,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    runtime_operation_lock,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
+)
+
+LEASE_SECONDS = 3900
+RETRY_BACKOFF_SECONDS = (60, 300)
+TERMINAL_RETENTION_DAYS = 35
+KNOWN_OUTCOMES = frozenset(
+    {"success", "routine_failed", "dispatch_error", "finalize_error"}
+)
+
+
+@dataclass(frozen=True)
+class ScheduleWindow:
+    """Immutable canonical identity of one schedule cadence window."""
+
+    schedule_id: str
+    routine: str
+    cadence: str
+    window_start: str
+    window_end: str
+    execution_id: str
+
+
+@dataclass(frozen=True)
+class ScheduleClaim:
+    """A durable one-owner lease returned only after publication."""
+
+    schedule_id: str
+    routine: str
+    cadence: str
+    window_start: str
+    window_end: str
+    execution_id: str
+    token: str
+    claimant_id: str
+    lease_expires_at: str
+    attempt: int
+
+
+class ScheduleClaimStore:
+    """Serialize one-window claims and exact-token finalization under one lock."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | str,
+        runtime_root: Path | str,
+        ops: ScheduleClaimOps | None = None,
+        token_factory: Callable[[], str] | None = None,
+        claimant_id: str | None = None,
+    ) -> None:
+        self.repo_root = Path(repo_root).resolve()
+        root = validate_runtime_root_path(runtime_root, repo_root=self.repo_root)
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.runtime_root = validate_runtime_root_path(
+            root, repo_root=self.repo_root
+        )
+        self.state_path = validate_runtime_artifact_path(
+            self.runtime_root / "schedule_claim_state.json",
+            repo_root=self.repo_root,
+            allowed_root=self.runtime_root,
+        )
+        self.ops = ops or ScheduleClaimOps()
+        self.token_factory = token_factory or (lambda: secrets.token_urlsafe(24))
+        self.claimant_id = claimant_id or f"worker-{secrets.token_hex(12)}"
+        if not _valid_opaque(self.claimant_id):
+            raise ScheduleStateError("schedule_claim_claimant_invalid")
+
+    def claim_window(
+        self, window: ScheduleWindow, *, now: datetime
+    ) -> ScheduleClaim | None:
+        """Durably claim one canonical window immediately before dispatch."""
+        _validate_window(window)
+        current = normalized_utc(now)
+        if not parse_time(window.window_start) <= current < parse_time(
+            window.window_end
+        ):
+            return None
+        with runtime_operation_lock(self.state_path):
+            state = self._load_state()
+            changed = _prune_terminal_records(state, current)
+            claim, record_changed = self._claim_window(state, window, current)
+            if changed or record_changed:
+                self._save_state(state, current)
+            return claim
+
+    def finalize(
+        self,
+        token: str,
+        *,
+        success: bool,
+        outcome_code: str,
+        now: datetime,
+    ) -> bool:
+        """Finalize the current exact token, including expired-unreclaimed."""
+        if not _valid_opaque(token) or type(success) is not bool:
+            return False
+        current = normalized_utc(now)
+        with runtime_operation_lock(self.state_path):
+            state = self._load_state()
+            record = _record_for_token(state, token)
+            if record is None:
+                return False
+            _apply_finalization(record, success, outcome_code, current)
+            self._save_state(state, current)
+            return True
+
+    def _claim_window(
+        self,
+        state: dict,
+        window: ScheduleWindow,
+        now: datetime,
+    ) -> tuple[ScheduleClaim | None, bool]:
+        records = state["executions"]
+        record = records.get(window.execution_id)
+        if record is None:
+            if len(records) >= MAX_EXECUTION_RECORDS:
+                raise ScheduleStateError(
+                    "schedule_claim_state_capacity_exhausted"
+                )
+            record = _new_record(window)
+            records[window.execution_id] = record
+        else:
+            _validate_record_matches_window(record, window)
+            eligible, changed = _prepare_existing_record(record, now)
+            if not eligible:
+                return None, changed
+        token = self.token_factory()
+        if not _valid_opaque(token):
+            raise ScheduleStateError("schedule_claim_token_invalid")
+        if _record_for_token(state, token) is not None:
+            raise ScheduleStateError("schedule_claim_token_collision")
+        _apply_claim(record, token, self.claimant_id, now)
+        return _claim_from_record(record), True
+
+    def _load_state(self) -> dict:
+        return load_claim_state(
+            self.state_path,
+            repo_root=self.repo_root,
+            runtime_root=self.runtime_root,
+        )
+
+    def _save_state(self, state: dict, now: datetime) -> None:
+        save_claim_state(
+            state,
+            now,
+            path=self.state_path,
+            runtime_root=self.runtime_root,
+            ops=self.ops,
+        )
+
+
+def _new_record(window: ScheduleWindow) -> dict:
+    return {
+        "execution_id": window.execution_id,
+        "schedule_id": window.schedule_id,
+        "routine": window.routine,
+        "cadence": window.cadence,
+        "window_start": window.window_start,
+        "window_end": window.window_end,
+        "status": "new",
+        "attempt": 0,
+        "lease_recoveries": 0,
+        "token": None,
+        "claimant_id": None,
+        "claimed_at": None,
+        "lease_expires_at": None,
+        "next_attempt_at": None,
+        "completed_at": None,
+        "terminal_at": None,
+        "last_outcome": None,
+    }
+
+
+def _apply_claim(
+    record: dict, token: str, claimant_id: str, now: datetime
+) -> None:
+    record["attempt"] += 1
+    record["status"] = "claimed"
+    record["token"] = token
+    record["claimant_id"] = claimant_id
+    record["claimed_at"] = iso_time(now)
+    record["lease_expires_at"] = iso_time(
+        now + timedelta(seconds=LEASE_SECONDS)
+    )
+    record["next_attempt_at"] = None
+
+
+def _prepare_existing_record(record: dict, now: datetime) -> tuple[bool, bool]:
+    status = record["status"]
+    if status in {"completed", "exhausted"}:
+        return False, False
+    if status == "claimed":
+        if parse_time(record["lease_expires_at"]) > now:
+            return False, False
+        if (
+            record["lease_recoveries"] >= MAX_LEASE_RECOVERIES
+            or record["attempt"] >= MAX_ATTEMPTS
+        ):
+            _mark_exhausted(record, now)
+            return False, True
+        record["lease_recoveries"] += 1
+        return True, False
+    if status == "retry_wait":
+        if parse_time(record["next_attempt_at"]) > now:
+            return False, False
+        if record["attempt"] >= MAX_ATTEMPTS:
+            _mark_exhausted(record, now)
+            return False, True
+        return True, False
+    raise ScheduleStateError("schedule_claim_state_status_invalid")
+
+
+def _apply_finalization(
+    record: dict, success: bool, outcome_code: str, now: datetime
+) -> None:
+    _clear_owner(record)
+    record["last_outcome"] = _safe_outcome(outcome_code)
+    if success:
+        record["status"] = "completed"
+        record["completed_at"] = iso_time(now)
+        record["terminal_at"] = iso_time(now)
+        record["next_attempt_at"] = None
+    elif record["attempt"] >= MAX_ATTEMPTS:
+        _mark_exhausted(record, now)
+    else:
+        delay = RETRY_BACKOFF_SECONDS[record["attempt"] - 1]
+        record["status"] = "retry_wait"
+        record["next_attempt_at"] = iso_time(
+            now + timedelta(seconds=delay)
+        )
+
+
+def _mark_exhausted(record: dict, now: datetime) -> None:
+    record["status"] = "exhausted"
+    _clear_owner(record)
+    record["next_attempt_at"] = None
+    record["terminal_at"] = iso_time(now)
+
+
+def _clear_owner(record: dict) -> None:
+    for key in ("token", "claimant_id", "lease_expires_at"):
+        record[key] = None
+
+
+def _claim_from_record(record: dict) -> ScheduleClaim:
+    return ScheduleClaim(
+        schedule_id=record["schedule_id"],
+        routine=record["routine"],
+        cadence=record["cadence"],
+        window_start=record["window_start"],
+        window_end=record["window_end"],
+        execution_id=record["execution_id"],
+        token=record["token"],
+        claimant_id=record["claimant_id"],
+        lease_expires_at=record["lease_expires_at"],
+        attempt=record["attempt"],
+    )
+
+
+def _record_for_token(state: dict, token: str) -> dict | None:
+    matches = [
+        record
+        for record in state["executions"].values()
+        if record["status"] == "claimed" and record["token"] == token
+    ]
+    if len(matches) > 1:
+        raise ScheduleStateError("schedule_claim_token_not_unique")
+    return matches[0] if matches else None
+
+
+def _validate_window(window: ScheduleWindow) -> None:
+    if not isinstance(window, ScheduleWindow):
+        raise ScheduleStateError("schedule_claim_window_type_invalid")
+    start, end = parse_time(window.window_start), parse_time(window.window_end)
+    if start >= end:
+        raise ScheduleStateError("schedule_claim_window_range_invalid")
+    expected = build_execution_id(
+        window.schedule_id,
+        window.routine,
+        window.cadence,
+        window.window_start,
+        window.window_end,
+    )
+    if not secrets.compare_digest(window.execution_id, expected):
+        raise ScheduleStateError("schedule_claim_window_id_invalid")
+
+
+def _validate_record_matches_window(
+    record: dict, window: ScheduleWindow
+) -> None:
+    fields = (
+        "execution_id",
+        "schedule_id",
+        "routine",
+        "cadence",
+        "window_start",
+        "window_end",
+    )
+    if any(record[field] != getattr(window, field) for field in fields):
+        raise ScheduleStateError("schedule_claim_window_record_mismatch")
+
+
+def _prune_terminal_records(state: dict, now: datetime) -> bool:
+    cutoff = now - timedelta(days=TERMINAL_RETENTION_DAYS)
+    expired = [
+        execution_id
+        for execution_id, record in state["executions"].items()
+        if (
+            record["terminal_at"] is not None
+            and parse_time(record["terminal_at"]) < cutoff
+        )
+        or (
+            record["terminal_at"] is None
+            and parse_time(record["window_end"]) < cutoff
+        )
+    ]
+    for execution_id in expired:
+        del state["executions"][execution_id]
+    return bool(expired)
+
+
+def _safe_outcome(value: object) -> str:
+    if isinstance(value, str) and value in KNOWN_OUTCOMES:
+        return value
+    digest = hashlib.sha256(str(value).encode("utf-8")).hexdigest()[:24]
+    return f"digest:{digest}"
+
+
+def _valid_opaque(value: object) -> bool:
+    return isinstance(value, str) and 0 < len(value) <= 256
+
+
+__all__ = [
+    "LEASE_SECONDS",
+    "MAX_ATTEMPTS",
+    "RETRY_BACKOFF_SECONDS",
+    "ScheduleClaim",
+    "ScheduleClaimOps",
+    "ScheduleClaimStore",
+    "ScheduleStateError",
+    "ScheduleWindow",
+    "build_execution_id",
+]

--- a/modules/infrastructure/idle_automation/src/schedule_evaluator.py
+++ b/modules/infrastructure/idle_automation/src/schedule_evaluator.py
@@ -17,11 +17,20 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    ScheduleClaim,
+    ScheduleClaimOps,
+    ScheduleClaimStore,
+    ScheduleWindow,
+    build_execution_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -179,18 +188,35 @@ class ScheduleParser:
 class ScheduleEvaluator:
     """Evaluate and manage scheduled OpenClaw routines."""
 
-    def __init__(self, schedules_path: Optional[Path] = None):
+    def __init__(
+        self,
+        schedules_path: Optional[Path] = None,
+        *,
+        runtime_root: Optional[Path] = None,
+        repo_root: Optional[Path] = None,
+        claim_ops: Optional[ScheduleClaimOps] = None,
+    ):
         """
         Initialize schedule evaluator.
 
         Args:
             schedules_path: Path to schedules.json. Defaults to module memory dir.
         """
-        if schedules_path is None:
+        explicit_schedules_path = schedules_path is not None
+        if not explicit_schedules_path:
             module_path = Path(__file__).parent.parent
             schedules_path = module_path / "memory" / "schedules.json"
         self.schedules_path = Path(schedules_path)
         self.schedules_path.parent.mkdir(parents=True, exist_ok=True)
+        repository = repo_root or Path(__file__).resolve().parents[4]
+        claim_root = runtime_root or _default_claim_root(
+            self.schedules_path, explicit_schedules_path, Path(repository)
+        )
+        self.claim_store = ScheduleClaimStore(
+            repo_root=repository,
+            runtime_root=claim_root,
+            ops=claim_ops,
+        )
         self._schedules: Dict[str, ScheduleSpec] = {}
         self._load_schedules()
 
@@ -283,56 +309,53 @@ class ScheduleEvaluator:
         2. Current hour is within the cadence window
         3. It hasn't run during the current cadence window
         """
-        if now is None:
-            now = utc_now()
+        current = _utc_value(now or utc_now())
+        return [
+            spec
+            for spec in self._schedules.values()
+            if _schedule_is_due(spec, current)
+        ]
 
-        due = []
-        current_hour = now.hour
+    def claim_schedule(
+        self,
+        spec: ScheduleSpec,
+        *,
+        now: Optional[datetime] = None,
+    ) -> Optional[ScheduleClaim]:
+        """Durably claim one currently due schedule immediately before dispatch."""
 
-        for spec in self._schedules.values():
-            if not spec.enabled:
-                continue
+        current = _utc_value(now or utc_now())
+        known = self._schedules.get(spec.id)
+        if (
+            known is None
+            or not known.enabled
+            or known.routine != spec.routine
+            or known.cadence != spec.cadence
+            or known.routine not in SUPPORTED_ROUTINES
+            or known.cadence not in CADENCE_WINDOWS
+        ):
+            return None
+        window = _schedule_window(known, current)
+        if window is None:
+            return None
+        return self.claim_store.claim_window(window, now=current)
 
-            window = CADENCE_WINDOWS.get(spec.cadence)
-            if window is None:
-                continue
+    def finalize_claim(
+        self,
+        token: str,
+        *,
+        success: bool,
+        outcome_code: str,
+        now: Optional[datetime] = None,
+    ) -> bool:
+        """Finalize only the current exact durable claim token."""
 
-            # Check if current hour is within window
-            start_hour = window["start_hour"]
-            end_hour = window["end_hour"]
-            in_window = start_hour <= current_hour < end_hour
-
-            if not in_window:
-                continue
-
-            # Check if already ran in this window
-            if spec.last_run:
-                try:
-                    last_run_dt = datetime.fromisoformat(
-                        spec.last_run.replace("Z", "+00:00")
-                    )
-                    if last_run_dt.tzinfo is None:
-                        last_run_dt = last_run_dt.replace(tzinfo=UTC)
-
-                    # Calculate window start for today
-                    window_start = now.replace(
-                        hour=start_hour, minute=0, second=0, microsecond=0
-                    )
-                    if spec.cadence == "daily":
-                        # For daily, window starts at midnight of current day
-                        window_start = now.replace(
-                            hour=0, minute=0, second=0, microsecond=0
-                        )
-
-                    # If last run is after window start, skip
-                    if last_run_dt >= window_start:
-                        continue
-                except ValueError:
-                    pass  # Invalid timestamp, treat as never run
-
-            due.append(spec)
-
-        return due
+        return self.claim_store.finalize(
+            token,
+            success=success,
+            outcome_code=outcome_code,
+            now=_utc_value(now or utc_now()),
+        )
 
     def record_execution(
         self, spec_id: str, success: bool, result_summary: str
@@ -372,3 +395,83 @@ def get_supported_phrases() -> List[str]:
         for cadence in CADENCE_WINDOWS:
             examples.append(f"run {primary_alias} {cadence}")
     return examples
+
+
+def _default_claim_root(
+    path: Path, explicit_path: bool, repo_root: Path
+) -> Path:
+    configured = os.getenv("IDLE_AUTOMATION_RUNTIME_ROOT", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    if explicit_path and not _is_within(path.parent, repo_root):
+        return path.parent / "claim-runtime"
+    return Path.home() / ".foundups-agent" / "idle_automation"
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _utc_value(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _schedule_window(
+    spec: ScheduleSpec, now: datetime
+) -> Optional[ScheduleWindow]:
+    bounds = CADENCE_WINDOWS.get(spec.cadence)
+    if bounds is None:
+        return None
+    start = now.replace(
+        hour=bounds["start_hour"], minute=0, second=0, microsecond=0
+    )
+    end_hour = bounds["end_hour"]
+    end = (
+        now.replace(hour=end_hour, minute=0, second=0, microsecond=0)
+        if end_hour < 24
+        else now.replace(hour=0, minute=0, second=0, microsecond=0)
+        + timedelta(days=1)
+    )
+    if not start <= now < end:
+        return None
+    start_text, end_text = start.isoformat(), end.isoformat()
+    execution_id = build_execution_id(
+        spec.id, spec.routine, spec.cadence, start_text, end_text
+    )
+    return ScheduleWindow(
+        schedule_id=spec.id,
+        routine=spec.routine,
+        cadence=spec.cadence,
+        window_start=start_text,
+        window_end=end_text,
+        execution_id=execution_id,
+    )
+
+
+def _schedule_is_due(spec: ScheduleSpec, now: datetime) -> bool:
+    if not spec.enabled:
+        return False
+    bounds = CADENCE_WINDOWS.get(spec.cadence)
+    if bounds is None:
+        return False
+    if not bounds["start_hour"] <= now.hour < bounds["end_hour"]:
+        return False
+    if not spec.last_run:
+        return True
+    try:
+        last_run = _utc_value(
+            datetime.fromisoformat(spec.last_run.replace("Z", "+00:00"))
+        )
+    except ValueError:
+        return True
+    start_hour = 0 if spec.cadence == "daily" else bounds["start_hour"]
+    window_start = now.replace(
+        hour=start_hour, minute=0, second=0, microsecond=0
+    )
+    return last_run < window_start

--- a/modules/infrastructure/idle_automation/src/schedule_evaluator.py
+++ b/modules/infrastructure/idle_automation/src/schedule_evaluator.py
@@ -369,7 +369,8 @@ class ScheduleEvaluator:
             return False
 
         spec = self._schedules[spec_id]
-        spec.last_run = utc_now_iso()
+        if success:
+            spec.last_run = utc_now_iso()
         spec.last_result = f"{'success' if success else 'failed'}: {result_summary}"
         self._save_schedules()
         return True
@@ -474,4 +475,10 @@ def _schedule_is_due(spec: ScheduleSpec, now: datetime) -> bool:
     window_start = now.replace(
         hour=start_hour, minute=0, second=0, microsecond=0
     )
-    return last_run < window_start
+    if last_run < window_start:
+        return True
+    return not _is_canonical_legacy_success(spec.last_result)
+
+
+def _is_canonical_legacy_success(value: object) -> bool:
+    return isinstance(value, str) and value.startswith("success:")

--- a/modules/infrastructure/idle_automation/tests/TestModLog.md
+++ b/modules/infrastructure/idle_automation/tests/TestModLog.md
@@ -7,6 +7,31 @@
 
 ---
 
+## 2026-07-24: Durable Schedule Claim Lease Phase 1
+
+**Files**: `test_schedule_claim_state.py`, `test_schedule_evaluator.py`,
+`test_scheduled_routines_integration.py`
+
+- Proves two independent stores cannot double-claim one canonical window.
+- Proves active-lease blocking, one expiry recovery, and stale-token rejection.
+- Proves restart completion idempotency and 60/300/max-three failure retry.
+- Proves malformed, partial, duplicate-key, timestamp-order, and token-collision
+  state fails closed without mutation.
+- Proves writer and wrong-success replacer failures preserve exact prior bytes
+  and leave no owned temp files.
+- Proves outside-repository confinement and payload path non-influence.
+- Proves disabled/unknown/out-of-window schedules create no claim.
+- Proves DAE performs zero dispatch on claim uncertainty and treats finalize
+  failure as completion unknown without legacy `last_run`.
+
+**Focused Result**: `83 passed`
+
+**Full Module Result**: `117 passed, 1 pre-existing failure`
+
+**Neighbor Runtime Safety**: `11 passed, 1 skipped`
+
+---
+
 ## 2026-03-27: Caller Wiring + Runtime Emitter Instrumentation
 
 **File**: `test_caller_wiring.py`

--- a/modules/infrastructure/idle_automation/tests/TestModLog.md
+++ b/modules/infrastructure/idle_automation/tests/TestModLog.md
@@ -7,6 +7,23 @@
 
 ---
 
+## 2026-07-24: Legacy Failed-Row Migration Regression
+
+- Proves a persisted current-window `failed:` row remains due after restart and
+  receives a durable claim.
+- Proves missing, empty, case-variant, and unknown legacy results fail safe as
+  due.
+- Proves only explicit canonical `success:` suppresses the current window.
+- Proves failed `record_execution()` calls do not advance `last_run`.
+
+**Focused Result**: `91 passed`
+
+**Full Module Result**: `125 passed, 1 pre-existing failure`
+
+**Neighbor Runtime Safety**: `11 passed, 1 skipped`
+
+---
+
 ## 2026-07-24: Durable Schedule Claim Lease Phase 1
 
 **Files**: `test_schedule_claim_state.py`, `test_schedule_evaluator.py`,

--- a/modules/infrastructure/idle_automation/tests/test_schedule_claim_state.py
+++ b/modules/infrastructure/idle_automation/tests/test_schedule_claim_state.py
@@ -1,0 +1,367 @@
+"""Adversarial tests for durable scheduled-routine claim ownership."""
+
+from __future__ import annotations
+
+import ast
+import json
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    LEASE_SECONDS,
+    MAX_ATTEMPTS,
+    RETRY_BACKOFF_SECONDS,
+    ScheduleClaimOps,
+    ScheduleClaimStore,
+    ScheduleStateError,
+    ScheduleWindow,
+    build_execution_id,
+)
+
+NOW = datetime(2026, 7, 24, 1, 0, tzinfo=UTC)
+
+
+def _window(
+    *,
+    schedule_id: str = "schedule-1",
+    routine: str = "self_research",
+    cadence: str = "daily",
+    start: datetime = NOW.replace(hour=0),
+    end: datetime = NOW.replace(hour=0) + timedelta(days=1),
+) -> ScheduleWindow:
+    start_text = start.isoformat()
+    end_text = end.isoformat()
+    return ScheduleWindow(
+        schedule_id=schedule_id,
+        routine=routine,
+        cadence=cadence,
+        window_start=start_text,
+        window_end=end_text,
+        execution_id=build_execution_id(
+            schedule_id, routine, cadence, start_text, end_text
+        ),
+    )
+
+
+def _store(tmp_path: Path, **kwargs: object) -> ScheduleClaimStore:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    runtime = tmp_path / "runtime"
+    return ScheduleClaimStore(
+        repo_root=repo,
+        runtime_root=runtime,
+        **kwargs,
+    )
+
+
+def _claim(store: ScheduleClaimStore, now: datetime = NOW):
+    return store.claim_window(_window(), now=now)
+
+
+def test_two_independent_evaluators_cannot_double_claim(tmp_path: Path) -> None:
+    first = _store(tmp_path)
+    second = _store(tmp_path)
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        claims = list(pool.map(lambda store: _claim(store), (first, second)))
+    assert sum(claim is not None for claim in claims) == 1
+
+
+def test_lease_allows_only_one_expiry_recovery(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    first = _claim(store)
+    assert first is not None
+    assert _claim(store, NOW + timedelta(seconds=LEASE_SECONDS - 1)) is None
+
+    recovered = _claim(store, NOW + timedelta(seconds=LEASE_SECONDS))
+    assert recovered is not None
+    assert recovered.token != first.token
+    assert (
+        _claim(
+            store,
+            NOW + timedelta(seconds=(LEASE_SECONDS * 2) + 1),
+        )
+        is None
+    )
+
+
+def test_stale_token_cannot_finalize_renewed_or_completed_claim(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    first = _claim(store)
+    assert first is not None
+    recovered_at = NOW + timedelta(seconds=LEASE_SECONDS)
+    recovered = _claim(store, recovered_at)
+    assert recovered is not None
+
+    assert not store.finalize(
+        first.token,
+        success=True,
+        outcome_code="success",
+        now=recovered_at,
+    )
+    assert store.finalize(
+        recovered.token,
+        success=True,
+        outcome_code="success",
+        now=recovered_at + timedelta(seconds=1),
+    )
+    assert not store.finalize(
+        recovered.token,
+        success=True,
+        outcome_code="success",
+        now=recovered_at + timedelta(seconds=2),
+    )
+
+
+def test_expired_unreclaimed_token_can_still_finalize(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(store)
+    assert claim is not None
+    assert store.finalize(
+        claim.token,
+        success=True,
+        outcome_code="success",
+        now=NOW + timedelta(seconds=LEASE_SECONDS + 1),
+    )
+    assert _claim(store, NOW + timedelta(seconds=LEASE_SECONDS + 2)) is None
+
+
+def test_completed_window_is_idempotent_after_restart(tmp_path: Path) -> None:
+    first_store = _store(tmp_path)
+    claim = _claim(first_store)
+    assert claim is not None
+    assert first_store.finalize(
+        claim.token,
+        success=True,
+        outcome_code="success",
+        now=NOW + timedelta(seconds=1),
+    )
+    assert _claim(_store(tmp_path), NOW + timedelta(seconds=2)) is None
+
+
+def test_failures_use_bounded_backoff_and_attempt_cap(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    now = NOW
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        claim = _claim(store, now)
+        assert claim is not None
+        assert claim.attempt == attempt
+        assert store.finalize(
+            claim.token,
+            success=False,
+            outcome_code="routine_failed",
+            now=now,
+        )
+        if attempt < MAX_ATTEMPTS:
+            delay = RETRY_BACKOFF_SECONDS[attempt - 1]
+            assert _claim(store, now + timedelta(seconds=delay - 1)) is None
+            now += timedelta(seconds=delay)
+    assert _claim(store, now + timedelta(days=1)) is None
+
+
+@pytest.mark.parametrize(
+    "mutator",
+    [
+        lambda window: ScheduleWindow(
+            **{**window.__dict__, "execution_id": "not-canonical"}
+        ),
+        lambda window: ScheduleWindow(
+            **{
+                **window.__dict__,
+                "window_start": (
+                    datetime.fromisoformat(window.window_end) + timedelta(hours=1)
+                ).isoformat(),
+            }
+        ),
+    ],
+)
+def test_noncanonical_or_invalid_window_fails_closed(
+    tmp_path: Path, mutator
+) -> None:
+    store = _store(tmp_path)
+    with pytest.raises(ScheduleStateError):
+        store.claim_window(mutator(_window()), now=NOW)
+    assert not store.state_path.exists()
+
+
+def test_now_outside_window_fails_closed(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    assert (
+        store.claim_window(
+            _window(), now=NOW.replace(hour=0) - timedelta(seconds=1)
+        )
+        is None
+    )
+    assert store.claim_window(_window(), now=NOW + timedelta(days=1)) is None
+    assert not store.state_path.exists()
+
+
+def test_token_collision_fails_closed_without_mutating_lkg(tmp_path: Path) -> None:
+    tokens = iter(("same-token", "same-token"))
+    store = _store(tmp_path, token_factory=lambda: next(tokens))
+    assert store.claim_window(_window(schedule_id="one"), now=NOW)
+    before = store.state_path.read_bytes()
+    with pytest.raises(ScheduleStateError):
+        store.claim_window(_window(schedule_id="two"), now=NOW)
+    assert store.state_path.read_bytes() == before
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"{",
+        b'{"schema_version":"idle_automation_schedule_claim_state.v1"}',
+        b'{"schema_version":"idle_automation_schedule_claim_state.v1",'
+        b'"updated_at":"2026-07-24T00:00:00+00:00","executions":{},'
+        b'"executions":{}}',
+    ],
+)
+def test_malformed_or_partial_state_fails_closed(
+    tmp_path: Path, payload: bytes
+) -> None:
+    store = _store(tmp_path)
+    store.runtime_root.mkdir(parents=True, exist_ok=True)
+    store.state_path.write_bytes(payload)
+    with pytest.raises(ScheduleStateError):
+        _claim(store)
+    assert store.state_path.read_bytes() == payload
+
+
+def test_write_failure_preserves_exact_prior_state(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(store)
+    assert claim is not None
+    before = store.state_path.read_bytes()
+
+    def broken_writer(stream, payload: bytes) -> None:
+        stream.write(payload[:8])
+        raise OSError("simulated")
+
+    broken = _store(tmp_path, ops=ScheduleClaimOps(writer=broken_writer))
+    with pytest.raises(OSError, match="simulated"):
+        broken.finalize(
+            claim.token,
+            success=True,
+            outcome_code="success",
+            now=NOW + timedelta(seconds=1),
+        )
+    assert store.state_path.read_bytes() == before
+    assert not list(store.runtime_root.glob(".schedule-claims.*.tmp"))
+
+
+def test_bad_replacer_is_detected_and_exact_lkg_restored(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(store)
+    assert claim is not None
+    before = store.state_path.read_bytes()
+
+    def corrupt_replacer(source: Path, target: Path) -> None:
+        target.write_bytes(b"corrupt")
+        source.unlink()
+
+    broken = _store(tmp_path, ops=ScheduleClaimOps(replacer=corrupt_replacer))
+    with pytest.raises(OSError, match="post_replace"):
+        broken.finalize(
+            claim.token,
+            success=True,
+            outcome_code="success",
+            now=NOW + timedelta(seconds=1),
+        )
+    assert store.state_path.read_bytes() == before
+    assert not list(store.runtime_root.glob(".schedule-claims.*.tmp"))
+
+
+def test_runtime_state_must_be_outside_repository(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pytest.raises(ValueError):
+        ScheduleClaimStore(repo_root=repo, runtime_root=repo / "memory")
+
+
+def test_arbitrary_dispatch_text_is_not_persisted(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    claim = _claim(store)
+    assert claim is not None
+    secret = "sk-live-should-never-be-in-claim-state"
+    assert store.finalize(
+        claim.token,
+        success=False,
+        outcome_code=secret,
+        now=NOW + timedelta(seconds=1),
+    )
+    assert secret.encode() not in store.state_path.read_bytes()
+
+
+def test_old_terminal_records_are_pruned_before_growth(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    old_now = NOW - timedelta(days=40)
+    old_window = _window(
+        start=old_now.replace(hour=0),
+        end=old_now.replace(hour=0) + timedelta(days=1),
+    )
+    claim = store.claim_window(old_window, now=old_now)
+    assert claim is not None
+    assert store.finalize(
+        claim.token,
+        success=True,
+        outcome_code="success",
+        now=old_now + timedelta(seconds=1),
+    )
+
+    new_window = _window(
+        schedule_id="new",
+        start=NOW + timedelta(days=1),
+        end=NOW + timedelta(days=2),
+    )
+    assert store.claim_window(new_window, now=NOW + timedelta(days=1))
+    refreshed = json.loads(store.state_path.read_text(encoding="utf-8"))
+    assert len(refreshed["executions"]) == 1
+
+
+@pytest.mark.parametrize("field", ["lease_expires_at", "next_attempt_at"])
+def test_timestamp_order_corruption_fails_closed(
+    tmp_path: Path, field: str
+) -> None:
+    store = _store(tmp_path)
+    claim = _claim(store)
+    assert claim is not None
+    if field == "next_attempt_at":
+        assert store.finalize(
+            claim.token,
+            success=False,
+            outcome_code="routine_failed",
+            now=NOW + timedelta(seconds=1),
+        )
+    state = json.loads(store.state_path.read_text(encoding="utf-8"))
+    record = next(iter(state["executions"].values()))
+    record[field] = (NOW - timedelta(seconds=1)).isoformat()
+    payload = json.dumps(state).encode()
+    store.state_path.write_bytes(payload)
+
+    with pytest.raises(ScheduleStateError, match="order"):
+        _claim(store, NOW + timedelta(seconds=2))
+    assert store.state_path.read_bytes() == payload
+
+
+def test_claim_control_layer_has_no_provider_or_network_imports() -> None:
+    source_root = Path(__file__).parents[1] / "src"
+    forbidden = {"httpx", "openai", "requests", "urllib"}
+    for filename in ("schedule_claim_codec.py", "schedule_claim_state.py"):
+        tree = ast.parse((source_root / filename).read_text(encoding="utf-8"))
+        direct_imports = {
+            alias.name.split(".", 1)[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        from_imports = {
+            node.module.split(".", 1)[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        imports = direct_imports | from_imports
+        assert imports.isdisjoint(forbidden)

--- a/modules/infrastructure/idle_automation/tests/test_schedule_evaluator.py
+++ b/modules/infrastructure/idle_automation/tests/test_schedule_evaluator.py
@@ -23,6 +23,9 @@ from modules.infrastructure.idle_automation.src.schedule_evaluator import (
     CADENCE_WINDOWS,
     get_supported_phrases,
 )
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    LEASE_SECONDS,
+)
 
 
 class TestScheduleParser:
@@ -292,3 +295,80 @@ class TestScheduleSpec:
         assert restored.phrase == spec.phrase
         assert restored.routine == spec.routine
         assert restored.last_run == spec.last_run
+
+
+class TestDurableScheduleClaims:
+    """Test evaluator-to-claim-store integration boundaries."""
+
+    def test_two_due_windows_are_claimed_one_at_a_time(self, tmp_path):
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        first = evaluator.add_schedule("run self research daily")
+        second = evaluator.add_schedule("run queue audit daily")
+        now = datetime(2026, 7, 24, 1, tzinfo=UTC)
+
+        first_claim = evaluator.claim_schedule(first, now=now)
+        assert first_claim is not None
+        state = json.loads(
+            evaluator.claim_store.state_path.read_text(encoding="utf-8")
+        )
+        assert list(state["executions"]) == [first_claim.execution_id]
+
+        second_claim = evaluator.claim_schedule(second, now=now)
+        assert second_claim is not None
+        assert second_claim.execution_id != first_claim.execution_id
+
+    def test_next_cadence_window_has_new_execution_id(self, tmp_path):
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        spec = evaluator.add_schedule("run self research daily")
+        first_now = datetime(2026, 7, 24, 1, tzinfo=UTC)
+        first = evaluator.claim_schedule(spec, now=first_now)
+        assert first is not None
+        assert evaluator.finalize_claim(
+            first.token,
+            success=True,
+            outcome_code="success",
+            now=first_now,
+        )
+
+        second = evaluator.claim_schedule(
+            spec, now=first_now + timedelta(days=1)
+        )
+        assert second is not None
+        assert second.execution_id != first.execution_id
+
+    def test_disabled_or_unknown_schedule_is_never_claimed(self, tmp_path):
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        spec = evaluator.add_schedule("run self research daily")
+        now = datetime(2026, 7, 24, 1, tzinfo=UTC)
+        evaluator.set_enabled(spec.id, False)
+        assert evaluator.claim_schedule(spec, now=now) is None
+        unknown = ScheduleSpec(
+            id="unknown",
+            phrase="unknown",
+            routine="not_supported",
+            cadence="daily",
+        )
+        assert evaluator.claim_schedule(unknown, now=now) is None
+        assert not evaluator.claim_store.state_path.exists()
+
+    def test_before_cadence_window_is_never_claimed(self, tmp_path):
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        spec = evaluator.add_schedule("run self research morning")
+        before = datetime(2026, 7, 24, 5, 59, tzinfo=UTC)
+        assert evaluator.claim_schedule(spec, now=before) is None
+        assert not evaluator.claim_store.state_path.exists()
+
+    def test_claim_lease_exceeds_maximum_dispatch_timeout(self):
+        assert LEASE_SECONDS >= 3660
+
+    def test_payload_like_phrase_cannot_select_claim_path(self, tmp_path):
+        untrusted = tmp_path / "payload-owned"
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        phrase = f"run self research daily runtime_root={untrusted}"
+        spec = evaluator.add_schedule(phrase)
+        claim = evaluator.claim_schedule(
+            spec, now=datetime(2026, 7, 24, 1, tzinfo=UTC)
+        )
+        assert claim is not None
+        assert evaluator.claim_store.runtime_root != untrusted
+        assert not untrusted.exists()

--- a/modules/infrastructure/idle_automation/tests/test_schedule_evaluator.py
+++ b/modules/infrastructure/idle_automation/tests/test_schedule_evaluator.py
@@ -13,14 +13,11 @@ Tests cover:
 import json
 import pytest
 from datetime import datetime, timedelta, UTC
-from pathlib import Path
 
 from modules.infrastructure.idle_automation.src.schedule_evaluator import (
     ScheduleParser,
     ScheduleEvaluator,
     ScheduleSpec,
-    SUPPORTED_ROUTINES,
-    CADENCE_WINDOWS,
     get_supported_phrases,
 )
 from modules.infrastructure.idle_automation.src.schedule_claim_state import (
@@ -177,6 +174,14 @@ class TestScheduleEvaluator:
         assert updated.last_run is not None
         assert "success" in updated.last_result
 
+    def test_failed_execution_does_not_advance_last_run(self, evaluator):
+        """A failed legacy record must remain eligible for durable retry."""
+        spec = evaluator.add_schedule("run self research daily")
+        assert evaluator.record_execution(spec.id, False, "failed")
+        updated = evaluator.get_schedule(spec.id)
+        assert updated.last_run is None
+        assert updated.last_result == "failed: failed"
+
 
 class TestDueScheduleEvaluation:
     """Test due schedule evaluation logic."""
@@ -205,6 +210,7 @@ class TestDueScheduleEvaluation:
         now = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
         ran_at = now.replace(hour=8)
         evaluator._schedules[spec.id].last_run = ran_at.isoformat()
+        evaluator._schedules[spec.id].last_result = "success: completed"
         evaluator._save_schedules()
 
         # Check at noon - should not be due
@@ -372,3 +378,43 @@ class TestDurableScheduleClaims:
         assert claim is not None
         assert evaluator.claim_store.runtime_root != untrusted
         assert not untrusted.exists()
+
+    def test_persisted_current_window_failure_is_due_and_claimable(
+        self, tmp_path
+    ):
+        schedules_path = tmp_path / "schedules.json"
+        evaluator = ScheduleEvaluator(schedules_path=schedules_path)
+        spec = evaluator.add_schedule("run self research daily")
+        now = datetime(2026, 7, 24, 1, tzinfo=UTC)
+        spec.last_run = now.isoformat()
+        spec.last_result = "failed: legacy failure"
+        evaluator._save_schedules()
+
+        restarted = ScheduleEvaluator(schedules_path=schedules_path)
+        due = restarted.get_due_schedules(now)
+        assert [item.id for item in due] == [spec.id]
+        assert restarted.claim_schedule(due[0], now=now) is not None
+
+    @pytest.mark.parametrize(
+        "legacy_result",
+        [None, "", "completed", "Success: completed", "unknown: completed"],
+    )
+    def test_unknown_legacy_result_is_due_fail_safe(
+        self, tmp_path, legacy_result
+    ):
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        spec = evaluator.add_schedule("run self research daily")
+        now = datetime(2026, 7, 24, 1, tzinfo=UTC)
+        spec.last_run = now.isoformat()
+        spec.last_result = legacy_result
+        assert evaluator.get_due_schedules(now) == [spec]
+
+    def test_explicit_canonical_legacy_success_suppresses_window(
+        self, tmp_path
+    ):
+        evaluator = ScheduleEvaluator(schedules_path=tmp_path / "schedules.json")
+        spec = evaluator.add_schedule("run self research daily")
+        now = datetime(2026, 7, 24, 1, tzinfo=UTC)
+        spec.last_run = now.isoformat()
+        spec.last_result = "success: completed"
+        assert evaluator.get_due_schedules(now) == []

--- a/modules/infrastructure/idle_automation/tests/test_scheduled_routines_integration.py
+++ b/modules/infrastructure/idle_automation/tests/test_scheduled_routines_integration.py
@@ -199,6 +199,84 @@ class TestScheduledRoutinesDispatch:
         assert result["success"] is False
         assert "disabled" in result["error"].lower()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure", ["malformed", "write_failed"])
+    async def test_claim_state_failure_causes_zero_dispatch(
+        self, mock_dae, failure
+    ):
+        """Uncertain claim durability fails closed before any routine runs."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+        from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+            ScheduleStateError,
+        )
+
+        evaluator = MagicMock()
+        evaluator.get_due_schedules.return_value = [
+            MagicMock(id="one", routine="self_research", cadence="daily")
+        ]
+        evaluator.claim_schedule.side_effect = ScheduleStateError(failure)
+        mock_dae._dispatch_scheduled_routine = AsyncMock()
+
+        with patch(
+            "modules.infrastructure.idle_automation.src.schedule_evaluator.ScheduleEvaluator",
+            return_value=evaluator,
+        ):
+            result = await IdleAutomationDAE._execute_scheduled_routines(mock_dae)
+
+        assert result["success"] is False
+        assert "claim state" in result["error"].lower()
+        mock_dae._dispatch_scheduled_routine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_disabled_mode_does_not_construct_or_dispatch(self, mock_dae):
+        """Disabled scheduling performs zero claim-state or dispatch work."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        mock_dae._parse_bool_env = lambda key, default: (
+            False if key == "AUTO_SCHEDULED_ROUTINES" else default
+        )
+        mock_dae._dispatch_scheduled_routine = AsyncMock()
+        with patch(
+            "modules.infrastructure.idle_automation.src.schedule_evaluator.ScheduleEvaluator"
+        ) as evaluator_type:
+            result = await IdleAutomationDAE._execute_scheduled_routines(mock_dae)
+
+        assert result["success"] is False
+        evaluator_type.assert_not_called()
+        mock_dae._dispatch_scheduled_routine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_finalize_failure_is_completion_unknown(self, mock_dae):
+        """A publish failure after dispatch does not update legacy last-run."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        spec = MagicMock(id="one", routine="self_research", cadence="daily")
+        claim = MagicMock(token="opaque", routine="self_research")
+        evaluator = MagicMock()
+        evaluator.get_due_schedules.return_value = [spec]
+        evaluator.claim_schedule.return_value = claim
+        evaluator.finalize_claim.side_effect = OSError("simulated")
+        mock_dae._dispatch_scheduled_routine = AsyncMock(
+            return_value={"success": True, "summary": "done"}
+        )
+        with patch(
+            "modules.infrastructure.idle_automation.src.schedule_evaluator.ScheduleEvaluator",
+            return_value=evaluator,
+        ):
+            result = await IdleAutomationDAE._execute_scheduled_routines(mock_dae)
+
+        assert result["success"] is False
+        assert result["finalization_failed_count"] == 1
+        assert result["executed_count"] == 0
+        evaluator.record_execution.assert_not_called()
+        mock_dae._dispatch_scheduled_routine.assert_awaited_once()
+
 
 class TestDispatchScheduledRoutine:
     """Test individual routine dispatch."""


### PR DESCRIPTION
## Summary
- retain IdleAutomation/ScheduleEvaluator as the single recurring-cadence authority
- durably claim one canonical schedule window immediately before each dispatch
- finalize only the exact current token, with bounded lease recovery and retry/backoff
- store claim authority under a trusted outside-repository runtime root
- fail closed on malformed/uncertain state and preserve exact last-known-good state on publication failures
- migrate failed/unknown legacy schedule rows into claim control while treating only canonical legacy success as completed

## WSP_97 scope
This is the P0 scheduler prerequisite only. It does **not** add the OpenRouter/provider routine, a startup hook, a second scheduler, or any model-selection/promotion/runtime-binding authority.

## Validation
- focused scheduler/evaluator/DAE: 91 passed
- runtime artifact safety neighbor: 11 passed, 1 Windows platform skip
- full idle automation: 125 passed; 1 unchanged pre-existing Holo startup mock-target mismatch outside this diff
- Ruff/new sources, compile, diff/show, WSP file/function/ModLog gates: green
- independent contradiction review: GO at `b386ae86351f5afa270897f4d2f7a03c44ddbe50`

## Boundaries and residuals
- 3900-second lease exceeds the currently registered 3600-second maximum routine timeout
- recovery is bounded at-least-once, not exactly-once; routines must be repeat-safe or independently fenced
- Windows `Local\\` mutex coordinates the same logon session; runtime root must remain private/non-shared
- repo-local `last_run`/`last_result` remains compatibility metadata only and cannot grant dispatch
- no provider, network, Holo, startup, main.py, AI Gateway, Hermes, OpenClaw, or live-runtime calls were made