### PR TITLE
feat(ai-gateway): bind provider execution controls

### DIFF
--- a/docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_ASSUMPTION_AUDIT_20260724.md
+++ b/docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_ASSUMPTION_AUDIT_20260724.md
@@ -1,0 +1,113 @@
+# OpenRouter Model Execution-Control Evidence Phase B1 WSP_97 Audit
+
+- Date: 2026-07-24
+- Owner: 0102 RedDog Architect / Codex isolated worker lane
+- Slice: `OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1`
+- WSP_15 score: Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19 (P0)
+- Base commit: `c7a3373b867efd077b153901db693979eb3966f7`
+- Branch: `codex/openrouter-model-execution-control-evidence-phase-b1-20260724`
+- Public metadata source: `https://openrouter.ai/api/v1/models`
+- Public metadata evidence timestamp: 2026-07-24 (date-granularity; the exact
+  request time was not retained in the supplied architect review evidence)
+- Schema/type source: `https://openrouter.ai/openapi.json`, schemas
+  `ModelReasoning`, `ReasoningEffort`, and `TopProviderInfo`, retrieved
+  2026-07-24
+
+## 1. Problem and authority boundary
+
+The direct OpenRouter candidate snapshot already bound model IDs, prices,
+context, parameters, freshness, and discovery lineage, but discarded optional
+model-level reasoning and top-provider execution assertions. The configured
+research runner therefore could not compare its operator-authored controls with
+provider-asserted candidate evidence.
+
+This slice may preserve a bounded recognized projection and derive immutable
+exact-model evidence from a fresh candidate. It may not discover an execution
+endpoint, choose sampling defaults, admit a canonical route, call a provider,
+rank or promote a model, alter runtime selection, access credentials, or wire
+`main.py`.
+
+## 2. Retrieval and repository evidence
+
+WSP_00 awakening completed in 0102 state and the tracker reported Zen
+compliance. WSP 00, 5, 6, 15, 22, 50, 62, 81, and 97 plus the RedDog external
+state bootstrap were read before implementation.
+
+The required HoloIndex-first query exited successfully but returned no retrieval
+output. This is recorded as an impaired/silent retrieval path, not semantic
+evidence. Direct `rg`, file reads, focused tests, module-wide tests, AST checks,
+and diff inspection were used as the explicit fallback. No WSP framework file
+changed, so WSP_81 created no knowledge backup.
+
+The current OpenAPI marks `mandatory` and `is_moderated` required in their
+complete upstream objects. B1 deliberately accepts a strict partial recognized
+projection for legacy compatibility and evidence collection, but grants that
+partial evidence no route or runtime admission. Explicit null is preserved only
+where the schema permits it. Null entries inside `supported_efforts` fail
+closed because the public selector semantics do not define a coherent meaning.
+
+## 3. Assumptions, evidence, and confidence
+
+| Assumption | Evidence | Confidence |
+|---|---|---|
+| Existing v1 candidates remain valid | Legacy rows without either optional control rehydrate and emit explicit absent evidence controls | High |
+| Optional provider assertions must not become admission requirements | Partial objects, empty effort lists, omitted fields, and explicit null effort claims are retained | High |
+| OpenRouter nullable fields remain distinct from omission | Presence-aware evidence retains explicit null `default_effort`, `supported_efforts`, `context_length`, and `max_completion_tokens` claims | High |
+| Unknown nested fields can be ignored safely | Only recognized fields enter the sanitized projection; secret/prose/default/limit fixtures do not survive | High |
+| Malformed recognized claims must poison duplicate groups | Type, enum, order, bound, relationship, and duplicate-group tests fail closed | High |
+| Candidate evidence can bind one exact model deterministically | Exact model, candidate, receipt, freshness, price, parameter, record/control digest, and evidence-ID tests pass | High |
+| Provider assertions identify a canonical executable route | False: no independently admitted endpoint route exists | High |
+| Provider assertions determine safe sampling defaults | False: optional fields may be partial, empty, omitted, or null | High |
+| This evidence authorizes a live K3-versus-GLM comparison | False: transport, usage, sampling, route, and runtime-directory gates remain open | High |
+
+## 4. Failure modes and mitigations
+
+| Failure mode | Mitigation | Residual boundary |
+|---|---|---|
+| Provider adds prose, provider name, key-like data, defaults, or limits | Drop every unknown field before equality, digest, and evidence construction | Global bounded JSON parsing remains the outer input boundary |
+| A malformed recognized field hides inside a duplicate set | Any malformed member poisons the complete duplicate ID group | None within candidate normalization |
+| Omitted controls are confused with explicit null | Presence-aware reasoning and top-provider evidence preserves the distinction | Later admission must define sufficiency |
+| Mandatory reasoning contradicts explicit disable/none claims | Reject only contradictory co-present assertions | Null/partial provider assertions remain non-authoritative |
+| Model alias or case variation selects another record | Exact string identity and exactly one matching candidate record | A future trusted alias map would require separate evidence |
+| Attacker edits evidence and recomputes its ID | Rebuild the entire expected evidence from the supplied canonical candidate and compare exact payloads | Candidate authenticity remains bounded by the existing discovery trust model |
+| Provider metadata is mistaken for runtime permission | Dedicated provider-asserted trust class and explicit documentation HALT | Canonical route/sampling/usage/transport evidence is still required |
+
+## 5. Alternatives considered
+
+1. Hard-code K3 reasoning and pricing into runtime selection. Rejected: current
+   provider metadata is candidate evidence and changes over time.
+2. Preserve entire OpenRouter model records. Rejected: descriptions, provider
+   identity, default parameters, limits, and possible secret-like material are
+   outside this boundary.
+3. Require every reasoning field before evidence construction. Rejected:
+   OpenRouter assertions are optional and partial; this would turn collection
+   into unauthorized admission.
+4. Treat provider assertions as an executable route. Rejected: endpoint,
+   sampling, usage, and transport evidence remain independent unsatisfied gates.
+5. Add a pure provider-asserted evidence boundary with adversarial offline
+   tests. Accepted.
+
+## 6. Decision
+
+**PROCEED** with the bounded optional projection and immutable
+`provider_asserted_model_execution_controls` evidence.
+
+**HALT** canonical execution admission and all live comparative model work until
+independent evidence supplies:
+
+- exact executable route and endpoint admission;
+- explicit task/campaign sampling-control policy;
+- authoritative provider-reported usage;
+- pre-buffer response-byte transport bounds;
+- bounded artifact reads and an identity-preserving runtime-directory claim;
+- benchmark, verifier, promotion, and runtime-binding evidence already required
+  by the existing architecture.
+
+The K3 fixture reflects the cited public provider-asserted metadata only as an
+offline test claim:
+`moonshotai/kimi-k3`, 1,048,576 context, canonicalized per-token prices of
+`0.000003` input and `0.000015` output, efforts `max/high/low`, non-mandatory
+reasoning, unmoderated top-provider status, and an explicit null
+`max_completion_tokens`. No runtime value is hard-coded by this slice and no
+provider call was made in this worker lane. The public response is not treated
+as authenticated canonical route or runtime authority.

