### PR TITLE
fix(holoindex): bind persistent reads to invoking repository

### DIFF
--- a/docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1.md
+++ b/docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1.md
@@ -1,0 +1,206 @@
+# HoloIndex Query Root Admission P0 Phase 1
+
+**Slice:** `HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1`
+**Date:** 2026-07-24
+**Original base:** `c7a3373b867efd077b153901db693979eb3966f7`
+**Rebased base:** `545f4b3b828cf083c20e266961c6df2fde1565c7`
+**Branch:** `fix/holoindex-root-bound-query-p0`
+**Owner:** 0102 architect operating in WSP_00 state
+**WSP:** 00, 15, 22, 50, 62, 81, 97
+
+## Assumption Audit
+
+### 1. Problem
+
+The authenticated RedDog owner already enforced exact repository freshness,
+but raw persistent CLI search, persistent bundle retrieval, and the explicitly
+diagnostic direct adapter could construct a local backend without first
+proving that the store receipt belonged to the invoking worktree. A linked or
+foreign worktree could therefore read vectors for another root/HEAD before a
+later diagnostic check reported staleness.
+
+This slice adds only a read-admission boundary. It does not refresh, migrate,
+namespace, or repair the store and grants no worker maintenance authority.
+
+### 2. Assumptions
+
+| ID | Assumption | Evidence | Confidence |
+|---|---|---|---|
+| A1 | The canonical owner freshness gate is the correct proof source. | Existing owner tests and `holo_query_freshness_gate.py`. | HIGH |
+| A2 | A persistent read is truthful only for the explicit invoking root and SSD. | New foreign-root and wrong-SSD regressions. | HIGH |
+| A3 | Clean exact HEAD, generation, complete baseline, and embedding proof are indivisible admission requirements. | Existing owner freshness gate reused without duplicating its proof rules; new focused helper tests. | HIGH |
+| A4 | Maintenance must be inactive and provable before backend construction. | Existing maintenance probe reused; fail-before-backend tests. | HIGH |
+| A5 | Offline lexical retrieval is useful diagnostic evidence but is not persistent semantic evidence. | CLI bypass test and degraded metadata. | HIGH |
+| A6 | Content-free reason codes are sufficient for admission logs and raw CLI/bundle denial. | Admission serialization excludes roots, SSD paths, receipt bindings, prompts, and hits. The direct diagnostic preserves its pre-existing caller-local `query` response field; only its new reasons are content-free, and this adapter does not log the payload here. | HIGH |
+| A7 | Persistent admission must run before resolving a caller-controlled module hint. | Ordering regression makes module resolution fail if called before a denied admission. | HIGH |
+| A8 | Raw CLI and bundle offline module/WSP/NAVIGATION/artifact discovery must share repository-confined, no-follow, resource-bounded reads. Oversized discovery roots cannot yield a partial filesystem-order-dependent result. | Raw-CLI symlink/reparse/NAVIGATION-byte tests; absolute-drive, traversal, root/component reparse, nested-walk, artifact, module-domain/WSP `cap + 1`, and before/after-cap tests. | HIGH |
+| A9 | Direct diagnostic receipt and maintenance identities come from the admitted SSD, never a caller-selected receipt location. | The noncanonical external-receipt regression rejects before repository evaluation, receipt admission, or backend access; `_direct_paths` and both maintenance locations are SSD-derived by code. | HIGH |
+| A10 | Module-file evidence is truthful only when the bounded walk proves it saw the complete eligible set. | Match-before/after-cap, depth overflow, scan error, and reverse-order regressions. | HIGH |
+
+### 3. Failure Modes
+
+| ID | Failure mode | Impact | Mitigation |
+|---|---|---|---|
+| F1 | A foreign worktree reads the canonical store. | HIGH | Compare explicit root with receipt before backend construction. |
+| F2 | Same root but wrong HEAD reads stale vectors. | HIGH | Require clean exact receipt HEAD. |
+| F3 | A different SSD is silently accepted. | HIGH | Bind the explicit resolved SSD to the receipt store identity. |
+| F4 | Missing generation or partial baseline is treated as current. | HIGH | Reuse the canonical complete-baseline evaluator. |
+| F5 | A query races maintenance. | CRITICAL | Probe maintenance before receipt evaluation; existing direct diagnostic post-probe remains as race detection. |
+| F6 | Raw CLI/bundle admission denial leaks paths, prompts, or binding metadata. | HIGH | Serialize only stable error/freshness/reason flags. The direct adapter's existing caller-local query echo is outside this narrower serialized-admission claim. |
+| F7 | Offline lexical fallback is mistaken for semantic retrieval. | HIGH | Bypass the persistent gate/store and label output degraded with UNKNOWN freshness and index gap. |
+| F8 | Bundle JSON bypasses the raw CLI gate by importing its own backend. | HIGH | Apply the same helper inside the bundle path before its local backend import. |
+| F9 | Absolute/traversal module hints touch a foreign root before admission. | HIGH | Admit persistent queries first; lexical resolution accepts relative components only. |
+| F10 | Raw CLI bypasses confinement, NAVIGATION is read without a byte ceiling, or module-domain/WSP discovery returns a partial set after unbounded/filesystem-order-dependent enumeration. A nested link/reparse may also escape a confined module or artifact root. | HIGH | Route raw CLI through the shared lexical loader; lstat every component; reject oversize NAVIGATION; use no-follow classification; bound nested walks; inspect discovery roots only through `cap + 1`; reject the whole discovery result on overflow; sort only a complete bounded set. |
+| F11 | An outside receipt redirects direct maintenance probes away from the admitted SSD. | CRITICAL | Derive both redundant direct probes solely from `maintenance_lock_path(ssd_path)`. |
+| F12 | A path is replaced between lstat/confinement proof and a later open. | HIGH | P0 performs bounded no-follow checks and fails closed on observed links; descriptor-relative/final-handle identity hardening remains explicit P1 debt. |
+| F13 | A valid caller-supplied receipt outside the SSD overrides a disagreeing canonical receipt. | CRITICAL | Derive the receipt solely from `freshness_receipt_path(ssd)`; reject a noncanonical explicit path or final receipt link/reparse before any receipt/backend read. |
+| F14 | Entry/depth overflow or a scan error leaves a plausible but incomplete module-file prefix. | HIGH | Make bounded module enumeration complete-or-empty and sort only a fully verified set. |
+
+### 4. Alternatives
+
+| Alternative | Disposition |
+|---|---|
+| Duplicate the owner freshness logic in each caller. | Rejected: divergent proof semantics would recur. |
+| Infer the invoking repository from process CWD or singleton state. | Rejected: linked worktrees and embedding callers require an explicit root. |
+| Query first, then mark the result stale. | Rejected: the wrong persistent substrate has already been accessed. |
+| Refresh automatically when admission fails. | Rejected: a read consumer cannot mutate its evidence substrate. |
+| Disable direct diagnostics completely. | Rejected for P0: a trusted-host diagnostic remains useful when admitted, but stays non-operational. |
+| Add multi-root namespaces now. | Deferred P1: it requires receipt/store migration and broader maintenance policy. |
+
+### 5. Decision
+
+Proceed with one reusable read-only admission helper that delegates to the
+existing canonical freshness/maintenance gate. Call it before persistent
+backend construction in raw CLI search, persistent bundle retrieval, and the
+RedDog direct diagnostic. Keep offline lexical retrieval current-repository
+only and explicitly degraded. Persistent admission precedes module-hint
+resolution. Raw CLI and bundle lexical retrieval share the same confined
+loader; lexical path/artifact discovery is relative-only, byte/entry bounded,
+and no-follow. NAVIGATION and oversized discovery roots fail closed rather
+than returning partial evidence. Persistent receipt identity and both direct
+maintenance race probes derive solely from the admitted SSD; a caller receipt
+argument is accepted only as an exact canonical assertion. Module-file
+enumeration is complete-or-empty on entry cap, depth overflow, and scan error.
+
+**Timestamp:** 2026-07-24T06:16:12+09:00
+
+## WSP_15 Priority
+
+| Dimension | Score | Rationale |
+|---|---:|---|
+| Complexity | 3 | Three callers, but one existing proof can be reused. |
+| Importance | 5 | Wrong-root evidence invalidates architectural conclusions. |
+| Deferability | 5 | Current RedDog diagnostic behavior can cross worktree identity. |
+| Impact | 5 | Closes the common pre-backend read boundary. |
+| **Total** | **18 / P0** | Implement immediately as a focused repair. |
+
+LLME is not applied because this is a cross-module work item, not a module
+maturity score.
+
+## WSP_62 Boundary
+
+- `holo_index/query_admission.py` is a focused helper module; its public
+  evaluator remains below the 50-line Python function threshold.
+- The helper deliberately imports the existing infrastructure-owned
+  `HoloQueryFreshnessGate` for P0 semantic parity instead of cloning proof
+  rules. This is a known dependency-direction debt: lower-level HoloIndex code
+  depends on an infrastructure owner module. Import-time tests show no cycle.
+  P0 does not relocate that contract or introduce a neutral-owner migration;
+  ownership extraction is reserved for a separate reviewed architecture slice.
+- The legacy CLI and bundle routers receive only narrow admission hooks; no
+  command, indexing, migration, or rendering responsibilities move into them.
+- New path confinement is isolated in
+  `holo_index/cli/bundle_path_confinement.py` (288 lines; maximum function 47
+  lines), and all focused test files remain below the 500-line test threshold.
+- `handle_bundle_json` is decomposed to 49 lines through narrow helpers; this
+  slice does not add a broad WSP_62 exemption for the handler.
+- The direct adapter retains its existing post-query maintenance race probe.
+- Historical monolith decomposition remains in `holo_index/ROADMAP.md`; this
+  security repair makes no repository-wide WSP_62 compliance claim.
+
+## Execution Boundaries and Evidence
+
+- The work was performed in the dedicated worktree
+  `O:\Foundups-Agent-worktrees\holoindex-root-bound-query-p0-20260724`.
+- No framework WSP, knowledge backup, canonical index, or `E:\HoloIndex` state
+  was modified.
+- RED: the focused suite failed collection because
+  `holo_index.query_admission` did not exist.
+- A second RED proved offline bundle retrieval consumed a foreign SSD
+  `wsp_summary.json`; GREEN derives bounded WSP metadata from the invoking
+  repository and records zero supplied-SSD reads.
+- Independent-review REDs proved module resolution preceded persistent
+  admission, absolute/traversal hints escaped, receipt location selected the
+  direct maintenance lock, nested reparse enumeration was unbounded, and
+  artifact existence checks followed links. GREEN derives canonical receipt
+  and maintenance locations from the SSD by code; current regressions prove a
+  noncanonical external receipt rejects before repository evaluation, receipt
+  admission, or backend access and cover the other listed boundaries. Real
+  symlink integrations remain portable skips on this host while deterministic
+  reparse seams execute without skips.
+- Second-amend REDs proved raw CLI directly followed/read NAVIGATION, oversize
+  NAVIGATION was accepted, module-domain/WSP discovery ignored entry caps, and
+  a capped partial result remained filesystem-order dependent. GREEN routes raw
+  CLI through the shared loader, rejects oversize NAVIGATION, and makes
+  `cap + 1` overflow return no discovery result whether a match appears before
+  or after the cap.
+- Third-amend REDs proved that a valid external receipt could override a
+  disagreeing canonical SSD receipt, a final receipt reparse was not rejected
+  before reads, capped/depth/error module walks returned partial evidence, and
+  `handle_bundle_json` remained 132 lines. The RED matrix was `10 failed, 32
+  passed, 4 skipped`. GREEN binds receipt reads to the SSD-derived canonical
+  path, makes module walks complete-or-empty and order-independent, and
+  decomposes the handler to 49 lines while preserving malformed-payload
+  exception containment.
+- GREEN and static validation results are recorded in the paired WSP_97
+  execution receipt and module TestModLogs.
+- Two stale test assertions failed unchanged on detached exact-base
+  `c7a3373b8` and current-main `545f4b3b8`: an extension exact-string assertion
+  predated semantic-first conditional model selection, and a direct test called
+  a removed runtime-private hit normalizer. The tests now target the existing
+  semantic/lexical environment contract and canonical adapter normalizer; no
+  production compatibility shim or unrelated extension/runtime edit was made.
+
+## Deferred P1
+
+The named
+`Neutral Freshness-Gate Contract Extraction / Dependency Inversion` P1 item
+must move the proof contract to a neutral owner and invert the current
+lower-level-to-infrastructure dependency without cloning semantics. Explicit
+multi-repository store namespaces, legacy receipt metadata migration, and
+mechanically exclusive maintenance ownership across all direct-store consumers
+also require separate reviewed slices. Descriptor-relative/final-handle
+identity checks are required to close concurrent path-replacement TOCTOU; P0
+stable-ancestor canonical comparison does not close that replacement window,
+and P0 does not claim hostile concurrent filesystem mutation resistance.
+
+## Validation Record
+
+- Unfiltered changed-file matrix: `62 passed, 5 skipped`; skips are optional
+  real-symlink integrations unavailable under this Windows privilege profile,
+  while deterministic link/reparse seam tests ran and passed.
+- Canonical owner service/freshness matrix: `60 passed`, including the exact
+  repository-root and SSD identity mismatch parameter cases.
+- Wider bundle, receipt, owner-client, and RedDog query boundary matrix:
+  `126 passed, 4 skipped`; skips are the optional real-symlink integrations.
+- WSP_62 guards: `3 passed` for exact bridge exemptions and `16 passed` for
+  modular-audit thresholds. AST measurements: admission evaluator 35 lines;
+  direct diagnostic 50; focused confinement module 288 lines with a maximum
+  function size of 47 lines; bundle handler 49 lines.
+- Wider CLI/index command:
+  `python -B -m pytest -p no:cacheprovider holo_index/tests/test_cli_index_maintenance_integration.py holo_index/tests/test_cli_index_selection.py holo_index/tests/test_holoindex_storage_contract.py holo_index/tests/test_index_refresh_repair.py -q`
+  returned `32 passed, 1 failed`. The exact baseline node is
+  `holo_index/tests/test_index_refresh_repair.py::TestWspPurity::test_wsp_purity_only_wsp_files`;
+  its source-string assertion requires literal `glob("WSP_*.md")` (or the
+  single-quoted equivalent) inside `index_wsp_entries`. It fails identically on
+  unmodified `545f4b3b8` and does not import or inspect a touched surface.
+- Static checks: focused Ruff passed; legacy `_cli_main.py` critical
+  `E9/F63/F7/F82` selection passed; eleven changed Python files compiled in
+  memory; import-cycle smoke passed; `git diff --check` and WSP_97 receipt
+  validation passed.
+- Live offline/fast raw CLI smoke returned current-repository code and WSP
+  lexical hits with a caller-supplied nonexistent SSD, confirming the lexical
+  metadata path did not require the persistent store.
+- Runtime hygiene: two visible loopback owner processes were created more than
+  four hours before this worktree and had unrelated exited parent PIDs; this
+  lane did not spawn or terminate them and left no attributable service.

