### PR TITLE
feat(idle): schedule guarded OpenRouter catalog refresh

### DIFF
--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -139,6 +139,30 @@ must remain under a trusted-principal-controlled root; the cooperative lock
 does not defend against an arbitrary writer with directory access. Ledger state
 contains no response body, credential, or authorization data.
 
+#### Idle schedule adapter
+
+```python
+await run_openrouter_catalog_schedule_claim(
+    claim,
+    repo_root=...,
+    runtime_root=...,
+    transport=...,
+) -> dict[str, object]
+```
+
+The claim must be the exact durable `ScheduleClaim` type for canonical schedule
+ID `e324884d66c4`, routine `openrouter_catalog_refresh`, cadence `daily`, and a
+canonical midnight-to-midnight UTC window. The adapter derives the guarded
+invocation; callers cannot supply invocation or artifact identities.
+
+The result has exactly six keys: `success`, `status`, `reason`, `replayed`,
+`receipt_id`, and `candidate_snapshot_id`. Only canonically rehydrated
+`DiscoveryReceipt` and `ProviderCatalogCandidateSnapshot` evidence with exact
+invocation and observation lineage can yield `COMPLETED/completed`. Other
+results use fixed local codes and do not expose guard text. The API gathers
+candidate evidence only and has no bridge, selection, promotion, registry, or
+runtime-binding authority.
+
 #### Model Intelligence Selection
 
 ```python

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,38 @@
 # AI Gateway Module Change Log
 
+## [2026-07-24] - Idle OpenRouter Catalog Schedule Adapter
+
+**Who/Type/Slice:** 0102 Codex / Defensive Reliability /
+OPENROUTER_CATALOG_SCHEDULE_ADAPTER_PHASE1
+
+**What:** Added a daily-only adapter from the exact idle durable claim to the
+existing scheduled replay guard. The adapter derives the invocation, returns an
+exact six-key bounded projection, normalizes all status/reason codes locally,
+and canonically rehydrates typed receipt/candidate evidence before accepting
+completion.
+
+**Truth Boundary:** Default-off idle execution; tests use injected offline
+transport, and trusted runtime evidence remains outside the repository.
+Replay/finalization requires exact evidence lineage. No catalog bridge, model
+selection, promotion, registry mutation, runtime binding, startup hook, or
+general scheduler was added.
+
+**WSP_15 MPS:** Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19
+(P0).
+
+**MPS rationale/remediation:** A forged exact dataclass could previously
+carry matching oversized identifiers, and raw guard status/reason text could
+cross the adapter. Canonical rehydration, fixed local projection codes, bounded
+six-key output, recursive-data rejection, and cancellation-preserving tests
+close that false-evidence and secret-disclosure boundary.
+
+**Validation:** `174 passed, 1 skipped` focused; `575 passed, 3 skipped`
+combined AI Gateway + IdleAutomation + runtime-artifact-safety scope. All
+validation calls used injected offline transport; no live provider call was
+made.
+
+---
+
 ## [2026-07-24] - Scheduled Provider Discovery Replay Guard
 
 **Who:** 0102 Codex worker, architect-audited lane

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -114,6 +114,28 @@ boundary against an arbitrary writer with access to that directory.
 The fixed guarded artifact identities are exclusive to this API; manual/direct
 callers must use different attempt and candidate paths.
 
+### Idle daily catalog schedule adapter
+
+`run_openrouter_catalog_schedule_claim(...)` is the narrow bridge from one
+exact idle `ScheduleClaim` to the guarded discovery API. It accepts only the
+canonical `openrouter_catalog_refresh:daily` schedule, a canonical midnight
+UTC 24-hour window, and the exact execution digest. The claim maps to
+`schedule_id="idle:<execution_id>"`, the window start in milliseconds, and an
+inclusive expiry one millisecond before window end.
+
+The adapter returns exactly six bounded fields: `success`, `status`, `reason`,
+`replayed`, `receipt_id`, and `candidate_snapshot_id`. Guard status/reason text
+is never forwarded. Completion succeeds only after exact typed receipt and
+candidate evidence is serialized, canonically rehydrated, and proven to match
+the derived invocation and each other. All malformed, forged, nonterminal, or
+exceptional results become fixed content-free failures; cancellation still
+propagates.
+
+This is candidate-evidence collection only. It performs no catalog bridge,
+model selection, promotion, registry mutation, or runtime binding. Production
+enablement is owned by idle automation and remains default-off. Tests inject
+transport and remain offline.
+
 ## Model Selection Receipts
 
 `src/model_intelligence_selection.py` consumes a `ModelCatalogSnapshot` and

--- a/modules/ai_intelligence/ai_gateway/ROADMAP.md
+++ b/modules/ai_intelligence/ai_gateway/ROADMAP.md
@@ -40,9 +40,11 @@
 - [x] Scheduled-only durable replay guard with per-invocation `ARMED` admission,
   bounded terminal ledger evidence, pre-ledger migration, cross-process
   serialization, and fail-closed replay recovery.
-- [ ] Operator-owned scheduling integration. Phase 1 provides scheduled
-  invocation admission and replay enforcement but intentionally installs no
-  scheduler.
+- [x] Default-off idle scheduling POC for the exact daily OpenRouter refresh
+  claim, with canonical invocation mapping and a six-key evidence-only adapter.
+- [ ] General provider-discovery cadence and scheduler expansion remains out of
+  scope; the POC does not grant discovery any startup, selection, promotion,
+  registry, or runtime authority.
 - [ ] Evaluate directory-handle publication on non-Windows hosts and stronger
   directory durability. Their current boundary requires a trusted non-shared
   runtime directory and all parent-directory fsync remains best-effort.

--- a/modules/ai_intelligence/ai_gateway/src/model_openrouter_schedule_adapter.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_openrouter_schedule_adapter.py
@@ -1,0 +1,238 @@
+"""Narrow idle-schedule adapter for guarded OpenRouter catalog discovery."""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from modules.ai_intelligence.ai_gateway.src.model_openrouter_scheduled_discovery import (
+    ScheduledDiscoveryResult,
+    discover_scheduled_openrouter_model_catalog,
+)
+from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_snapshot import (
+    DiscoveryInvocation,
+    DiscoveryReceipt,
+    ProviderCatalogCandidateSnapshot,
+    build_discovery_invocation,
+    rehydrate_candidate_snapshot,
+    rehydrate_discovery_receipt,
+)
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    ScheduleClaim,
+    build_execution_id,
+)
+from modules.infrastructure.idle_automation.src.schedule_claim_codec import (
+    MAX_ATTEMPTS,
+)
+
+_ROUTINE = "openrouter_catalog_refresh"
+_SCHEDULE_ID = "e324884d66c4"
+_RESULT_KEYS = ("success", "status", "reason", "replayed", "receipt_id",
+                "candidate_snapshot_id")
+_NONCOMPLETED = {
+    "FAILED": ("FAILED", "scheduled_discovery_failed"),
+    "INDETERMINATE": ("INDETERMINATE", "scheduled_discovery_indeterminate"),
+    "BLOCKED_PRECALL": ("BLOCKED_PRECALL", "scheduled_discovery_blocked"),
+}
+
+
+async def run_openrouter_catalog_schedule_claim(
+    claim: ScheduleClaim,
+    *,
+    repo_root: Path | str,
+    runtime_root: Path | str,
+    transport: object | None = None,
+) -> dict[str, Any]:
+    """Validate one exact daily claim and invoke only the guarded API."""
+
+    invocation = _derive_invocation(claim)
+    if invocation is None:
+        return _result("BLOCKED_PRECALL", "claim_invalid")
+    try:
+        guarded = await discover_scheduled_openrouter_model_catalog(
+            invocation,
+            repo_root=repo_root,
+            runtime_root=runtime_root,
+            transport=transport,
+        )
+    except Exception:
+        return _result("INDETERMINATE", "scheduled_discovery_adapter_failed")
+    return _project_guarded(guarded, invocation)
+
+
+def _derive_invocation(claim: object) -> DiscoveryInvocation | None:
+    if (
+        type(claim) is not ScheduleClaim
+        or claim.schedule_id != _SCHEDULE_ID
+        or claim.routine != _ROUTINE
+        or claim.cadence != "daily"
+        or not _bounded_claim_fields(claim)
+    ):
+        return None
+    try:
+        expected = build_execution_id(
+            claim.schedule_id,
+            claim.routine,
+            claim.cadence,
+            claim.window_start,
+            claim.window_end,
+        )
+        if not secrets.compare_digest(claim.execution_id, expected):
+            return None
+        bounds = _daily_bounds(claim.window_start, claim.window_end)
+        if bounds is None:
+            return None
+        start_ms, end_ms = bounds
+        return build_discovery_invocation(
+            mode="scheduled", schedule_id=f"idle:{claim.execution_id}",
+            scheduled_for_ms=start_ms, expires_at_ms=end_ms - 1,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _bounded_claim_fields(claim: ScheduleClaim) -> bool:
+    if (
+        type(claim.token) is not str
+        or not 0 < len(claim.token) <= 256
+        or type(claim.claimant_id) is not str
+        or not 0 < len(claim.claimant_id) <= 256
+        or type(claim.attempt) is not int
+        or not 1 <= claim.attempt <= MAX_ATTEMPTS
+    ):
+        return False
+    try:
+        lease = datetime.fromisoformat(claim.lease_expires_at)
+    except (TypeError, ValueError):
+        return False
+    return (
+        lease.tzinfo is not None
+        and lease.utcoffset() == timedelta(0)
+        and lease.isoformat() == claim.lease_expires_at
+    )
+
+
+def _daily_bounds(start_text: str, end_text: str) -> tuple[int, int] | None:
+    try:
+        start = datetime.fromisoformat(start_text)
+        end = datetime.fromisoformat(end_text)
+    except (TypeError, ValueError):
+        return None
+    if (
+        start.tzinfo is None
+        or end.tzinfo is None
+        or start.utcoffset() != timedelta(0)
+        or end.utcoffset() != timedelta(0)
+        or start.isoformat() != start_text
+        or end.isoformat() != end_text
+        or start
+        != start.astimezone(UTC).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        or end - start != timedelta(days=1)
+    ):
+        return None
+    return _epoch_ms(start), _epoch_ms(end)
+
+
+def _epoch_ms(value: datetime) -> int:
+    delta = value.astimezone(UTC) - datetime(1970, 1, 1, tzinfo=UTC)
+    return (
+        delta.days * 86_400_000
+        + delta.seconds * 1_000
+        + delta.microseconds // 1_000
+    )
+
+
+def _project_guarded(
+    guarded: object, invocation: DiscoveryInvocation
+) -> dict[str, Any]:
+    if type(guarded) is not ScheduledDiscoveryResult:
+        return _result(
+            "INDETERMINATE", "scheduled_discovery_result_invalid"
+        )
+    if guarded.status != "COMPLETED":
+        projection = (
+            _NONCOMPLETED.get(guarded.status)
+            if type(guarded.status) is str
+            else None
+        )
+        if projection is None:
+            projection = (
+                "INDETERMINATE",
+                "scheduled_discovery_result_invalid",
+            )
+        return _result(
+            *projection,
+            replayed=guarded.replayed is True,
+        )
+    evidence, invalid_reason = _canonical_completed_evidence(guarded)
+    if evidence is None:
+        return _result("INDETERMINATE", invalid_reason)
+    receipt, candidate = evidence
+    if not _completed_lineage(receipt, candidate, invocation):
+        return _result("INDETERMINATE", "completed_lineage_invalid")
+    return _result(
+        "COMPLETED",
+        "completed",
+        success=True,
+        replayed=guarded.replayed is True,
+        receipt_id=receipt.receipt_id,
+        candidate_snapshot_id=candidate.snapshot_id,
+    )
+
+
+def _canonical_completed_evidence(
+    guarded: ScheduledDiscoveryResult,
+) -> tuple[tuple[DiscoveryReceipt, ProviderCatalogCandidateSnapshot] | None, str]:
+    receipt, candidate = guarded.receipt, guarded.candidate
+    if type(receipt) is not DiscoveryReceipt:
+        return None, "completed_receipt_invalid"
+    try:
+        canonical_receipt = rehydrate_discovery_receipt(receipt.to_dict())
+    except (AttributeError, KeyError, TypeError, ValueError, OverflowError,
+            RecursionError):
+        return None, "completed_receipt_invalid"
+    if type(candidate) is not ProviderCatalogCandidateSnapshot:
+        return None, "completed_candidate_invalid"
+    try:
+        canonical_candidate = rehydrate_candidate_snapshot(
+            candidate.to_dict(),
+            now_ms=candidate.observed_at_ms,
+        )
+    except (AttributeError, KeyError, TypeError, ValueError, OverflowError,
+            RecursionError):
+        return None, "completed_candidate_invalid"
+    return (canonical_receipt, canonical_candidate), ""
+
+
+def _completed_lineage(
+    receipt: DiscoveryReceipt,
+    candidate: ProviderCatalogCandidateSnapshot,
+    invocation: DiscoveryInvocation,
+) -> bool:
+    return (
+        receipt.outcome == "COMPLETED"
+        and receipt.invocation == invocation
+        and candidate.observation_receipt == receipt
+        and candidate.snapshot_id == receipt.candidate_snapshot_id
+    )
+
+
+def _result(
+    status: str,
+    reason: str,
+    *,
+    success: bool = False,
+    replayed: bool = False,
+    receipt_id: str | None = None,
+    candidate_snapshot_id: str | None = None,
+) -> dict[str, Any]:
+    values = (success, status, reason, replayed, receipt_id,
+              candidate_snapshot_id)
+    return dict(zip(_RESULT_KEYS, values))
+
+
+__all__ = ["run_openrouter_catalog_schedule_claim"]

--- a/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
+++ b/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
@@ -1,5 +1,22 @@
 # AI Gateway TestModLog
 
+## 2026-07-24 - Idle OpenRouter schedule adapter
+
+Scope: offline adversarial validation of the exact daily claim-to-guard bridge.
+
+- Proves canonical claim/invocation mapping and exact six-key output.
+- Proves default-independent injected transport with no live network.
+- Proves fixed local status/reason codes do not expose guard or exception text.
+- Proves receipt and candidate `.to_dict()` evidence is canonically rehydrated
+  before lineage/output.
+- Rejects forged, malformed, matching 10,000-character, recursive, and
+  nonterminal evidence with bounded content-free results.
+- Preserves `CancelledError` and enforces no direct discovery, catalog bridge,
+  selection, promotion, registry, or runtime-binding escape hatch.
+
+Focused cross-module result: `174 passed, 1 skipped`. Combined AI Gateway +
+IdleAutomation + runtime-artifact-safety result: `575 passed, 3 skipped`.
+
 ## 2026-07-24 - Scheduled provider discovery replay guard
 
 Scope: offline-only adversarial verification of scheduled replay admission

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_schedule_adapter.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_schedule_adapter.py
@@ -1,0 +1,623 @@
+"""Red contract tests for the idle schedule-to-discovery adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib
+import json
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from modules.ai_intelligence.ai_gateway.src.model_openrouter_scheduled_discovery import (
+    ScheduledDiscoveryResult,
+)
+from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_snapshot import (
+    build_candidate_snapshot,
+    build_discovery_invocation,
+    build_discovery_receipt,
+    candidate_snapshot_id,
+    parse_and_sanitize_openrouter_catalog,
+    sha256_bytes,
+)
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    ScheduleClaim,
+    build_execution_id,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures/openrouter_models_success.json"
+START = "2026-07-24T00:00:00+00:00"
+END = "2026-07-25T00:00:00+00:00"
+SCHEDULE_ID = hashlib.sha256(
+    b"openrouter_catalog_refresh:daily"
+).hexdigest()[:12]
+
+
+def _adapter():
+    return importlib.import_module(
+        "modules.ai_intelligence.ai_gateway.src."
+        "model_openrouter_schedule_adapter"
+    )
+
+
+def _claim(
+    *,
+    schedule_id: str = SCHEDULE_ID,
+    routine: str = "openrouter_catalog_refresh",
+    cadence: str = "daily",
+    start: str = START,
+    end: str = END,
+    execution_id: str | None = None,
+    token: str = "opaque-claim-token",
+    claimant_id: str = "idle-dae",
+    lease_expires_at: str = "2026-07-24T01:00:00+00:00",
+    attempt: int = 1,
+) -> ScheduleClaim:
+    return ScheduleClaim(
+        schedule_id=schedule_id,
+        routine=routine,
+        cadence=cadence,
+        window_start=start,
+        window_end=end,
+        execution_id=execution_id
+        or build_execution_id(
+            schedule_id, routine, cadence, start, end
+        ),
+        token=token,
+        claimant_id=claimant_id,
+        lease_expires_at=lease_expires_at,
+        attempt=attempt,
+    )
+
+
+class _ScheduleClaimSubclass(ScheduleClaim):
+    """Structurally similar claims are not exact durable claim evidence."""
+
+
+def _expected_invocation(claim: ScheduleClaim):
+    start_ms = int(
+        datetime.fromisoformat(claim.window_start).timestamp() * 1000
+    )
+    end_ms = int(
+        datetime.fromisoformat(claim.window_end).timestamp() * 1000
+    )
+    return build_discovery_invocation(
+        mode="scheduled",
+        schedule_id=f"idle:{claim.execution_id}",
+        scheduled_for_ms=start_ms,
+        expires_at_ms=end_ms - 1,
+    )
+
+
+def _completed_guard_result(invocation) -> ScheduledDiscoveryResult:
+    raw = FIXTURE.read_bytes()
+    payload, rejected, counts = parse_and_sanitize_openrouter_catalog(raw)
+    snapshot_id = candidate_snapshot_id(payload)
+    completed = int(
+        datetime.fromisoformat(START).timestamp() * 1000
+    )
+    receipt = build_discovery_receipt(
+        invocation=invocation,
+        call_id="offline-schedule-adapter",
+        request_envelope_digest=sha256_bytes(b"fixed-request"),
+        attempted=True,
+        outcome="COMPLETED",
+        reason="completed",
+        started_at_ms=completed,
+        completed_at_ms=completed,
+        http_status=200,
+        response_body_digest=sha256_bytes(raw),
+        response_byte_count=len(raw),
+        candidate_snapshot_id=snapshot_id,
+        accepted_record_count=len(payload["data"]),
+        rejected_record_count=rejected,
+        rejection_counts=counts,
+    )
+    candidate = build_candidate_snapshot(
+        catalog_payload=payload,
+        rejected_record_count=rejected,
+        rejection_counts=counts,
+        observed_at_ms=completed,
+        observation_receipt=receipt,
+    )
+    return ScheduledDiscoveryResult(
+        status="COMPLETED",
+        reason="completed",
+        replayed=False,
+        receipt=receipt,
+        candidate=candidate,
+        attempt_path=Path("not-exported-attempt"),
+        candidate_path=Path("not-exported-candidate"),
+        ledger_path=Path("not-exported-ledger"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_valid_daily_claim_maps_exact_guarded_invocation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _adapter()
+    claim = _claim()
+    expected = _expected_invocation(claim)
+    guard_result = _completed_guard_result(expected)
+    guarded = AsyncMock(return_value=guard_result)
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "trusted-runtime"
+    transport = object()
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        claim,
+        repo_root=repo,
+        runtime_root=runtime,
+        transport=transport,
+    )
+
+    guarded.assert_awaited_once_with(
+        expected,
+        repo_root=repo,
+        runtime_root=runtime,
+        transport=transport,
+    )
+    assert result == {
+        "success": True,
+        "status": "COMPLETED",
+        "reason": "completed",
+        "replayed": False,
+        "receipt_id": guard_result.receipt.receipt_id,
+        "candidate_snapshot_id": guard_result.candidate.snapshot_id,
+    }
+    assert len(json.dumps(result)) < 1024
+    assert not any("path" in key or "candidate" == key for key in result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "claim",
+    [
+        _claim(cadence="nightly"),
+        _claim(routine="self_research"),
+        _claim(schedule_id="forged-schedule"),
+        _claim(execution_id="0" * 64),
+        _claim(
+            start="2026-07-24T01:00:00+00:00",
+            end="2026-07-25T01:00:00+00:00",
+        ),
+        _claim(
+            start="2026-07-24T00:00:00Z",
+            end="2026-07-25T00:00:00Z",
+        ),
+        _claim(
+            start="2026-07-24T00:00:00+09:00",
+            end="2026-07-25T00:00:00+09:00",
+        ),
+        _claim(end="2026-07-24T23:00:00+00:00"),
+        _claim(token="x" * 257),
+        _claim(claimant_id=""),
+        _claim(lease_expires_at="not-a-time"),
+        _claim(attempt=0),
+    ],
+)
+async def test_forged_claim_fails_before_guarded_provider_call(
+    claim: ScheduleClaim, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _adapter()
+    guarded = AsyncMock()
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        claim,
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result == {
+        "success": False,
+        "status": "BLOCKED_PRECALL",
+        "reason": "claim_invalid",
+        "replayed": False,
+        "receipt_id": None,
+        "candidate_snapshot_id": None,
+    }
+    guarded.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "claim_like",
+    [
+        _claim().__dict__,
+        _ScheduleClaimSubclass(**_claim().__dict__),
+    ],
+)
+async def test_non_exact_claim_type_fails_before_guard(
+    claim_like: object,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    guarded = AsyncMock()
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        claim_like,
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result["reason"] == "claim_invalid"
+    assert set(result) == {
+        "success",
+        "status",
+        "reason",
+        "replayed",
+        "receipt_id",
+        "candidate_snapshot_id",
+    }
+    guarded.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "reason", "expected_status", "expected_reason"),
+    [
+        ("FAILED", "transport_failed", "FAILED", "scheduled_discovery_failed"),
+        (
+            "INDETERMINATE",
+            "replay_state_invalid",
+            "INDETERMINATE",
+            "scheduled_discovery_indeterminate",
+        ),
+        (
+            "BLOCKED_PRECALL",
+            "runtime_path_invalid",
+            "BLOCKED_PRECALL",
+            "scheduled_discovery_blocked",
+        ),
+    ],
+)
+async def test_noncompleted_guard_status_never_promotes_success(
+    status: str,
+    reason: str,
+    expected_status: str,
+    expected_reason: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    completed = _completed_guard_result(_expected_invocation(_claim()))
+    guarded = AsyncMock(
+        return_value=replace(
+            completed,
+            status=status,
+            reason=reason,
+            receipt=None,
+            candidate=None,
+        )
+    )
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result == {
+        "success": False,
+        "status": expected_status,
+        "reason": expected_reason,
+        "replayed": False,
+        "receipt_id": None,
+        "candidate_snapshot_id": None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("completed", [False, True])
+async def test_guard_status_and_reason_are_never_forwarded(
+    completed: bool,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    secret = "Bearer sk-secret-must-not-escape"
+    guard_result = _completed_guard_result(_expected_invocation(_claim()))
+    if completed:
+        guard_result = replace(guard_result, reason=secret)
+    else:
+        guard_result = replace(
+            guard_result,
+            status=f"FAILED-{secret}",
+            reason=secret,
+            receipt=None,
+            candidate=None,
+        )
+    guarded = AsyncMock(return_value=guard_result)
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    encoded = json.dumps(result)
+    assert secret not in encoded
+    assert len(encoded) < 1024
+    if completed:
+        assert result["status"] == "COMPLETED"
+        assert result["reason"] == "completed"
+        assert result["success"] is True
+    else:
+        assert result["status"] == "INDETERMINATE"
+        assert result["reason"] == "scheduled_discovery_result_invalid"
+        assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_unhashable_guard_status_returns_fixed_invalid_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    guard_result = replace(
+        _completed_guard_result(_expected_invocation(_claim())),
+        status={},
+        receipt=None,
+        candidate=None,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "discover_scheduled_openrouter_model_catalog",
+        AsyncMock(return_value=guard_result),
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "INDETERMINATE"
+    assert result["reason"] == "scheduled_discovery_result_invalid"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        {"receipt": None},
+        {"candidate": None},
+        {"receipt": object()},
+        {"candidate": object()},
+    ],
+)
+async def test_completed_requires_exact_receipt_and_candidate(
+    replacement: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter = _adapter()
+    expected = _expected_invocation(_claim())
+    guard_result = _completed_guard_result(expected)
+    guarded = AsyncMock(return_value=replace(guard_result, **replacement))
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result["success"] is False
+    assert set(result) == {
+        "success",
+        "status",
+        "reason",
+        "replayed",
+        "receipt_id",
+        "candidate_snapshot_id",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mismatch", ["receipt_invocation", "candidate"])
+async def test_completed_requires_exact_derived_lineage(
+    mismatch: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    claim = _claim()
+    expected = _expected_invocation(claim)
+    expected_result = _completed_guard_result(expected)
+    other = build_discovery_invocation(
+        mode="scheduled",
+        schedule_id=f"idle:{'a' * 64}",
+        scheduled_for_ms=expected.scheduled_for_ms,
+        expires_at_ms=expected.expires_at_ms,
+    )
+    other_result = _completed_guard_result(other)
+    guard_result = (
+        other_result
+        if mismatch == "receipt_invocation"
+        else replace(expected_result, candidate=other_result.candidate)
+    )
+    guarded = AsyncMock(return_value=guard_result)
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        claim,
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result == {
+        "success": False,
+        "status": "INDETERMINATE",
+        "reason": "completed_lineage_invalid",
+        "replayed": False,
+        "receipt_id": None,
+        "candidate_snapshot_id": None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "forgery",
+    ["receipt_id", "candidate_snapshot_id", "matching_oversized_ids"],
+)
+async def test_completed_evidence_is_canonically_rehydrated(
+    forgery: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    guard_result = _completed_guard_result(_expected_invocation(_claim()))
+    receipt = guard_result.receipt
+    candidate = guard_result.candidate
+    if forgery == "receipt_id":
+        receipt = replace(receipt, receipt_id="forged-receipt")
+        candidate = replace(candidate, observation_receipt=receipt)
+    elif forgery == "candidate_snapshot_id":
+        candidate = replace(candidate, snapshot_id="forged-snapshot")
+    else:
+        oversized = "secret-" + ("x" * 10_000)
+        receipt = replace(receipt, candidate_snapshot_id=oversized)
+        candidate = replace(
+            candidate,
+            snapshot_id=oversized,
+            observation_receipt=receipt,
+        )
+    guarded = AsyncMock(
+        return_value=replace(
+            guard_result,
+            receipt=receipt,
+            candidate=candidate,
+        )
+    )
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    encoded = json.dumps(result)
+    assert result["success"] is False
+    assert result["reason"] in {
+        "completed_receipt_invalid",
+        "completed_candidate_invalid",
+    }
+    assert len(encoded) < 1024
+    assert "secret" not in encoded
+    assert "forged" not in encoded
+
+
+@pytest.mark.asyncio
+async def test_recursive_receipt_mapping_returns_fixed_invalid_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    guard_result = _completed_guard_result(_expected_invocation(_claim()))
+    recursive_counts = {}
+    recursive_counts["secret"] = recursive_counts
+    receipt = replace(
+        guard_result.receipt,
+        rejection_counts=recursive_counts,
+    )
+    candidate = replace(
+        guard_result.candidate,
+        observation_receipt=receipt,
+    )
+    monkeypatch.setattr(
+        adapter,
+        "discover_scheduled_openrouter_model_catalog",
+        AsyncMock(
+            return_value=replace(
+                guard_result,
+                receipt=receipt,
+                candidate=candidate,
+            )
+        ),
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "INDETERMINATE"
+    assert result["reason"] == "completed_receipt_invalid"
+    assert len(json.dumps(result)) < 1024
+
+
+@pytest.mark.asyncio
+async def test_guard_exception_returns_content_free_bounded_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    guarded = AsyncMock(
+        side_effect=RuntimeError("Bearer sk-secret-must-not-escape")
+    )
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    result = await adapter.run_openrouter_catalog_schedule_claim(
+        _claim(),
+        repo_root=Path("repo"),
+        runtime_root=Path("runtime"),
+        transport=object(),
+    )
+
+    encoded = json.dumps(result)
+    assert result["success"] is False
+    assert result["reason"] == "scheduled_discovery_adapter_failed"
+    assert "secret" not in encoded and "Bearer" not in encoded
+    assert len(encoded) < 1024
+
+
+@pytest.mark.asyncio
+async def test_cancellation_from_guard_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _adapter()
+    guarded = AsyncMock(side_effect=asyncio.CancelledError)
+    monkeypatch.setattr(
+        adapter, "discover_scheduled_openrouter_model_catalog", guarded
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.run_openrouter_catalog_schedule_claim(
+            _claim(),
+            repo_root=Path("repo"),
+            runtime_root=Path("runtime"),
+            transport=object(),
+        )

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
@@ -8,8 +8,13 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[4]
 MODULE = REPO / "modules/ai_intelligence/ai_gateway"
+IDLE_PROJECTION = (
+    REPO
+    / "modules/infrastructure/idle_automation/src/openrouter_catalog_projection.py"
+)
 NEW_MODULE_NAMES = {
     "model_openrouter_direct_discovery",
+    "model_openrouter_schedule_adapter",
     "model_openrouter_scheduled_discovery",
     "model_provider_catalog_replay_state",
     "model_provider_catalog_snapshot",
@@ -18,6 +23,7 @@ NEW_MODULE_NAMES = {
 FUNCTION_LIMIT_MODULES = (
     "model_intelligence_catalog.py",
     "model_openrouter_direct_discovery.py",
+    "model_openrouter_schedule_adapter.py",
     "model_openrouter_scheduled_discovery.py",
     "model_provider_catalog_atomic_io.py",
     "model_provider_catalog_artifact_store.py",
@@ -98,6 +104,11 @@ def test_new_surfaces_stay_below_phase_one_size_limits() -> None:
         ).splitlines()
     ) < 500
     assert len(
+        (MODULE / "src/model_openrouter_schedule_adapter.py").read_text(
+            encoding="utf-8"
+        ).splitlines()
+    ) < 250
+    assert len(
         (MODULE / "src/model_provider_catalog_replay_state.py").read_text(
             encoding="utf-8"
         ).splitlines()
@@ -137,6 +148,7 @@ def test_no_implicit_scheduler_or_runtime_hook_was_added() -> None:
 def test_scheduled_guard_has_no_authority_surface_imports() -> None:
     imports = set()
     for name in (
+        "model_openrouter_schedule_adapter.py",
         "model_openrouter_scheduled_discovery.py",
         "model_provider_catalog_replay_state.py",
     ):
@@ -157,6 +169,7 @@ def test_scheduled_guard_has_no_authority_surface_imports() -> None:
 
 def test_manual_surfaces_do_not_import_or_export_scheduled_guard() -> None:
     scheduled_names = (
+        "model_openrouter_schedule_adapter",
         "model_openrouter_scheduled_discovery",
         "model_provider_catalog_replay_state",
     )
@@ -173,3 +186,44 @@ def test_manual_surfaces_do_not_import_or_export_scheduled_guard() -> None:
             for name in scheduled_names
         )
         assert not any(name in source for name in scheduled_names)
+
+
+def test_schedule_adapter_has_no_direct_or_bridge_escape_hatch() -> None:
+    path = MODULE / "src/model_openrouter_schedule_adapter.py"
+    source = path.read_text(encoding="utf-8")
+    imports = _imports(path)
+    forbidden = (
+        "model_openrouter_direct_discovery",
+        "aiohttp",
+        "requests",
+        "urllib",
+        "socket",
+    )
+    assert not any(
+        fragment in imported
+        for imported in imports
+        for fragment in forbidden
+    )
+    assert "discover_openrouter_model_catalog" not in source
+    assert "bridge_candidate_to_canonical_catalog" not in source
+
+
+def test_idle_projection_boundary_stays_pure_and_bounded() -> None:
+    source = IDLE_PROJECTION.read_text(encoding="utf-8")
+    imports = " ".join(_imports(IDLE_PROJECTION))
+    forbidden = (
+        "ai_gateway",
+        "aiohttp",
+        "requests",
+        "urllib",
+        "socket",
+        "subprocess",
+    )
+    assert not any(fragment in imports for fragment in forbidden)
+    assert len(source.splitlines()) < 100
+    tree = ast.parse(source)
+    assert all(
+        node.end_lineno - node.lineno + 1 <= 50
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+    )

--- a/modules/infrastructure/idle_automation/INTERFACE.md
+++ b/modules/infrastructure/idle_automation/INTERFACE.md
@@ -138,6 +138,8 @@ if result["overall_success"]:
 | `MAX_DAILY_EXECUTIONS` | int | `3` | Maximum executions per day |
 | `AUTO_SCHEDULED_ROUTINES` | bool | `true` | Enable scheduled routine claims and dispatch |
 | `IDLE_AUTOMATION_RUNTIME_ROOT` | path | `~/.foundups-agent/idle_automation` | Trusted private claim-state root outside the repository |
+| `AUTO_OPENROUTER_CATALOG_REFRESH` | bool | `false` | Enable the exact daily OpenRouter catalog refresh claim |
+| `OPENROUTER_CATALOG_RUNTIME_ROOT` | path | `~/.foundups-agent/ai_gateway/openrouter_catalog` | Trusted outside-repository provider evidence root |
 
 ### Safety Controls
 
@@ -250,6 +252,30 @@ Performs exact-token compare-and-set finalization. A token that expired may
 finalize only while it remains current; recovery immediately makes the old
 token stale. Outcome state stores only bounded codes or a digest, never raw
 dispatcher text.
+
+### Daily OpenRouter catalog claim
+
+`ScheduleParser` accepts `openrouter_catalog_refresh` only with `daily`
+cadence and generates canonical schedule ID `e324884d66c4`.
+`IdleAutomationDAE._claim_and_dispatch(...)` passes the full exact
+`ScheduleClaim` to the provider branch. The final boundary is default-off via
+`AUTO_OPENROUTER_CATALOG_REFRESH=false`.
+
+When enabled, the DAE supplies only the code-derived repository root and trusted
+`OPENROUTER_CATALOG_RUNTIME_ROOT` to the AI Gateway adapter. Its response must
+be an exact six-key dictionary. Success requires exact boolean `true`,
+`COMPLETED/completed`, an exact boolean replay flag, and canonical 64-hex
+receipt/candidate evidence IDs. Every other shape becomes the fixed
+`routine_failed` outcome without forwarding provider text.
+
+Claim finalization occurs before legacy `last_run` recording. A successful
+adapter projection records success only after exact-token finalization; failed
+or uncertain finalization leaves legacy suppression untouched. This interface
+collects candidate evidence only and grants no selection, promotion, registry,
+or runtime-binding authority.
+
+Cancellation propagates without finalizing or recording the claim. The claim
+remains leased for the existing bounded expiry and replay-recovery policy.
 
 ### Durability Contract
 

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,49 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-07-24 - Daily OpenRouter Catalog Schedule POC
+
+**WSP Protocol:** WSP 00, WSP 15, WSP 22, WSP 62, WSP 97
+
+- Added `openrouter_catalog_refresh` as a daily-only allowlisted schedule with
+  canonical ID `e324884d66c4`.
+- Passed the full exact durable claim through DAE dispatch while leaving the
+  legacy string dispatcher unchanged.
+- Added default-off `AUTO_OPENROUTER_CATALOG_REFRESH` and trusted
+  `OPENROUTER_CATALOG_RUNTIME_ROOT`, defaulting outside the repository.
+- Added a pure exact-projection boundary: only six-key
+  `COMPLETED/completed` evidence with canonical receipt/candidate IDs may
+  finalize success; every malformed or nonterminal result becomes a fixed
+  content-free failure.
+- Preserved claim ordering: dispatch, exact-token finalize, then legacy
+  successful `last_run` recording. Finalization uncertainty records no legacy
+  completion.
+- Kept candidate discovery separate from selection, promotion, registry
+  mutation, and runtime binding.
+
+**WSP_15 MPS:** Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19
+(P0).
+
+**MPS rationale/remediation:** Truthy non-boolean adapter values could have
+been coerced into successful claim finalization. Exact six-key/type/token/ID
+validation now rejects truthy strings/integers, wrong states, missing or forged
+IDs, extra/missing keys, and secret-bearing text before finalization. Deep claim
+validation remains canonical in the AI Gateway adapter; the DAE retains only
+the narrow exact type/routine/daily/schedule-ID pre-import check.
+
+**Validation:** `174 passed, 1 skipped` focused; `575 passed, 3 skipped`
+combined AI Gateway + IdleAutomation + runtime-artifact-safety scope. The
+concatenation test uses real parser, schedule ID, durable claim, dispatch, and
+finalization with an offline mocked provider boundary.
+
+**WSP_62 remediation status:** `test_scheduled_routines_integration.py` is
+1,057 lines, above the 1,000-line remediation trigger but below the current
+1,200-line Python limit; future provider-schedule tests move to
+`test_openrouter_catalog_schedule_integration.py`. `idle_automation_dae.py` is
+1,444 lines in the 1,200-1,500 DAE guideline window; scheduled-claim
+orchestration/configuration must be extracted before further feature growth or
+the 1,500-line boundary.
+
 ### 2026-07-24 - Legacy Failed-Row Durable Retry Migration
 
 **WSP Protocol**: WSP 22, WSP 62, WSP 97

--- a/modules/infrastructure/idle_automation/README.md
+++ b/modules/infrastructure/idle_automation/README.md
@@ -52,6 +52,21 @@ The Idle Automation module provides autonomous background tasks that execute whe
 - Claim control state is stored under a trusted, private runtime root outside
   the repository; schedule phrases cannot select its path.
 
+### Daily OpenRouter Catalog Refresh POC
+- `openrouter_catalog_refresh` is allowlisted for `daily` cadence only.
+- The exact parser-owned schedule ID is `e324884d66c4`; full durable claim
+  evidence reaches the final dispatch boundary.
+- `AUTO_OPENROUTER_CATALOG_REFRESH` defaults to `false`, so the provider adapter
+  is not called unless an operator explicitly enables this routine.
+- `OPENROUTER_CATALOG_RUNTIME_ROOT` defaults to
+  `~/.foundups-agent/ai_gateway/openrouter_catalog` and must remain a trusted
+  outside-repository runtime root.
+- Only an exact six-key `COMPLETED/completed` projection with canonical receipt
+  and candidate IDs finalizes success. Malformed or nonterminal projections
+  finalize as fixed content-free failure; legacy routine dispatch is unchanged.
+- This POC gathers replay-protected candidate evidence only. It does not select
+  or promote models, mutate registries, or bind runtime roles.
+
 ### Safety & Controls
 - Opt-in configuration via environment variables
 - Network availability checks
@@ -87,6 +102,9 @@ wre_integration.record_idle_execution(
 - `IDLE_TASK_TIMEOUT=300`: Maximum execution time per idle task
 - `AUTO_SCHEDULED_ROUTINES=true`: Enable scheduled safe-routine dispatch
 - `IDLE_AUTOMATION_RUNTIME_ROOT=...`: Trusted outside-repository claim-state root
+- `AUTO_OPENROUTER_CATALOG_REFRESH=false`: Opt in to the daily catalog POC
+- `OPENROUTER_CATALOG_RUNTIME_ROOT=...`: Trusted catalog evidence root; defaults
+  to `~/.foundups-agent/ai_gateway/openrouter_catalog`
 
 ### Safety Controls
 - `--no-auto-push` CLI flag to disable during testing

--- a/modules/infrastructure/idle_automation/ROADMAP.md
+++ b/modules/infrastructure/idle_automation/ROADMAP.md
@@ -26,6 +26,22 @@ wsp_cycle(input="idle_automation", log=True)
 - **Durable Schedule Claims (Phase 1)**: Canonical windows, one-owner leases,
   exact-token finalization, restart idempotency, bounded retry/recovery, and
   fail-closed atomic outside-repository state
+- **Daily OpenRouter Catalog Refresh POC**: Exact daily claim, default-off final
+  boundary, trusted external evidence root, replay-protected six-key adapter
+  projection, and fail-closed exact-token finalization
+
+### WSP 62 Near-Term Remediation
+
+- `tests/test_scheduled_routines_integration.py` is 1,057 physical lines:
+  above the 1,000-line remediation trigger but below the 1,200-line
+  OK/guideline boundary. Add no further provider-schedule cases there. The next
+  provider-schedule test change must extract those cases into
+  `tests/test_openrouter_catalog_schedule_integration.py`, targeting roughly
+  500 lines in each resulting test module.
+- `src/idle_automation_dae.py` is 1,444 physical lines, within the 1,200-1,500
+  DAE guideline window. Extract remaining scheduled-claim orchestration and
+  configuration before any further feature growth and before the file reaches
+  1,500 lines.
 
 ## Development Phases
 
@@ -38,6 +54,7 @@ wsp_cycle(input="idle_automation", log=True)
 - [OK] Memory persistence and telemetry
 - [OK] YouTube DAE hook integration
 - [OK] Comprehensive safety controls
+- [OK] Offline-tested daily OpenRouter candidate-evidence schedule adapter
 
 ### Phase 2: Enhancement (IN PROGRESS [U+1F6A7])
 **Goal**: Expand automation capabilities and intelligence

--- a/modules/infrastructure/idle_automation/src/idle_automation_dae.py
+++ b/modules/infrastructure/idle_automation/src/idle_automation_dae.py
@@ -26,13 +26,43 @@ import json
 import logging
 import os
 import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 
 from modules.infrastructure.shared_utilities.corpus_resolver import resolve_corpus_path
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    ScheduleClaim,
+)
+from modules.infrastructure.idle_automation.src.openrouter_catalog_projection import (
+    project_openrouter_catalog_dispatch_outcome,
+)
 from typing import Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
+_OPENROUTER_ROUTINE = "openrouter_catalog_refresh"
+_OPENROUTER_SCHEDULE_ID = "e324884d66c4"
+
+
+def _catalog_dispatch_result(
+    status: str, reason: str
+) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "status": status,
+        "reason": reason,
+        "replayed": False,
+        "receipt_id": None,
+        "candidate_snapshot_id": None,
+    }
+
+
+def _valid_openrouter_catalog_claim(claim: object) -> bool:
+    return (
+        type(claim) is ScheduleClaim
+        and claim.schedule_id == _OPENROUTER_SCHEDULE_ID
+        and claim.routine == _OPENROUTER_ROUTINE
+        and claim.cadence == "daily"
+    )
 
 
 class IdleAutomationDAE:
@@ -335,6 +365,20 @@ class IdleAutomationDAE:
         config["auto_git_push"] = self._parse_bool_env("AUTO_GIT_PUSH", False)
         config["auto_linkedin_post"] = self._parse_bool_env("AUTO_LINKEDIN_POST", False)
         config["auto_self_research"] = self._parse_bool_env("AUTO_SELF_RESEARCH", True)
+        config["auto_openrouter_catalog_refresh"] = self._parse_bool_env(
+            "AUTO_OPENROUTER_CATALOG_REFRESH", False
+        )
+        configured_catalog_root = os.getenv(
+            "OPENROUTER_CATALOG_RUNTIME_ROOT", ""
+        ).strip()
+        config["openrouter_catalog_runtime_root"] = (
+            Path(configured_catalog_root).expanduser()
+            if configured_catalog_root
+            else Path.home()
+            / ".foundups-agent"
+            / "ai_gateway"
+            / "openrouter_catalog"
+        )
 
         # Numeric configurations with bounds
         config["idle_task_timeout"] = self._parse_int_env("IDLE_TASK_TIMEOUT", 300, 30, 3600)
@@ -842,7 +886,7 @@ class IdleAutomationDAE:
             result["skipped_count"] += 1
             result["lease_conflict_count"] += 1
             return True
-        dispatch = await self._dispatch_claimed_routine(claim.routine)
+        dispatch = await self._dispatch_claimed_routine(claim)
         outcome = "success" if dispatch["success"] else dispatch["outcome"]
         try:
             finalized = evaluator.finalize_claim(
@@ -856,14 +900,27 @@ class IdleAutomationDAE:
         self._record_claim_result(evaluator, spec, dispatch, finalized, result)
         return finalized
 
-    async def _dispatch_claimed_routine(self, routine: str) -> Dict[str, Any]:
+    async def _dispatch_claimed_routine(
+        self, claim: ScheduleClaim
+    ) -> Dict[str, Any]:
         """Convert dispatcher exceptions to a bounded durable outcome code."""
         try:
-            response = await self._dispatch_scheduled_routine(routine)
+            if claim.routine == _OPENROUTER_ROUTINE:
+                response = await self._dispatch_openrouter_catalog_claim(
+                    claim
+                )
+                return project_openrouter_catalog_dispatch_outcome(response)
+            else:
+                response = await self._dispatch_scheduled_routine(
+                    claim.routine
+                )
+            success = bool(response.get("success", False))
             return {
-                "success": bool(response.get("success", False)),
+                "success": success,
                 "outcome": "routine_failed",
-                "error": response.get("error"),
+                "error": None
+                if success
+                else response.get("reason", response.get("error")),
             }
         except Exception as exc:
             logger.warning("Scheduled dispatch failed on %s", type(exc).__name__)
@@ -872,6 +929,32 @@ class IdleAutomationDAE:
                 "outcome": "dispatch_error",
                 "error": "Scheduled routine dispatch failed",
             }
+
+    async def _dispatch_openrouter_catalog_claim(
+        self, claim: ScheduleClaim
+    ) -> Dict[str, Any]:
+        """Final default-off boundary for one exact provider refresh claim."""
+        if not _valid_openrouter_catalog_claim(claim):
+            return _catalog_dispatch_result(
+                "BLOCKED_PRECALL", "claim_invalid"
+            )
+        if not self._parse_bool_env(
+            "AUTO_OPENROUTER_CATALOG_REFRESH", False
+        ):
+            return _catalog_dispatch_result(
+                "BLOCKED_PRECALL", "refresh_disabled"
+            )
+        from modules.ai_intelligence.ai_gateway.src.model_openrouter_schedule_adapter import (
+            run_openrouter_catalog_schedule_claim,
+        )
+
+        repo_root = Path(self.module_path).resolve().parents[2]
+        runtime_root = self.config["openrouter_catalog_runtime_root"]
+        return await run_openrouter_catalog_schedule_claim(
+            claim,
+            repo_root=repo_root,
+            runtime_root=runtime_root,
+        )
 
     def _record_claim_result(
         self, evaluator, spec, dispatch, finalized, result

--- a/modules/infrastructure/idle_automation/src/openrouter_catalog_projection.py
+++ b/modules/infrastructure/idle_automation/src/openrouter_catalog_projection.py
@@ -1,0 +1,57 @@
+"""Fail-closed projection of provider catalog evidence into claim finalization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+_RESULT_KEYS = frozenset(
+    (
+        "success",
+        "status",
+        "reason",
+        "replayed",
+        "receipt_id",
+        "candidate_snapshot_id",
+    )
+)
+
+
+def project_openrouter_catalog_dispatch_outcome(
+    response: object,
+) -> dict[str, Any]:
+    """Admit only one exact evidence-bearing completion projection."""
+
+    if (
+        type(response) is dict
+        and set(response) == _RESULT_KEYS
+        and response["success"] is True
+        and response["status"] == "COMPLETED"
+        and response["reason"] == "completed"
+        and type(response["replayed"]) is bool
+        and _evidence_id(
+            response["receipt_id"],
+            "model_provider_catalog_discovery_receipt:",
+        )
+        and _evidence_id(
+            response["candidate_snapshot_id"],
+            "model_provider_catalog_candidate_snapshot:",
+        )
+    ):
+        return {"success": True, "outcome": "routine_failed", "error": None}
+    return {
+        "success": False,
+        "outcome": "routine_failed",
+        "error": "Provider catalog refresh failed",
+    }
+
+
+def _evidence_id(value: object, prefix: str) -> bool:
+    return (
+        type(value) is str
+        and value.startswith(prefix)
+        and len(value) == len(prefix) + 64
+        and all(character in "0123456789abcdef" for character in value[len(prefix):])
+    )
+
+
+__all__ = ["project_openrouter_catalog_dispatch_outcome"]

--- a/modules/infrastructure/idle_automation/src/schedule_evaluator.py
+++ b/modules/infrastructure/idle_automation/src/schedule_evaluator.py
@@ -48,6 +48,11 @@ SUPPORTED_ROUTINES = {
         "description": "Refresh external grant watchlist",
         "aliases": ["grant watchlist", "grant refresh", "grants", "watchlist"],
     },
+    "openrouter_catalog_refresh": {
+        "description": "Refresh bounded OpenRouter catalog candidate evidence",
+        "aliases": ["openrouter catalog refresh"],
+        "cadences": ["daily"],
+    },
 }
 
 # Cadence definitions with preferred execution windows (hour ranges, UTC)
@@ -155,7 +160,11 @@ class ScheduleParser:
                 routine = routine_name
                 break
 
-        if routine is None or cadence not in CADENCE_WINDOWS:
+        if (
+            routine is None
+            or cadence not in CADENCE_WINDOWS
+            or not _routine_allows_cadence(routine, cadence)
+        ):
             return None
 
         return (routine, cadence)
@@ -333,6 +342,9 @@ class ScheduleEvaluator:
             or known.cadence != spec.cadence
             or known.routine not in SUPPORTED_ROUTINES
             or known.cadence not in CADENCE_WINDOWS
+            or not _routine_allows_cadence(
+                known.routine, known.cadence
+            )
         ):
             return None
         window = _schedule_window(known, current)
@@ -393,9 +405,16 @@ def get_supported_phrases() -> List[str]:
     examples = []
     for routine, info in SUPPORTED_ROUTINES.items():
         primary_alias = info["aliases"][0]
-        for cadence in CADENCE_WINDOWS:
+        for cadence in info.get("cadences", CADENCE_WINDOWS):
             examples.append(f"run {primary_alias} {cadence}")
     return examples
+
+
+def _routine_allows_cadence(routine: str, cadence: str) -> bool:
+    info = SUPPORTED_ROUTINES.get(routine)
+    if info is None:
+        return False
+    return cadence in info.get("cadences", CADENCE_WINDOWS)
 
 
 def _default_claim_root(

--- a/modules/infrastructure/idle_automation/tests/TestModLog.md
+++ b/modules/infrastructure/idle_automation/tests/TestModLog.md
@@ -2,10 +2,37 @@
 
 **Module**: `modules/infrastructure/idle_automation`
 **Framework**: pytest
-**Last Updated**: 2026-03-27
+**Last Updated**: 2026-07-24
 **WSP Compliance**: WSP 22 (Module ModLog Protocol), WSP 34 (Test Validation)
 
 ---
+
+## 2026-07-24: Daily OpenRouter Catalog Schedule POC
+
+**Files:** `test_schedule_evaluator.py`,
+`test_scheduled_routines_integration.py`, and AI Gateway provider-catalog tests.
+
+- Proves the parser accepts only the exact daily routine and rejects forged
+  cadence before adapter/provider work.
+- Proves default-off execution makes zero adapter/provider calls and trusted
+  runtime roots are code/config owned.
+- Proves exact full-claim mapping, replay/finalize ordering, and no legacy
+  `last_run` after failed finalization.
+- Rejects truthy string/integer success, wrong status/reason, malformed replay,
+  missing/forged IDs, extra/missing keys, and secret-bearing projections with a
+  fixed content-free failure.
+- Runs a real offline concatenation from `add_schedule` through canonical ID
+  `e324884d66c4`, durable claim, DAE dispatch, exact-token finalization, and
+  successful legacy recording.
+- Proves cancellation propagates without finalization or legacy recording,
+  leaving the claim leased for bounded expiry/replay recovery.
+- Provider tests remain offline and verify no selection, promotion, registry,
+  runtime-binding, direct-discovery, or catalog-bridge authority expansion.
+
+**Focused Result:** `174 passed, 1 skipped`
+
+**Combined AI Gateway + IdleAutomation + Runtime-Artifact-Safety Result:**
+`575 passed, 3 skipped`
 
 ## 2026-07-24: Canonical HoloIndex Maintenance Dispatch Mock
 

--- a/modules/infrastructure/idle_automation/tests/test_schedule_evaluator.py
+++ b/modules/infrastructure/idle_automation/tests/test_schedule_evaluator.py
@@ -53,6 +53,16 @@ class TestScheduleParser:
         assert routine == expected_routine
         assert cadence == expected_cadence
 
+    def test_openrouter_catalog_refresh_is_daily_only(self):
+        """Provider discovery has one allowlisted daily schedule surface."""
+        assert ScheduleParser.parse(
+            "run openrouter catalog refresh daily"
+        ) == ("openrouter_catalog_refresh", "daily")
+        for cadence in ("nightly", "morning", "evening"):
+            assert ScheduleParser.parse(
+                f"run openrouter catalog refresh {cadence}"
+            ) is None
+
     @pytest.mark.parametrize(
         "phrase",
         [

--- a/modules/infrastructure/idle_automation/tests/test_scheduled_routines_integration.py
+++ b/modules/infrastructure/idle_automation/tests/test_scheduled_routines_integration.py
@@ -9,7 +9,11 @@ Tests cover:
 - Result recording and status reporting
 """
 
+import asyncio
 import json
+import hashlib
+import sys
+import types
 import pytest
 from datetime import datetime, UTC
 from pathlib import Path
@@ -18,6 +22,55 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from modules.infrastructure.idle_automation.src.schedule_evaluator import (
     ScheduleEvaluator,
 )
+from modules.infrastructure.idle_automation.src.schedule_claim_state import (
+    ScheduleClaim,
+    build_execution_id,
+)
+
+RECEIPT_ID = "model_provider_catalog_discovery_receipt:" + ("a" * 64)
+CANDIDATE_ID = "model_provider_catalog_candidate_snapshot:" + ("b" * 64)
+
+
+def _schedule_claim(
+    *,
+    routine: str = "openrouter_catalog_refresh",
+    cadence: str = "daily",
+) -> ScheduleClaim:
+    start = "2026-07-24T00:00:00+00:00"
+    end = "2026-07-25T00:00:00+00:00"
+    schedule_id = hashlib.sha256(
+        b"openrouter_catalog_refresh:daily"
+    ).hexdigest()[:12]
+    return ScheduleClaim(
+        schedule_id=schedule_id,
+        routine=routine,
+        cadence=cadence,
+        window_start=start,
+        window_end=end,
+        execution_id=build_execution_id(
+            schedule_id, routine, cadence, start, end
+        ),
+        token="opaque-claim-token",
+        claimant_id="idle-dae",
+        lease_expires_at="2026-07-24T01:00:00+00:00",
+        attempt=1,
+    )
+
+
+def _adapter_projection(
+    status: str,
+    reason: str,
+    *,
+    success: bool = False,
+) -> dict:
+    return {
+        "success": success,
+        "status": status,
+        "reason": reason,
+        "replayed": False,
+        "receipt_id": RECEIPT_ID if success else None,
+        "candidate_snapshot_id": CANDIDATE_ID if success else None,
+    }
 
 
 class TestScheduledRoutinesDispatch:
@@ -61,6 +114,28 @@ class TestScheduledRoutinesDispatch:
             dae._save_idle_state = MagicMock()
 
             return dae
+
+    def test_openrouter_runtime_config_defaults_safe(
+        self, mock_dae, monkeypatch, tmp_path
+    ):
+        """Provider refresh is opt-in with one code-owned runtime root."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        monkeypatch.delenv("AUTO_OPENROUTER_CATALOG_REFRESH", raising=False)
+        monkeypatch.delenv("OPENROUTER_CATALOG_RUNTIME_ROOT", raising=False)
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            config = IdleAutomationDAE._load_and_validate_config(mock_dae)
+
+        assert config["auto_openrouter_catalog_refresh"] is False
+        assert config["openrouter_catalog_runtime_root"] == (
+            tmp_path
+            / "home"
+            / ".foundups-agent"
+            / "ai_gateway"
+            / "openrouter_catalog"
+        )
 
     @pytest.mark.asyncio
     async def test_execute_scheduled_routines_no_due_schedules(
@@ -277,6 +352,403 @@ class TestScheduledRoutinesDispatch:
         evaluator.record_execution.assert_not_called()
         mock_dae._dispatch_scheduled_routine.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    async def test_claim_dispatch_passes_full_exact_schedule_claim(
+        self, mock_dae
+    ):
+        """The durable claim identity must reach final dispatch intact."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        spec = MagicMock(
+            id="canonical-schedule",
+            routine="openrouter_catalog_refresh",
+            cadence="daily",
+        )
+        claim = _schedule_claim()
+        evaluator = MagicMock()
+        evaluator.claim_schedule.return_value = claim
+        evaluator.finalize_claim.return_value = True
+        mock_dae._dispatch_claimed_routine = AsyncMock(
+            return_value={"success": True, "outcome": "completed"}
+        )
+        result = IdleAutomationDAE._scheduled_routines_result()
+
+        continued = await IdleAutomationDAE._claim_and_dispatch(
+            mock_dae, evaluator, spec, result
+        )
+
+        assert continued is True
+        mock_dae._dispatch_claimed_routine.assert_awaited_once_with(claim)
+
+    @pytest.mark.asyncio
+    async def test_openrouter_final_dispatch_defaults_disabled(
+        self, mock_dae, monkeypatch
+    ):
+        """The last dispatch boundary is opt-in and makes no adapter call."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        adapter_name = (
+            "modules.ai_intelligence.ai_gateway.src."
+            "model_openrouter_schedule_adapter"
+        )
+        adapter = types.ModuleType(adapter_name)
+        adapter.run_openrouter_catalog_schedule_claim = AsyncMock()
+        monkeypatch.setitem(sys.modules, adapter_name, adapter)
+        parsed = []
+
+        def parse_bool(key, default):
+            parsed.append((key, default))
+            return default
+
+        mock_dae._parse_bool_env = parse_bool
+        result = await IdleAutomationDAE._dispatch_openrouter_catalog_claim(
+            mock_dae, _schedule_claim()
+        )
+
+        assert parsed == [("AUTO_OPENROUTER_CATALOG_REFRESH", False)]
+        assert result == {
+            "success": False,
+            "status": "BLOCKED_PRECALL",
+            "reason": "refresh_disabled",
+            "replayed": False,
+            "receipt_id": None,
+            "candidate_snapshot_id": None,
+        }
+        adapter.run_openrouter_catalog_schedule_claim.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_enabled_final_dispatch_passes_exact_claim_and_roots_once(
+        self, mock_dae, monkeypatch, tmp_path
+    ):
+        """Enabled dispatch forwards only code/config-owned roots."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        adapter_name = (
+            "modules.ai_intelligence.ai_gateway.src."
+            "model_openrouter_schedule_adapter"
+        )
+        adapter = types.ModuleType(adapter_name)
+        expected = _adapter_projection(
+            "COMPLETED", "completed", success=True
+        )
+        adapter.run_openrouter_catalog_schedule_claim = AsyncMock(
+            return_value=expected
+        )
+        monkeypatch.setitem(sys.modules, adapter_name, adapter)
+        mock_dae._parse_bool_env = lambda key, default: (
+            True if key == "AUTO_OPENROUTER_CATALOG_REFRESH" else default
+        )
+        repo = tmp_path / "repo"
+        mock_dae.module_path = (
+            repo / "modules/infrastructure/idle_automation"
+        )
+        runtime = tmp_path / "trusted-catalog-runtime"
+        mock_dae.config["openrouter_catalog_runtime_root"] = runtime
+        claim = _schedule_claim()
+
+        result = await IdleAutomationDAE._dispatch_openrouter_catalog_claim(
+            mock_dae, claim
+        )
+
+        assert result == expected
+        adapter.run_openrouter_catalog_schedule_claim.assert_awaited_once_with(
+            claim,
+            repo_root=repo,
+            runtime_root=runtime,
+        )
+
+    @pytest.mark.asyncio
+    async def test_forged_non_daily_claim_stops_before_adapter(
+        self, mock_dae, monkeypatch
+    ):
+        """Persisted/forged cadence cannot reach adapter or provider."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        adapter_name = (
+            "modules.ai_intelligence.ai_gateway.src."
+            "model_openrouter_schedule_adapter"
+        )
+        adapter = types.ModuleType(adapter_name)
+        adapter.run_openrouter_catalog_schedule_claim = AsyncMock()
+        monkeypatch.setitem(sys.modules, adapter_name, adapter)
+        mock_dae._parse_bool_env = lambda key, default: (
+            True if key == "AUTO_OPENROUTER_CATALOG_REFRESH" else default
+        )
+
+        result = await IdleAutomationDAE._dispatch_openrouter_catalog_claim(
+            mock_dae, _schedule_claim(cadence="nightly")
+        )
+
+        assert result == {
+            "success": False,
+            "status": "BLOCKED_PRECALL",
+            "reason": "claim_invalid",
+            "replayed": False,
+            "receipt_id": None,
+            "candidate_snapshot_id": None,
+        }
+        adapter.run_openrouter_catalog_schedule_claim.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("projection", "success", "outcome"),
+        [
+            (
+                _adapter_projection(
+                    "COMPLETED", "completed", success=True
+                ),
+                True,
+                "success",
+            ),
+            (
+                _adapter_projection("FAILED", "transport_failed"),
+                False,
+                "routine_failed",
+            ),
+            (
+                _adapter_projection(
+                    "INDETERMINATE", "replay_state_invalid"
+                ),
+                False,
+                "routine_failed",
+            ),
+            (
+                _adapter_projection(
+                    "BLOCKED_PRECALL", "refresh_disabled"
+                ),
+                False,
+                "routine_failed",
+            ),
+        ],
+    )
+    async def test_provider_projection_finalizes_exact_claim_token(
+        self, mock_dae, projection, success, outcome
+    ):
+        """Only completed evidence finalizes the claim as success."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        claim = _schedule_claim()
+        spec = MagicMock(
+            id=claim.schedule_id,
+            routine=claim.routine,
+            cadence=claim.cadence,
+        )
+        evaluator = MagicMock()
+        evaluator.claim_schedule.return_value = claim
+        evaluator.finalize_claim.return_value = True
+        mock_dae._dispatch_openrouter_catalog_claim = AsyncMock(
+            return_value=projection
+        )
+        result = IdleAutomationDAE._scheduled_routines_result()
+
+        continued = await IdleAutomationDAE._claim_and_dispatch(
+            mock_dae, evaluator, spec, result
+        )
+
+        assert continued is True
+        evaluator.finalize_claim.assert_called_once_with(
+            claim.token,
+            success=success,
+            outcome_code=outcome,
+        )
+        if success:
+            evaluator.record_execution.assert_called_once()
+            assert result["executed_count"] == 1
+        else:
+            evaluator.record_execution.assert_not_called()
+            assert result["failed_count"] == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "projection",
+        [
+            {**_adapter_projection("COMPLETED", "completed", success=True), "success": "false"},
+            {**_adapter_projection("COMPLETED", "completed", success=True), "success": 1},
+            {**_adapter_projection("COMPLETED", "completed", success=True), "status": "FAILED"},
+            {**_adapter_projection("COMPLETED", "wrong", success=True)},
+            {**_adapter_projection("COMPLETED", "completed", success=True), "receipt_id": None},
+            {
+                **_adapter_projection("COMPLETED", "completed", success=True),
+                "candidate_snapshot_id": "forged",
+            },
+            {**_adapter_projection("COMPLETED", "completed", success=True), "extra": True},
+            {
+                key: value
+                for key, value in _adapter_projection(
+                    "COMPLETED", "completed", success=True
+                ).items()
+                if key != "reason"
+            },
+            {
+                **_adapter_projection("COMPLETED", "completed", success=True),
+                "reason": "Bearer sk-secret-must-not-escape",
+            },
+            {
+                **_adapter_projection("COMPLETED", "completed", success=True),
+                "replayed": 1,
+            },
+        ],
+    )
+    async def test_malformed_provider_projection_never_finalizes_success(
+        self, mock_dae, projection
+    ):
+        """Truthy and malformed adapter projections fail closed without content."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        claim = _schedule_claim()
+        spec = MagicMock(
+            id=claim.schedule_id,
+            routine=claim.routine,
+            cadence=claim.cadence,
+        )
+        evaluator = MagicMock()
+        evaluator.claim_schedule.return_value = claim
+        evaluator.finalize_claim.return_value = True
+        mock_dae._dispatch_openrouter_catalog_claim = AsyncMock(
+            return_value=projection
+        )
+        result = IdleAutomationDAE._scheduled_routines_result()
+
+        continued = await IdleAutomationDAE._claim_and_dispatch(
+            mock_dae, evaluator, spec, result
+        )
+
+        assert continued is True
+        evaluator.finalize_claim.assert_called_once_with(
+            claim.token,
+            success=False,
+            outcome_code="routine_failed",
+        )
+        evaluator.record_execution.assert_not_called()
+        assert result["failed_count"] == 1
+        encoded = json.dumps(result)
+        assert "secret" not in encoded
+        assert "Bearer" not in encoded
+        assert "forged" not in encoded
+
+    @pytest.mark.asyncio
+    async def test_openrouter_schedule_claim_dispatch_finalize_concatenation(
+        self, mock_dae, tmp_path, monkeypatch
+    ):
+        """The parser-owned ID survives real claim, dispatch, and finalization."""
+        from modules.infrastructure.idle_automation.src import schedule_evaluator
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        now = datetime(2026, 7, 24, 12, tzinfo=UTC)
+        monkeypatch.setattr(schedule_evaluator, "utc_now", lambda: now)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        evaluator = ScheduleEvaluator(
+            schedules_path=repo / "memory" / "schedules.json",
+            repo_root=repo,
+            runtime_root=tmp_path / "claim-runtime",
+        )
+        spec = evaluator.add_schedule("run openrouter catalog refresh daily")
+        assert spec is not None
+        assert spec.id == "e324884d66c4"
+        mock_dae._dispatch_openrouter_catalog_claim = AsyncMock(
+            return_value=_adapter_projection(
+                "COMPLETED", "completed", success=True
+            )
+        )
+        result = IdleAutomationDAE._scheduled_routines_result()
+
+        continued = await IdleAutomationDAE._claim_and_dispatch(
+            mock_dae, evaluator, spec, result
+        )
+
+        assert continued is True
+        claim = mock_dae._dispatch_openrouter_catalog_claim.await_args.args[0]
+        assert type(claim) is ScheduleClaim
+        assert claim.schedule_id == spec.id
+        assert claim.routine == "openrouter_catalog_refresh"
+        assert claim.cadence == "daily"
+        assert result["executed_count"] == 1
+        assert result["failed_count"] == 0
+        assert evaluator.get_schedule(spec.id).last_result.startswith("success:")
+
+    @pytest.mark.asyncio
+    async def test_provider_cancellation_leaves_claim_unfinalized(
+        self, mock_dae
+    ):
+        """Cancellation preserves the leased claim for expiry/replay recovery."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        claim = _schedule_claim()
+        spec = MagicMock(
+            id=claim.schedule_id,
+            routine=claim.routine,
+            cadence=claim.cadence,
+        )
+        evaluator = MagicMock()
+        evaluator.claim_schedule.return_value = claim
+        mock_dae._dispatch_openrouter_catalog_claim = AsyncMock(
+            side_effect=asyncio.CancelledError
+        )
+        result = IdleAutomationDAE._scheduled_routines_result()
+
+        with pytest.raises(asyncio.CancelledError):
+            await IdleAutomationDAE._claim_and_dispatch(
+                mock_dae, evaluator, spec, result
+            )
+
+        evaluator.finalize_claim.assert_not_called()
+        evaluator.record_execution.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_provider_finalize_failure_keeps_legacy_last_run_untouched(
+        self, mock_dae
+    ):
+        """Completion without durable token finalization remains unknown."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        claim = _schedule_claim()
+        spec = MagicMock(
+            id=claim.schedule_id,
+            routine=claim.routine,
+            cadence=claim.cadence,
+        )
+        evaluator = MagicMock()
+        evaluator.claim_schedule.return_value = claim
+        evaluator.finalize_claim.return_value = False
+        mock_dae._dispatch_openrouter_catalog_claim = AsyncMock(
+            return_value=_adapter_projection(
+                "COMPLETED", "completed", success=True
+            )
+        )
+        result = IdleAutomationDAE._scheduled_routines_result()
+
+        continued = await IdleAutomationDAE._claim_and_dispatch(
+            mock_dae, evaluator, spec, result
+        )
+
+        assert continued is False
+        evaluator.finalize_claim.assert_called_once_with(
+            claim.token,
+            success=True,
+            outcome_code="success",
+        )
+        evaluator.record_execution.assert_not_called()
+        assert result["finalization_failed_count"] == 1
+
 
 class TestDispatchScheduledRoutine:
     """Test individual routine dispatch."""
@@ -360,6 +832,70 @@ class TestDispatchScheduledRoutine:
 
         assert result["success"] is False
         assert "unknown" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_claimed_legacy_routine_keeps_native_string_dispatch(
+        self, mock_dae
+    ):
+        """Full claims enter once, but legacy native dispatch stays unchanged."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        claim = _schedule_claim(routine="self_research")
+        mock_dae._dispatch_scheduled_routine = AsyncMock(
+            return_value={"success": True}
+        )
+
+        result = await IdleAutomationDAE._dispatch_claimed_routine(
+            mock_dae, claim
+        )
+
+        assert result["success"] is True
+        mock_dae._dispatch_scheduled_routine.assert_awaited_once_with(
+            "self_research"
+        )
+
+    @pytest.mark.asyncio
+    async def test_claimed_provider_routine_uses_exact_final_boundary(
+        self, mock_dae
+    ):
+        """Provider claims never fall through the legacy routine dispatcher."""
+        from modules.infrastructure.idle_automation.src.idle_automation_dae import (
+            IdleAutomationDAE,
+        )
+
+        claim = _schedule_claim()
+        mock_dae._dispatch_openrouter_catalog_claim = AsyncMock(
+            return_value={
+                "success": False,
+                "status": "BLOCKED_PRECALL",
+                "reason": "refresh_disabled",
+                "replayed": False,
+                "receipt_id": None,
+                "candidate_snapshot_id": None,
+            }
+        )
+        mock_dae._dispatch_scheduled_routine = AsyncMock(
+            return_value={
+                "success": False,
+                "error": "legacy path used",
+            }
+        )
+
+        result = await IdleAutomationDAE._dispatch_claimed_routine(
+            mock_dae, claim
+        )
+
+        assert result == {
+            "success": False,
+            "outcome": "routine_failed",
+            "error": "Provider catalog refresh failed",
+        }
+        mock_dae._dispatch_openrouter_catalog_claim.assert_awaited_once_with(
+            claim
+        )
+        mock_dae._dispatch_scheduled_routine.assert_not_awaited()
 
 
 class TestGetScheduledRoutinesStatus:


### PR DESCRIPTION
## Summary
- add an exact daily-only `openrouter_catalog_refresh` IdleAutomation routine
- keep the final provider boundary default-off and preserve the full durable `ScheduleClaim`
- map only code/config-owned roots into the existing scheduled OpenRouter replay guard
- accept success only from canonical receipt/candidate lineage through an exact six-key projection
- add offline adversarial and end-to-end schedule/claim/finalization coverage
- document WSP_15 P0 rationale, WSP_22 contracts, and WSP_62 remediation

## Truth boundaries
- candidate-evidence collection only
- no catalog bridge, selection, promotion, registry mutation, runtime binding, startup hook, or general cadence expansion
- no live provider/network call in validation
- root checkout and other worker lanes untouched

## Validation
- focused: 174 passed, 1 skipped
- combined AI Gateway + IdleAutomation + runtime-artifact-safety: 575 passed, 3 skipped
- full owning modules (independent architect run): 564 passed, 2 skipped
- Ruff, compileall, WSP_62 AST/size gates, and git diff --check passed
- two independent WSP_97 reviewers: GO