--- a/docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_EXECUTION_RECEIPT.json
+++ b/docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_EXECUTION_RECEIPT.json
@@ -1,0 +1,76 @@
+{
+  "execution_id": "OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1",
+  "execution_plane": "runtime",
+  "outcome": "completed",
+  "action_evidence": {
+    "retrieve_wsps": [
+      "WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md",
+      "WSP_framework/src/WSP_05_WSP_Micro_Coding_Protocol.md",
+      "WSP_framework/src/WSP_06_Module_Test_Audit_Coverage_Verification.md",
+      "WSP_framework/src/WSP_15_Module_Prioritization_Scoring_System.md",
+      "WSP_framework/src/WSP_22_ModLog_and_Roadmap_Protocol.md",
+      "WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md",
+      "WSP_framework/src/WSP_62_Large_File_Refactoring_Enforcement_Protocol.md",
+      "WSP_framework/src/WSP_81_Cube-Level_DAE_Orchestration_Protocol.md",
+      "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md"
+    ],
+    "retrieve_evidence": [
+      "HoloIndex-first retrieval exited 0 with no output and was recorded as impaired/silent.",
+      "Direct rg/file-read fallback inspected candidate sanitization, discovery lineage, model evidence, tests, module documentation, and protected-surface gates.",
+      "docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_ASSUMPTION_AUDIT_20260724.md"
+    ],
+    "research": [
+      "Compared existing candidate-schema normalization, duplicate poisoning, freshness, receipt lineage, canonical prices, configured runner control claims, and execution HALT gates.",
+      "Applied documented OpenRouter descending reasoning efforts, optional control semantics, current K3 fixture metadata, and the existing 100000000-token local bound."
+    ],
+    "micro_pass": [
+      "Focused execution-control, candidate-snapshot, and protected-surface matrix: 112 passed.",
+      "Tests-first RED evidence: initial 20 failures/19 passes, then optional-assertion correction 8 failures/48 passes."
+    ],
+    "macro_pass": [
+      "Full modules/ai_intelligence/ai_gateway/tests matrix: 647 passed, 2 platform-capability skips.",
+      "Changed Python scope passed Ruff and WSP_62 AST/file checks."
+    ],
+    "hard_think": [
+      "docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_ASSUMPTION_AUDIT_20260724.md#4-failure-modes-and-mitigations",
+      "Separated truthful optional provider assertions from later route and sampling admission."
+    ],
+    "dialectic_sweep": [
+      "docs/audits/ai_intelligence/OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1_WSP97_ASSUMPTION_AUDIT_20260724.md#5-alternatives-considered",
+      "Rejected runtime hard-coding, whole-record retention, required-field overreach, and live-route authority."
+    ],
+    "first_principles": [
+      "Only recognized bounded provider claims may cross the candidate boundary; absence, null, and explicit empty claims are materially different evidence.",
+      "Provider-asserted metadata cannot authorize execution without independent route, sampling, usage, transport, benchmark, promotion, and runtime-binding evidence."
+    ],
+    "execute": [
+      "modules/ai_intelligence/ai_gateway/src/model_provider_catalog_snapshot.py",
+      "modules/ai_intelligence/ai_gateway/src/model_provider_execution_control_projection.py",
+      "modules/ai_intelligence/ai_gateway/src/model_provider_execution_control_evidence.py",
+      "modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_snapshot.py",
+      "modules/ai_intelligence/ai_gateway/tests/test_model_provider_execution_control_evidence.py"
+    ]
+  },
+  "wsps_applied": [
+    "WSP_00",
+    "WSP_05",
+    "WSP_06",
+    "WSP_15",
+    "WSP_22",
+    "WSP_50",
+    "WSP_62",
+    "WSP_81",
+    "WSP_97"
+  ],
+  "compliance_evidence": [
+    "Isolated worktree and branch: codex/openrouter-model-execution-control-evidence-phase-b1-20260724.",
+    "No framework WSP or knowledge-backup file changed; WSP_81 backup action was not applicable.",
+    "No provider, model, network, credential, transport, startup, promotion, or runtime-binding call was made.",
+    "Provider controls remain candidate evidence with no canonical route or execution authority.",
+    "modules/ai_intelligence/ai_gateway/README.md",
+    "modules/ai_intelligence/ai_gateway/INTERFACE.md",
+    "modules/ai_intelligence/ai_gateway/ROADMAP.md",
+    "modules/ai_intelligence/ai_gateway/ModLog.md",
+    "modules/ai_intelligence/ai_gateway/tests/TestModLog.md"
+  ]
+}

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -70,13 +70,40 @@ bridge_candidate_to_canonical_catalog(..., prior_admitted_candidate_id=...) -> C
 Discovery is an explicit manual or pre-authorized scheduled operation. It
 persists an attempt receipt separately from the last-known-good candidate under
 one validated outside-repository runtime root. Candidate IDs bind only the
-schema, provider, endpoint, and sanitized payload, while embedded observation
-receipts and a 24-hour freshness window are revalidated on admission.
+schema, provider, model-list source endpoint, and sanitized payload, while
+embedded observation receipts and a 24-hour freshness window are revalidated
+on admission.
 
 The bridge is idempotent for an unchanged prior candidate ID and invokes the
 existing canonical catalog builder with `static_registry=False`. It does not
 mutate the registry, select or promote a model, bind runtime roles, or create a
 scheduler.
+
+#### Provider model execution-control evidence
+
+```python
+build_provider_model_execution_control_evidence(
+    candidate=...,
+    model_id=...,
+    now_ms=...,
+) -> ProviderModelExecutionControlEvidence
+
+rehydrate_provider_model_execution_control_evidence(
+    payload,
+    candidate=...,
+    now_ms=...,
+) -> ProviderModelExecutionControlEvidence
+```
+
+The builder requires an exact model ID and a fresh, canonical candidate
+snapshot. It binds candidate/receipt lineage, exact prices, supported
+parameters, and strict optional projections of provider `reasoning` and
+`top_provider` metadata. The rehydrator recomputes the complete evidence object
+and content ID from the supplied candidate.
+
+The trust class is `provider_asserted_model_execution_controls`. These APIs do
+not call providers, discover an execution endpoint, select sampling defaults,
+admit a canonical route, rank a model, or grant runtime authority.
 
 `ProviderCatalogArtifactStore` is the confined persistence boundary used for
 both attempt and candidate artifacts. Replacement is same-directory and atomic:

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,38 @@
 # AI Gateway Module Change Log
 
+## [2026-07-24] - OpenRouter Model Execution-Control Evidence Phase B1
+
+**Who/Type/Slice:** 0102 RedDog Architect isolated worker / Provider Evidence /
+`OPENROUTER_MODEL_EXECUTION_CONTROL_EVIDENCE_PHASE_B1`
+
+**What:** Evolved the v1 candidate payload compatibly to retain only strict
+optional `reasoning` and `top_provider` projections, then added immutable
+exact-model evidence binding canonical prices, supported parameters, candidate
+and discovery lineage, source-record/control digests, freshness, and a
+recomputed content ID.
+
+**Truth boundary:** Unknown provider prose, names, secrets, default parameters,
+and per-request limits are dropped. Partial assertions, explicit empty effort
+lists, and omitted/null distinctions remain truthful candidate evidence.
+Malformed recognized fields and contradictory co-present claims fail closed.
+This trust class is provider-asserted only: no endpoint discovery, sampling
+default, canonical route, selection, promotion, transport, provider call,
+credential access, startup wiring, or live authority was added.
+
+**WSP_15 MPS:** Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19
+(P0 defensive trust boundary).
+
+**Validation:** Focused execution-control/catalog/protected matrix: `112
+passed`. Full AI Gateway: `647 passed, 2 skipped`. Ruff and WSP_62 source-file/
+function gates passed. The projection and evidence modules are explicitly
+enrolled in authority-import, network-purity, line-ceiling, and AST function
+guards. Tests were offline; no provider, model, network, or credential call
+occurred.
+
+**WSP References:** WSP 00, WSP 15, WSP 22, WSP 50, WSP 62, WSP 81, WSP 97.
+
+---
+
 ## [2026-07-24] - Configured AutoResearch Gateway Safety Contract v2
 
 **Who/Type/Slice:** 0102 Codex worker / Defensive Reliability /

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -136,6 +136,23 @@ model selection, promotion, registry mutation, or runtime binding. Production
 enablement is owned by idle automation and remains default-off. Tests inject
 transport and remain offline.
 
+### Provider-asserted execution-control evidence
+
+`src/model_provider_execution_control_evidence.py` derives immutable,
+content-addressed evidence for one exact model from a fresh, rehydrated
+`ProviderCatalogCandidateSnapshot`. It binds the OpenRouter model-list source
+endpoint, candidate and discovery lineage, exact canonical prompt/completion
+prices, supported parameters, and allowlisted optional `reasoning` and
+`top_provider` assertions.
+
+Optional provider fields remain optional: omitted and explicit-null effort,
+default-effort, or top-provider numeric claims are distinct, partial assertions
+survive, and unknown nested fields are dropped. Malformed recognized values
+and contradictory co-present claims poison the record. The result has trust class
+`provider_asserted_model_execution_controls`; it is candidate evidence only,
+not canonical route admission, endpoint discovery, sampling defaults,
+selection, promotion, runtime binding, or permission to call a provider.
+
 ## Model Selection Receipts
 
 `src/model_intelligence_selection.py` consumes a `ModelCatalogSnapshot` and