--- a/docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_WSP97_EXECUTION_RECEIPT_PHASE1.json
+++ b/docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_WSP97_EXECUTION_RECEIPT_PHASE1.json
@@ -1,0 +1,93 @@
+{
+  "execution_id": "HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1",
+  "execution_plane": "wre_runtime",
+  "outcome": "completed",
+  "action_evidence": {
+    "retrieve_wsps": [
+      "WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md",
+      "WSP_framework/src/WSP_15_Module_Prioritization_Scoring_System.md",
+      "WSP_framework/src/WSP_22_ModLog_Structure.md",
+      "WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md",
+      "WSP_framework/src/WSP_62_Large_File_Refactoring_Enforcement_Protocol.md",
+      "WSP_framework/src/WSP_81_Framework_Backup_Governance_Protocol.md",
+      "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md"
+    ],
+    "retrieve_evidence": [
+      "docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1.md",
+      "modules/infrastructure/foundups_mcp_bridge/src/holo_query_freshness_gate.py",
+      "holo_index/freshness_receipt.py",
+      "modules/communication/moltbot_bridge/src/reddog_holoindex_query_adapter.py"
+    ],
+    "research": [
+      "Traced raw CLI, bundle JSON, owner client, and direct diagnostic backend-construction boundaries.",
+      "Confirmed bundle JSON locally imports HoloIndex and required its own pre-backend admission hook.",
+      "Traced raw-CLI and bundle module-hint, NAVIGATION, WSP metadata, nested module walk, artifact snapshot, and direct maintenance-lock derivation after independent review.",
+      "Second-amend review proved the raw CLI bypassed the confined loader and that capped directory prefixes remained filesystem-order dependent; overflow now fails closed at cap + 1.",
+      "Third-amend review proved an external valid receipt could override a disagreeing canonical SSD receipt, final receipt reparse points were not rejected before reads, bounded module walks returned partial evidence on cap/depth/error, and the bundle handler exceeded WSP 62.",
+      "Compared framework WSP authority with knowledge backups; neither copy was modified."
+    ],
+    "micro_pass": [
+      "Focused tests cover foreign root, wrong SSD, wrong HEAD, missing generation, incomplete baseline, active maintenance, exact admission, canonical receipt disagreement/final-reparse denial, pre-resolution bundle ordering, relative-only path confinement, raw-CLI symlink/reparse/NAVIGATION-byte denial, deterministic cap + 1 overflow before/after a match, complete-or-empty module walks, artifact no-follow checks, direct maintenance fail-closed/race handling, and offline lexical bypass. Code review confirms canonical receipt and maintenance locations derive solely from the SSD.",
+      "holo_index/tests/test_bundle_path_confinement.py",
+      "holo_index/tests/test_bundle_path_completeness.py",
+      "holo_index/tests/test_holoindex_query_admission.py",
+      "holo_index/tests/test_holoindex_readonly_query_guard.py",
+      "modules/communication/moltbot_bridge/tests/test_reddog_holoindex_direct_query_boundary.py",
+      "modules/communication/moltbot_bridge/tests/test_reddog_holoindex_receipt_binding.py"
+    ],
+    "macro_pass": [
+      "Unfiltered changed-file matrix: 62 passed and 5 optional real-symlink tests skipped on the Windows privilege profile; deterministic reparse seams passed.",
+      "Canonical owner service/freshness matrix: 60 passed, including exact root and SSD mismatch cases.",
+      "Wider bundle, freshness receipt, owner-client, and RedDog query matrix: 126 passed and 4 optional real-symlink tests skipped.",
+      "WSP 62 guards: 3 bridge-exemption tests and 16 modular-audit tests passed; admission evaluator is 35 lines, direct diagnostic is 50, focused confinement module is 288 lines with maximum function size 47, and the bundle handler is 49 lines without a broad exemption.",
+      "Wider CLI/index diagnostic: 32 passed and one source-string purity assertion failed identically on unmodified origin/main 545f4b3b8.",
+      "Eleven changed Python files compiled in memory; focused Ruff, critical _cli_main lint, import smoke, diff-check, JSON parsing, and WSP_97 receipt validation passed.",
+      "A live offline/fast raw CLI smoke returned repository-local lexical code/WSP hits while a caller-supplied nonexistent SSD remained outside the lexical metadata path.",
+      "Visible loopback owner processes predated this worktree by more than four hours; this lane did not spawn or terminate them and left no attributable service."
+    ],
+    "hard_think": [
+      "docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1.md#3-failure-modes",
+      "Identified persistent bundle JSON as a separate local-backend bypass.",
+      "Identified caller-controlled module resolution, nested reparse enumeration, artifact link following, and receipt-derived maintenance locks as pre/post-admission bypasses.",
+      "Rejected caller-selected receipt authority: admission derives the canonical receipt solely from the resolved SSD and treats an explicit path only as an exact assertion.",
+      "Rejected a sorted capped prefix because its membership still depends on filesystem iteration order; discovery now rejects the entire result when cap + 1 exists.",
+      "Required complete-or-empty module evidence on cap, depth, scan, or verification failure; only a complete set is sorted.",
+      "Kept post-query maintenance probing in the diagnostic adapter to detect races after preflight."
+    ],
+    "dialectic_sweep": [
+      "docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1.md#4-alternatives",
+      "Rejected caller-local proof duplication, caller-selected receipt authority, CWD inference, query-then-stale behavior, automatic refresh, partial bounded walks, unbounded sorting, and filesystem-order-dependent capped prefixes."
+    ],
+    "first_principles": [
+      "Persistent evidence must be bound to the explicit invoking repository before any backend access.",
+      "Receipt authority follows the admitted SSD; a caller path may assert but cannot redirect that identity.",
+      "A read consumer cannot repair or refresh its own evidence substrate.",
+      "Bounded module evidence is truthful only when the scanner proves the complete eligible set fits inside all caps; overflow or uncertainty yields no evidence.",
+      "Admission reason codes and raw CLI/bundle denial serialization must be content-free; the direct diagnostic preserves its pre-existing caller-local query response field."
+    ],
+    "execute": [
+      "holo_index/query_admission.py",
+      "holo_index/_cli_main.py",
+      "holo_index/cli/bundle_path_confinement.py",
+      "holo_index/cli/commands/bundle_json.py",
+      "modules/communication/moltbot_bridge/src/reddog_holoindex_query_adapter.py"
+    ]
+  },
+  "wsps_applied": [
+    "WSP_00",
+    "WSP_15",
+    "WSP_22",
+    "WSP_50",
+    "WSP_62",
+    "WSP_81",
+    "WSP_97"
+  ],
+  "compliance_evidence": [
+    "Dedicated worktree and branch: fix/holoindex-root-bound-query-p0.",
+    "Rebased onto origin/main 545f4b3b828cf083c20e266961c6df2fde1565c7.",
+    "No framework WSP, knowledge backup, persistent index, or E:/HoloIndex state changed.",
+    "docs/audits/infrastructure/HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1.md",
+    "holo_index/tests/TESTModLog.md",
+    "modules/communication/moltbot_bridge/tests/TestModLog.md"
+  ]
+}

--- a/holo_index/INTERFACE.md
+++ b/holo_index/INTERFACE.md
@@ -193,6 +193,28 @@ python holo_index.py --bundle-json --search "task" --bundle-module-hint modules/
 
 Bundle schema ID: `wsp_memory_bundle_v1`
 
