### PR TITLE
test(idle-automation): mock canonical Holo maintenance handshake

### DIFF
--- a/modules/infrastructure/idle_automation/tests/TestModLog.md
+++ b/modules/infrastructure/idle_automation/tests/TestModLog.md
@@ -7,6 +7,27 @@
 
 ---
 
+## 2026-07-24: Canonical HoloIndex Maintenance Dispatch Mock
+
+**File**: `test_startup_maintenance_gate.py`
+
+- Replaced the obsolete `SelfResearchRefresher.refresh_holo_index` mock with
+  the canonical RedDog maintenance-handshake boundary.
+- Uses the production `RedDogHoloIndexOperationalResult` type and a complete,
+  secret-free ready receipt.
+- Proves exact `repo_root`, `requested=True`, and `auto_maintenance=True`
+  arguments without running HoloIndex, runtime maintenance, or network work.
+- Retains exact executor, success, structured receipt, and serialized receipt
+  assertions.
+
+**Targeted Result**: `1 passed`
+
+**Canonical Dispatch Result**: `3 passed`
+
+**Full Idle Automation Result**: `126 passed`
+
+---
+
 ## 2026-07-24: Legacy Failed-Row Migration Regression
 
 - Proves a persisted current-window `failed:` row remains due after restart and

--- a/modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py
+++ b/modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py
@@ -318,31 +318,52 @@ class TestStartupTaskExecution:
         # ok can be True or False depending on LM Studio state, but should not error
         assert "detail" in result
 
-    def test_holo_index_task_executes(self):
+    def test_holo_index_task_executes(self, tmp_path):
         """startup_refresh_holo_index task executes through dispatch path."""
         from modules.communication.moltbot_bridge.scripts.run_task import (
             _try_startup_maintenance_dispatch,
         )
+        from modules.infrastructure.foundups_mcp_bridge.src.reddog_holoindex_maintenance_handshake import (
+            RedDogHoloIndexOperationalResult,
+        )
 
-        # Use short timeout to avoid actual indexing
         with patch(
-            "modules.infrastructure.idle_automation.src.self_research_refresh.SelfResearchRefresher.refresh_holo_index"
-        ) as mock_refresh:
-            mock_refresh.return_value = {
-                "code_stale": False,
-                "wsp_stale": False,
-                "refresh_success": True,
-            }
-
+            "modules.infrastructure.foundups_mcp_bridge.src.reddog_holoindex_maintenance_handshake.ensure_reddog_holoindex_operational",
+            return_value=RedDogHoloIndexOperationalResult(
+                ready=True,
+                status="READY",
+                refreshed=False,
+                error="",
+                repo_head_sha="a" * 40,
+                generation_id=f"sha256:{'b' * 64}",
+                freshness_reasons=(),
+            ),
+        ) as mock_ensure:
             result = _try_startup_maintenance_dispatch(
-                repo_root=REPO_ROOT,
+                repo_root=tmp_path,
                 task_id="startup_refresh_holo_index",
                 context={"source": "startup_maintenance_gate"},
             )
 
+        mock_ensure.assert_called_once_with(
+            repo_root=tmp_path,
+            requested=True,
+            auto_maintenance=True,
+        )
         assert result is not None, "HoloIndex task should have an executor"
         assert result["executor"] == "startup:holo_index"
         assert result["ok"] is True
+        expected_receipt = {
+            "ready": True,
+            "status": "READY",
+            "refreshed": False,
+            "error": "",
+            "repo_head_sha": "a" * 40,
+            "generation_id": f"sha256:{'b' * 64}",
+            "freshness_reasons": [],
+        }
+        assert result["structured_result"] == expected_receipt
+        assert json.loads(result["detail"]) == expected_receipt
 
     def test_self_research_task_executes_live(self):
         """startup_refresh_self_research executes through live dispatch (no mocking)."""


### PR DESCRIPTION
## Summary
- update the stale IdleAutomation Holo startup smoke test to mock the canonical exact-HEAD maintenance handshake
- use `tmp_path` instead of the repository root
- assert exact handshake arguments and the complete structured/serialized receipt
- document the test correction in TestModLog

## Validation
- corrected test: 1 passed
- canonical Holo dispatch neighbors: 3 passed
- full IdleAutomation suite: 126 passed
- compile, WSP/TestModLog, diff/scope checks: green
- independent review: GO at `01531bcb0bd430fdf4a5ca9843e0668d26d1358f`

## Scope
Test-only. No production, Holo index, runtime, provider, network, startup authority, or model authority change.