--- a/modules/ai_intelligence/ai_gateway/ROADMAP.md
+++ b/modules/ai_intelligence/ai_gateway/ROADMAP.md
@@ -66,6 +66,11 @@
   serialization, and fail-closed replay recovery.
 - [x] Default-off idle scheduling POC for the exact daily OpenRouter refresh
   claim, with canonical invocation mapping and a six-key evidence-only adapter.
+- [x] Preserve bounded optional OpenRouter reasoning/top-provider assertions and
+  derive exact-model, lineage-bound provider-asserted execution-control evidence.
+- [ ] Keep execution halted until canonical route/endpoint admission, sampling
+  defaults, authoritative usage, and bounded transport response evidence are
+  supplied independently; provider assertions do not satisfy those gates.
 - [ ] General provider-discovery cadence and scheduler expansion remains out of
   scope; the POC does not grant discovery any startup, selection, promotion,
   registry, or runtime authority.

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_snapshot.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_catalog_snapshot.py
@@ -9,10 +9,11 @@ from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
 from typing import Any, Mapping, Sequence
 from .model_intelligence_catalog import ModelCatalogSnapshot, build_canonical_model_catalog
+from .model_provider_execution_control_projection import MAX_CONTEXT_LENGTH, project_optional_controls
 INVOCATION_SCHEMA, RECEIPT_SCHEMA = "model_provider_catalog_discovery_invocation.v1", "model_provider_catalog_discovery_receipt.v1"
 CANDIDATE_SCHEMA, PROVIDER = "model_provider_catalog_candidate_snapshot.v1", "openrouter"
 ENDPOINT_ID, DEFAULT_FRESHNESS_MS = "openrouter_models_api_v1", 86_400_000
-MAX_RESPONSE_BYTES, MAX_RECORDS, MAX_CONTEXT_LENGTH, MAX_PRICE = 8 * 1024 * 1024, 2048, 100_000_000, Decimal("1000")
+MAX_RESPONSE_BYTES, MAX_RECORDS, MAX_PRICE = 8 * 1024 * 1024, 2048, Decimal("1000")
 _ID = re.compile(r"[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?/"
                  r"[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?(?::free)?\Z")
 _TOKEN, _DIGEST = re.compile(r"[a-z0-9][a-z0-9._:-]{0,63}\Z"), re.compile(r"sha256:[0-9a-f]{64}\Z")
@@ -326,14 +327,12 @@ def _sanitize_record(raw: Mapping[str, Any]) -> dict[str, Any]:
         if type(value) is not int or not 0 < value <= MAX_CONTEXT_LENGTH:
             raise ValueError("record_invalid")
         result["context_length"] = value
-    result["pricing"] = {
-        key: _canonical_price(pricing[key]) for key in ("prompt", "completion") if key in pricing
-    }
-    result["architecture"] = {
-        key: list(_tokens(architecture.get(key, [])))
-        for key in ("input_modalities", "output_modalities")
-    }
+    result["pricing"] = {key: _canonical_price(pricing[key])
+                         for key in ("prompt", "completion") if key in pricing}
+    result["architecture"] = {key: list(_tokens(architecture.get(key, [])))
+                              for key in ("input_modalities", "output_modalities")}
     result["supported_parameters"] = list(_tokens(raw.get("supported_parameters", [])))