+Persistent `--search` and `--bundle-json` requests are admitted before backend
+construction only when the freshness receipt proves the invoking repository
+root, resolved SSD, clean exact HEAD, generation, complete canonical baseline,
+embedding space, and no active/unprovable maintenance. A denied raw CLI search
+exits with code `4`; JSON bundle denial returns content-free `error`,
+`stale_reasons`, and `index_gap_detected` fields. Offline/fast lexical mode
+does not open or read the persistent store and reports degraded/UNKNOWN
+freshness. Raw CLI and bundle lexical paths share the same root-confined,
+bounded, no-follow loader. Oversize NAVIGATION is rejected. WSP metadata is
+repository-local and the supplied SSD is not a lexical metadata source.
+Persistent admission reads only the canonical
+`freshness_receipt_path(ssd)`. An explicit receipt argument must resolve to
+that exact stable-ancestor identity, and a final symlink/reparse point is
+rejected before receipt or backend access.
+Module hints accept only repository-relative components. Traversal, absolute
+paths, links, and reparse points are rejected; nested enumeration has fixed
+entry/depth bounds. Module-domain and WSP discovery fail closed on `cap + 1`
+rather than selecting a partial directory prefix. Nested module-file
+enumeration is complete-or-empty: entry overflow, depth overflow, or a scan
+error returns no module-file evidence, and a complete set is sorted before
+selection.
+
 ### Monitoring / Orchestration
 ```bash
 python holo_index.py --start-holodae

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,36 @@
 # HoloIndex Package ModLog
 
+## [2026-07-24] HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1
+
+- Added a reusable content-free read-only admission decision that reuses the
+  canonical freshness/maintenance proof and requires the invoking repository
+  root, SSD, clean exact HEAD, generation, complete baseline, and embedding
+  binding before persistent backend construction.
+- Applied the gate to raw CLI search and persistent bundle retrieval. Offline
+  lexical retrieval bypasses Chroma and shared SSD summaries, derives bounded
+  WSP metadata from the invoking repository, and is labeled degraded/UNKNOWN.
+- Added fail-before-backend regressions for foreign roots, wrong HEAD/SSD,
+  missing generation/baseline proof, active maintenance, exact admission, and
+  persistent bundle denial. A foreign-SSD regression proves cached WSP paths
+  cannot contaminate offline bundle results.
+- Persistent bundle admission now precedes module-hint resolution. A focused
+  confinement helper rejects absolute/traversal/link/reparse escapes, bounds
+  nested walks, and applies the same no-follow policy to artifact checks.
+- Raw offline/fast CLI retrieval now reuses the bundle lexical loader rather
+  than opening `NAVIGATION.py` directly. NAVIGATION is rejected when it
+  exceeds its explicit byte cap; link/reparse components remain fail-closed.
+- Module-domain and WSP discovery inspect no more than `cap + 1` entries,
+  reject an oversized directory instead of returning a filesystem-order
+  dependent partial set, and sort only a proven-complete bounded set.
+- Canonical receipt admission now derives exclusively from the resolved SSD.
+  A noncanonical explicit override or final receipt link/reparse is rejected
+  before receipt loading; direct diagnostics pass only the SSD-derived receipt
+  onward.
+- Nested module-file discovery now returns complete sorted evidence or nothing:
+  cap overflow, depth overflow, and any scan/verification error fail empty.
+- Decomposed bundle request admission, retrieval, direct-read application, and
+  response emission; `handle_bundle_json` is now 49 lines without exemption.
+
 ## [2026-07-20] HOLOINDEX_REDDOG_REPO_AUDIT_GROUNDING_FALLBACK_PHASE1
 
 - Added read-only `repo_audit_grounding.v1` generation after the existing bundle retrieval path. Generation-bound semantic ownership is unchanged; the structured bundle supplies only bounded candidate/direct-read evidence.

--- a/holo_index/README.md
+++ b/holo_index/README.md
@@ -120,6 +120,27 @@ generation-unbound SearchCache, and requires restart rather than crossing
 generations. Owner strict-semantic mode rejects collection/model/encode/query
 failure instead of presenting lexical or exact-symbol fallback as semantic.
 
+Raw persistent `--search` and persistent `--bundle-json` reads use the same
+fail-closed admission proof before constructing a backend. The invoking
+repository root and SSD must match the current receipt; the clean HEAD,
+generation, complete canonical baseline, embedding space, and inactive
+maintenance state must also be proven. Denials expose stable, content-free
+reason codes. Admission derives the receipt only from the resolved SSD; an
+explicit override must canonicalize to that exact path and have no final
+link/reparse component or it fails before reading. `--offline` /
+`--fast-search` bypasses the persistent store and
+is explicitly labeled degraded current-repository lexical retrieval. Raw CLI
+and bundle lexical modes share the same root-confined loader. NAVIGATION is
+rejected if it exceeds its byte cap. WSP metadata is built with bounded reads
+from the invoking repository's authoritative `WSP_framework/src`; the lexical
+path never reads an SSD summary. Module hints are relative-only. Absolute,
+traversal, symlink, and Windows reparse escapes fail closed. Nested module
+enumeration is no-follow and capped; module-domain and WSP discovery inspect
+at most `cap + 1` entries and reject oversized directories instead of using a
+partial filesystem-order-dependent result. Module file discovery applies the
+same complete-or-empty rule to global entry overflow, depth overflow, and scan
+errors, and sorts only a complete verified result.
+
 Maintenance is owned by the trusted host. Startup may route a maintenance
 request through governed WRE dispatch, but neither WRE routing nor the query
 adapter grants a worker direct index-write authority. Use --index or

--- a/holo_index/ROADMAP.md
+++ b/holo_index/ROADMAP.md
@@ -1,5 +1,31 @@
 # HoloIndex Development Roadmap
 
+## [2026-07-24] Root-Bound Read Admission P0
+
+**Complete in this slice:** raw persistent CLI search, persistent bundle
+retrieval, and RedDog direct diagnostics share one fail-closed pre-backend
+admission proof for exact repository root, SSD, clean HEAD, generation,
+complete baseline/embedding evidence, and maintenance state. Offline lexical
+retrieval remains available only as explicitly degraded current-repository
+evidence.
+
+**Deferred P1:** introduce explicit multi-repository store namespaces and
+receipt metadata migration; consolidate maintenance ownership policy across
+legacy direct-store consumers. No index refresh or store migration belongs to
+this read-gate slice. Add descriptor-relative/final-handle path identity where
+hostile concurrent path replacement must be excluded; P0's bounded lstat-based
+no-follow checks do not claim to close that TOCTOU window.
+
+### P1: Neutral Freshness-Gate Contract Extraction / Dependency Inversion
+
+Extract the freshness/admission proof contract into a neutral HoloIndex-owned
+or shared infrastructure package, then invert both the owner service and raw
+clients onto that contract. Remove the current lower-level
+`holo_index.query_admission` dependency on the infrastructure-owned
+`HoloQueryFreshnessGate` without cloning proof semantics or changing reason
+codes. Require import-cycle, exact-receipt-parity, and owner/raw/direct
+cross-surface tests before retiring the P0 dependency direction.
+
 ## [2026-07-18] Operational Truth Boundary and WSP_62 Remediation
 
 **Current P0:** Land the canonical storage, exact-HEAD maintenance, complete

--- a/holo_index/_cli_main.py
+++ b/holo_index/_cli_main.py
@@ -60,6 +60,7 @@ from holo_index.storage_contract import (
     READONLY_QUERY_ENV,
     resolve_holoindex_ssd_path,
 )
+from holo_index.query_admission import evaluate_readonly_query_admission  # noqa: E402
 # WSP 97: Lazy import codeindex_reporter (4s+ startup cost) - only needed for --code-index-report
 CodeIndexReporter = None  # Lazy loaded
 resolve_module_paths = None  # Lazy loaded
@@ -127,6 +128,7 @@ def _env_truthy(name: str, default: str = "false") -> bool:
 
 READONLY_GUARD_CODE = "HOLOINDEX_READONLY_QUERY_GUARD"
 STORAGE_ERROR_EXIT_CODE = 3
+QUERY_ADMISSION_EXIT_CODE = 4
 
 
 def _query_only_requested(args) -> bool:
@@ -170,6 +172,11 @@ def _exit_storage_error(exc: HoloIndexStorageError) -> None:
 def _exit_maintenance_error(exc: MaintenanceSessionError) -> None:
     safe_print(json.dumps(exc.to_dict(), sort_keys=True))
     raise SystemExit(MAINTENANCE_FAILURE_EXIT_CODE)
+
+
+def _exit_query_admission_error(result: Any) -> None:
+    safe_print(json.dumps(result.to_dict(), sort_keys=True))
+    raise SystemExit(QUERY_ADMISSION_EXIT_CODE)
 
 # 0102 speed knob: allow bundle-json/offline/fast-search fastpath without importing Chroma/model stack.
 _skip_heavy_imports = (
@@ -1083,6 +1090,13 @@ def main():
                 "Run DocDAE changes, commit them, then refresh HoloIndex.",
             )
         )
+    if HoloIndex is not None and args.search and not maintenance_plan:
+        admission = evaluate_readonly_query_admission(
+            repo_root=project_root,
+            ssd_path=Path(args.ssd),
+        )
+        if not admission.allowed:
+            _exit_query_admission_error(admission)
     maintenance_session = None
     if maintenance_plan:
         try:
@@ -1101,7 +1115,10 @@ def main():
             _exit_maintenance_error(
                 MaintenanceSessionError("HOLOINDEX_MAINTENANCE_BACKEND_UNAVAILABLE")
             )
-        safe_print("[INFO] HoloIndex unavailable (offline/fast mode) - using lexical search only")
+        safe_print(
+            "[DEGRADED] Persistent HoloIndex unavailable (offline/fast mode); "
+            "using current-repository lexical search only."
+        )
         holo = None
     else:
         try:
@@ -1556,67 +1573,18 @@ def main():
             if holo is None:
                 # WSP 97: Fallback to lexical search when HoloIndex unavailable
                 safe_print(f"[OFFLINE] Running lexical search for: {args.search}")
-                import re as _re
-                from datetime import datetime as _dt
                 from pathlib import Path as _Path
+                from holo_index.cli.commands.bundle_json import (
+                    _lexical_task_retrieval,
+                )
 
                 repo_root = _Path(__file__).resolve().parents[1]
-
-                # Reuse the lexical search logic from bundle-json path
-                def _tokenize(query: str):
-                    return [t for t in _re.findall(r"[a-z0-9_]+", (query or "").lower()) if t]
-
-                def _score_text(tokens, *fields):
-                    score = 0.0
-                    for tok in tokens:
-                        for idx, field in enumerate(fields):
-                            if tok in (field or "").lower():
-                                score += (2.0 if idx == 0 else 1.0)
-                    return score
-
-                # Load NAVIGATION.py NEED_TO
-                import ast
-                nav_path = repo_root / "NAVIGATION.py"
-                need_to = {}
-                if nav_path.exists():
-                    try:
-                        tree = ast.parse(nav_path.read_text(encoding="utf-8-sig", errors="ignore"))
-                        for node in ast.walk(tree):
-                            if isinstance(node, ast.Assign):
-                                for target in node.targets:
-                                    if isinstance(target, ast.Name) and target.id == "NEED_TO":
-                                        need_to = ast.literal_eval(node.value)
-                    except Exception:
-                        pass
-
-                tokens = _tokenize(args.search)
-                code_hits = []
-                for need, location in need_to.items():
-                    score = _score_text(tokens, need, location)
-                    if score > 0:
-                        similarity = min(1.0, score / max(1.0, len(tokens) * 3.0))
-                        code_hits.append({
-                            "need": need,
-                            "location": location,
-                            "similarity": f"{similarity*100:.1f}%",
-                            "type": "code",
-                            "priority": 1,
-                        })
-                code_hits.sort(key=lambda x: float(x["similarity"].rstrip("%")), reverse=True)
-                code_hits = code_hits[:args.limit]
-
-                search_payload = {
-                    "code_hits": code_hits,
-                    "wsp_hits": [],
-                    "code": code_hits,
-                    "wsps": [],
-                    "metadata": {
-                        "query": args.search,
-                        "mode": "lexical_offline",
-                        "code_count": len(code_hits),
-                        "wsp_count": 0,
-                    }
-                }
+                search_payload = _lexical_task_retrieval(
+                    repo_root,
+                    args.search,
+                    int(args.limit),
+                    "",
+                )
                 # WSP 97: Offline mode returns results immediately without heavy post-processing
                 _render_fast_search_summary(search_payload, limit=args.limit)
                 return

--- a/holo_index/cli/bundle_path_confinement.py
+++ b/holo_index/cli/bundle_path_confinement.py
@@ -1,0 +1,288 @@
+"""Bounded, repository-confined filesystem helpers for bundle retrieval."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+LEXICAL_MODULE_DOMAIN_MAX_ENTRIES = 64
+LEXICAL_MODULE_MAX_ENTRIES = 2048
+LEXICAL_MODULE_MAX_DEPTH = 8
+LEXICAL_NAVIGATION_MAX_BYTES = 262144
+WINDOWS_REPARSE_POINT = 0x400
+
+
+def _safe_relative_parts(value: str) -> tuple[str, ...] | None:
+    normalized = str(value or "").replace("\\", "/")
+    posix = PurePosixPath(normalized)
+    windows = PureWindowsPath(normalized)
+    if (
+        not normalized
+        or posix.is_absolute()
+        or windows.is_absolute()
+        or windows.drive
+    ):
+        return None
+    parts = tuple(posix.parts)
+    if not parts or any(part in {"", ".", ".."} for part in parts):
+        return None
+    return parts
+
+
+def _is_link_or_reparse(path: Path) -> bool:
+    try:
+        metadata = os.lstat(path)
+    except OSError:
+        return True
+    attributes = int(getattr(metadata, "st_file_attributes", 0) or 0)
+    return path.is_symlink() or bool(attributes & WINDOWS_REPARSE_POINT)
+
+
+def _confined_repo_path(
+    repo_root: Path | str,
+    relative_path: str,
+    *,
+    directory: bool,
+) -> Path | None:
+    parts = _safe_relative_parts(relative_path)
+    root = Path(repo_root)
+    if parts is None or not root.is_absolute() or _is_link_or_reparse(root):
+        return None
+    try:
+        resolved_root = root.resolve(strict=True)
+    except OSError:
+        return None
+    if not resolved_root.is_dir():
+        return None
+    candidate = resolved_root
+    for part in parts:
+        candidate = candidate / part
+        if _is_link_or_reparse(candidate):
+            return None
+    try:
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(resolved_root)
+    except (OSError, ValueError):
+        return None
+    if directory and not resolved.is_dir():
+        return None
+    if not directory and not resolved.is_file():
+        return None
+    return resolved
+
+
+def _bounded_directory_names(
+    repo_root: Path | str,
+    relative_dir: str,
+    *,
+    entry_cap: int,
+    prefix: str = "",
+    suffix: str = "",
+    directories: bool,
+) -> tuple[str, ...]:
+    """Return sorted names from a bounded, no-follow directory scan."""
+    root = Path(os.path.abspath(repo_root))
+    directory = _confined_repo_path(root, relative_dir, directory=True)
+    if directory is None or entry_cap <= 0:
+        return ()
+    names: list[str] = []
+    try:
+        with os.scandir(directory) as entries:
+            for inspected, entry in enumerate(entries):
+                if inspected >= entry_cap:
+                    return ()
+                path = Path(entry.path)
+                if _is_link_or_reparse(path):
+                    continue
+                expected_kind = (
+                    entry.is_dir(follow_symlinks=False)
+                    if directories
+                    else entry.is_file(follow_symlinks=False)
+                )
+                if not expected_kind:
+                    continue
+                if prefix and not entry.name.startswith(prefix):
+                    continue
+                if suffix and not entry.name.endswith(suffix):
+                    continue
+                names.append(entry.name)
+    except OSError:
+        return ()
+    return tuple(sorted(names, key=lambda name: (name.casefold(), name)))
+
+
+def _read_confined_bytes(
+    repo_root: Path | str,
+    relative_path: str,
+    *,
+    max_bytes: int,
+    reject_oversize: bool,
+) -> bytes | None:
+    """Read one bounded regular file after repository/no-follow validation."""
+    path = _confined_repo_path(repo_root, relative_path, directory=False)
+    if path is None or max_bytes < 0:
+        return None
+    try:
+        if reject_oversize:
+            metadata = os.stat(path, follow_symlinks=False)
+            if metadata.st_size > max_bytes:
+                return None
+        with path.open("rb") as handle:
+            raw = handle.read(max_bytes + 1 if reject_oversize else max_bytes)
+    except (OSError, ValueError):
+        return None
+    if reject_oversize and len(raw) > max_bytes:
+        return None
+    return raw[:max_bytes]
+
+
+def _read_confined_text(
+    repo_root: Path | str,
+    relative_path: str,
+    *,
+    max_bytes: int,
+    reject_oversize: bool,
+) -> str | None:
+    """Decode a bounded repository-confined file without following links."""
+    raw = _read_confined_bytes(
+        repo_root,
+        relative_path,
+        max_bytes=max_bytes,
+        reject_oversize=reject_oversize,
+    )
+    if raw is None:
+        return None
+    return raw.decode("utf-8-sig", errors="ignore")
+
+
+def _resolve_module_dir(repo_root: Path | str, hint: str) -> Path | None:
+    """Resolve one repository-relative module hint without following links."""
+    raw = (hint or "").strip()
+    parts = _safe_relative_parts(raw)
+    if parts is None:
+        return None
+    norm = "/".join(parts)
+    direct = _confined_repo_path(repo_root, norm, directory=True)
+    if direct is not None:
+        return direct
+    if "/" in norm and not norm.startswith("modules/"):
+        prefixed = _confined_repo_path(
+            repo_root, f"modules/{norm}", directory=True
+        )
+        if prefixed is not None:
+            return prefixed
+    modules_root = _confined_repo_path(repo_root, "modules", directory=True)
+    if modules_root is None:
+        return None
+    domains = _bounded_directory_names(
+        repo_root,
+        "modules",
+        entry_cap=LEXICAL_MODULE_DOMAIN_MAX_ENTRIES,
+        directories=True,
+    )
+    for domain_name in domains:
+        candidate = _confined_repo_path(
+            repo_root,
+            f"modules/{domain_name}/{norm}",
+            directory=True,
+        )
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _sorted_module_paths(files: list[Path], root: Path) -> tuple[Path, ...]:
+    def relative_key(path: Path) -> tuple[str, str]:
+        relative = path.relative_to(root).as_posix()
+        return relative.casefold(), relative
+
+    return tuple(sorted(files, key=relative_key))
+
+
+def _bounded_module_files(
+    repo_root: Path | str,
+    module_dir: Path | str,
+) -> tuple[Path, ...]:
+    """Enumerate a confined module without following links or reparse points."""
+    root = Path(os.path.abspath(repo_root))
+    module = Path(os.path.abspath(module_dir))
+    try:
+        relative_module = module.relative_to(root).as_posix()
+    except ValueError:
+        return ()
+    confined = _confined_repo_path(root, relative_module, directory=True)
+    if confined is None:
+        return ()
+    files: list[Path] = []
+    stack: list[tuple[Path, int]] = [(confined, 0)]
+    inspected = 0
+    while stack:
+        current, depth = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    inspected += 1
+                    if inspected > LEXICAL_MODULE_MAX_ENTRIES:
+                        return ()
+                    path = Path(entry.path)
+                    if _is_link_or_reparse(path):
+                        continue
+                    is_dir = entry.is_dir(follow_symlinks=False)
+                    is_file = entry.is_file(follow_symlinks=False)
+                    if not is_dir and not is_file:
+                        continue
+                    relative = path.relative_to(root).as_posix()
+                    verified = _confined_repo_path(
+                        root, relative, directory=is_dir
+                    )
+                    if verified is None:
+                        return ()
+                    if is_dir:
+                        if depth >= LEXICAL_MODULE_MAX_DEPTH:
+                            return ()
+                        stack.append((verified, depth + 1))
+                    else:
+                        files.append(verified)
+        except (OSError, ValueError):
+            return ()
+    return _sorted_module_paths(files, root)
+
+
+def _artifact_exists(
+    repo_root: Path | str,
+    module_dir: Path | str,
+    name: str,
+    *,
+    directory: bool,
+) -> bool:
+    root = Path(os.path.abspath(repo_root))
+    module = Path(os.path.abspath(module_dir))
+    try:
+        module_relative = module.relative_to(root)
+    except ValueError:
+        return False
+    artifact_relative = module_relative / name.rstrip("/")
+    return (
+        _confined_repo_path(
+            root,
+            artifact_relative.as_posix(),
+            directory=directory,
+        )
+        is not None
+    )
+
+
+__all__ = [
+    "LEXICAL_MODULE_DOMAIN_MAX_ENTRIES",
+    "LEXICAL_MODULE_MAX_DEPTH",
+    "LEXICAL_MODULE_MAX_ENTRIES",
+    "LEXICAL_NAVIGATION_MAX_BYTES",
+    "_artifact_exists",
+    "_bounded_directory_names",
+    "_bounded_module_files",
+    "_confined_repo_path",
+    "_is_link_or_reparse",
+    "_read_confined_bytes",
+    "_read_confined_text",
+    "_resolve_module_dir",
+]

--- a/holo_index/cli/commands/bundle_json.py
+++ b/holo_index/cli/commands/bundle_json.py
@@ -6,16 +6,45 @@ Extracted from holo_index/cli.py (lines 634-960).
 Self-contained lexical search + artifact snapshot + JSON bundle output.
 """
 
+import json as _json
 import os
 import re
 import sys
 import logging
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, List, Any, Optional, Tuple
+
+from holo_index.cli.bundle_path_confinement import (
+    LEXICAL_NAVIGATION_MAX_BYTES,
+    _artifact_exists,
+    _bounded_directory_names,
+    _bounded_module_files,
+    _confined_repo_path,
+    _read_confined_text,
+    _resolve_module_dir,
+)
+from holo_index.query_admission import evaluate_readonly_query_admission
 
 
 def _env_truthy(key: str, default: str = "false") -> bool:
     """Check if environment variable is truthy."""
     return os.getenv(key, default).lower() in {"1", "true", "yes", "on"}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _persistent_query_denial(repo_root, ssd_path):
+    """Return a content-free denial before bundle backend construction."""
+    admission = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+    )
+    if admission.allowed:
+        return None
+    return admission.to_dict()
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +79,9 @@ DIRECT_READ_SYMBOL_LEAD_LINES = 6        # context lines kept BEFORE the def lin
 # Cap symbol targets per file so a caller naming MANY (plausible-but-absent) symbols of ONE file
 # cannot consume all target slots (DIRECT_READ_MAX_TARGETS) and starve other required targets.
 DIRECT_READ_MAX_SYMBOLS_PER_PATH = 8
+LEXICAL_WSP_MAX_ENTRIES = 512
+LEXICAL_WSP_MAX_FILES = 256
+LEXICAL_WSP_READ_BYTES = 16384
 # A valid symbol is a bounded identifier. Rejecting anything else keeps the symbol an opaque, safe
 # search key (no regex-injection, no path traversal via the '#' suffix).
 _SYMBOL_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
@@ -448,44 +480,7 @@ def _direct_read_fetch(repo_root, requested_paths, seen_locations=None):
     return {"telemetry": telemetry, "hits": hits}
 
 
-def _resolve_module_dir(repo_root, hint: str):
-    """Resolve a module hint to an actual directory path."""
-    from pathlib import Path as _Path
-
-    raw = (hint or "").strip()
-    if not raw:
-        return None
-
-    norm = raw.replace("\\", "/").strip("/")
-
-    # Allow direct relative paths (modules/... or holo_index/...)
-    direct = repo_root / norm
-    if direct.exists() and direct.is_dir():
-        return direct
-
-    # Allow shorthand "communication/livechat" by prefixing "modules/"
-    if "/" in norm and not norm.startswith("modules/"):
-        prefixed = repo_root / "modules" / norm
-        if prefixed.exists() and prefixed.is_dir():
-            return prefixed
-
-    # Allow module name-only resolution under modules/<domain>/<module>
-    modules_root = repo_root / "modules"
-    if modules_root.exists():
-        try:
-            for domain_dir in modules_root.iterdir():
-                if not domain_dir.is_dir():
-                    continue
-                candidate = domain_dir / norm
-                if candidate.exists() and candidate.is_dir():
-                    return candidate
-        except Exception:
-            return None
-
-    return None
-
-
-def _artifact_snapshot(module_dir) -> Dict[str, Any]:
+def _artifact_snapshot(repo_root, module_dir) -> Dict[str, Any]:
     """Generate artifact snapshot for a module directory."""
     # Tier definitions mirror WSP_CORE "Tiered Holo Retrieval Targets" (minimal v1)
     tiers: Dict[str, Dict[str, Any]] = {
@@ -510,18 +505,14 @@ def _artifact_snapshot(module_dir) -> Dict[str, Any]:
     missing_required: List[str] = []
     missing_optional: List[str] = []
 
-    def _exists(p, is_dir: bool) -> bool:
-        try:
-            return p.is_dir() if is_dir else p.exists()
-        except Exception:
-            return False
-
     for tier_key, tier_def in tiers.items():
         tier_num = int(tier_key)
         for name in tier_def["required"]:
             is_dir = name.endswith("/")
             p = module_dir / name.rstrip("/")
-            exists = _exists(p, is_dir=is_dir)
+            exists = _artifact_exists(
+                repo_root, module_dir, name, directory=is_dir
+            )
             rel = str(p.relative_to(module_dir)).replace("\\", "/")
             artifacts.append({
                 "tier": tier_num,
@@ -537,7 +528,9 @@ def _artifact_snapshot(module_dir) -> Dict[str, Any]:
         for name in tier_def["optional"]:
             is_dir = name.endswith("/")
             p = module_dir / name.rstrip("/")
-            exists = _exists(p, is_dir=is_dir)
+            exists = _artifact_exists(
+                repo_root, module_dir, name, directory=is_dir
+            )
             rel = str(p.relative_to(module_dir)).replace("\\", "/")
             artifacts.append({
                 "tier": tier_num,
@@ -580,11 +573,16 @@ def _score_text(tokens: List[str], *fields: str) -> float:
 
 def _load_need_to(repo_root) -> Dict[str, str]:
     import ast as _ast
-    nav_path = repo_root / "NAVIGATION.py"
-    if not nav_path.exists():
+    text = _read_confined_text(
+        repo_root,
+        "NAVIGATION.py",
+        max_bytes=LEXICAL_NAVIGATION_MAX_BYTES,
+        reject_oversize=True,
+    )
+    if text is None:
         return {}
     try:
-        tree = _ast.parse(nav_path.read_text(encoding="utf-8-sig", errors="ignore"))
+        tree = _ast.parse(text)
     except Exception:
         return {}
     for node in _ast.walk(tree):
@@ -598,25 +596,54 @@ def _load_need_to(repo_root) -> Dict[str, str]:
     return {}
 
 
-def _load_wsp_summary(ssd_path: str) -> Dict[str, Dict[str, str]]:
-    import json as _json
-    from pathlib import Path as _Path
-    try:
-        summary_path = _Path(ssd_path) / "indexes" / "wsp_summary.json"
-        if not summary_path.exists():
-            return {}
-        return _json.loads(summary_path.read_text(encoding="utf-8", errors="ignore"))
-    except Exception:
-        return {}
+def _load_repo_wsp_summary(repo_root) -> Dict[str, Dict[str, str]]:
+    """Build bounded lexical WSP metadata from the invoking repository only."""
+    summary: Dict[str, Dict[str, str]] = {}
+    repo_root = Path(repo_root)
+    wsp_root = _confined_repo_path(
+        repo_root, "WSP_framework/src", directory=True
+    )
+    if wsp_root is None:
+        return summary
+    repo_root = wsp_root.parents[1]
+    candidates = _bounded_directory_names(
+        repo_root,
+        "WSP_framework/src",
+        entry_cap=LEXICAL_WSP_MAX_ENTRIES,
+        prefix="WSP_",
+        suffix=".md",
+        directories=False,
+    )[:LEXICAL_WSP_MAX_FILES]
+    for name in candidates:
+        relative = f"WSP_framework/src/{name}"
+        text = _read_confined_text(
+            repo_root,
+            relative,
+            max_bytes=LEXICAL_WSP_READ_BYTES,
+            reject_oversize=False,
+        )
+        if text is None:
+            continue
+        match = re.match(r"^WSP_(\d+)", name, flags=re.IGNORECASE)
+        if not match:
+            continue
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        title = lines[0].lstrip("# ").strip() if lines else Path(name).stem
+        detail = next((line for line in lines[1:] if not line.startswith("#")), "")
+        summary[f"WSP {int(match.group(1))}"] = {
+            "title": title,
+            "summary": detail[:500],
+            "path": relative,
+        }
+    return summary
 
 
-def _lexical_task_retrieval(repo_root, task: str, limit: int, ssd_path: str, module_dir=None) -> Dict[str, Any]:
+def _lexical_task_retrieval(repo_root, task: str, limit: int, _ssd_path: str, module_dir=None) -> Dict[str, Any]:
     """Lexical search fallback when embeddings are unavailable."""
-    from datetime import datetime as _dt
 
     tokens = _tokenize(task)
     need_to = _load_need_to(repo_root)
-    wsp_summary = _load_wsp_summary(ssd_path)
+    wsp_summary = _load_repo_wsp_summary(repo_root)
 
     code_hits: List[Dict[str, Any]] = []
     for need, location in list(need_to.items()):
@@ -640,11 +667,9 @@ def _lexical_task_retrieval(repo_root, task: str, limit: int, ssd_path: str, mod
         })
 
     # Path-based fallback when module hint is provided (fast lexical, no embeddings)
-    if module_dir is not None and module_dir.exists():
+    if module_dir is not None:
         allowed_ext = {".py", ".js", ".md", ".txt", ".json", ".yaml", ".yml"}
-        for path in module_dir.rglob("*"):
-            if not path.is_file():
-                continue
+        for path in _bounded_module_files(repo_root, module_dir):
             if path.suffix.lower() not in allowed_ext:
                 continue
             rel_path = str(path.relative_to(repo_root)).replace("\\", "/")
@@ -713,12 +738,17 @@ def _lexical_task_retrieval(repo_root, task: str, limit: int, ssd_path: str, mod
         "metadata": {
             "query": task,
             "mode": "lexical",
+            "retrieval_mode": "lexical",
+            "freshness": "UNKNOWN",
+            "index_gap_detected": True,
+            "no_holoindex_store_access": True,
+            "wsp_source": "current_repository",
             "skip_model": True,
             "code_count": len(code_hits),
             "wsp_count": len(wsp_hits),
             "test_count": 0,
             "skill_count": 0,
-            "timestamp": _dt.utcnow().isoformat() + "Z",
+            "timestamp": _utc_now_iso(),
         }
     }
 
@@ -754,113 +784,156 @@ def _apply_repo_audit_grounding(repo_root, task, search_payload):
     return audit["receipt"], audit["telemetry"]
 
 
-def handle_bundle_json(args):
-    """Handle --bundle-json command. Returns True if handled, False otherwise."""
-    if not getattr(args, "bundle_json", False):
-        return False
+def _write_bundle_payload(payload: Dict[str, Any], *, sort_keys=False) -> None:
+    sys.stdout.write(
+        _json.dumps(
+            payload,
+            ensure_ascii=True,
+            sort_keys=sort_keys,
+        )
+        + "\n"
+    )
 
-    import json as _json
-    from datetime import datetime as _dt
-    from pathlib import Path as _Path
 
-    # Hard silence: bundle-json requires stdout = JSON only
+def _activate_bundle_silence() -> None:
     os.environ.setdefault("HOLO_SILENT", "1")
     try:
         logging.disable(logging.CRITICAL)
     except Exception:
         pass
 
-    repo_root = _Path(__file__).resolve().parents[3]
-    task = (getattr(args, "bundle_task", None) or getattr(args, "search", None) or "").strip()
-    module_hint = (getattr(args, "bundle_module_hint", None) or "").strip()
 
-    if not task:
-        sys.stdout.write(_json.dumps({
-            "schema_version": "wsp_memory_bundle_v1",
-            "generated_at": _dt.utcnow().isoformat() + "Z",
-            "ok": False,
-            "error": "bundle-json requires --search or --bundle-task",
-        }, ensure_ascii=True) + "\n")
-        return True
-
-    module_dir = _resolve_module_dir(repo_root, module_hint) if module_hint else None
+def _bundle_module_context(repo_root: Path, module_hint: str):
+    module_dir = (
+        _resolve_module_dir(repo_root, module_hint) if module_hint else None
+    )
     module_path = None
     if module_dir is not None:
         try:
-            module_path = str(module_dir.relative_to(repo_root)).replace("\\", "/")
-        except Exception:
-            module_path = str(module_dir).replace("\\", "/")
+            module_path = module_dir.relative_to(repo_root).as_posix()
+        except ValueError:
+            module_dir = None
+    return module_dir, module_path
 
-    # Task retrieval: fast lexical path when HOLO_SKIP_MODEL=1, otherwise full HoloIndex search.
-    skip_model = _env_truthy("HOLO_SKIP_MODEL", "false")
+
+def _bundle_search(
+    args,
+    repo_root: Path,
+    task: str,
+    module_hint: str,
+    module_dir,
+    module_path,
+    *,
+    skip_model: bool,
+):
     if skip_model:
-        search_payload = _lexical_task_retrieval(repo_root, task, int(args.limit), str(args.ssd), module_dir=module_dir)
-    else:
-        try:
-            from holo_index.core import HoloIndex as _HoloIndex  # local import to avoid heavy imports in fastpath
-            holo = _HoloIndex(ssd_path=args.ssd, quiet=True)
-            search_payload = holo.search(task, limit=args.limit, doc_type_filter=getattr(args, "doc_type", "all"))
-        except Exception as exc:
-            sys.stdout.write(_json.dumps({
-                "schema_version": "wsp_memory_bundle_v1",
-                "generated_at": _dt.utcnow().isoformat() + "Z",
-                "ok": False,
-                "task": task,
-                "module_hint": module_hint,
-                "module_path": module_path,
-                "error": f"holo_search_failed: {exc}",
-            }, ensure_ascii=True) + "\n")
-            return True
+        return _lexical_task_retrieval(
+            repo_root,
+            task,
+            int(args.limit),
+            str(args.ssd),
+            module_dir=module_dir,
+        ), None
+    try:
+        from holo_index.core import HoloIndex as _HoloIndex
 
-    structured_memory = None
-    if module_dir is not None:
-        structured_memory = _artifact_snapshot(module_dir)
+        holo = _HoloIndex(ssd_path=args.ssd, quiet=True)
+        return holo.search(
+            task,
+            limit=args.limit,
+            doc_type_filter=getattr(args, "doc_type", "all"),
+        ), None
+    except Exception as exc:
+        return None, {
+            "schema_version": "wsp_memory_bundle_v1",
+            "generated_at": _utc_now_iso(),
+            "ok": False,
+            "task": task,
+            "module_hint": module_hint,
+            "module_path": module_path,
+            "error": f"holo_search_failed: {exc}",
+        }
 
-    # HoloIndex evidence is evaluated first.  Audit prompts with insufficient
-    # source + independent evidence receive a fixed-policy, read-only fallback.
-    repo_audit_grounding, direct_read = _apply_repo_audit_grounding(repo_root, task, search_payload)
 
-    # REDDOG_DIRECT_READ_FALLBACK_BY_PATH_PHASE1 (slice 2/3): governed direct-read.
-    # When the extension names must-include target paths (from an explicit
-    # "Required direct-read targets" prompt list) that the semantic bundle did
-    # not surface, fetch those exact files here under the hard security allowlist
-    # and splice them into code_hits so slice-1's recall check sees real content.
-    must_include_raw = getattr(args, "bundle_must_include", None)
-    must_include: List[str] = []
-    if must_include_raw:
-        if isinstance(must_include_raw, (list, tuple)):
-            for item in must_include_raw:
-                must_include.extend([p for p in str(item).split(",") if p.strip()])
-        else:
-            must_include.extend([p for p in str(must_include_raw).split(",") if p.strip()])
+def _bundle_must_include(raw) -> List[str]:
+    if not raw:
+        return []
+    items = raw if isinstance(raw, (list, tuple)) else (raw,)
+    return [
+        path
+        for item in items
+        for path in str(item).split(",")
+        if path.strip()
+    ]
 
-    if must_include:
+
+def _apply_bundle_direct_read(
+    repo_root: Path,
+    search_payload: Dict[str, Any],
+    direct_read,
+    must_include_raw,
+):
+    must_include = _bundle_must_include(must_include_raw)
+    if not must_include:
+        return direct_read
+    try:
+        existing_locations = {
+            str(hit.get("location") or "").replace("\\", "/").lower()
+            for hit in (search_payload.get("code_hits") or [])
+            if str(hit.get("location") or "")
+        }
+    except Exception:
         existing_locations = set()
+    fetched = _direct_read_fetch(
+        repo_root,
+        must_include,
+        seen_locations=existing_locations,
+    )
+    direct_read = _merge_direct_read_telemetry(
+        direct_read,
+        fetched["telemetry"],
+    )
+    if fetched["hits"]:
         try:
-            for hit in (search_payload.get("code_hits") or []):
-                loc = str(hit.get("location") or "").replace("\\", "/").lower()
-                if loc:
-                    existing_locations.add(loc)
+            hits = fetched["hits"] + list(search_payload.get("code_hits") or [])
+            search_payload["code_hits"] = hits
+            search_payload["code"] = hits
+            metadata = search_payload.get("metadata")
+            if isinstance(metadata, dict):
+                metadata["code_count"] = len(hits)
+                metadata["direct_read_fallback_used"] = direct_read[
+                    "direct_read_fallback_used"
+                ]
         except Exception:
-            existing_locations = set()
-        fetched = _direct_read_fetch(repo_root, must_include, seen_locations=existing_locations)
-        direct_read = _merge_direct_read_telemetry(direct_read, fetched["telemetry"])
-        if fetched["hits"]:
-            try:
-                # Prepend direct-read hits (highest priority) so recall + display
-                # both see the fetched content-bearing locations first.
-                search_payload["code_hits"] = fetched["hits"] + list(search_payload.get("code_hits") or [])
-                search_payload["code"] = search_payload["code_hits"]
-                meta = search_payload.get("metadata")
-                if isinstance(meta, dict):
-                    meta["code_count"] = len(search_payload["code_hits"])
-                    meta["direct_read_fallback_used"] = direct_read["direct_read_fallback_used"]
-            except Exception:
-                pass
+            pass
+    return direct_read
 
-    bundle = {
+
+def _bundle_persistent_denial(args, repo_root: Path, skip_model: bool):
+    if skip_model:
+        return None
+    denial = _persistent_query_denial(repo_root, Path(args.ssd))
+    if denial is None:
+        return None
+    return {
         "schema_version": "wsp_memory_bundle_v1",
-        "generated_at": _dt.utcnow().isoformat() + "Z",
+        "generated_at": _utc_now_iso(),
+        **denial,
+    }
+
+
+def _bundle_success_payload(
+    task: str,
+    module_hint: str,
+    module_path,
+    structured_memory,
+    search_payload,
+    direct_read,
+    repo_audit_grounding,
+) -> Dict[str, Any]:
+    return {
+        "schema_version": "wsp_memory_bundle_v1",
+        "generated_at": _utc_now_iso(),
         "ok": True,
         "task": task,
         "module_hint": module_hint,
@@ -871,5 +944,53 @@ def handle_bundle_json(args):
         "repo_audit_grounding": repo_audit_grounding,
     }
 
-    sys.stdout.write(_json.dumps(bundle, ensure_ascii=True) + "\n")
+
+def handle_bundle_json(args):
+    """Handle --bundle-json command. Returns True if handled, False otherwise."""
+    if not getattr(args, "bundle_json", False):
+        return False
+
+    _activate_bundle_silence()
+    repo_root = Path(__file__).resolve().parents[3]
+    task = (getattr(args, "bundle_task", None) or getattr(args, "search", None) or "").strip()
+    module_hint = (getattr(args, "bundle_module_hint", None) or "").strip()
+
+    if not task:
+        _write_bundle_payload({
+            "schema_version": "wsp_memory_bundle_v1",
+            "generated_at": _utc_now_iso(),
+            "ok": False,
+            "error": "bundle-json requires --search or --bundle-task",
+        })
+        return True
+
+    # Persistent admission must precede every caller-controlled filesystem hint.
+    skip_model = _env_truthy("HOLO_SKIP_MODEL", "false")
+    denial = _bundle_persistent_denial(args, repo_root, skip_model)
+    if denial is not None:
+        _write_bundle_payload(denial, sort_keys=True)
+        return True
+
+    module_dir, module_path = _bundle_module_context(repo_root, module_hint)
+    search_payload, search_error = _bundle_search(
+        args, repo_root, task, module_hint, module_dir, module_path,
+        skip_model=skip_model,
+    )
+    if search_error is not None:
+        _write_bundle_payload(search_error)
+        return True
+    structured_memory = (
+        _artifact_snapshot(repo_root, module_dir) if module_dir else None
+    )
+    repo_audit_grounding, direct_read = _apply_repo_audit_grounding(repo_root, task, search_payload)
+    direct_read = _apply_bundle_direct_read(
+        repo_root,
+        search_payload,
+        direct_read,
+        getattr(args, "bundle_must_include", None),
+    )
+    _write_bundle_payload(_bundle_success_payload(
+        task, module_hint, module_path, structured_memory,
+        search_payload, direct_read, repo_audit_grounding,
+    ))
     return True

--- a/holo_index/query_admission.py
+++ b/holo_index/query_admission.py
@@ -1,0 +1,194 @@
+"""Fail-closed admission for read-only queries against a persistent store.
+
+The canonical owner service remains authoritative for RedDog. This helper
+reuses its freshness gate so raw CLI and direct diagnostic reads cannot bypass
+repository-root, SSD, generation, baseline, or maintenance proof.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from holo_index.freshness_receipt import (
+    evaluate_freshness_for_paths,
+    freshness_receipt_path,
+    load_freshness_receipt,
+)
+from holo_index.repository_state import (
+    REPOSITORY_DIRTY_CODE,
+    REPOSITORY_STATE_UNAVAILABLE_CODE,
+    read_repository_state,
+)
+from modules.infrastructure.foundups_mcp_bridge.src.holo_query_freshness_gate import (
+    HoloQueryFreshnessGate,
+    maintenance_reason_for_error,
+    snapshot_error,
+)
+
+RECEIPT_PATH_MISMATCH_CODE = "HOLOINDEX_FRESHNESS_RECEIPT_PATH_MISMATCH"
+RECEIPT_PATH_MISMATCH_REASON = "freshness_receipt_path_not_canonical"
+WINDOWS_REPARSE_POINT = 0x400
+
+
+@dataclass(frozen=True)
+class ReadonlyQueryAdmission:
+    """Content-free decision returned before persistent backend construction."""
+
+    allowed: bool
+    error: str
+    reasons: tuple[str, ...]
+    freshness: str
+    binding: Mapping[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.allowed,
+            "error": self.error,
+            "freshness": self.freshness,
+            "stale_reasons": list(self.reasons),
+            "index_gap_detected": not self.allowed,
+            "no_holoindex_reindex_performed": True,
+        }
+
+
+def _repository_reason(error: str) -> str:
+    maintenance_reason = maintenance_reason_for_error(error)
+    if maintenance_reason:
+        return maintenance_reason
+    if error == REPOSITORY_DIRTY_CODE:
+        return "repository_dirty"
+    if error == REPOSITORY_STATE_UNAVAILABLE_CODE:
+        return "repository_state_unavailable"
+    return "repository_state_unproven"
+
+
+def _final_receipt_link_or_reparse(path: Path) -> bool:
+    """Reject a present final receipt component that redirects elsewhere."""
+    try:
+        metadata = os.lstat(path)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    attributes = int(getattr(metadata, "st_file_attributes", 0) or 0)
+    return stat.S_ISLNK(metadata.st_mode) or bool(
+        attributes & WINDOWS_REPARSE_POINT
+    )
+
+
+def _stable_path_identity(path: Path | str) -> str:
+    """Canonicalize through the stable existing ancestor for comparison."""
+    try:
+        return os.path.normcase(str(Path(path).resolve(strict=False)))
+    except (OSError, RuntimeError, ValueError):
+        return ""
+
+
+def _canonical_receipt_binding(
+    ssd: Path,
+    supplied: Path | str | None,
+) -> tuple[Path, bool]:
+    expected = freshness_receipt_path(ssd)
+    supplied_path = Path(supplied) if supplied is not None else expected
+    invalid = (
+        not _stable_path_identity(expected)
+        or _stable_path_identity(supplied_path)
+        != _stable_path_identity(expected)
+        or _final_receipt_link_or_reparse(expected)
+        or _final_receipt_link_or_reparse(supplied_path)
+    )
+    return expected, invalid
+
+
+def _build_gate(
+    root: Path,
+    ssd: Path,
+    receipt_path: Path,
+    receipt_loader: Callable[[Path], Any] | None,
+    freshness_evaluator: Callable[..., Any] | None,
+    maintenance_probe: Callable[[Path], Any] | None,
+) -> HoloQueryFreshnessGate:
+    return HoloQueryFreshnessGate(
+        root,
+        ssd,
+        receipt_path,
+        receipt_loader or load_freshness_receipt,
+        freshness_evaluator or evaluate_freshness_for_paths,
+        maintenance_probe,
+    )
+
+
+def _evaluate_gate(
+    gate: HoloQueryFreshnessGate,
+    root: Path,
+    repository_state_reader: Callable[[Path], Any] | None,
+) -> ReadonlyQueryAdmission:
+    error, head_sha = gate.repository_error(
+        repository_state_reader or read_repository_state,
+        root,
+    )
+    if error:
+        return ReadonlyQueryAdmission(
+            False, error, (_repository_reason(error),), "UNKNOWN", {}
+        )
+    snapshot = gate.snapshot(head_sha)
+    if not snapshot.valid:
+        return ReadonlyQueryAdmission(
+            False,
+            snapshot_error(snapshot),
+            snapshot.stale_reasons,
+            snapshot.freshness,
+            snapshot.binding,
+        )
+    return ReadonlyQueryAdmission(
+        True, "", (), snapshot.freshness, snapshot.binding
+    )
+
+
+def evaluate_readonly_query_admission(
+    *,
+    repo_root: Path | str,
+    ssd_path: Path | str,
+    receipt_path: Path | str | None = None,
+    repository_state_reader: Callable[[Path], Any] | None = None,
+    receipt_loader: Callable[[Path], Any] | None = None,
+    freshness_evaluator: Callable[..., Any] | None = None,
+    maintenance_probe: Callable[[Path], Any] | None = None,
+) -> ReadonlyQueryAdmission:
+    """Prove one exact repository generation before opening persistent Chroma."""
+
+    root = Path(repo_root).resolve(strict=False)
+    ssd = Path(ssd_path).resolve(strict=False)
+    canonical_receipt, invalid_receipt = _canonical_receipt_binding(
+        ssd,
+        receipt_path,
+    )
+    if invalid_receipt:
+        return ReadonlyQueryAdmission(
+            False,
+            RECEIPT_PATH_MISMATCH_CODE,
+            (RECEIPT_PATH_MISMATCH_REASON,),
+            "UNKNOWN",
+            {},
+        )
+    gate = _build_gate(
+        root,
+        ssd,
+        canonical_receipt,
+        receipt_loader,
+        freshness_evaluator,
+        maintenance_probe,
+    )
+    return _evaluate_gate(gate, root, repository_state_reader)
+
+
+__all__ = [
+    "RECEIPT_PATH_MISMATCH_CODE",
+    "RECEIPT_PATH_MISMATCH_REASON",
+    "ReadonlyQueryAdmission",
+    "evaluate_readonly_query_admission",
+]

--- a/holo_index/tests/TESTModLog.md
+++ b/holo_index/tests/TESTModLog.md
@@ -1,5 +1,34 @@
 ﻿# HoloIndex Test Suite TESTModLog
 
+## [2026-07-24] HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1
+
+- Added exact proof tests for foreign worktree receipts, maintenance,
+  same-root wrong HEAD/SSD, missing generation, incomplete baseline, and a
+  clean admitted generation.
+- Added CLI and bundle fail-before-backend tests plus an offline lexical
+  no-persistent-admission regression. A foreign-summary test records every
+  read and proves the supplied SSD is untouched while current-repository WSP
+  metadata remains available.
+- Added focused `test_bundle_path_confinement.py` coverage for absolute and
+  traversal hints, root/component/nested reparse denial, optional real
+  symlinks, artifact no-follow checks, and nested-walk entry budgets.
+- Added raw-CLI NAVIGATION symlink/reparse/oversize coverage plus explicit
+  module-domain and WSP discovery caps. Oversized directories are tested with
+  a match both before and after the cap so no partial filesystem-order result
+  can be accepted.
+- Final unfiltered admission/confinement/direct matrix: 62 passed with five
+  portable real-symlink skips; deterministic reparse cases all executed.
+- Added canonical-receipt override/final-reparse denial, module-walk
+  complete-or-empty cap/depth/error/order, and bundle-handler WSP_62
+  regressions. Split completeness tests into a focused file; no exemption was
+  added.
+- RED was the missing `holo_index.query_admission` module; focused GREEN
+  evidence is recorded in the WSP_97 execution receipt.
+- Wider CLI/index diagnostic passed 32 and retained one exact origin/main
+  baseline failure:
+  `test_index_refresh_repair.py::TestWspPurity::test_wsp_purity_only_wsp_files`
+  expects a literal `glob("WSP_*.md")` source string in untouched indexing code.
+
 ## [2026-07-20] RedDog Repository-Audit Consumer Binding Repair
 
 - Added `.worktrees` pruning coverage alongside vendor/generated roots.

--- a/holo_index/tests/test_bundle_path_completeness.py
+++ b/holo_index/tests/test_bundle_path_completeness.py
@@ -1,0 +1,97 @@
+"""Complete-or-empty bounds for repository-local bundle discovery."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+from pathlib import Path
+
+import pytest
+
+from holo_index.cli import bundle_path_confinement as confinement
+from holo_index.cli.commands import bundle_json
+
+
+@pytest.mark.parametrize("match_name", ["a_match.py", "z_match.py"])
+def test_module_walk_entry_overflow_fails_empty_regardless_of_match_order(
+    tmp_path: Path,
+    monkeypatch,
+    match_name: str,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    module_dir.mkdir(parents=True)
+    for name in (match_name, "m_other.py", "n_other.py"):
+        (module_dir / name).write_text("VALUE = 1\n", encoding="utf-8")
+    monkeypatch.setattr(confinement, "LEXICAL_MODULE_MAX_ENTRIES", 2)
+
+    assert confinement._bounded_module_files(repo_root, module_dir) == ()
+
+
+def test_module_walk_result_is_independent_of_scandir_order(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    module_dir.mkdir(parents=True)
+    for name in ("z.py", "a.py", "m.py"):
+        (module_dir / name).write_text("VALUE = 1\n", encoding="utf-8")
+    expected = confinement._bounded_module_files(repo_root, module_dir)
+    real_scandir = os.scandir
+
+    class ReverseEntries:
+        def __init__(self, path) -> None:
+            with real_scandir(path) as entries:
+                self.entries = list(reversed(list(entries)))
+
+        def __enter__(self):
+            return iter(self.entries)
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+    monkeypatch.setattr(os, "scandir", ReverseEntries)
+    assert confinement._bounded_module_files(repo_root, module_dir) == expected
+
+
+def test_module_walk_depth_overflow_fails_empty_not_partial(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    nested = module_dir / "one" / "two"
+    nested.mkdir(parents=True)
+    (module_dir / "partial.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (nested / "deep.py").write_text("VALUE = 2\n", encoding="utf-8")
+    monkeypatch.setattr(confinement, "LEXICAL_MODULE_MAX_DEPTH", 1)
+
+    assert confinement._bounded_module_files(repo_root, module_dir) == ()
+
+
+def test_module_walk_scandir_error_fails_empty_not_partial(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    nested = module_dir / "nested"
+    nested.mkdir(parents=True)
+    (module_dir / "partial.py").write_text("VALUE = 1\n", encoding="utf-8")
+    real_scandir = os.scandir
+
+    def error_on_nested(path):
+        if Path(path) == nested:
+            raise OSError("simulated scan failure")
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", error_on_nested)
+    assert confinement._bounded_module_files(repo_root, module_dir) == ()
+
+
+def test_bundle_handler_meets_wsp62_function_threshold() -> None:
+    function = ast.parse(inspect.getsource(bundle_json.handle_bundle_json)).body[0]
+
+    assert function.end_lineno - function.lineno + 1 <= 50

--- a/holo_index/tests/test_bundle_path_confinement.py
+++ b/holo_index/tests/test_bundle_path_confinement.py
@@ -1,0 +1,424 @@
+"""Repository-confinement tests for offline bundle filesystem access."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from holo_index.cli import bundle_path_confinement as bundle_confinement
+from holo_index.cli.commands import bundle_json
+
+
+def test_module_hint_rejects_absolute_drive_without_touching_it(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    real_exists = Path.exists
+
+    def guarded_exists(path: Path) -> bool:
+        if str(path).replace("\\", "/").lower().startswith("e:/holoindex"):
+            raise AssertionError("absolute foreign hint was touched")
+        return real_exists(path)
+
+    monkeypatch.setattr(Path, "exists", guarded_exists)
+
+    assert bundle_confinement._resolve_module_dir(
+        repo_root, "E:/HoloIndex"
+    ) is None
+
+
+def test_module_hint_rejects_traversal_and_foreign_module_symlink(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "modules" / "communication").mkdir(parents=True)
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+
+    assert bundle_confinement._resolve_module_dir(repo_root, "../foreign") is None
+
+    linked = repo_root / "modules" / "communication" / "linked"
+    try:
+        linked.symlink_to(foreign, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+
+    assert bundle_confinement._resolve_module_dir(
+        repo_root, "modules/communication/linked"
+    ) is None
+
+
+def test_module_domain_discovery_is_sorted_deterministically(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "modules" / "z_last" / "example").mkdir(parents=True)
+    expected = repo_root / "modules" / "a_first" / "example"
+    expected.mkdir(parents=True)
+
+    resolved = bundle_confinement._resolve_module_dir(repo_root, "example")
+
+    assert resolved == expected.resolve()
+
+
+def test_module_domain_discovery_honors_entry_cap_before_match(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    modules_root = repo_root / "modules"
+    for name in ("a_one", "b_two"):
+        (modules_root / name).mkdir(parents=True)
+    beyond_cap = modules_root / "c_three" / "example"
+    beyond_cap.mkdir(parents=True)
+    monkeypatch.setattr(
+        bundle_confinement,
+        "LEXICAL_MODULE_DOMAIN_MAX_ENTRIES",
+        2,
+        raising=False,
+    )
+
+    assert bundle_confinement._resolve_module_dir(repo_root, "example") is None
+
+
+def test_module_domain_discovery_fails_closed_when_match_precedes_cap(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    modules_root = repo_root / "modules"
+    (modules_root / "a_one" / "example").mkdir(parents=True)
+    for name in ("b_two", "c_three"):
+        (modules_root / name).mkdir(parents=True)
+    monkeypatch.setattr(
+        bundle_confinement,
+        "LEXICAL_MODULE_DOMAIN_MAX_ENTRIES",
+        2,
+    )
+
+    assert bundle_confinement._resolve_module_dir(repo_root, "example") is None
+
+
+def test_load_need_to_rejects_foreign_navigation_symlink(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    foreign_nav = tmp_path / "NAVIGATION.py"
+    foreign_nav.write_text(
+        "NEED_TO = {'foreign secret': 'E:/HoloIndex/private.py'}\n",
+        encoding="utf-8",
+    )
+    nav_path = repo_root / "NAVIGATION.py"
+    try:
+        nav_path.symlink_to(foreign_nav)
+    except OSError as exc:
+        pytest.skip(f"file symlink unavailable: {exc}")
+
+    assert bundle_json._load_need_to(repo_root) == {}
+
+
+def test_navigation_loader_rejects_oversize_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    monkeypatch.setattr(
+        bundle_json,
+        "LEXICAL_NAVIGATION_MAX_BYTES",
+        64,
+        raising=False,
+    )
+    (repo_root / "NAVIGATION.py").write_bytes(
+        b"NEED_TO = {'oversize marker': 'must_not_be_read.py'}\n" + b"#" * 64
+    )
+
+    assert bundle_json._load_need_to(repo_root) == {}
+
+
+def test_load_repo_wsp_summary_rejects_symlinked_wsp_root(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "WSP_framework").mkdir(parents=True)
+    foreign_wsp_root = tmp_path / "foreign-wsps"
+    foreign_wsp_root.mkdir()
+    (foreign_wsp_root / "WSP_999_FOREIGN.md").write_text(
+        "# WSP 999 Foreign\n\nforeign secret\n",
+        encoding="utf-8",
+    )
+    linked_root = repo_root / "WSP_framework" / "src"
+    try:
+        linked_root.symlink_to(foreign_wsp_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+
+    assert bundle_json._load_repo_wsp_summary(repo_root) == {}
+
+
+def test_wsp_discovery_honors_entry_cap_before_sorting(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    wsp_root = repo_root / "WSP_framework" / "src"
+    wsp_root.mkdir(parents=True)
+    for index in range(6):
+        (wsp_root / f"WSP_{index + 1}_CAP.md").write_text(
+            f"# WSP {index + 1} Cap\n\nentry {index + 1}\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setattr(
+        bundle_json,
+        "LEXICAL_WSP_MAX_ENTRIES",
+        2,
+        raising=False,
+    )
+
+    summary = bundle_json._load_repo_wsp_summary(repo_root)
+
+    assert summary == {}
+
+
+def test_wsp_discovery_does_not_use_unbounded_glob_materialization() -> None:
+    import inspect
+
+    source = inspect.getsource(bundle_json._load_repo_wsp_summary)
+
+    assert ".glob(" not in source
+    assert "LEXICAL_WSP_MAX_ENTRIES" in source
+
+
+def test_reparse_detection_seam_rejects_module_nav_and_wsp_components(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "junction"
+    module_dir.mkdir(parents=True)
+    nav_path = repo_root / "NAVIGATION.py"
+    nav_path.write_text("NEED_TO = {'foreign': 'foreign.py'}\n", encoding="utf-8")
+    wsp_root = repo_root / "WSP_framework" / "src"
+    wsp_root.mkdir(parents=True)
+    (wsp_root / "WSP_999_FOREIGN.md").write_text(
+        "# WSP 999 Foreign\n", encoding="utf-8"
+    )
+    rejected = {
+        module_dir.resolve(strict=False),
+        nav_path.resolve(strict=False),
+        wsp_root.resolve(strict=False),
+    }
+    real_detector = bundle_confinement._is_link_or_reparse
+
+    monkeypatch.setattr(
+        bundle_confinement,
+        "_is_link_or_reparse",
+        lambda path: (
+            Path(path).resolve(strict=False) in rejected or real_detector(path)
+        ),
+    )
+
+    assert bundle_confinement._resolve_module_dir(
+        repo_root, "modules/communication/junction"
+    ) is None
+    assert bundle_json._load_need_to(repo_root) == {}
+    assert bundle_json._load_repo_wsp_summary(repo_root) == {}
+
+
+def test_reparse_detection_seam_rejects_repository_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    (repo_root / "NAVIGATION.py").write_text(
+        "NEED_TO = {'foreign': 'foreign.py'}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        bundle_confinement,
+        "_is_link_or_reparse",
+        lambda path: Path(path) == repo_root,
+    )
+
+    assert bundle_json._load_need_to(repo_root) == {}
+    assert bundle_confinement._resolve_module_dir(
+        repo_root, "modules/example"
+    ) is None
+
+
+def test_offline_module_walk_rejects_nested_reparse_before_enumeration(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    nested = module_dir / "junction"
+    nested.mkdir(parents=True)
+    (repo_root / "NAVIGATION.py").write_text("NEED_TO = {}\n", encoding="utf-8")
+    (nested / "foreign_secret.py").write_text("SECRET = True\n", encoding="utf-8")
+    real_detector = bundle_confinement._is_link_or_reparse
+    real_scandir = os.scandir
+
+    monkeypatch.setattr(
+        bundle_confinement,
+        "_is_link_or_reparse",
+        lambda path: (
+            Path(path).resolve(strict=False) == nested.resolve(strict=False)
+            or real_detector(path)
+        ),
+    )
+
+    def guarded_scandir(path):
+        if Path(path).resolve(strict=False) == nested.resolve(strict=False):
+            raise AssertionError("nested reparse directory was enumerated")
+        return real_scandir(path)
+
+    monkeypatch.setattr(os, "scandir", guarded_scandir)
+
+    payload = bundle_json._lexical_task_retrieval(
+        repo_root,
+        "foreign secret",
+        8,
+        str(tmp_path / "unused-ssd"),
+        module_dir=module_dir,
+    )
+
+    assert all("foreign_secret.py" not in str(hit) for hit in payload["code_hits"])
+
+
+def test_offline_module_walk_rejects_nested_foreign_file_symlink(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    module_dir.mkdir(parents=True)
+    (repo_root / "NAVIGATION.py").write_text("NEED_TO = {}\n", encoding="utf-8")
+    foreign = tmp_path / "foreign_secret.py"
+    foreign.write_text("SECRET = True\n", encoding="utf-8")
+    linked = module_dir / "foreign_secret.py"
+    try:
+        linked.symlink_to(foreign)
+    except OSError as exc:
+        pytest.skip(f"file symlink unavailable: {exc}")
+
+    payload = bundle_json._lexical_task_retrieval(
+        repo_root,
+        "foreign secret",
+        8,
+        str(tmp_path / "unused-ssd"),
+        module_dir=module_dir,
+    )
+
+    assert all("foreign_secret.py" not in str(hit) for hit in payload["code_hits"])
+
+
+def test_offline_module_walk_honors_entry_budget(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    module_dir.mkdir(parents=True)
+    (repo_root / "NAVIGATION.py").write_text("NEED_TO = {}\n", encoding="utf-8")
+    for index in range(6):
+        (module_dir / f"budget_match_{index}.py").write_text(
+            f"VALUE = {index}\n", encoding="utf-8"
+        )
+    monkeypatch.setattr(bundle_confinement, "LEXICAL_MODULE_MAX_ENTRIES", 2)
+
+    payload = bundle_json._lexical_task_retrieval(
+        repo_root,
+        "budget match",
+        20,
+        str(tmp_path / "unused-ssd"),
+        module_dir=module_dir,
+    )
+
+    module_hits = [
+        hit for hit in payload["code_hits"] if "budget_match_" in hit["location"]
+    ]
+    assert module_hits == []
+
+
+def test_artifact_snapshot_rejects_nested_reparse_without_exists_follow(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    module_dir = repo_root / "modules" / "communication" / "example"
+    module_dir.mkdir(parents=True)
+    readme = module_dir / "README.md"
+    readme.write_text("# Foreign-linked contract\n", encoding="utf-8")
+    real_detector = bundle_confinement._is_link_or_reparse
+    real_exists = Path.exists
+    touched: list[Path] = []
+
+    monkeypatch.setattr(
+        bundle_confinement,
+        "_is_link_or_reparse",
+        lambda path: (
+            Path(path).resolve(strict=False) == readme.resolve(strict=False)
+            or real_detector(path)
+        ),
+    )
+
+    def guarded_exists(path: Path) -> bool:
+        if path == readme:
+            touched.append(path)
+            raise AssertionError("artifact link target existence was followed")
+        return real_exists(path)
+
+    monkeypatch.setattr(Path, "exists", guarded_exists)
+
+    snapshot = bundle_json._artifact_snapshot(repo_root, module_dir)
+    readme_row = next(
+        item for item in snapshot["artifacts"] if item["name"] == "README.md"
+    )
+    assert readme_row["exists"] is False
+    assert touched == []
+
+
+def test_offline_bundle_lexical_never_reads_foreign_ssd_summary(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    wsp_root = repo_root / "WSP_framework" / "src"
+    wsp_root.mkdir(parents=True)
+    (repo_root / "NAVIGATION.py").write_text("NEED_TO = {}\n", encoding="utf-8")
+    (wsp_root / "WSP_97_System_Execution_Prompting_Protocol.md").write_text(
+        "# WSP 97 System Execution Prompting Protocol\n\n"
+        "Root-bound current repository evidence.\n",
+        encoding="utf-8",
+    )
+    foreign_ssd = tmp_path / "foreign-store"
+    foreign_summary = foreign_ssd / "indexes" / "wsp_summary.json"
+    foreign_summary.parent.mkdir(parents=True)
+    foreign_summary.write_text(
+        '{"WSP 999":{"title":"foreign secret","summary":"foreign",'
+        '"path":"Q:/other-repo/WSP_999.md"}}',
+        encoding="utf-8",
+    )
+    reads: list[Path] = []
+    real_read_text = Path.read_text
+
+    def recording_read_text(path: Path, *args, **kwargs) -> str:
+        reads.append(path.resolve(strict=False))
+        return real_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", recording_read_text)
+
+    payload = bundle_json._lexical_task_retrieval(
+        repo_root,
+        "foreign secret WSP 97 root-bound",
+        8,
+        str(foreign_ssd),
+    )
+
+    assert all(str(foreign_ssd) not in str(path) for path in reads)
+    assert all("Q:/other-repo" not in str(hit) for hit in payload["wsp_hits"])
+    assert any(hit["wsp"] == "WSP 97" for hit in payload["wsp_hits"])
+    assert payload["metadata"]["no_holoindex_store_access"] is True

--- a/holo_index/tests/test_holoindex_query_admission.py
+++ b/holo_index/tests/test_holoindex_query_admission.py
@@ -1,0 +1,281 @@
+"""Read-only persistent-query admission regressions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import holo_index.query_admission as query_admission
+from holo_index.freshness_receipt import freshness_receipt_path
+from holo_index.query_admission import evaluate_readonly_query_admission
+from modules.infrastructure.foundups_mcp_bridge.tests.test_holo_query_service import (
+    _receipt,
+)
+
+
+SHA = "a" * 40
+
+
+def _clear_maintenance(_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(clear=True, held=False, status="idle")
+
+
+def _clean_repository(head_sha: str = SHA):
+    return lambda _root: SimpleNamespace(
+        proven_clean=True,
+        head_sha=head_sha,
+        error="",
+    )
+
+
+def _write_receipt(
+    ssd_path: Path,
+    *,
+    repo_root: Path,
+    head_sha: str = SHA,
+    omit: str = "",
+    receipt_ssd_path: Path | None = None,
+    generation: str = "generation-1",
+) -> Path:
+    path = freshness_receipt_path(ssd_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            _receipt(
+                sha=head_sha,
+                generation=generation,
+                repo_root=repo_root,
+                ssd_path=receipt_ssd_path or ssd_path,
+                omit=omit,
+            )
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_foreign_worktree_receipt_is_rejected_before_backend_use(
+    tmp_path: Path,
+) -> None:
+    invoking_root = tmp_path / "lane-a"
+    foreign_root = tmp_path / "lane-b"
+    invoking_root.mkdir()
+    foreign_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(ssd_path, repo_root=foreign_root)
+
+    result = evaluate_readonly_query_admission(
+        repo_root=invoking_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "STALE_INDEX"
+    assert result.reasons == ("freshness_repo_root_mismatch",)
+
+
+def test_active_maintenance_is_rejected_before_receipt_or_backend(
+    tmp_path: Path,
+) -> None:
+    receipt_loaded = False
+
+    def unexpected_loader(_path: Path):
+        nonlocal receipt_loaded
+        receipt_loaded = True
+        raise AssertionError("maintenance must reject before receipt loading")
+
+    result = evaluate_readonly_query_admission(
+        repo_root=tmp_path / "repo",
+        ssd_path=tmp_path / "ssd",
+        repository_state_reader=_clean_repository(),
+        receipt_loader=unexpected_loader,
+        maintenance_probe=lambda _path: SimpleNamespace(
+            clear=False,
+            held=True,
+            status="held",
+        ),
+    )
+
+    assert result.allowed is False
+    assert result.error == "HOLOINDEX_MAINTENANCE_ACTIVE"
+    assert result.reasons == ("holoindex_maintenance_active",)
+    assert receipt_loaded is False
+
+
+def test_same_root_wrong_head_is_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(ssd_path, repo_root=repo_root, head_sha="b" * 40)
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(SHA),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "REPO_HEAD_MISMATCH"
+    assert "stale_repo_head_sha" in result.reasons
+
+
+def test_same_root_wrong_ssd_is_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(
+        ssd_path,
+        repo_root=repo_root,
+        receipt_ssd_path=tmp_path / "other-ssd",
+    )
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "STALE_INDEX"
+    assert "freshness_ssd_path_mismatch" in result.reasons
+
+
+def test_missing_generation_binding_is_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(
+        ssd_path,
+        repo_root=repo_root,
+        generation="",
+    )
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "MISSING_GENERATION_BINDING"
+    assert "missing_holoindex_generation_id" in result.reasons
+
+
+def test_incomplete_baseline_generation_is_rejected(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(
+        ssd_path,
+        repo_root=repo_root,
+        omit="navigation_knowledge",
+    )
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "STALE_INDEX"
+    assert "missing_collection_receipt:navigation_knowledge" in result.reasons
+
+
+def test_exact_clean_generation_is_admitted(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(ssd_path, repo_root=repo_root)
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is True
+    assert result.error == ""
+    assert result.reasons == ()
+    assert result.freshness == "CURRENT"
+
+
+def test_explicit_noncanonical_receipt_is_rejected_before_any_read(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    foreign_root = tmp_path / "foreign"
+    repo_root.mkdir()
+    foreign_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(ssd_path, repo_root=foreign_root)
+    external = tmp_path / "external" / "holoindex_freshness_receipt.json"
+    external.parent.mkdir()
+    external.write_text(
+        json.dumps(
+            _receipt(
+                sha=SHA,
+                generation="generation-external",
+                repo_root=repo_root,
+                ssd_path=ssd_path,
+            )
+        ),
+        encoding="utf-8",
+    )
+    reads: list[Path] = []
+
+    def recording_loader(path: Path):
+        reads.append(Path(path))
+        return json.loads(Path(path).read_text(encoding="utf-8"))
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        receipt_path=external,
+        repository_state_reader=_clean_repository(),
+        receipt_loader=recording_loader,
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "HOLOINDEX_FRESHNESS_RECEIPT_PATH_MISMATCH"
+    assert result.reasons == ("freshness_receipt_path_not_canonical",)
+    assert reads == []
+
+
+def test_canonical_receipt_final_link_or_reparse_fails_before_read(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    canonical = _write_receipt(ssd_path, repo_root=repo_root)
+    monkeypatch.setattr(
+        query_admission,
+        "_final_receipt_link_or_reparse",
+        lambda path: Path(path) == canonical,
+        raising=False,
+    )
+    reads: list[Path] = []
+
+    result = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        repository_state_reader=_clean_repository(),
+        receipt_loader=lambda path: reads.append(Path(path)),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "HOLOINDEX_FRESHNESS_RECEIPT_PATH_MISMATCH"
+    assert result.reasons == ("freshness_receipt_path_not_canonical",)
+    assert reads == []

--- a/holo_index/tests/test_holoindex_readonly_query_guard.py
+++ b/holo_index/tests/test_holoindex_readonly_query_guard.py
@@ -8,9 +8,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 os.environ.setdefault("HOLO_SKIP_MODEL", "1")
 
 from holo_index import _cli_main
+from holo_index.cli import bundle_path_confinement as bundle_confinement
+from holo_index.cli.commands import bundle_json
+from holo_index.query_admission import ReadonlyQueryAdmission
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -36,6 +41,36 @@ def _args(**overrides):
     }
     values.update(overrides)
     return argparse.Namespace(**values)
+
+
+def _run_raw_offline_cli(
+    repo_root: Path,
+    monkeypatch,
+    capsys,
+    query: str,
+) -> str:
+    (repo_root / "holo_index").mkdir(exist_ok=True)
+    monkeypatch.setattr(_cli_main, "HoloIndex", None)
+    monkeypatch.setattr(
+        _cli_main,
+        "__file__",
+        str(repo_root / "holo_index" / "_cli_main.py"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "holo_index.py",
+            "--offline",
+            "--fast-search",
+            "--search",
+            query,
+            "--limit",
+            "5",
+        ],
+    )
+    _cli_main.main()
+    return capsys.readouterr().out
 
 
 def test_query_mode_sets_readonly_env(monkeypatch) -> None:
@@ -141,6 +176,272 @@ def test_auto_refresh_branch_is_gated_in_cli_source() -> None:
     assert "if holo is not None and not (index_code or index_wsp or indexing_awarded)" not in source
 
 
+def test_persistent_search_admission_precedes_backend_construction() -> None:
+    source = (REPO_ROOT / "holo_index" / "_cli_main.py").read_text(encoding="utf-8")
+
+    admission = source.index("evaluate_readonly_query_admission(")
+    backend = source.index("holo = HoloIndex(", admission)
+
+    assert admission < backend
+
+
+def test_cli_foreign_root_denial_precedes_backend_construction(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    backend_constructed = False
+
+    class UnexpectedBackend:
+        def __init__(self, *args, **kwargs) -> None:
+            nonlocal backend_constructed
+            backend_constructed = True
+
+    monkeypatch.setattr(_cli_main, "HoloIndex", UnexpectedBackend)
+    monkeypatch.setattr(
+        _cli_main,
+        "evaluate_readonly_query_admission",
+        lambda **_kwargs: ReadonlyQueryAdmission(
+            allowed=False,
+            error="STALE_INDEX",
+            reasons=("freshness_repo_root_mismatch",),
+            freshness="STALE",
+            binding={},
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["holo_index.py", "--search", "WSP 97", "--ssd", str(tmp_path)],
+    )
+
+    with pytest.raises(SystemExit) as raised:
+        _cli_main.main()
+
+    assert raised.value.code == _cli_main.QUERY_ADMISSION_EXIT_CODE
+    assert backend_constructed is False
+    output = capsys.readouterr().out
+    assert "freshness_repo_root_mismatch" in output
+    assert str(tmp_path) not in output
+
+
+def test_cli_offline_lexical_never_runs_persistent_admission(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(_cli_main, "HoloIndex", None)
+    monkeypatch.setattr(
+        _cli_main,
+        "evaluate_readonly_query_admission",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("offline lexical retrieval must bypass persistent admission")
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "holo_index.py",
+            "--offline",
+            "--fast-search",
+            "--search",
+            "WSP 97",
+            "--ssd",
+            str(tmp_path),
+        ],
+    )
+
+    _cli_main.main()
+
+    output = capsys.readouterr().out
+    assert "[DEGRADED]" in output
+    assert "current-repository lexical search only" in output
+
+
+def test_raw_cli_offline_rejects_foreign_navigation_symlink(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    foreign_nav = tmp_path / "foreign-navigation.py"
+    foreign_nav.write_text(
+        "NEED_TO = {'foreign marker': 'foreign_location.py'}\n",
+        encoding="utf-8",
+    )
+    try:
+        (repo_root / "NAVIGATION.py").symlink_to(foreign_nav)
+    except OSError as exc:
+        pytest.skip(f"file symlink unavailable: {exc}")
+
+    output = _run_raw_offline_cli(
+        repo_root,
+        monkeypatch,
+        capsys,
+        "foreign marker",
+    )
+
+    assert "foreign_location.py" not in output
+
+
+def test_raw_cli_offline_rejects_navigation_reparse_seam(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    nav_path = repo_root / "NAVIGATION.py"
+    nav_path.write_text(
+        "NEED_TO = {'reparse marker': 'reparse_location.py'}\n",
+        encoding="utf-8",
+    )
+    real_detector = bundle_confinement._is_link_or_reparse
+    monkeypatch.setattr(
+        bundle_confinement,
+        "_is_link_or_reparse",
+        lambda path: (
+            Path(path).resolve(strict=False) == nav_path.resolve(strict=False)
+            or real_detector(path)
+        ),
+    )
+
+    output = _run_raw_offline_cli(
+        repo_root,
+        monkeypatch,
+        capsys,
+        "reparse marker",
+    )
+
+    assert "reparse_location.py" not in output
+
+
+def test_raw_cli_offline_rejects_oversize_navigation(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    monkeypatch.setattr(
+        bundle_json,
+        "LEXICAL_NAVIGATION_MAX_BYTES",
+        64,
+        raising=False,
+    )
+    (repo_root / "NAVIGATION.py").write_bytes(
+        b"NEED_TO = {'oversize marker': 'oversize_location.py'}\n" + b"#" * 64
+    )
+
+    output = _run_raw_offline_cli(
+        repo_root,
+        monkeypatch,
+        capsys,
+        "oversize marker",
+    )
+
+    assert "oversize_location.py" not in output
+
+
+def test_offline_lexical_search_bypasses_persistent_admission() -> None:
+    source = (REPO_ROOT / "holo_index" / "_cli_main.py").read_text(encoding="utf-8")
+
+    assert "if HoloIndex is not None and args.search and not maintenance_plan:" in source
+    assert "_lexical_task_retrieval(" in source
+    assert "evaluate_readonly_query_admission(" not in source[
+        source.index("if holo is None:") : source.index(
+            "# Process search results for throttler"
+        )
+    ]
+
+
+def test_bundle_persistent_query_denial_precedes_backend_construction(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    backend_constructed = False
+    real_import = __import__
+
+    def guarded_import(name, *args, **kwargs):
+        nonlocal backend_constructed
+        if name == "holo_index.core":
+            backend_constructed = True
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delenv("HOLO_SKIP_MODEL", raising=False)
+    monkeypatch.setattr("builtins.__import__", guarded_import)
+    monkeypatch.setattr(
+        bundle_json,
+        "evaluate_readonly_query_admission",
+        lambda **_kwargs: ReadonlyQueryAdmission(
+            allowed=False,
+            error="STALE_INDEX",
+            reasons=("freshness_repo_root_mismatch",),
+            freshness="STALE",
+            binding={},
+        ),
+    )
+    args = argparse.Namespace(
+        bundle_json=True,
+        bundle_task=None,
+        search="WSP 97",
+        bundle_module_hint=None,
+        bundle_must_include=None,
+        limit=5,
+        ssd=str(tmp_path),
+        doc_type="all",
+    )
+
+    assert bundle_json.handle_bundle_json(args) is True
+
+    assert backend_constructed is False
+    output = capsys.readouterr().out
+    assert "freshness_repo_root_mismatch" in output
+    assert str(tmp_path) not in output
+
+
+def test_bundle_persistent_admission_precedes_module_hint_resolution(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.delenv("HOLO_SKIP_MODEL", raising=False)
+    monkeypatch.setattr(
+        bundle_json,
+        "evaluate_readonly_query_admission",
+        lambda **_kwargs: ReadonlyQueryAdmission(
+            allowed=False,
+            error="STALE_INDEX",
+            reasons=("freshness_repo_root_mismatch",),
+            freshness="STALE",
+            binding={},
+        ),
+    )
+    monkeypatch.setattr(
+        bundle_json,
+        "_resolve_module_dir",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("module hint resolution must follow persistent admission")
+        ),
+    )
+    args = argparse.Namespace(
+        bundle_json=True,
+        bundle_task=None,
+        search="WSP 97",
+        bundle_module_hint="E:/HoloIndex",
+        bundle_must_include=None,
+        limit=5,
+        ssd=str(tmp_path),
+        doc_type="all",
+    )
+
+    assert bundle_json.handle_bundle_json(args) is True
+    assert "freshness_repo_root_mismatch" in capsys.readouterr().out
+
+
 def test_collection_reset_refuses_readonly_context() -> None:
     source = (REPO_ROOT / "holo_index" / "core" / "holo_index.py").read_text(encoding="utf-8")
     assert "HOLOINDEX_QUERY_READONLY" in source
@@ -151,4 +452,5 @@ def test_collection_reset_refuses_readonly_context() -> None:
 def test_reddog_extension_sets_readonly_env_for_holoindex_calls() -> None:
     source = (REPO_ROOT / "extensions" / "reddog" / "extension.js").read_text(encoding="utf-8")
     assert "HOLOINDEX_QUERY_READONLY: '1'" in source
-    assert "HOLO_SKIP_MODEL: '1', HOLOINDEX_QUERY_READONLY: '1'" in source
+    assert "env.HOLO_SKIP_MODEL = '1';" in source
+    assert "delete env.HOLO_SKIP_MODEL;" in source

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -156,7 +156,15 @@ code. The owner's authenticated health gate also requires a non-empty semantic
 canary and repository/generation binding.
 
 Passing an explicit SSD/receipt enables a diagnostic-only direct adapter. It
-always returns a non-operational freshness state and can never satisfy CURRENT.
+derives the only admissible receipt from `freshness_receipt_path(ssd)`. A
+supplied receipt path must stable-ancestor-canonicalize to that exact path and
+cannot have a link/reparse final component. Mismatch denies before receipt
+loading or backend construction. The canonical receipt must then prove the
+explicit invoking repository root and SSD, clean exact HEAD, generation,
+complete canonical baseline and embedding space, with no active or unprovable
+maintenance. Denial returns stable content-free reasons with zero hits. An
+admitted result still returns a non-operational freshness state and can never
+satisfy CURRENT.
 Only the trusted host maintenance handshake may refresh the canonical store;
 startup may route the request through governed WRE dispatch, and the RedDog
 adapter has no index-write surface. This is not an OS privilege boundary:

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,17 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-24: HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 62, 81, 97
+
+- RedDog's explicit-SSD direct diagnostic now runs the canonical read-only
+  admission proof before constructing a direct backend.
+- Foreign root/SSD, wrong HEAD, missing generation/baseline/embedding proof,
+  and active/unprovable maintenance fail with content-free reasons and zero
+  hits. Both race probes and the receipt path derive from the admitted SSD.
+  An external receipt path is rejected before any receipt read or backend,
+  even when that external receipt would otherwise validate.
+
 ## 2026-07-23: REDDOG_PROVIDER_CALL_EVIDENCE_PHASE2A_REVIEW_REPAIR_ROUND3
 
 **WSP Protocol**: WSP 00, 15, 22, 50, 62, 84, 97

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -123,8 +123,14 @@ model work as an index gap. If neither an explicit service nor a live
 private handoff exists, the adapter fails with
 HOLOINDEX_QUERY_SERVICE_NOT_CONFIGURED and never opens local Chroma.
 
-An explicit SSD/receipt argument enables direct host diagnostics only. That
-path is always labeled non-operational and can never return CURRENT. Trusted
+An explicit SSD enables direct host diagnostics only. The freshness receipt is
+derived exclusively from `freshness_receipt_path(ssd)`. An explicitly supplied
+receipt must canonicalize to that exact path and must not be a final-component
+link/reparse point; otherwise the request fails before receipt or backend
+access. The path then runs the same root/SSD/HEAD/generation/baseline/
+maintenance admission proof. Failure returns content-free stale reasons and
+zero hits. An admitted direct result is still labeled non-operational and can
+never return CURRENT. Trusted
 interactive/headless host preflight performs any required semantic full
 refresh before worker dispatch; startup may route that request through
 governed WRE dispatch, but the query adapter has no maintenance surface.

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -125,6 +125,10 @@ These remain deferred until the FoundUp Memex POC and MVP contracts are proven.
 
 ## 2026-07-18: RedDog / HoloIndex Truth Boundary Follow-ups
 
+- Completed 2026-07-24 P0: direct diagnostics now share the canonical
+  root/SSD/HEAD/generation/baseline/maintenance admission proof before backend
+  construction. P1 store namespaces and legacy metadata migration remain owned
+  by the HoloIndex roadmap.
 - Complete post-merge activation at the exact merge SHA before treating the
   persistent semantic store as CURRENT.
 - Bind resident governed work orders to process-private owner handoffs without

--- a/modules/communication/moltbot_bridge/src/reddog_holoindex_query_adapter.py
+++ b/modules/communication/moltbot_bridge/src/reddog_holoindex_query_adapter.py
@@ -18,6 +18,7 @@ from holo_index.freshness_receipt import (
     freshness_receipt_path,
 )
 from holo_index.maintenance_lock import maintenance_lock_path, probe_maintenance_lock
+from holo_index.query_admission import evaluate_readonly_query_admission
 from holo_index.storage_contract import (
     HoloIndexStorageError,
     resolve_holoindex_ssd_path,
@@ -284,8 +285,68 @@ def _direct_diagnostic_result(
     )
 
 
+def _direct_admission_failure(
+    *,
+    repo_root: Path,
+    ssd_path: Path,
+    receipt_path: Path | str | None,
+    query: str,
+    started: float,
+) -> Mapping[str, Any] | None:
+    admission = evaluate_readonly_query_admission(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        receipt_path=receipt_path,
+    )
+    if admission.allowed:
+        return None
+    return _direct_failure(
+        query=query,
+        started=started,
+        error=admission.error,
+        stale_reasons=admission.reasons,
+    )
+
+
+def _direct_paths(
+    ssd_path_value: Path | str | None,
+) -> tuple[Path, Path]:
+    ssd_path = resolve_holoindex_ssd_path(ssd_path_value)
+    return ssd_path, freshness_receipt_path(ssd_path)
+
+
+def _direct_preflight(
+    repo_root: Path,
+    ssd_path_value: Path | str | None,
+    receipt_path_value: Path | str | None,
+    query: str,
+    started: float,
+) -> tuple[Path, Path, Mapping[str, Any] | None]:
+    ssd_path, receipt_path = _direct_paths(ssd_path_value)
+    failure = _direct_admission_failure(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        receipt_path=receipt_path_value,
+        query=query,
+        started=started,
+    )
+    if failure is None:
+        error, reason = _maintenance_block(
+            maintenance_lock_path(ssd_path)
+        )
+        if error:
+            failure = _direct_failure(
+                query=query,
+                started=started,
+                error=error,
+                stale_reasons=[reason],
+            )
+    return ssd_path, receipt_path, failure
+
+
 def _query_direct_diagnostic(
     *,
+    repo_root: Path,
     ssd_path_value: Path | str | None,
     receipt_path_value: Path | str | None,
     query: str,
@@ -294,21 +355,12 @@ def _query_direct_diagnostic(
     started = time.monotonic()
     bounded_limit = max(1, min(int(limit or 8), 20))
     try:
-        ssd_path = resolve_holoindex_ssd_path(ssd_path_value)
-        receipt_path = (
-            Path(receipt_path_value)
-            if receipt_path_value is not None
-            else freshness_receipt_path(ssd_path)
+        ssd_path, receipt_path, preflight_failure = _direct_preflight(
+            repo_root, ssd_path_value, receipt_path_value, query, started
         )
-        lock_path = maintenance_lock_path(receipt_path.parent.parent)
-        maintenance_error, maintenance_reason = _maintenance_block(lock_path)
-        if maintenance_error:
-            return _direct_failure(
-                query=query,
-                started=started,
-                error=maintenance_error,
-                stale_reasons=[maintenance_reason],
-            )
+        if preflight_failure is not None:
+            return preflight_failure
+        lock_path = maintenance_lock_path(ssd_path)
         result, fallback_mode = _direct_backend_query(
             ssd_path=ssd_path,
             query=query,
@@ -415,6 +467,7 @@ class HoloIndexReadOnlyQueryAdapter:
             }
         return _scope_result_hits(
             _query_direct_diagnostic(
+                repo_root=self.repo_root,
                 ssd_path_value=self.ssd_path,
                 receipt_path_value=self.freshness_receipt_path,
                 query=str(query or ""),

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,13 @@
+## 2026-07-24: HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1
+
+- Added direct regressions for pre-backend foreign-root denial and rejection
+  of a noncanonical external receipt before repository evaluation, receipt
+  admission, or backend access. Canonical receipt and maintenance locations
+  are SSD-derived by the current adapter code.
+- Unfiltered admission/confinement/direct matrix passed 62 with five portable
+  symlink skips; owner passed 60/60; wider retrieval passed 126 with four
+  portable symlink skips; WSP_62 guards passed 19/19.
+
 ## 2026-07-23: REDDOG_PROVIDER_CALL_EVIDENCE_PHASE2A_REVIEW_REPAIR_ROUND3
 
 - Added requested-provider and requested-model secret/raw-shape rejection at
@@ -264,6 +274,9 @@ test_reddog_readonly_audit_task_executor.py (UPDATED)
 - Split boundary tests by owner-client transport, private handoff/response
   binding, adapter behavior, and direct diagnostics to stay within WSP_62
   domain thresholds without a new-file exemption.
+- Added a focused canonical-receipt test proving a valid external receipt
+  cannot override a disagreeing SSD-derived receipt and is rejected before
+  receipt loading or direct backend construction.
 
 **Impact**: The migrated downstream model/audit paths are designed to stop on
 absent, lexical, stale, dirty, raced, narrowed, or unbound HoloIndex evidence.

--- a/modules/communication/moltbot_bridge/tests/test_reddog_holoindex_direct_query_boundary.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_holoindex_direct_query_boundary.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from holo_index.core.holo_index import HoloIndex
 from holo_index.maintenance_lock import (
     acquire_maintenance_lease,
@@ -17,13 +19,29 @@ from holo_index.storage_contract import (
 from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
     HoloIndexReadOnlyQueryAdapter,
 )
-import modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime as readonly_worker_runtime
 import modules.communication.moltbot_bridge.src.reddog_holoindex_query_adapter as holo_query_adapter
+from holo_index.query_admission import ReadonlyQueryAdmission
 from modules.communication.moltbot_bridge.tests.test_reddog_holoindex_query_boundary import (
     _patch_holo_search,
     _set_repo_head,
     _write_holo_receipt,
 )
+
+
+@pytest.fixture(autouse=True)
+def _admit_existing_direct_diagnostic_fixtures(monkeypatch) -> None:
+    monkeypatch.setattr(
+        holo_query_adapter,
+        "evaluate_readonly_query_admission",
+        lambda **_kwargs: ReadonlyQueryAdmission(
+            allowed=True,
+            error="",
+            reasons=(),
+            freshness="CURRENT",
+            binding={},
+        ),
+    )
+
 
 def test_holoindex_adapter_preserves_typed_storage_error(
     tmp_path: Path,
@@ -57,7 +75,7 @@ def test_holoindex_adapter_preserves_typed_storage_error(
 
 
 def test_holoindex_hit_normalization_preserves_wsp_and_knowledge_buckets() -> None:
-    hits = readonly_worker_runtime._holoindex_hits(
+    hits = holo_query_adapter.holoindex_hits(
         {
             "wsp_hits": [
                 {
@@ -176,6 +194,55 @@ def test_holoindex_direct_adapter_blocks_active_maintenance_before_backend(
     assert result["ok"] is False
     assert result["error"] == "HOLOINDEX_MAINTENANCE_ACTIVE"
     assert result["stale_reasons"] == ["holoindex_maintenance_active"]
+    assert result["hits"] == []
+
+
+def test_holoindex_direct_adapter_blocks_foreign_root_before_backend(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root = tmp_path / "lane-a"
+    foreign_root = tmp_path / "lane-b"
+    repo_root.mkdir()
+    foreign_root.mkdir()
+    head_sha = "8" * 40
+    _set_repo_head(repo_root, head_sha)
+    ssd_path = tmp_path / "ssd"
+    receipt_path = ssd_path / "indexes" / "holoindex_freshness_receipt.json"
+    _write_holo_receipt(
+        receipt_path,
+        repo_root=foreign_root,
+        head_sha=head_sha,
+    )
+    monkeypatch.delenv("HOLOINDEX_QUERY_SERVICE_URL", raising=False)
+    monkeypatch.setattr(
+        holo_query_adapter,
+        "_direct_backend_query",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("foreign-root admission must prevent backend access")
+        ),
+    )
+    monkeypatch.setattr(
+        holo_query_adapter,
+        "evaluate_readonly_query_admission",
+        lambda **_kwargs: ReadonlyQueryAdmission(
+            allowed=False,
+            error="STALE_INDEX",
+            reasons=("freshness_repo_root_mismatch",),
+            freshness="STALE",
+            binding={},
+        ),
+    )
+
+    result = HoloIndexReadOnlyQueryAdapter(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        freshness_receipt_path=receipt_path,
+    ).query(query="evidence", allowed_paths=(), limit=8)
+
+    assert result["ok"] is False
+    assert result["error"] == "STALE_INDEX"
+    assert result["stale_reasons"] == ["freshness_repo_root_mismatch"]
     assert result["hits"] == []
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_holoindex_receipt_binding.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_holoindex_receipt_binding.py
@@ -1,0 +1,69 @@
+"""Canonical receipt identity regressions for direct HoloIndex diagnostics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import holo_index.query_admission as query_admission
+import modules.communication.moltbot_bridge.src.reddog_holoindex_query_adapter as adapter
+from holo_index.query_admission import evaluate_readonly_query_admission
+from modules.communication.moltbot_bridge.src.reddog_readonly_0102_audit_worker_runtime import (
+    HoloIndexReadOnlyQueryAdapter,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_holoindex_query_boundary import (
+    _set_repo_head,
+    _write_holo_receipt,
+)
+
+
+def _conflicting_receipts(tmp_path: Path):
+    repo_root = tmp_path / "repo"
+    foreign_root = tmp_path / "foreign"
+    repo_root.mkdir()
+    foreign_root.mkdir()
+    head_sha = "9" * 40
+    _set_repo_head(repo_root, head_sha)
+    ssd_path = tmp_path / "ssd"
+    canonical = ssd_path / "indexes" / "holoindex_freshness_receipt.json"
+    external = tmp_path / "external" / "holoindex_freshness_receipt.json"
+    _write_holo_receipt(canonical, repo_root=foreign_root, head_sha=head_sha)
+    _write_holo_receipt(external, repo_root=repo_root, head_sha=head_sha)
+    return repo_root, ssd_path, external
+
+
+def test_external_valid_receipt_rejects_before_any_read_or_backend(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    repo_root, ssd_path, external = _conflicting_receipts(tmp_path)
+    reads: list[Path] = []
+    real_loader = query_admission.load_freshness_receipt
+    monkeypatch.delenv("HOLOINDEX_QUERY_SERVICE_URL", raising=False)
+    monkeypatch.setattr(
+        adapter,
+        "evaluate_readonly_query_admission",
+        evaluate_readonly_query_admission,
+    )
+    monkeypatch.setattr(
+        query_admission,
+        "load_freshness_receipt",
+        lambda path: (reads.append(Path(path)), real_loader(path))[1],
+    )
+    monkeypatch.setattr(
+        adapter,
+        "_direct_backend_query",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("receipt mismatch must reject before backend")
+        ),
+    )
+
+    result = HoloIndexReadOnlyQueryAdapter(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        freshness_receipt_path=external,
+    ).query(query="evidence", allowed_paths=(), limit=8)
+
+    assert result["error"] == "HOLOINDEX_FRESHNESS_RECEIPT_PATH_MISMATCH"
+    assert result["stale_reasons"] == ["freshness_receipt_path_not_canonical"]
+    assert result["hits"] == []
+    assert reads == []

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -24,7 +24,7 @@ exemptions:
       Legacy module interface registry. This slice adds one bounded transport
       contract beside its canonical resident-client boundary; splitting the
       historical registry is separate documentation-maintenance work.
-    threshold_override: 1140
+    threshold_override: 1148
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -382,7 +382,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 8778
+    threshold_override: 8790
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -394,7 +394,7 @@ exemptions:
     reason: >-
       Legacy WSP_22 test journal. Current entries record focused validation;
       historical test evidence is not split during a runtime-security slice.
-    threshold_override: 1584
+    threshold_override: 1597
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"


### PR DESCRIPTION
## Outcome

Fail closed before persistent HoloIndex reads unless the invoking repository, exact HEAD/generation/baseline, canonical SSD-derived freshness receipt, and maintenance state are admitted.

## Scope

- binds raw CLI, bundle, and RedDog direct-diagnostic persistent reads to the invoking repository
- requires the canonical freshness receipt derived from the admitted SSD
- keeps offline lexical fallback repository-confined, bounded, deterministic, and complete-or-empty
- rejects absolute/traversal/symlink/junction/reparse module escapes
- decomposes the touched bundle handler to 49 lines under WSP_62
- records P1 debt for root-scoped namespaces, neutral gate ownership, semantic recovery, and TOCTOU hardening

No provider/model calls, production storage mutation, or autonomous reindexing are introduced.

## Evidence

- changed admission matrix: 62 passed, 5 optional platform skips
- canonical owner matrix: 60 passed
- wider receipt/client/bundle/transport matrix: 126 passed, 4 optional platform skips
- WSP_62: 19 passed
- live offline raw CLI smoke: passed
- Ruff, compile/import, JSON, diff check, and WSP_97 receipt validation: passed
- one wider CLI purity assertion is unchanged from the parent; the referenced implementation and test are byte-identical to the base

Independent adversarial review: APPROVE at `fce38890b1cccf392b46b76227d7b4c3a770bb75`.