+    result.update(project_optional_controls(raw))
     return result
 def _canonical_price(value: Any) -> str:
     if not isinstance(value, str) or len(value) > 64 or not _PRICE.fullmatch(value):

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_execution_control_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_execution_control_evidence.py
@@ -1,0 +1,334 @@
+"""Pure provider-asserted model execution-control evidence boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from .model_provider_catalog_snapshot import (
+    ENDPOINT_ID,
+    PROVIDER,
+    ProviderCatalogCandidateSnapshot,
+    rehydrate_candidate_snapshot,
+)
+
+
+SCHEMA_VERSION = "provider_model_execution_control_evidence.v1"
+TRUST_CLASS = "provider_asserted_model_execution_controls"
+_EVIDENCE_KEYS = frozenset(
+    """schema_version evidence_id provider endpoint_id candidate_snapshot_id
+    candidate_payload_digest discovery_receipt_id observed_at_ms fresh_until_ms
+    model_id prompt_price completion_price supported_parameters reasoning
+    top_provider source_record_digest source_control_digest trust_class""".split()
+)
+_EVIDENCE_ID = re.compile(
+    r"provider_model_execution_control_evidence:[0-9a-f]{64}\Z"
+)
+
+
+@dataclass(frozen=True)
+class ProviderModelReasoningControl:
+    supported_efforts_present: bool
+    supported_efforts: tuple[str, ...] | None
+    default_effort_present: bool
+    default_effort: str | None
+    default_enabled: bool | None
+    supports_max_tokens: bool | None
+    mandatory: bool | None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.supported_efforts_present:
+            result["supported_efforts"] = (
+                None
+                if self.supported_efforts is None
+                else list(self.supported_efforts)
+            )
+        if self.default_effort_present:
+            result["default_effort"] = self.default_effort
+        if self.default_enabled is not None:
+            result["default_enabled"] = self.default_enabled
+        if self.supports_max_tokens is not None:
+            result["supports_max_tokens"] = self.supports_max_tokens
+        if self.mandatory is not None:
+            result["mandatory"] = self.mandatory
+        return result
+
+
+@dataclass(frozen=True)
+class ProviderModelTopProviderControl:
+    context_length_present: bool
+    context_length: int | None
+    max_completion_tokens_present: bool
+    max_completion_tokens: int | None
+    is_moderated: bool | None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        if self.context_length_present:
+            result["context_length"] = self.context_length
+        if self.max_completion_tokens_present:
+            result["max_completion_tokens"] = self.max_completion_tokens
+        if self.is_moderated is not None:
+            result["is_moderated"] = self.is_moderated
+        return result
+
+
+@dataclass(frozen=True)
+class ProviderModelExecutionControlEvidence:
+    evidence_id: str
+    candidate_snapshot_id: str
+    candidate_payload_digest: str
+    discovery_receipt_id: str
+    observed_at_ms: int
+    fresh_until_ms: int
+    model_id: str
+    prompt_price: str
+    completion_price: str
+    supported_parameters: tuple[str, ...]
+    reasoning: ProviderModelReasoningControl | None
+    top_provider: ProviderModelTopProviderControl | None
+    source_record_digest: str
+    source_control_digest: str
+    provider: str = field(init=False, default=PROVIDER)
+    endpoint_id: str = field(init=False, default=ENDPOINT_ID)
+    trust_class: str = field(init=False, default=TRUST_CLASS)
+    schema_version: str = field(init=False, default=SCHEMA_VERSION)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "evidence_id": self.evidence_id,
+            "provider": self.provider,
+            "endpoint_id": self.endpoint_id,
+            "candidate_snapshot_id": self.candidate_snapshot_id,
+            "candidate_payload_digest": self.candidate_payload_digest,
+            "discovery_receipt_id": self.discovery_receipt_id,
+            "observed_at_ms": self.observed_at_ms,
+            "fresh_until_ms": self.fresh_until_ms,
+            "model_id": self.model_id,
+            "prompt_price": self.prompt_price,
+            "completion_price": self.completion_price,
+            "supported_parameters": list(self.supported_parameters),
+            "reasoning": None if self.reasoning is None else self.reasoning.to_dict(),
+            "top_provider": (
+                None if self.top_provider is None else self.top_provider.to_dict()
+            ),
+            "source_record_digest": self.source_record_digest,
+            "source_control_digest": self.source_control_digest,
+            "trust_class": self.trust_class,
+        }
+
+
+def build_provider_model_execution_control_evidence(
+    *,
+    candidate: ProviderCatalogCandidateSnapshot,
+    model_id: str,
+    now_ms: int,
+) -> ProviderModelExecutionControlEvidence:
+    if not isinstance(candidate, ProviderCatalogCandidateSnapshot):
+        raise ValueError("candidate_snapshot_invalid")
+    canonical = rehydrate_candidate_snapshot(candidate.to_dict(), now_ms=now_ms)
+    return _build_from_candidate(canonical, model_id)
+
+
+def rehydrate_provider_model_execution_control_evidence(
+    payload: Mapping[str, Any],
+    *,
+    candidate: ProviderCatalogCandidateSnapshot,
+    now_ms: int,
+) -> ProviderModelExecutionControlEvidence:
+    if not isinstance(payload, Mapping) or set(payload) != _EVIDENCE_KEYS:
+        raise ValueError("execution_control_evidence_invalid")
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("execution_control_evidence_invalid")
+    if not _EVIDENCE_ID.fullmatch(str(payload.get("evidence_id"))):
+        raise ValueError("execution_control_evidence_invalid")
+    try:
+        expected = build_provider_model_execution_control_evidence(
+            candidate=candidate,
+            model_id=payload.get("model_id"),  # type: ignore[arg-type]
+            now_ms=now_ms,
+        )
+    except ValueError as exc:
+        if str(exc) in {
+            "candidate_snapshot_stale",
+            "candidate_snapshot_future_observation",
+            "candidate_snapshot_invalid",
+        }:
+            raise
+        raise ValueError("execution_control_evidence_invalid") from None
+    if dict(payload) != expected.to_dict():
+        raise ValueError("execution_control_evidence_invalid")
+    return expected
+
+
+def _build_from_candidate(
+    candidate: ProviderCatalogCandidateSnapshot,
+    model_id: str,
+) -> ProviderModelExecutionControlEvidence:
+    record, pricing = _select_record(candidate, model_id)
+    reasoning = _reasoning(record.get("reasoning")) if "reasoning" in record else None
+    top_provider = (
+        _top_provider(record.get("top_provider"))
+        if "top_provider" in record
+        else None
+    )
+    parameters = tuple(record["supported_parameters"])
+    control = _control_body(
+        model_id=model_id,
+        prompt_price=pricing["prompt"],
+        completion_price=pricing["completion"],
+        supported_parameters=parameters,
+        reasoning=reasoning,
+        top_provider=top_provider,
+    )
+    values = _evidence_values(
+        candidate, control, _sha256(record), _sha256(control)
+    )
+    identity_body = {
+        "schema_version": SCHEMA_VERSION,
+        "provider": PROVIDER,
+        "endpoint_id": ENDPOINT_ID,
+        **values,
+        "trust_class": TRUST_CLASS,
+    }
+    evidence_id = _content_id(
+        "provider_model_execution_control_evidence", identity_body
+    )
+    return ProviderModelExecutionControlEvidence(
+        evidence_id=evidence_id,
+        candidate_snapshot_id=values["candidate_snapshot_id"],
+        candidate_payload_digest=values["candidate_payload_digest"],
+        discovery_receipt_id=values["discovery_receipt_id"],
+        observed_at_ms=values["observed_at_ms"],
+        fresh_until_ms=values["fresh_until_ms"],
+        model_id=values["model_id"],
+        prompt_price=values["prompt_price"],
+        completion_price=values["completion_price"],
+        supported_parameters=tuple(values["supported_parameters"]),
+        reasoning=reasoning,
+        top_provider=top_provider,
+        source_record_digest=values["source_record_digest"],
+        source_control_digest=values["source_control_digest"],
+    )
+
+
+def _select_record(
+    candidate: ProviderCatalogCandidateSnapshot,
+    model_id: str,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    if not isinstance(model_id, str):
+        raise ValueError("execution_control_model_missing")
+    matches = [
+        item
+        for item in candidate.catalog_payload["data"]
+        if item.get("id") == model_id
+    ]
+    if len(matches) != 1:
+        raise ValueError("execution_control_model_missing")
+    record = matches[0]
+    pricing = record.get("pricing")
+    if (
+        not isinstance(pricing, Mapping)
+        or set(pricing) != {"prompt", "completion"}
+        or not all(isinstance(pricing[key], str) for key in pricing)
+    ):
+        raise ValueError("execution_control_price_missing")
+    return record, pricing
+
+
+def _control_body(
+    *,
+    model_id: str,
+    prompt_price: str,
+    completion_price: str,
+    supported_parameters: tuple[str, ...],
+    reasoning: ProviderModelReasoningControl | None,
+    top_provider: ProviderModelTopProviderControl | None,
+) -> dict[str, Any]:
+    return {
+        "model_id": model_id,
+        "prompt_price": prompt_price,
+        "completion_price": completion_price,
+        "supported_parameters": list(supported_parameters),
+        "reasoning": None if reasoning is None else reasoning.to_dict(),
+        "top_provider": None if top_provider is None else top_provider.to_dict(),
+    }
+
+
+def _evidence_values(
+    candidate: ProviderCatalogCandidateSnapshot,
+    control: Mapping[str, Any],
+    source_record_digest: str,
+    source_control_digest: str,
+) -> dict[str, Any]:
+    return {
+        "candidate_snapshot_id": candidate.snapshot_id,
+        "candidate_payload_digest": candidate.catalog_payload_digest,
+        "discovery_receipt_id": candidate.observation_receipt.receipt_id,
+        "observed_at_ms": candidate.observed_at_ms,
+        "fresh_until_ms": candidate.fresh_until_ms,
+        "model_id": control["model_id"],
+        "prompt_price": control["prompt_price"],
+        "completion_price": control["completion_price"],
+        "supported_parameters": list(control["supported_parameters"]),
+        "reasoning": control["reasoning"],
+        "top_provider": control["top_provider"],
+        "source_record_digest": source_record_digest,
+        "source_control_digest": source_control_digest,
+    }
+
+
+def _reasoning(value: Any) -> ProviderModelReasoningControl:
+    if not isinstance(value, Mapping):
+        raise ValueError("execution_control_evidence_invalid")
+    efforts_present = "supported_efforts" in value
+    efforts = value.get("supported_efforts")
+    return ProviderModelReasoningControl(
+        supported_efforts_present=efforts_present,
+        supported_efforts=None if efforts is None else tuple(efforts),
+        default_effort_present="default_effort" in value,
+        default_effort=value.get("default_effort"),
+        default_enabled=value.get("default_enabled"),
+        supports_max_tokens=value.get("supports_max_tokens"),
+        mandatory=value.get("mandatory"),
+    )
+
+
+def _top_provider(value: Any) -> ProviderModelTopProviderControl:
+    if not isinstance(value, Mapping):
+        raise ValueError("execution_control_evidence_invalid")
+    return ProviderModelTopProviderControl(
+        context_length_present="context_length" in value,
+        context_length=value.get("context_length"),
+        max_completion_tokens_present="max_completion_tokens" in value,
+        max_completion_tokens=value.get("max_completion_tokens"),
+        is_moderated=value.get("is_moderated"),
+    )
+
+
+def _sha256(value: object) -> str:
+    return "sha256:" + hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _content_id(prefix: str, value: object) -> str:
+    return f"{prefix}:{hashlib.sha256(_canonical(value)).hexdigest()}"
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+
+
+__all__ = [
+    "ProviderModelExecutionControlEvidence",
+    "ProviderModelReasoningControl",
+    "ProviderModelTopProviderControl",
+    "build_provider_model_execution_control_evidence",
+    "rehydrate_provider_model_execution_control_evidence",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_provider_execution_control_projection.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_provider_execution_control_projection.py
@@ -1,0 +1,117 @@
+"""Strict projection of optional provider-asserted execution controls."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+MAX_CONTEXT_LENGTH = 100_000_000
+REASONING_EFFORTS = (
+    "max",
+    "xhigh",
+    "high",
+    "medium",
+    "low",
+    "minimal",
+    "none",
+)
+
+
+def project_optional_controls(value: Mapping[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    if "reasoning" in value:
+        reasoning = sanitize_reasoning_control(value["reasoning"])
+        if reasoning:
+            result["reasoning"] = reasoning
+    if "top_provider" in value:
+        top_provider = sanitize_top_provider_control(value["top_provider"])
+        if top_provider:
+            result["top_provider"] = top_provider
+    return result
+
+
+def sanitize_reasoning_control(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("record_invalid")
+    result: dict[str, Any] = {}
+    if "supported_efforts" in value:
+        efforts = value["supported_efforts"]
+        if efforts is not None:
+            _validate_efforts(efforts)
+        result["supported_efforts"] = (
+            None if efforts is None else list(efforts)
+        )
+    if "default_effort" in value:
+        effort = value["default_effort"]
+        if effort is not None and (
+            not isinstance(effort, str) or effort not in REASONING_EFFORTS
+        ):
+            raise ValueError("record_invalid")
+        result["default_effort"] = effort
+    for key in ("default_enabled", "supports_max_tokens", "mandatory"):
+        if key in value:
+            if type(value[key]) is not bool:
+                raise ValueError("record_invalid")
+            result[key] = value[key]
+    _validate_reasoning_relationships(result)
+    return result
+
+
+def sanitize_top_provider_control(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError("record_invalid")
+    result: dict[str, Any] = {}
+    for key in ("context_length", "max_completion_tokens"):
+        if key in value:
+            item = value[key]
+            if item is not None and (
+                type(item) is not int or not 0 < item <= MAX_CONTEXT_LENGTH
+            ):
+                raise ValueError("record_invalid")
+            result[key] = item
+    if (
+        type(result.get("context_length")) is int
+        and type(result.get("max_completion_tokens")) is int
+        and result["max_completion_tokens"] > result["context_length"]
+    ):
+        raise ValueError("record_invalid")
+    if "is_moderated" in value:
+        if type(value["is_moderated"]) is not bool:
+            raise ValueError("record_invalid")
+        result["is_moderated"] = value["is_moderated"]
+    return result
+
+
+def _validate_efforts(value: Any) -> None:
+    if not isinstance(value, list) or len(value) > len(REASONING_EFFORTS):
+        raise ValueError("record_invalid")
+    if any(
+        not isinstance(item, str) or item not in REASONING_EFFORTS
+        for item in value
+    ):
+        raise ValueError("record_invalid")
+    positions = [REASONING_EFFORTS.index(item) for item in value]
+    if positions != sorted(set(positions)):
+        raise ValueError("record_invalid")
+
+
+def _validate_reasoning_relationships(value: Mapping[str, Any]) -> None:
+    efforts = value.get("supported_efforts")
+    default = value.get("default_effort")
+    if isinstance(efforts, list) and default is not None and default not in efforts:
+        raise ValueError("record_invalid")
+    if value.get("mandatory") is True and (
+        value.get("default_enabled") is False
+        or default == "none"
+        or isinstance(efforts, list) and "none" in efforts
+    ):
+        raise ValueError("record_invalid")
+
+
+__all__ = [
+    "MAX_CONTEXT_LENGTH",
+    "REASONING_EFFORTS",
+    "project_optional_controls",
+    "sanitize_reasoning_control",
+    "sanitize_top_provider_control",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
+++ b/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
@@ -1,5 +1,29 @@
 # AI Gateway TestModLog
 
+## 2026-07-24 - OpenRouter model execution-control evidence phase B1
+
+Scope: offline adversarial coverage of optional provider-control projection and
+exact-model evidence lineage.
+
+- Preserves current K3 price/context/reasoning assertions without hard-coding
+  runtime behavior.
+- Proves descending effort order, duplicate/enum/bool/token bounds,
+  mandatory contradictions, and top-provider context/completion relationships.
+- Proves partial assertions, explicit empty lists, null-versus-omitted effort,
+  default-effort, and top-provider numeric claims, and omitted
+  `supports_max_tokens` remain distinct.
+- Drops unknown provider names, prose, secrets, defaults, and per-request limits
+  before duplicate equality and evidence construction.
+- Rehydrates legacy v1 candidates, rejects stale/future/tampered candidates,
+  exact-ID aliases, evidence field tampering, and recomputed attacker IDs.
+- Enrolls both new modules in persistent protected-authority import guards,
+  AST network/runtime-dependency purity, explicit `<200`/`<400` source
+  ceilings, and WSP_62 function ceilings.
+
+Focused execution-control/catalog/protected result: `112 passed`. Full AI
+Gateway: `647 passed, 2 skipped`. Ruff passed. No provider, model, network, or
+credential call occurred.
+
 ## 2026-07-24 - Configured AutoResearch gateway safety contract v2
 
 Scope: offline adversarial verification of configured provider calls, prompt

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
@@ -18,6 +18,8 @@ NEW_MODULE_NAMES = {
     "model_openrouter_scheduled_discovery",
     "model_provider_catalog_replay_state",
     "model_provider_catalog_snapshot",
+    "model_provider_execution_control_evidence",
+    "model_provider_execution_control_projection",
     "openrouter_model_catalog_snapshot_once",
 }
 FUNCTION_LIMIT_MODULES = (
@@ -29,7 +31,20 @@ FUNCTION_LIMIT_MODULES = (
     "model_provider_catalog_artifact_store.py",
     "model_provider_catalog_snapshot.py",
     "model_provider_catalog_replay_state.py",
+    "model_provider_execution_control_evidence.py",
+    "model_provider_execution_control_projection.py",
 )
+SOURCE_LINE_LIMITS = {
+    "model_provider_catalog_snapshot.py": 450,
+    "model_openrouter_direct_discovery.py": 400,
+    "model_provider_catalog_atomic_io.py": 400,
+    "model_provider_catalog_artifact_store.py": 250,
+    "model_openrouter_scheduled_discovery.py": 500,
+    "model_openrouter_schedule_adapter.py": 250,
+    "model_provider_catalog_replay_state.py": 500,
+    "model_provider_execution_control_projection.py": 200,
+    "model_provider_execution_control_evidence.py": 400,
+}
 
 
 def _imports(path: Path) -> set[str]:
@@ -77,42 +92,43 @@ def test_snapshot_is_pure_and_discovery_is_the_only_network_boundary() -> None:
     assert "os.environ" not in discovery_source
 
 
+def test_execution_control_surfaces_have_no_network_or_runtime_authority_imports() -> None:
+    forbidden = (
+        "ai_gateway",
+        "aiohttp",
+        "http",
+        "httpx",
+        "requests",
+        "urllib",
+        "socket",
+        "subprocess",
+        "websocket",
+        "model_openrouter_direct_discovery",
+        "model_intelligence_catalog",
+        "model_intelligence_selection",
+        "model_promotion_gate",
+        "model_registry",
+        "model_runtime_binding",
+        "model_signed_evidence",
+        "model_autoresearch_configured_gateway_runner",
+        "reddog_provider_call_evidence",
+    )
+    for name in (
+        "model_provider_execution_control_projection.py",
+        "model_provider_execution_control_evidence.py",
+    ):
+        imports = _imports(MODULE / "src" / name)
+        assert not any(
+            fragment in imported
+            for imported in imports
+            for fragment in forbidden
+        ), name
+
+
 def test_new_surfaces_stay_below_phase_one_size_limits() -> None:
-    assert len(
-        (MODULE / "src/model_provider_catalog_snapshot.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 450
-    assert len(
-        (MODULE / "src/model_openrouter_direct_discovery.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 400
-    assert len(
-        (MODULE / "src/model_provider_catalog_atomic_io.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 400
-    assert len(
-        (MODULE / "src/model_provider_catalog_artifact_store.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 250
-    assert len(
-        (MODULE / "src/model_openrouter_scheduled_discovery.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 500
-    assert len(
-        (MODULE / "src/model_openrouter_schedule_adapter.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 250
-    assert len(
-        (MODULE / "src/model_provider_catalog_replay_state.py").read_text(
-            encoding="utf-8"
-        ).splitlines()
-    ) < 500
+    for name, limit in SOURCE_LINE_LIMITS.items():
+        source = (MODULE / "src" / name).read_text(encoding="utf-8")
+        assert len(source.splitlines()) < limit, name
     assert len(
         (REPO / "scripts/openrouter_model_catalog_snapshot_once.py").read_text(
             encoding="utf-8"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_snapshot.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_snapshot.py
@@ -75,11 +75,12 @@ def test_success_fixture_is_allowlisted_canonical_and_sorted() -> None:
     assert zeta["pricing"] == {"completion": "0.000015", "prompt": "0.000003"}
     assert zeta["architecture"]["input_modalities"] == ["image", "text"]
     assert zeta["supported_parameters"] == ["response_format", "tools"]
+    assert zeta["top_provider"] == {"context_length": 131072}
     assert set(zeta) == {
-        "id", "context_length", "pricing", "architecture", "supported_parameters"
+        "id", "context_length", "pricing", "architecture", "supported_parameters",
+        "top_provider",
     }
     assert "name" not in json.dumps(payload)
-    assert "top_provider" not in json.dumps(payload)
 
 
 def test_duplicate_groups_collapse_conflict_and_poison_fail_closed() -> None:

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_execution_control_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_execution_control_evidence.py
@@ -1,0 +1,631 @@
+"""Offline contract for provider-asserted model execution-control evidence."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+
+from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_snapshot import (
+    DEFAULT_FRESHNESS_MS,
+    build_candidate_snapshot,
+    build_discovery_invocation,
+    build_discovery_receipt,
+    candidate_snapshot_id,
+    rehydrate_candidate_snapshot,
+    sanitize_openrouter_catalog_payload,
+    sha256_bytes,
+)
+from modules.ai_intelligence.ai_gateway.src.model_provider_execution_control_evidence import (
+    build_provider_model_execution_control_evidence,
+    rehydrate_provider_model_execution_control_evidence,
+)
+
+
+K3_ID = "moonshotai/kimi-k3"
+
+
+def _k3_row() -> dict:
+    return {
+        "id": K3_ID,
+        "description": "discard provider prose; prices/context match current metadata",
+        "context_length": 1_048_576,
+        "pricing": {"prompt": "0.0000030", "completion": "0.000015"},
+        "architecture": {
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+        },
+        "supported_parameters": ["reasoning", "max_tokens"],
+        "reasoning": {
+            "supported_efforts": ["max", "high", "low"],
+            "default_effort": "max",
+            "default_enabled": True,
+            "mandatory": False,
+        },
+        "top_provider": {
+            "context_length": 1_048_576,
+            "max_completion_tokens": None,
+            "is_moderated": False,
+        },
+        "default_parameters": {"temperature": 0.7},
+        "per_request_limits": {"prompt_tokens": 1},
+    }
+
+
+def _legacy_row() -> dict:
+    return {
+        "id": "legacy/model",
+        "context_length": 8_192,
+        "pricing": {"prompt": "0.000001", "completion": "0.000003"},
+        "architecture": {
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+        },
+        "supported_parameters": ["tools"],
+    }
+
+
+def _snapshot(rows: list[dict], *, observed_at_ms: int = 1_000):
+    payload, rejected, counts = sanitize_openrouter_catalog_payload({"data": rows})
+    snapshot_id = candidate_snapshot_id(payload)
+    raw = json.dumps({"data": rows}, sort_keys=True).encode("utf-8")
+    receipt = build_discovery_receipt(
+        call_id=f"offline-controls-{observed_at_ms}",
+        invocation=build_discovery_invocation(mode="manual"),
+        request_envelope_digest=sha256_bytes(b"fixed-request"),
+        attempted=True,
+        outcome="COMPLETED",
+        reason="completed",
+        started_at_ms=observed_at_ms - 1,
+        completed_at_ms=observed_at_ms,
+        http_status=200,
+        response_body_digest=sha256_bytes(raw),
+        response_byte_count=len(raw),
+        candidate_snapshot_id=snapshot_id,
+        accepted_record_count=len(payload["data"]),
+        rejected_record_count=rejected,
+        rejection_counts=counts,
+    )
+    return build_candidate_snapshot(
+        catalog_payload=payload,
+        rejected_record_count=rejected,
+        rejection_counts=counts,
+        observed_at_ms=observed_at_ms,
+        observation_receipt=receipt,
+    )
+
+
+def _sha256(value: object) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _evidence_id(payload: dict) -> str:
+    body = {key: value for key, value in payload.items() if key != "evidence_id"}
+    return "provider_model_execution_control_evidence:" + _sha256(body)[7:]
+
+
+def test_k3_controls_survive_sanitization_and_bind_exact_lineage() -> None:
+    candidate = _snapshot([_k3_row()])
+    record = candidate.catalog_payload["data"][0]
+    assert record["reasoning"] == {
+        "supported_efforts": ["max", "high", "low"],
+        "default_effort": "max",
+        "default_enabled": True,
+        "mandatory": False,
+    }
+    assert record["top_provider"] == {
+        "context_length": 1_048_576,
+        "max_completion_tokens": None,
+        "is_moderated": False,
+    }
+    assert "description" not in record
+    assert "default_parameters" not in record
+    assert "per_request_limits" not in record
+
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id=K3_ID,
+        now_ms=1_001,
+    )
+    assert evidence.provider == "openrouter"
+    assert evidence.endpoint_id == "openrouter_models_api_v1"
+    assert evidence.candidate_snapshot_id == candidate.snapshot_id
+    assert evidence.candidate_payload_digest == candidate.catalog_payload_digest
+    assert evidence.discovery_receipt_id == candidate.observation_receipt.receipt_id
+    assert evidence.observed_at_ms == candidate.observed_at_ms
+    assert evidence.fresh_until_ms == candidate.fresh_until_ms
+    assert evidence.model_id == K3_ID
+    assert evidence.prompt_price == "0.000003"
+    assert evidence.completion_price == "0.000015"
+    assert evidence.supported_parameters == ("max_tokens", "reasoning")
+    assert evidence.reasoning is not None
+    assert evidence.reasoning.mandatory is False
+    assert evidence.top_provider is not None
+    assert evidence.top_provider.context_length == 1_048_576
+    assert evidence.top_provider.context_length_present is True
+    assert evidence.top_provider.max_completion_tokens is None
+    assert evidence.top_provider.max_completion_tokens_present is True
+    assert evidence.top_provider.to_dict()["max_completion_tokens"] is None
+    assert evidence.trust_class == "provider_asserted_model_execution_controls"
+    assert rehydrate_provider_model_execution_control_evidence(
+        evidence.to_dict(),
+        candidate=candidate,
+        now_ms=1_001,
+    ) == evidence
+    with pytest.raises(FrozenInstanceError):
+        evidence.model_id = "other/model"  # type: ignore[misc]
+
+
+def test_legacy_v1_candidate_rehydrates_and_emits_explicit_absent_controls() -> None:
+    candidate = _snapshot([_legacy_row()])
+    legacy = rehydrate_candidate_snapshot(candidate.to_dict(), now_ms=1_001)
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=legacy,
+        model_id="legacy/model",
+        now_ms=1_001,
+    )
+    assert "reasoning" not in legacy.catalog_payload["data"][0]
+    assert "top_provider" not in legacy.catalog_payload["data"][0]
+    assert evidence.reasoning is None
+    assert evidence.top_provider is None
+    assert evidence.to_dict()["reasoning"] is None
+    assert evidence.to_dict()["top_provider"] is None
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("supported_efforts", ["medium", "high"]),
+        ("supported_efforts", ["medium", "medium"]),
+        ("supported_efforts", ["turbo"]),
+        ("supported_efforts", ["max", None]),
+        ("supported_efforts", ["max", "xhigh", "high", "medium", "low", "minimal", "none", "none"]),
+        ("default_effort", "turbo"),
+        ("default_effort", True),
+        ("default_enabled", 1),
+        ("supports_max_tokens", 0),
+        ("mandatory", 1),
+    ),
+)
+def test_reasoning_control_types_bounds_enum_order_and_duplicates_poison(
+    field: str, value: object
+) -> None:
+    row = _k3_row()
+    row["reasoning"]["supported_efforts"] = ["high", "medium"]
+    row["reasoning"]["default_effort"] = "high"
+    row["reasoning"][field] = value
+    payload, rejected, counts = sanitize_openrouter_catalog_payload(
+        {"data": [_legacy_row(), row]}
+    )
+    assert [item["id"] for item in payload["data"]] == ["legacy/model"]
+    assert rejected == 1
+    assert counts == {"record_invalid": 1}
+
+
+def test_reasoning_default_membership_and_mandatory_semantics_are_exact() -> None:
+    missing_default = _k3_row()
+    missing_default["reasoning"]["supported_efforts"] = ["medium", "low"]
+    missing_default["reasoning"]["default_effort"] = "high"
+    mandatory_disabled = _k3_row()
+    mandatory_disabled["id"] = "other/model"
+    mandatory_disabled["reasoning"]["default_enabled"] = False
+    mandatory_disabled["reasoning"]["mandatory"] = True
+    mandatory_none = _k3_row()
+    mandatory_none["id"] = "third/model"
+    mandatory_none["reasoning"]["supported_efforts"] = ["max", "none"]
+    mandatory_none["reasoning"]["mandatory"] = True
+    mandatory_default_none = _k3_row()
+    mandatory_default_none["id"] = "fourth/model"
+    mandatory_default_none["reasoning"]["supported_efforts"] = ["none"]
+    mandatory_default_none["reasoning"]["default_effort"] = "none"
+    mandatory_default_none["reasoning"]["mandatory"] = True
+    payload, rejected, counts = sanitize_openrouter_catalog_payload(
+        {
+            "data": [
+                _legacy_row(),
+                missing_default,
+                mandatory_disabled,
+                mandatory_none,
+                mandatory_default_none,
+            ]
+        }
+    )
+    assert [item["id"] for item in payload["data"]] == ["legacy/model"]
+    assert rejected == 4
+    assert counts == {"record_invalid": 4}
+
+
+def test_optional_reasoning_list_and_nonmandatory_disabled_are_preserved() -> None:
+    row = _k3_row()
+    row["reasoning"] = {
+        "supported_efforts": ["max", "xhigh", "high", "medium", "low", "minimal", "none"],
+        "default_effort": "medium",
+        "default_enabled": False,
+        "supports_max_tokens": True,
+        "mandatory": False,
+    }
+    candidate = _snapshot([row])
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id=K3_ID, now_ms=1_001
+    )
+    assert evidence.reasoning is not None
+    assert evidence.reasoning.supported_efforts == (
+        "max",
+        "xhigh",
+        "high",
+        "medium",
+        "low",
+        "minimal",
+        "none",
+    )
+    assert evidence.reasoning.default_enabled is False
+    assert evidence.reasoning.mandatory is False
+
+
+def test_null_and_omitted_effort_controls_remain_distinct() -> None:
+    null_row = _k3_row()
+    null_row["id"] = "synthetic/null-efforts"
+    null_row["reasoning"] = {
+        "supported_efforts": None,
+        "default_effort": "high",
+        "default_enabled": True,
+        "mandatory": False,
+    }
+    omitted_row = _k3_row()
+    omitted_row["id"] = "synthetic/omitted-efforts"
+    omitted_row["reasoning"] = {
+        "default_effort": "high",
+        "default_enabled": True,
+        "mandatory": False,
+        "provider_note": "drop me",
+    }
+    candidate = _snapshot([null_row, omitted_row])
+    null_evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id="synthetic/null-efforts", now_ms=1_001
+    )
+    omitted_evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id="synthetic/omitted-efforts", now_ms=1_001
+    )
+    assert null_evidence.reasoning is not None
+    assert null_evidence.reasoning.supported_efforts_present is True
+    assert null_evidence.reasoning.supported_efforts is None
+    assert null_evidence.reasoning.supports_max_tokens is None
+    assert null_evidence.reasoning.to_dict()["supported_efforts"] is None
+    assert "supports_max_tokens" not in null_evidence.reasoning.to_dict()
+    assert omitted_evidence.reasoning is not None
+    assert omitted_evidence.reasoning.supported_efforts_present is False
+    assert "supported_efforts" not in omitted_evidence.reasoning.to_dict()
+    assert "supports_max_tokens" not in omitted_evidence.reasoning.to_dict()
+
+
+def test_null_and_omitted_default_effort_remain_distinct() -> None:
+    null_row = _k3_row()
+    null_row["id"] = "synthetic/null-default-effort"
+    null_row["reasoning"] = {"mandatory": False, "default_effort": None}
+    omitted_row = _k3_row()
+    omitted_row["id"] = "synthetic/omitted-default-effort"
+    omitted_row["reasoning"] = {"mandatory": False}
+    candidate = _snapshot([null_row, omitted_row])
+    null_evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id="synthetic/null-default-effort", now_ms=1_001
+    )
+    omitted_evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id="synthetic/omitted-default-effort",
+        now_ms=1_001,
+    )
+    assert null_evidence.reasoning is not None
+    assert null_evidence.reasoning.default_effort_present is True
+    assert null_evidence.reasoning.default_effort is None
+    assert null_evidence.reasoning.to_dict()["default_effort"] is None
+    assert omitted_evidence.reasoning is not None
+    assert omitted_evidence.reasoning.default_effort_present is False
+    assert "default_effort" not in omitted_evidence.reasoning.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("reasoning", "expected"),
+    (
+        ({"supported_efforts": []}, {"supported_efforts": []}),
+        ({"supported_efforts": None}, {"supported_efforts": None}),
+        ({"default_effort": "high"}, {"default_effort": "high"}),
+        ({"default_enabled": False}, {"default_enabled": False}),
+        ({"supports_max_tokens": True}, {"supports_max_tokens": True}),
+        ({"mandatory": True}, {"mandatory": True}),
+        (
+            {"supported_efforts": None, "mandatory": True},
+            {"supported_efforts": None, "mandatory": True},
+        ),
+    ),
+)
+def test_partial_reasoning_assertions_remain_candidate_evidence(
+    reasoning: dict, expected: dict
+) -> None:
+    row = _k3_row()
+    row["reasoning"] = reasoning
+    candidate = _snapshot([row])
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id=K3_ID, now_ms=1_001
+    )
+    assert candidate.catalog_payload["data"][0]["reasoning"] == expected
+    assert evidence.reasoning is not None
+    assert evidence.reasoning.to_dict() == expected
+
+
+def test_unknown_only_reasoning_projection_is_omitted() -> None:
+    row = _k3_row()
+    row["reasoning"] = {"provider_note": "ignored"}
+    candidate = _snapshot([row])
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id=K3_ID, now_ms=1_001
+    )
+    assert "reasoning" not in candidate.catalog_payload["data"][0]
+    assert evidence.reasoning is None
+
+
+@pytest.mark.parametrize(
+    "top_provider",
+    (
+        {"context_length": True},
+        {"context_length": 0},
+        {"context_length": 100_000_001},
+        {"max_completion_tokens": True},
+        {"max_completion_tokens": 0},
+        {"max_completion_tokens": 100_000_001},
+        {"context_length": 1_000, "max_completion_tokens": 1_001},
+        {"is_moderated": 1},
+    ),
+)
+def test_top_provider_recognized_bool_cap_and_relationship_values_poison(
+    top_provider: object,
+) -> None:
+    row = _k3_row()
+    row["top_provider"] = top_provider
+    payload, rejected, counts = sanitize_openrouter_catalog_payload(
+        {"data": [_legacy_row(), row]}
+    )
+    assert [item["id"] for item in payload["data"]] == ["legacy/model"]
+    assert rejected == 1
+    assert counts == {"record_invalid": 1}
+
+
+def test_top_provider_null_and_omitted_numeric_claims_remain_distinct() -> None:
+    nullable = _k3_row()
+    nullable["id"] = "synthetic/nullable-top-provider"
+    nullable["top_provider"] = {
+        "context_length": None,
+        "max_completion_tokens": None,
+        "is_moderated": False,
+    }
+    omitted = _k3_row()
+    omitted["id"] = "synthetic/omitted-top-provider"
+    omitted["top_provider"] = {"is_moderated": False}
+    candidate = _snapshot([nullable, omitted])
+    nullable_evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id="synthetic/nullable-top-provider",
+        now_ms=1_001,
+    )
+    omitted_evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id="synthetic/omitted-top-provider",
+        now_ms=1_001,
+    )
+    assert nullable_evidence.top_provider is not None
+    assert nullable_evidence.top_provider.context_length_present is True
+    assert nullable_evidence.top_provider.max_completion_tokens_present is True
+    assert nullable_evidence.top_provider.to_dict()["context_length"] is None
+    assert nullable_evidence.top_provider.to_dict()["max_completion_tokens"] is None
+    assert omitted_evidence.top_provider is not None
+    assert omitted_evidence.top_provider.context_length_present is False
+    assert omitted_evidence.top_provider.max_completion_tokens_present is False
+    assert "context_length" not in omitted_evidence.top_provider.to_dict()
+    assert "max_completion_tokens" not in omitted_evidence.top_provider.to_dict()
+
+
+def test_unknown_control_fields_are_dropped_without_leak_or_poison() -> None:
+    row = _k3_row()
+    row["reasoning"]["provider_note"] = "drop reasoning prose"
+    row["top_provider"].update(
+        {
+            "provider_name": "drop-provider",
+            "api_key": "sensitive-provider-value",
+            "default_parameters": {"temperature": 0.7},
+            "per_request_limits": {"prompt_tokens": 1},
+        }
+    )
+    candidate = _snapshot([row])
+    record = candidate.catalog_payload["data"][0]
+    serialized = json.dumps(record, sort_keys=True)
+    assert "provider_note" not in serialized
+    assert "provider_name" not in serialized
+    assert "api_key" not in serialized
+    assert "sensitive-provider-value" not in serialized
+    assert "default_parameters" not in serialized
+    assert "per_request_limits" not in serialized
+
+    unknown_only = _k3_row()
+    unknown_only["id"] = "synthetic/unknown-top-provider"
+    unknown_only["top_provider"] = {"provider_name": "drop-me"}
+    candidate = _snapshot([unknown_only])
+    assert "top_provider" not in candidate.catalog_payload["data"][0]
+
+
+def test_duplicate_control_groups_collapse_conflict_and_poison() -> None:
+    first = _k3_row()
+    identical = copy.deepcopy(first)
+    identical["top_provider"]["provider_name"] = "ignored-before-equality"
+    collapsed, rejected, counts = sanitize_openrouter_catalog_payload(
+        {"data": [first, identical]}
+    )
+    assert [item["id"] for item in collapsed["data"]] == [K3_ID]
+    assert rejected == 1
+    assert counts == {"duplicate_identical_collapsed": 1}
+
+    conflict = copy.deepcopy(first)
+    conflict["reasoning"]["default_effort"] = "high"
+    conflict["reasoning"]["supported_efforts"] = ["max", "high"]
+    payload, rejected, counts = sanitize_openrouter_catalog_payload(
+        {"data": [_legacy_row(), first, conflict]}
+    )
+    assert [item["id"] for item in payload["data"]] == ["legacy/model"]
+    assert rejected == 2
+    assert counts == {"duplicate_id_conflict": 2}
+
+    poisoned = copy.deepcopy(first)
+    poisoned["top_provider"]["context_length"] = True
+    payload, rejected, counts = sanitize_openrouter_catalog_payload(
+        {"data": [_legacy_row(), first, poisoned]}
+    )
+    assert [item["id"] for item in payload["data"]] == ["legacy/model"]
+    assert rejected == 2
+    assert counts == {"duplicate_group_poisoned": 2}
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    (
+        "moonshotai/Kimi-k3",
+        "moonshotai/kimi-k3:free",
+        "openrouter/moonshotai/kimi-k3",
+        "moonshotai/kimi-k3 ",
+    ),
+)
+def test_exact_model_case_and_alias_mismatch_reject(model_id: str) -> None:
+    candidate = _snapshot([_k3_row()])
+    with pytest.raises(ValueError, match="model_missing"):
+        build_provider_model_execution_control_evidence(
+            candidate=candidate,
+            model_id=model_id,
+            now_ms=1_001,
+        )
+
+
+def test_stale_future_and_tampered_candidate_reject() -> None:
+    candidate = _snapshot([_k3_row()])
+    with pytest.raises(ValueError, match="candidate_snapshot_stale"):
+        build_provider_model_execution_control_evidence(
+            candidate=candidate,
+            model_id=K3_ID,
+            now_ms=1_000 + DEFAULT_FRESHNESS_MS + 1,
+        )
+    with pytest.raises(ValueError, match="candidate_snapshot_future_observation"):
+        build_provider_model_execution_control_evidence(
+            candidate=candidate,
+            model_id=K3_ID,
+            now_ms=999,
+        )
+    tampered = replace(candidate, catalog_payload_digest="sha256:" + "0" * 64)
+    with pytest.raises(ValueError, match="candidate_snapshot_invalid"):
+        build_provider_model_execution_control_evidence(
+            candidate=tampered,
+            model_id=K3_ID,
+            now_ms=1_001,
+        )
+
+
+def test_source_record_and_control_digests_are_exact() -> None:
+    candidate = _snapshot([_k3_row()])
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id=K3_ID,
+        now_ms=1_001,
+    )
+    record = candidate.catalog_payload["data"][0]
+    control = {
+        "model_id": K3_ID,
+        "prompt_price": "0.000003",
+        "completion_price": "0.000015",
+        "supported_parameters": ["max_tokens", "reasoning"],
+        "reasoning": record["reasoning"],
+        "top_provider": record["top_provider"],
+    }
+    assert evidence.source_record_digest == _sha256(record)
+    assert evidence.source_control_digest == _sha256(control)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("provider", "openai"),
+        ("endpoint_id", "alias"),
+        ("candidate_snapshot_id", "model_provider_catalog_candidate_snapshot:" + "0" * 64),
+        ("candidate_payload_digest", "sha256:" + "0" * 64),
+        ("discovery_receipt_id", "model_provider_catalog_discovery_receipt:" + "0" * 64),
+        ("observed_at_ms", 999),
+        ("fresh_until_ms", 1_001),
+        ("model_id", "other/model"),
+        ("prompt_price", "0.5"),
+        ("completion_price", "0.5"),
+        ("supported_parameters", []),
+        ("reasoning", None),
+        ("top_provider", None),
+        ("source_record_digest", "sha256:" + "0" * 64),
+        ("source_control_digest", "sha256:" + "0" * 64),
+        ("trust_class", "canonical_route_admission"),
+    ),
+)
+def test_evidence_tamper_rejects_even_when_attacker_recomputes_id(
+    field: str, value: object
+) -> None:
+    candidate = _snapshot([_k3_row()])
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id=K3_ID,
+        now_ms=1_001,
+    )
+    payload = copy.deepcopy(evidence.to_dict())
+    payload[field] = value
+    payload["evidence_id"] = _evidence_id(payload)
+    with pytest.raises(ValueError, match="execution_control_evidence_invalid"):
+        rehydrate_provider_model_execution_control_evidence(
+            payload,
+            candidate=candidate,
+            now_ms=1_001,
+        )
+
+
+def test_evidence_missing_extra_fields_and_id_mismatch_reject() -> None:
+    candidate = _snapshot([_k3_row()])
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate,
+        model_id=K3_ID,
+        now_ms=1_001,
+    )
+    missing = evidence.to_dict()
+    missing.pop("reasoning")
+    extra = evidence.to_dict()
+    extra["description"] = "not allowlisted"
+    mismatch = evidence.to_dict()
+    mismatch["evidence_id"] = "provider_model_execution_control_evidence:" + "0" * 64
+    for payload in (missing, extra, mismatch):
+        with pytest.raises(ValueError, match="execution_control_evidence_invalid"):
+            rehydrate_provider_model_execution_control_evidence(
+                payload,
+                candidate=candidate,
+                now_ms=1_001,
+            )
+
+
+def test_execution_control_module_has_zero_network_or_caller_surface() -> None:
+    path = (
+        "modules/ai_intelligence/ai_gateway/src/"
+        "model_provider_execution_control_evidence.py"
+    )
+    source = Path(path).read_text(encoding="utf-8")
+    assert not {
+        "requests",
+        "aiohttp",
+        "urllib",
+        "socket",
+        "subprocess",
+        "AIGateway",
+        "call_model",
+    }.intersection(source.split())


### PR DESCRIPTION
## Summary
- preserve a strict bounded projection of OpenRouter model-list `reasoning` and `top_provider` assertions, including omitted-vs-null distinctions
- derive immutable exact-model execution-control evidence bound to candidate/discovery lineage, canonical price strings, freshness, source digests, and a provider-asserted-only trust class
- keep route admission, sampling defaults, transport, model calls, selection, promotion, and runtime authority explicitly halted
- enroll the new modules in persistent authority-import, network-purity, WSP_62 source/function, and protected-surface guards

## Current K3 evidence
The offline fixture matches the 2026-07-24 public OpenRouter catalog shape for `moonshotai/kimi-k3` (model-list metadata only). The implementation does not hard-code K3 into runtime selection and makes no provider/model call.

## Validation
- focused execution-control/catalog/protected matrix: 112 passed
- full AI Gateway: 647 passed, 2 skipped
- Ruff and compileall: passed
- WSP_62 guards: passed
- WSP_97 receipt validator: compliant
- independent read-only review: AMEND/MERGE GO

## Safety boundary
This PR is evidence-only and default inert. Live K3/GLM/comparator execution remains NO-GO pending endpoint-specific route admission, explicit sampling policy, bounded response transport, authoritative provider usage, bounded artifact reads, and exclusive runtime identity.