### PR TITLE
feat(ai-gateway): add offline endpoint call eligibility evidence

### DIFF
--- a/docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_ASSUMPTION_AUDIT_20260724.md
+++ b/docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_ASSUMPTION_AUDIT_20260724.md
@@ -1,0 +1,139 @@
+# OpenRouter Endpoint Route Single-Call Admission Phase B2A WSP_97 Audit
+
+- Date: 2026-07-24
+- Owner: 0102 RedDog Architect / Codex isolated worker lane
+- Slice: `OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A`
+- WSP_15 score: Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19 (P0)
+- Original implementation base: `545f4b3b828cf083c20e266961c6df2fde1565c7`
+- Integrated base: `a3c13f05299bf745a1fc01650e1ae91f0db2f820`
+- Branch: `codex/openrouter-endpoint-route-admission-phase-b2a-20260724`
+- Schema source: `https://openrouter.ai/openapi.json`, retrieved 2026-07-24
+  (`PublicEndpoint`, `EndpointStatus`: `0, -1, -2, -3, -5, -10`)
+- Route documentation: `https://openrouter.ai/docs/api-reference/chat-completion`
+  and `https://openrouter.ai/docs/features/provider-routing`, retrieved
+  2026-07-24
+
+## 1. Problem and authority boundary
+
+Phase B1 retained provider-asserted model controls but did not independently
+identify one executable endpoint route or certify one bounded job. B2A may
+project externally supplied endpoint fixtures, preserve exact immutable
+lineage, and issue a pure task-specific eligibility receipt. It may not fetch
+metadata, authenticate, read credentials, call a model/provider, wire a gateway
+or configured runner, mutate runtime selection, or grant live authority.
+
+## 2. Repository retrieval
+
+WSP_00 awakening was applied in 0102 architect state. WSP 00, 15, 22, 50, 62,
+and 97 plus the module README, INTERFACE, ROADMAP, ModLog, and TestModLog were
+read before implementation. The HoloIndex-first offline query exited 0 in
+lexical-only mode and returned unrelated hits, so it was recorded as impaired
+semantic retrieval. Direct `rg`, bounded file reads, tests, AST inspection, and
+diff review were the truthful fallback.
+
+No framework WSP changed, so no WSP knowledge backup was required. The receipt
+lists only verified framework paths that exist at the pinned base.
+
+### Integration migration after WSP_97 PR #1334
+
+The one focused B2A commit was rebased without conflict onto verified
+`origin/main` `a3c13f05299bf745a1fc01650e1ae91f0db2f820`. This is a receipt
+migration and integration correction, not a claim that the original retrieval
+and research actions were rerun. Their truthful evidence is preserved.
+
+The receipt migrated to `wsp97_execution_receipt.v1.1`, binds the exact
+integrated base in `repository_context`, and retains canonical tracked WSP
+paths/IDs. Integration RED proved that the Chat Completions control object used
+the internal budget name `max_completion_tokens`. The corrected object contains
+exactly `max_tokens`, `reasoning`, and `provider`; internal
+`max_completion_tokens` remains separately bound for budgeting. Admission IDs
+and the rehydration expectation are derived again from that corrected object.
+The endpoint fixture bytes and endpoint-evidence IDs are unaffected because
+they contain no request-control payload.
+
+Integration RED was `2 failed, 34 passed`. Post-correction validation was `65`
+focused endpoint/admission tests, `134` combined protected catalog/execution-
+control tests, and `712 passed, 2 skipped` for the full AI Gateway. Ruff,
+WSP_62, JSON/diff checks, and the WSP_97 v1.1 CLI with exact expected base
+passed. This validation is integration evidence; it does not relabel earlier
+research/retrieval actions as newly performed.
+
+## 3. Assumptions and evidence
+
+| Assumption | Evidence | Confidence |
+|---|---|---|
+| Endpoint payloads can identify one exact route | Strict model equality, exact tag selection, duplicate rejection, and base-tag/prefix collision rejection | High |
+| Endpoint prices supersede model-summary prices | Exact canonical Decimal reconciliation and independent policy caps; both values remain in the receipt | High |
+| An unknown zero-valued pricing key is safe to drop | False; additive cost-schema drift is rejected outside the complete explicit allowlist | High |
+| Null and omission mean the same | False; presence flags preserve nullable caps, status, and quantization distinctly | High |
+| Official negative endpoint statuses may remain evidence | Yes; they survive projection but fail the initial trusted exact `(0,)` admission policy | High |
+| Status-policy membership proves availability | False; `endpoint_status_policy_accepted` is only a policy-membership proof | High |
+| A trusted policy may weaken the parameters emitted by the request | False; policy normalization and independent admission derivation both require exact `max_tokens` and `reasoning` controls | High |
+| Internal budget vocabulary may be copied directly to Chat Completions | False; wire controls use exact `max_tokens`; `max_completion_tokens` remains internal evidence only | High |
+| Explicit `supports_max_tokens=false` can coexist with an emitted completion cap | False; the contradiction rejects before eligibility | High |
+| Missing `supports_max_tokens` means unsupported | Not by itself; exact endpoint and model supported-parameter evidence may independently satisfy the requirement, but explicit false wins | High |
+| Optional request price may be silently normalized to zero | False; presence is retained and absence becomes zero only under a named, content-digested PublicPricing schema policy | High |
+| Provider route availability certifies a job | False; a trusted policy and content-bound intent are independently required | High |
+| Job eligibility permits output training | False; training always fails without separate permission evidence | High |
+| Requesting ZDR can rely on endpoint-list data | False; the endpoint schema supplies no sufficient ZDR evidence, so the request fails closed | High |
+| This receipt permits a live call | False; authority is fixed to `eligibility_only` and HALTED reasons remain encoded | High |
+
+## 4. Failure modes and mitigations
+
+| Failure mode | Mitigation | Residual boundary |
+|---|---|---|
+| Secret-like or provider prose crosses the boundary | Allowlist projection before evidence construction; unknown fields are dropped | Upstream fixture supplier remains trusted to supply the exact bytes/receipt |
+| Ambiguous provider tag routes to a variant | Reject duplicate tags and base tags when any `tag/...` variant is present | Future alias policy needs separate evidence |
+| Optional price dimensions evade budget math | Preserve recognized dimensions and reject nonzero/overridden dimensions | Authoritative post-call usage is still absent |
+| Provider adds an unknown cost dimension with a zero default | Reject every pricing key outside the explicit allowlist before projection | A future schema addition requires reviewed code/policy |
+| Forward-unknown status is treated as healthy | Projection accepts only the current official enum | A future enum value requires reviewed code/policy |
+| Omitted or known-negative status reaches execution | Require presence and membership in trusted exact `(0,)` policy | Policy membership is not authoritative availability |
+| Policy names only a subset of emitted controls | Require exact immutable policy parameters and independently derive the mandatory set from the emitted request | Provider parameter evidence may still change and must match both sources |
+| Internal completion-budget key leaks into the wire overlay | Assert exact three-key wire set and explicit absence of `max_completion_tokens` | No provider call is authorized by the corrected object |
+| Model metadata explicitly denies max-token support | Reject `supports_max_tokens=false`; omitted/unknown needs exact supported-parameter evidence | Provider execution remains halted |
+| Optional request price absence is erased | Preserve `request_price_present` and bind schema-policy ID, semantics digest, and acceptance proof | This is not authoritative provider billing or usage |
+| Evidence is edited and its ID recomputed | Rebuild endpoint and model evidence from independent supplied sources and compare exact payloads | Authentic source transport is not implemented |
+| Context and endpoint caps disagree | Enforce prompt, completion, and combined context bounds independently | Provider-side tokenization remains authoritative after a call |
+| Eligibility is consumed twice | Fixed `max_calls=1`, but live authority stays halted | Atomic durable consumption remains unimplemented |
+| Response exceeds memory policy before accounting | Bind `max_response_bytes` in policy/admission | Transport-level pre-buffer enforcement remains unimplemented |
+
+## 5. Alternatives considered
+
+1. Reuse model-list `top_provider` as route admission. Rejected because it does
+   not identify an exact endpoint tag or independent per-route controls.
+2. Fetch endpoints inside the admission builder. Rejected because it would mix
+   network/authentication authority into a pure evidence gate.
+3. Assume ZDR or training permission from endpoint availability. Rejected
+   because the supplied endpoint schema does not prove either policy.
+4. Allow endpoint fallback and later inspect provider metadata. Rejected
+   because post-response display metadata cannot prevent wrong-route execution.
+5. Trust a caller-selected subset of required parameters. Rejected because the
+   policy could weaken controls the canonical request always emits.
+6. Treat missing request price as zero without evidence. Rejected; the
+   interpretation is named, content-digested, presence-preserving, and local to
+   the current PublicPricing contract.
+7. Reuse the internal completion-budget field name on the wire. Rejected
+   because Chat Completions requires `max_tokens`.
+8. Bind an exact no-fallback route and one trusted evaluation intent while
+   explicitly halting transport. Accepted.
+
+## 6. Decision
+
+**PROCEED** with pure offline endpoint-route evidence and
+`CanonicalSingleCallAdmission` as task-specific eligibility evidence.
+
+**HALT** all live provider execution until independent work supplies:
+
+- authenticated endpoint observation;
+- authoritative live endpoint availability;
+- atomic durable admission consumption;
+- authoritative provider usage reconciliation;
+- explicit caller/configured-runner wiring review;
+- response-byte enforcement before transport buffering;
+- an identity-preserving exclusive runtime directory.
+
+Availability, job certification, and output-training permission remain separate
+facts. `endpoint_status_policy_accepted` does not collapse availability into job
+certification. The request-price schema proof does not prove billing or usage.
+No live K3, GLM, OpenClaw, Hermes, gateway, model, or provider call was made by
+this slice.

--- a/docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_EXECUTION_RECEIPT.json
+++ b/docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_EXECUTION_RECEIPT.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": "wsp97_execution_receipt.v1.1",
+  "repository_context": {
+    "base_commit": "a3c13f05299bf745a1fc01650e1ae91f0db2f820"
+  },
+  "execution_id": "OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A",
+  "execution_plane": "runtime",
+  "outcome": "completed",
+  "action_evidence": {
+    "retrieve_wsps": [
+      "WSP_framework/src/WSP_00_Zen_State_Attainment_Protocol.md",
+      "WSP_framework/src/WSP_15_Module_Prioritization_Scoring_System.md",
+      "WSP_framework/src/WSP_22_ModLog_Structure.md",
+      "WSP_framework/src/WSP_50_Pre_Action_Verification_Protocol.md",
+      "WSP_framework/src/WSP_62_Large_File_Refactoring_Enforcement_Protocol.md",
+      "WSP_framework/src/WSP_97_System_Execution_Prompting_Protocol.md"
+    ],
+    "retrieve_evidence": [
+      "HoloIndex-first offline retrieval exited 0 in lexical-only mode with unrelated hits; semantic retrieval remained impaired.",
+      "Direct rg/file-read fallback inspected endpoint schemas, existing candidate/control evidence, module journals, protected-surface gates, and test fixtures.",
+      "docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_ASSUMPTION_AUDIT_20260724.md"
+    ],
+    "research": [
+      "Compared OpenRouter endpoint-list schema, exact provider routing controls, chat-completion route, metadata-header limits, nullable fields, price dimensions, and data-policy evidence gaps.",
+      "Pinned the current official EndpointStatus enum to 0, -1, -2, -3, -5, -10 and rejected forward-unknown values.",
+      "Rejected all unknown pricing keys, including zero values, so additive cost-schema drift cannot be dropped or inferred free.",
+      "Bound the exact emitted-control set max_tokens plus reasoning in both trusted policy normalization and independent admission derivation.",
+      "Rejected explicit reasoning.supports_max_tokens=false while allowing omission only when exact endpoint and model parameter evidence supports max_tokens.",
+      "Preserved request-price presence and bound optional-request absence-as-zero to a named, content-digested PublicPricing schema policy.",
+      "Integration migration preserved prior action evidence, rebased the one focused commit onto verified origin/main a3c13f05299bf745a1fc01650e1ae91f0db2f820, and adopted the v1.1 repository-bound receipt without claiming a research rerun.",
+      "Corrected the Chat Completions control overlay from internal max_completion_tokens vocabulary to exact max_tokens, reasoning, and provider keys; endpoint fixture bytes were unaffected.",
+      "Separated route availability, trusted job certification, output-training permission, and live runtime authority."
+    ],
+    "micro_pass": [
+      "Tests-first RED: collection failed because the admission module did not exist.",
+      "Amendment RED: 8 failed, 20 passed for unknown pricing and status-policy gaps.",
+      "Emitted-control/request-price amendment RED: 9 failed, 25 passed.",
+      "Integration wire-key RED: 2 failed, 34 passed.",
+      "Post-rebase offline endpoint/admission matrix: 65 passed.",
+      "Post-rebase combined protected catalog/execution-control matrix: 134 passed."
+    ],
+    "macro_pass": [
+      "Changed Python scope passed Ruff.",
+      "All new production files are below 500 lines and every function is at most 50 lines.",
+      "Post-rebase full AI Gateway matrix: 712 passed, 2 platform-capability skips.",
+      "Focused Ruff, WSP 62 file/function gates, JSON/diff checks, and WSP 97 v1.1 CLI validation passed."
+    ],
+    "hard_think": [
+      "docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_ASSUMPTION_AUDIT_20260724.md#4-failure-modes-and-mitigations",
+      "Kept authenticated observation, authoritative usage, atomic consumption, transport buffering, and runtime-directory identity outside the pure eligibility boundary."
+    ],
+    "dialectic_sweep": [
+      "docs/audits/ai_intelligence/OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_WSP97_ASSUMPTION_AUDIT_20260724.md#5-alternatives-considered",
+      "Rejected model-list route inference, in-builder network discovery, fallback routing, and inferred ZDR/training authority."
+    ],
+    "first_principles": [
+      "One exact model, one unambiguous endpoint tag, one trusted policy, one content-bound intent, exact Decimal bounds, and no runtime authority form the minimum truthful eligibility receipt.",
+      "A canonical request's mandatory controls cannot be weakened by caller-selected policy subsets.",
+      "Internal admission and budget names cannot substitute for exact provider wire keys.",
+      "Optional request-price absence is a preserved fact; zero is a named local schema-policy interpretation, not provider usage evidence.",
+      "Provider availability cannot imply job certification or output-training permission."
+    ],
+    "execute": [
+      "modules/ai_intelligence/ai_gateway/src/model_openrouter_endpoint_payload_projection.py",
+      "modules/ai_intelligence/ai_gateway/src/model_openrouter_endpoint_route_evidence.py",
+      "modules/ai_intelligence/ai_gateway/src/model_autoresearch_single_call_contracts.py",
+      "modules/ai_intelligence/ai_gateway/src/model_autoresearch_single_call_admission.py",
+      "modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_endpoint_route_evidence.py",
+      "modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_endpoint_contract_drift.py",
+      "modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_single_call_admission.py"
+    ]
+  },
+  "wsps_applied": [
+    "WSP_00",
+    "WSP_15",
+    "WSP_22",
+    "WSP_50",
+    "WSP_62",
+    "WSP_97"
+  ],
+  "compliance_evidence": [
+    "Isolated worktree and branch: codex/openrouter-endpoint-route-admission-phase-b2a-20260724.",
+    "Rebased the one focused commit onto verified origin/main a3c13f05299bf745a1fc01650e1ae91f0db2f820 after WSP_97 PR #1334.",
+    "No framework WSP or knowledge-backup file changed; no WSP_81 backup action was applicable.",
+    "No provider, model, network, credential, gateway, configured-runner, caller, startup, promotion, or runtime-binding call was made.",
+    "CanonicalSingleCallAdmission has runtime_authority=eligibility_only and explicit HALTED reasons.",
+    "endpoint_status_policy_accepted proves only exact trusted policy membership; authoritative endpoint availability remains HALTED.",
+    "request_price_present and the named PublicPricing schema-policy digest remain eligibility evidence only, not billing or usage authority.",
+    "modules/ai_intelligence/ai_gateway/README.md",
+    "modules/ai_intelligence/ai_gateway/INTERFACE.md",
+    "modules/ai_intelligence/ai_gateway/ROADMAP.md",
+    "modules/ai_intelligence/ai_gateway/ModLog.md",
+    "modules/ai_intelligence/ai_gateway/tests/TestModLog.md"
+  ]
+}

--- a/modules/ai_intelligence/ai_gateway/INTERFACE.md
+++ b/modules/ai_intelligence/ai_gateway/INTERFACE.md
@@ -105,6 +105,78 @@ The trust class is `provider_asserted_model_execution_controls`. These APIs do
 not call providers, discover an execution endpoint, select sampling defaults,
 admit a canonical route, rank a model, or grant runtime authority.
 
+#### OpenRouter endpoint-route evidence and single-call eligibility
+
+```python
+parse_and_sanitize_openrouter_endpoint_payload(
+    raw,
+    requested_model_id=...,
+) -> dict
+
+build_endpoint_observation_receipt(...) -> EndpointObservationReceipt
+
+build_openrouter_endpoint_route_evidence(
+    raw=...,
+    observation_receipt=...,
+    endpoint_tag=...,
+    now_ms=...,
+) -> OpenRouterEndpointRouteEvidence
+
+build_canonical_single_call_admission(
+    raw_endpoint_payload=...,
+    endpoint_observation_receipt=...,
+    endpoint_route_evidence=...,
+    model_candidate=...,
+    model_control_evidence=...,
+    policy=...,
+    intent=...,
+    now_ms=...,
+) -> CanonicalSingleCallAdmission
+```
+
+The endpoint payload is supplied by the caller and bounded before strict JSON
+projection; these APIs contain no network or credential boundary. Observation
+and route evidence bind exact bytes, request/response digests, model identity,
+one unambiguous endpoint tag, caps, prices, parameters, nullable controls, and
+freshness. Malformed recognized fields, unsafe secondary price dimensions,
+duplicate tags, and base-tag/prefix collisions fail closed.
+The pricing object is closed to the current explicit allowlist: unknown keys
+fail even when their value is zero. Endpoint status must be omitted or one of
+the current official enum values `0, -1, -2, -3, -5, -10`; known negative
+values remain route evidence.
+
+The admission builder rehydrates both independent evidence sources and binds
+one normalized `CanonicalSingleCallJobPolicy` to one
+`CanonicalSingleCallIntent`. Endpoint-specific prices supersede model-summary
+prices only after exact reconciliation and policy-cap checks. The receipt is
+evaluation-only and `runtime_authority=eligibility_only`; it deliberately does
+not invoke `AIGateway`, a configured runner, a provider caller, or any transport.
+Availability, job certification, and output-training permission are distinct.
+The initial trusted `accepted_endpoint_statuses` policy is exactly `(0,)`.
+`endpoint_status_policy_accepted=true` proves policy membership only; it is not
+authoritative availability evidence, and live availability remains HALTED.
+
+The trusted policy's `required_parameters` must be exactly
+`("max_tokens", "reasoning")`; admission also derives this mandatory set
+independently from the emitted `max_tokens` and `reasoning` controls.
+Both endpoint and model supported-parameter evidence must contain both names.
+An explicit model `reasoning.supports_max_tokens=false` contradicts the emitted
+cap and rejects. Omitted/unknown remains non-contradictory only because the two
+exact supported-parameter sources independently assert `max_tokens`.
+The resulting Chat Completions `request_control` contains exactly
+`max_tokens`, `reasoning`, and `provider`. Its `max_tokens` value is copied from
+the separately retained internal admission/budget field
+`max_completion_tokens`; the internal name is forbidden from the wire-control
+mapping. Route, model, intent, and prompt evidence remain in their dedicated
+receipt fields/digests.
+
+The receipt preserves `request_price_present`. OpenRouter `PublicPricing`
+requires prompt/completion prices and makes request price optional; an absent
+request price is interpreted as zero only under the named
+`openrouter_public_pricing_request_optional_absence_as_zero.v1` code-owned
+schema policy. Its digest and acceptance proof are admission-ID and rehydration
+bound. They do not prove provider billing, usage, or availability.
+
 `ProviderCatalogArtifactStore` is the confined persistence boundary used for
 both attempt and candidate artifacts. Replacement is same-directory and atomic:
 the target is untouched until exact UTF-8 bytes have been flushed and fsynced

--- a/modules/ai_intelligence/ai_gateway/ModLog.md
+++ b/modules/ai_intelligence/ai_gateway/ModLog.md
@@ -1,5 +1,56 @@
 # AI Gateway Module Change Log
 
+## [2026-07-24] - OpenRouter Endpoint Route Single-Call Admission Phase B2A
+
+**Who/Type/Slice:** 0102 RedDog Architect isolated worker / Defensive
+Eligibility / `OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A`
+
+**What:** Added strict bounded projection of externally supplied OpenRouter
+endpoint payloads, immutable byte/receipt/route lineage, trusted one-call policy
+and intent contracts, and a pure canonical admission receipt binding the exact
+POST route, provider order, no-fallback policy, supported controls, token/
+context/response limits, Decimal cost reservation, and trusted exact `(0,)`
+endpoint-status policy. Unknown additive price keys now fail closed even at
+zero; only the current official endpoint-status enum crosses projection. The
+trusted policy and independent admission derivation both require the exact
+emitted-control set `("max_tokens", "reasoning")`; explicit model
+`supports_max_tokens=false` contradicts the emitted cap. Request-price presence
+is preserved, and absence becomes zero only under a named, digested OpenRouter
+PublicPricing schema-policy proof.
+
+**Integration migration:** Rebased the single focused slice onto
+`origin/main` `a3c13f05299bf745a1fc01650e1ae91f0db2f820` after WSP_97 PR #1334.
+Migrated the execution receipt to `wsp97_execution_receipt.v1.1` with exact
+repository context. Corrected the Chat Completions wire overlay to the exact
+keys `max_tokens`, `reasoning`, and `provider`; `max_completion_tokens` remains
+only the internal admission/budget field. Deterministic admission IDs now
+rederive from the corrected control object.
+
+**Truth boundary:** `runtime_authority=eligibility_only`. No metadata-fetch,
+network, model, provider, credential, gateway, configured-runner, caller, or
+startup call was added. Availability, job certification, and output-training
+permission stay separate; the POC is evaluation-only and fails closed for
+requested ZDR or training authority. Live execution remains explicitly halted
+for authenticated endpoint supply, atomic consumption, authoritative
+availability and usage, caller wiring, pre-buffer response enforcement, and
+runtime-directory identity.
+`endpoint_status_policy_accepted` proves policy membership, not availability.
+The request-price schema proof is not authoritative billing/usage evidence.
+
+**WSP_15 MPS:** Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19
+(P0 defensive trust boundary).
+
+**Validation:** Initial amendment RED: `8 failed, 20 passed`; emitted-control/
+request-price amendment RED: `9 failed, 25 passed`; integration wire-key RED:
+`2 failed, 34 passed`. Post-rebase endpoint/admission: `65 passed`; combined
+protected catalog/execution-control: `134 passed`; full AI Gateway: `712 passed,
+2 skipped`. Ruff, WSP_62, JSON, diff, and WSP_97 v1.1 receipt validation passed.
+No provider, model, network, or credential call occurred.
+
+**WSP References:** WSP 00, WSP 15, WSP 22, WSP 50, WSP 62, WSP 97.
+
+---
+
 ## [2026-07-24] - OpenRouter Model Execution-Control Evidence Phase B1
 
 **Who/Type/Slice:** 0102 RedDog Architect isolated worker / Provider Evidence /

--- a/modules/ai_intelligence/ai_gateway/README.md
+++ b/modules/ai_intelligence/ai_gateway/README.md
@@ -153,6 +153,58 @@ and contradictory co-present claims poison the record. The result has trust clas
 not canonical route admission, endpoint discovery, sampling defaults,
 selection, promotion, runtime binding, or permission to call a provider.
 
+### Endpoint-route evidence and single-call eligibility
+
+`src/model_openrouter_endpoint_payload_projection.py` and
+`src/model_openrouter_endpoint_route_evidence.py` accept only externally
+supplied, bounded OpenRouter endpoint fixtures. They project a strict recognized
+schema, preserve null versus omission, bind exact response bytes and request
+lineage, reject duplicate or prefix-ambiguous endpoint tags, and produce
+immutable provider-asserted evidence for one exact route. They do not perform
+metadata discovery, networking, authentication, or credential access. Pricing
+is a closed allowlist: any unknown additive cost key is rejected even when its
+reported value is zero. Endpoint status is restricted to the current official
+enum; known negative states remain evidence but cannot satisfy the initial
+trusted accepted-status policy `(0,)`.
+
+`src/model_autoresearch_single_call_contracts.py` and
+`src/model_autoresearch_single_call_admission.py` combine that route evidence
+with fresh model-control evidence, one trusted job policy, and one content-bound
+call intent. The resulting `CanonicalSingleCallAdmission` fixes the
+`POST /chat/completions` route, endpoint order, no-fallback and
+required-parameter controls, reasoning effort, exact Decimal price ceiling,
+prompt/completion/context/response bounds, and a single-call limit.
+The policy must contain the exact immutable emitted-control set
+`("max_tokens", "reasoning")`, and admission independently derives the same
+mandatory set. A model-level `supports_max_tokens=false` assertion is an
+explicit contradiction and rejects; an omitted/unknown assertion is accepted
+only when exact endpoint and model parameter evidence both include
+`max_tokens`.
+For the Chat Completions route, `request_control` is exactly the three-key
+wire-control overlay `max_tokens`, `reasoning`, and `provider`.
+`max_completion_tokens` remains the internal admission/budget field and never
+appears in that wire overlay. Route headers, model/intent identity, stream
+policy, and prompt bounds remain separately admission-bound rather than being
+misrepresented as this control object.
+
+OpenRouter `PublicPricing` requires `prompt` and `completion` while `request`
+is optional. Admission preserves `request_price_present`; absence becomes zero
+only under the named, content-digested
+`openrouter_public_pricing_request_optional_absence_as_zero.v1` schema policy.
+This is a local eligibility policy proof, not provider billing or usage proof.
+The named `endpoint_status_policy_accepted` proof means only that the observed
+status was present and belonged to the trusted job policy; it is not proof of
+live or authoritative endpoint availability.
+
+This receipt has `runtime_authority=eligibility_only`. It cannot be consumed as
+permission to call a provider. Availability evidence, task-specific job
+certification, and permission to train on output are independent decisions:
+the current POC admits evaluation-only intent, fails closed when ZDR evidence is
+requested, and never grants output-training permission. Live execution remains
+halted pending authenticated endpoint supply, atomic admission consumption,
+authoritative availability and usage, caller wiring, a pre-buffer response-byte
+bound, and runtime-directory identity.
+
 ## Model Selection Receipts
 
 `src/model_intelligence_selection.py` consumes a `ModelCatalogSnapshot` and

--- a/modules/ai_intelligence/ai_gateway/ROADMAP.md
+++ b/modules/ai_intelligence/ai_gateway/ROADMAP.md
@@ -68,9 +68,18 @@
   claim, with canonical invocation mapping and a six-key evidence-only adapter.
 - [x] Preserve bounded optional OpenRouter reasoning/top-provider assertions and
   derive exact-model, lineage-bound provider-asserted execution-control evidence.
-- [ ] Keep execution halted until canonical route/endpoint admission, sampling
-  defaults, authoritative usage, and bounded transport response evidence are
-  supplied independently; provider assertions do not satisfy those gates.
+- [x] Add pure, externally supplied endpoint-route evidence and task-specific
+  single-call eligibility admission with exact route, sampling, token, cost,
+  response-byte, lineage, closed pricing schema, and evaluation-only status
+  policy controls. The admission independently derives its immutable emitted
+  parameter set and preserves optional request-price absence under a named,
+  digested PublicPricing schema policy. Chat Completions wire controls use exact
+  `max_tokens`, `reasoning`, and `provider` keys while the internal completion
+  budget remains `max_completion_tokens`.
+- [ ] Keep execution halted until authenticated endpoint supply, atomic
+  admission consumption, authoritative availability and usage, caller wiring,
+  pre-buffer response-byte enforcement, and runtime-directory identity are
+  supplied independently; eligibility receipts do not grant live authority.
 - [ ] General provider-discovery cadence and scheduler expansion remains out of
   scope; the POC does not grant discovery any startup, selection, promotion,
   registry, or runtime authority.

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_single_call_admission.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_single_call_admission.py
@@ -1,0 +1,353 @@
+"""Pure builder for one exact configured AutoResearch call eligibility receipt."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Mapping
+
+from .model_autoresearch_single_call_contracts import (
+    ADMISSION_ID_PATTERN,
+    ADMISSION_KEYS,
+    CanonicalSingleCallAdmission,
+    CanonicalSingleCallIntent,
+    CanonicalSingleCallJobPolicy,
+    GATEWAY_BASE_URL,
+    HALTED_REASONS,
+    HTTP_METHOD,
+    MANDATORY_REQUEST_PARAMETERS,
+    OMITTED_SAMPLING_PARAMETERS,
+    PRICE_RECONCILIATION,
+    PUBLIC_PRICING_SCHEMA_POLICY,
+    REQUEST_PATH,
+    RUNTIME_AUTHORITY,
+    SCHEMA_VERSION,
+    TRUST_CLASS,
+    content_id,
+    decimal_text,
+    digest_payload,
+    frozen,
+    is_uint,
+)
+from .model_openrouter_endpoint_route_evidence import (
+    EndpointObservationReceipt,
+    OpenRouterEndpointRouteEvidence,
+    rehydrate_openrouter_endpoint_route_evidence,
+)
+from .model_provider_catalog_snapshot import ProviderCatalogCandidateSnapshot
+from .model_provider_execution_control_evidence import (
+    ProviderModelExecutionControlEvidence,
+    rehydrate_provider_model_execution_control_evidence,
+)
+
+
+def build_canonical_single_call_admission(
+    *,
+    raw_endpoint_payload: bytes,
+    endpoint_observation_receipt: EndpointObservationReceipt,
+    endpoint_route_evidence: OpenRouterEndpointRouteEvidence,
+    model_candidate: ProviderCatalogCandidateSnapshot,
+    model_control_evidence: ProviderModelExecutionControlEvidence,
+    policy: CanonicalSingleCallJobPolicy,
+    intent: CanonicalSingleCallIntent,
+    now_ms: int,
+) -> CanonicalSingleCallAdmission:
+    if not is_uint(now_ms):
+        raise ValueError("single_call_admission_invalid")
+    endpoint = rehydrate_openrouter_endpoint_route_evidence(
+        endpoint_route_evidence.to_dict(),
+        raw=raw_endpoint_payload,
+        observation_receipt=endpoint_observation_receipt,
+        now_ms=now_ms,
+    )
+    model = rehydrate_provider_model_execution_control_evidence(
+        model_control_evidence.to_dict(), candidate=model_candidate, now_ms=now_ms
+    )
+    job, call = policy.normalized(), intent.normalized()
+    _validate_time(job, call, now_ms)
+    _validate_identities(endpoint, model, job, call)
+    _validate_controls(endpoint, model, job, call)
+    pricing = _validated_pricing(endpoint, job, call)
+    request_control = _request_control(job, pricing)
+    values = _admission_values(
+        endpoint, model, job, call, pricing, request_control, now_ms
+    )
+    return _materialize_admission(values, request_control)
+
+
+def _materialize_admission(
+    values: dict[str, Any], request_control: Mapping[str, Any]
+) -> CanonicalSingleCallAdmission:
+    admission_id = content_id(
+        "canonical_single_call_admission",
+        {"schema_version": SCHEMA_VERSION, **values},
+    )
+    constructor_values = {
+        **{
+            key: value
+            for key, value in values.items()
+            if key
+            not in {
+                "provider",
+                "gateway_base_url",
+                "http_method",
+                "request_path",
+                "trust_class",
+                "runtime_authority",
+            }
+        },
+        "request_control": frozen(request_control),
+    }
+    return CanonicalSingleCallAdmission(
+        admission_id=admission_id,
+        **constructor_values,
+    )
+
+
+def rehydrate_canonical_single_call_admission(
+    payload: Mapping[str, Any], **sources: Any
+) -> CanonicalSingleCallAdmission:
+    if (
+        not isinstance(payload, Mapping)
+        or set(payload) != ADMISSION_KEYS
+        or payload.get("schema_version") != SCHEMA_VERSION
+        or not ADMISSION_ID_PATTERN.fullmatch(str(payload.get("admission_id")))
+    ):
+        raise ValueError("single_call_admission_invalid")
+    try:
+        expected = build_canonical_single_call_admission(**sources)
+    except ValueError as exc:
+        if str(exc) in {
+            "endpoint_observation_stale",
+            "endpoint_observation_future",
+            "candidate_snapshot_stale",
+            "candidate_snapshot_future_observation",
+        }:
+            raise
+        raise ValueError("single_call_admission_invalid") from None
+    if dict(payload) != expected.to_dict():
+        raise ValueError("single_call_admission_invalid")
+    return expected
+
+
+def _validate_time(
+    policy: CanonicalSingleCallJobPolicy,
+    intent: CanonicalSingleCallIntent,
+    now_ms: int,
+) -> None:
+    if now_ms > policy.expires_at_ms or now_ms > intent.expires_at_ms:
+        raise ValueError("single_call_evidence_stale")
+    if now_ms < intent.issued_at_ms:
+        raise ValueError("single_call_intent_future")
+
+
+def _validate_identities(endpoint, model, policy, intent) -> None:
+    if len({endpoint.model_id, model.model_id, policy.model_id, intent.model_id}) != 1:
+        raise ValueError("single_call_model_mismatch")
+    if endpoint.endpoint_tag != policy.endpoint_tag:
+        raise ValueError("single_call_route_ambiguous")
+    if policy.task_type != intent.task_type or policy.output_use != intent.output_use:
+        raise ValueError("single_call_intent_invalid")
+    if policy.require_zdr:
+        raise ValueError("single_call_zdr_evidence_missing")
+    if policy.output_use == "training":
+        raise ValueError("single_call_output_training_permission_missing")
+    if policy.enforce_distillable_text:
+        raise ValueError("single_call_policy_invalid")
+
+
+def _validate_controls(endpoint, model, policy, intent) -> None:
+    if not endpoint.status_present:
+        raise ValueError("single_call_endpoint_status_missing")
+    if endpoint.status not in policy.accepted_endpoint_statuses:
+        raise ValueError("single_call_endpoint_status_not_accepted")
+    if endpoint.max_prompt_tokens is None or endpoint.max_completion_tokens is None:
+        raise ValueError("single_call_endpoint_caps_unknown")
+    if intent.prompt_token_upper_bound > min(
+        policy.max_prompt_tokens, endpoint.max_prompt_tokens
+    ):
+        raise ValueError("single_call_prompt_cap_exceeded")
+    if policy.max_completion_tokens > endpoint.max_completion_tokens:
+        raise ValueError("single_call_completion_cap_exceeded")
+    if intent.prompt_token_upper_bound + policy.max_completion_tokens > endpoint.context_length:
+        raise ValueError("single_call_context_cap_exceeded")
+    _validate_top_provider(model, intent, policy)
+    required = set(MANDATORY_REQUEST_PARAMETERS)
+    if not required.issubset(endpoint.supported_parameters) or not required.issubset(
+        model.supported_parameters
+    ):
+        raise ValueError("single_call_parameter_unsupported")
+    _validate_reasoning(model, policy)
+
+
+def _validate_top_provider(model, intent, policy) -> None:
+    top = model.top_provider
+    if top is None:
+        return
+    if top.context_length_present and top.context_length is not None:
+        if intent.prompt_token_upper_bound + policy.max_completion_tokens > top.context_length:
+            raise ValueError("single_call_context_cap_exceeded")
+    if top.max_completion_tokens_present and top.max_completion_tokens is not None:
+        if policy.max_completion_tokens > top.max_completion_tokens:
+            raise ValueError("single_call_completion_cap_exceeded")
+
+
+def _validate_reasoning(model, policy) -> None:
+    reasoning = model.reasoning
+    if (
+        reasoning is None
+        or not reasoning.supported_efforts_present
+        or reasoning.supported_efforts is None
+    ):
+        raise ValueError("single_call_reasoning_controls_missing")
+    if policy.reasoning_effort not in reasoning.supported_efforts:
+        raise ValueError("single_call_reasoning_effort_unsupported")
+    if reasoning.supports_max_tokens is False:
+        raise ValueError("single_call_max_tokens_contradicted")
+    if reasoning.mandatory and policy.reasoning_effort == "none":
+        raise ValueError("single_call_reasoning_effort_unsupported")
+
+
+def _validated_pricing(endpoint, policy, intent) -> dict[str, Any]:
+    if endpoint.unsafe_cost_dimensions:
+        raise ValueError("single_call_pricing_unsupported")
+    schema_policy = _public_pricing_schema_policy()
+    request_price = endpoint.request_price
+    if not endpoint.request_price_present:
+        request_price = schema_policy["absent_request_price"]
+    if request_price != "0" or policy.max_request_price != "0":
+        raise ValueError("single_call_pricing_unsupported")
+    prompt_million = _per_million(endpoint.prompt_price)
+    completion_million = _per_million(endpoint.completion_price)
+    if Decimal(prompt_million) > Decimal(policy.max_prompt_price_per_million):
+        raise ValueError("single_call_price_cap_exceeded")
+    if Decimal(completion_million) > Decimal(policy.max_completion_price_per_million):
+        raise ValueError("single_call_price_cap_exceeded")
+    reserved = (
+        Decimal(endpoint.prompt_price) * intent.prompt_token_upper_bound
+        + Decimal(endpoint.completion_price) * policy.max_completion_tokens
+        + Decimal(request_price)
+    )
+    return {
+        "prompt_price_per_million": prompt_million,
+        "completion_price_per_million": completion_million,
+        "request_price": request_price,
+        "request_price_present": endpoint.request_price_present,
+        "request_price_schema_policy": PUBLIC_PRICING_SCHEMA_POLICY,
+        "request_price_schema_policy_digest": digest_payload(schema_policy),
+        "request_price_schema_policy_accepted": True,
+        "reserved_upper_cost": decimal_text(reserved),
+    }
+
+
+def _public_pricing_schema_policy() -> dict[str, Any]:
+    return {
+        "schema_id": PUBLIC_PRICING_SCHEMA_POLICY,
+        "required": ["prompt", "completion"],
+        "request_presence": "optional",
+        "absent_request_price": "0",
+    }
+
+
+def _request_control(policy, pricing) -> dict[str, Any]:
+    return {
+        "max_tokens": policy.max_completion_tokens,
+        "reasoning": {"effort": policy.reasoning_effort},
+        "provider": {
+            "order": [policy.endpoint_tag],
+            "allow_fallbacks": False,
+            "require_parameters": True,
+            "data_collection": "deny",
+            "zdr": False,
+            "max_price": {
+                "prompt": pricing["prompt_price_per_million"],
+                "completion": pricing["completion_price_per_million"],
+                "request": pricing["request_price"],
+            },
+        },
+    }
+
+
+def _admission_values(endpoint, model, policy, intent, pricing, request, now_ms):
+    return {
+        "provider": "openrouter",
+        "model_control_evidence_id": model.evidence_id,
+        "model_control_digest": model.source_control_digest,
+        "endpoint_route_evidence_id": endpoint.evidence_id,
+        "endpoint_record_digest": endpoint.endpoint_record_digest,
+        "policy_id": policy.policy_id,
+        "intent_id": intent.intent_id,
+        "route_contract_digest": _route_contract_digest(),
+        "gateway_base_url": GATEWAY_BASE_URL,
+        "http_method": HTTP_METHOD,
+        "request_path": REQUEST_PATH,
+        "model_id": endpoint.model_id,
+        "endpoint_tag": endpoint.endpoint_tag,
+        "provider_order": (endpoint.endpoint_tag,),
+        "allow_fallbacks": False,
+        "require_parameters": True,
+        "data_collection": "deny",
+        "require_zdr": False,
+        "enforce_distillable_text": False,
+        "reasoning_effort": policy.reasoning_effort,
+        "omitted_sampling_parameters": OMITTED_SAMPLING_PARAMETERS,
+        "mandatory_request_parameters": MANDATORY_REQUEST_PARAMETERS,
+        **_status_proof(endpoint, policy),
+        "prompt_token_upper_bound": intent.prompt_token_upper_bound,
+        "max_completion_tokens": policy.max_completion_tokens,
+        "context_length": endpoint.context_length,
+        "max_response_bytes": policy.max_response_bytes,
+        "prompt_price": endpoint.prompt_price,
+        "completion_price": endpoint.completion_price,
+        **pricing,
+        "model_summary_prompt_price": model.prompt_price,
+        "model_summary_completion_price": model.completion_price,
+        "price_reconciliation": PRICE_RECONCILIATION,
+        "request_control": request,
+        "output_use": "evaluation_only",
+        "output_training_permission": False,
+        "issued_at_ms": now_ms,
+        "fresh_until_ms": min(
+            endpoint.fresh_until_ms,
+            model.fresh_until_ms,
+            policy.expires_at_ms,
+            intent.expires_at_ms,
+        ),
+        "max_calls": 1,
+        "halted_reasons": HALTED_REASONS,
+        "trust_class": TRUST_CLASS,
+        "runtime_authority": RUNTIME_AUTHORITY,
+    }
+
+
+def _status_proof(endpoint, policy) -> dict[str, Any]:
+    return {
+        "endpoint_status": endpoint.status,
+        "accepted_endpoint_statuses": policy.accepted_endpoint_statuses,
+        "endpoint_status_policy_accepted": True,
+    }
+
+
+def _route_contract_digest() -> str:
+    return digest_payload({
+        "gateway_base_url": GATEWAY_BASE_URL,
+        "http_method": HTTP_METHOD,
+        "request_path": REQUEST_PATH,
+        "headers": {
+            "Content-Type": "application/json",
+            "X-OpenRouter-Metadata": "enabled",
+        },
+        "stream": False,
+    })
+
+
+def _per_million(value: str) -> str:
+    return decimal_text(Decimal(value) * Decimal(1_000_000))
+
+
+__all__ = [
+    "CanonicalSingleCallAdmission",
+    "CanonicalSingleCallIntent",
+    "CanonicalSingleCallJobPolicy",
+    "build_canonical_single_call_admission",
+    "rehydrate_canonical_single_call_admission",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_autoresearch_single_call_contracts.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_autoresearch_single_call_contracts.py
@@ -1,0 +1,422 @@
+"""Immutable policy, intent, and eligibility receipt contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "canonical_single_call_admission.v1"
+POLICY_SCHEMA_VERSION = "canonical_single_call_job_policy.v1"
+INTENT_SCHEMA_VERSION = "canonical_single_call_intent.v1"
+TRUST_CLASS = "trusted_job_policy_over_provider_asserted_route_evidence"
+RUNTIME_AUTHORITY = "eligibility_only"
+GATEWAY_BASE_URL = "https://openrouter.ai/api/v1"
+HTTP_METHOD = "POST"
+REQUEST_PATH = "/chat/completions"
+PRICE_RECONCILIATION = "endpoint_specific_supersedes_model_summary"
+MANDATORY_REQUEST_PARAMETERS = ("max_tokens", "reasoning")
+PUBLIC_PRICING_SCHEMA_POLICY = (
+    "openrouter_public_pricing_request_optional_absence_as_zero.v1"
+)
+HALTED_REASONS = (
+    "atomic_admission_consumption_missing",
+    "authenticated_endpoint_supply_missing",
+    "authoritative_endpoint_availability_missing",
+    "authoritative_usage_missing",
+    "caller_wiring_absent",
+    "prebuffer_response_bound_missing",
+    "runtime_directory_identity_missing",
+)
+OMITTED_SAMPLING_PARAMETERS = (
+    "min_p", "seed", "temperature", "top_a", "top_k", "top_p",
+)
+ADMISSION_KEYS = frozenset(
+    """schema_version admission_id provider model_control_evidence_id
+    model_control_digest endpoint_route_evidence_id endpoint_record_digest
+    policy_id intent_id route_contract_digest gateway_base_url http_method
+    request_path model_id endpoint_tag provider_order allow_fallbacks
+    require_parameters data_collection require_zdr enforce_distillable_text
+    reasoning_effort omitted_sampling_parameters mandatory_request_parameters
+    endpoint_status
+    accepted_endpoint_statuses endpoint_status_policy_accepted
+    prompt_token_upper_bound
+    max_completion_tokens context_length max_response_bytes prompt_price
+    completion_price prompt_price_per_million completion_price_per_million
+    request_price request_price_present request_price_schema_policy
+    request_price_schema_policy_digest request_price_schema_policy_accepted
+    model_summary_prompt_price model_summary_completion_price
+    price_reconciliation reserved_upper_cost request_control output_use
+    output_training_permission issued_at_ms fresh_until_ms max_calls
+    halted_reasons trust_class runtime_authority""".split()
+)
+ADMISSION_ID_PATTERN = re.compile(
+    r"canonical_single_call_admission:[0-9a-f]{64}\Z"
+)
+_MODEL_ID = re.compile(
+    r"[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?/"
+    r"[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?(?::free)?\Z"
+)
+_TOKEN = re.compile(r"[a-z0-9][a-z0-9._:/-]{0,127}\Z")
+_DIGEST = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_NONCE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{7,159}\Z")
+_MAX_TOKEN_BOUND = 100_000_000
+_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class CanonicalSingleCallJobPolicy:
+    task_type: str
+    model_id: str
+    endpoint_tag: str
+    accepted_endpoint_statuses: tuple[int, ...]
+    max_prompt_tokens: int
+    max_completion_tokens: int
+    max_response_bytes: int
+    reasoning_effort: str
+    required_parameters: tuple[str, ...]
+    omitted_sampling_parameters: tuple[str, ...]
+    data_collection: str
+    require_zdr: bool
+    output_use: str
+    enforce_distillable_text: bool
+    max_prompt_price_per_million: str
+    max_completion_price_per_million: str
+    max_request_price: str
+    expires_at_ms: int
+    max_calls: int
+    schema_version: str = field(init=False, default=POLICY_SCHEMA_VERSION)
+
+    @property
+    def policy_id(self) -> str:
+        return content_id("canonical_single_call_job_policy", self.normalized().to_dict())
+
+    def normalized(self) -> "CanonicalSingleCallJobPolicy":
+        _validate_policy_scalars(self)
+        required = unique_tokens(self.required_parameters)
+        omitted = unique_tokens(self.omitted_sampling_parameters)
+        if required != MANDATORY_REQUEST_PARAMETERS:
+            raise ValueError("single_call_required_parameters_invalid")
+        if omitted != OMITTED_SAMPLING_PARAMETERS:
+            raise ValueError("single_call_sampling_policy_invalid")
+        return CanonicalSingleCallJobPolicy(
+            task_type=self.task_type,
+            model_id=self.model_id,
+            endpoint_tag=self.endpoint_tag,
+            accepted_endpoint_statuses=_accepted_statuses(
+                self.accepted_endpoint_statuses
+            ),
+            max_prompt_tokens=positive_int(self.max_prompt_tokens),
+            max_completion_tokens=positive_int(self.max_completion_tokens),
+            max_response_bytes=_response_bytes(self.max_response_bytes),
+            reasoning_effort=self.reasoning_effort,
+            required_parameters=required,
+            omitted_sampling_parameters=omitted,
+            data_collection="deny",
+            require_zdr=self.require_zdr,
+            output_use=self.output_use,
+            enforce_distillable_text=self.enforce_distillable_text,
+            max_prompt_price_per_million=canonical_price(
+                self.max_prompt_price_per_million
+            ),
+            max_completion_price_per_million=canonical_price(
+                self.max_completion_price_per_million
+            ),
+            max_request_price=canonical_price(self.max_request_price),
+            expires_at_ms=self.expires_at_ms,
+            max_calls=1,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "task_type": self.task_type,
+            "model_id": self.model_id,
+            "endpoint_tag": self.endpoint_tag,
+            "accepted_endpoint_statuses": list(self.accepted_endpoint_statuses),
+            "max_prompt_tokens": self.max_prompt_tokens,
+            "max_completion_tokens": self.max_completion_tokens,
+            "max_response_bytes": self.max_response_bytes,
+            "reasoning_effort": self.reasoning_effort,
+            "required_parameters": list(self.required_parameters),
+            "omitted_sampling_parameters": list(self.omitted_sampling_parameters),
+            "data_collection": self.data_collection,
+            "require_zdr": self.require_zdr,
+            "output_use": self.output_use,
+            "enforce_distillable_text": self.enforce_distillable_text,
+            "max_prompt_price_per_million": self.max_prompt_price_per_million,
+            "max_completion_price_per_million": self.max_completion_price_per_million,
+            "max_request_price": self.max_request_price,
+            "expires_at_ms": self.expires_at_ms,
+            "max_calls": self.max_calls,
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalSingleCallIntent:
+    task_type: str
+    model_id: str
+    prompt_digest: str
+    prompt_token_upper_bound: int
+    output_use: str
+    nonce: str
+    issued_at_ms: int
+    expires_at_ms: int
+    schema_version: str = field(init=False, default=INTENT_SCHEMA_VERSION)
+
+    @property
+    def intent_id(self) -> str:
+        return content_id("canonical_single_call_intent", self.normalized().to_dict())
+
+    def normalized(self) -> "CanonicalSingleCallIntent":
+        if (
+            self.schema_version != INTENT_SCHEMA_VERSION
+            or not valid_token(self.task_type)
+            or not valid_model(self.model_id)
+            or not _DIGEST.fullmatch(str(self.prompt_digest))
+            or not _NONCE.fullmatch(str(self.nonce))
+            or self.output_use not in {"evaluation_only", "training"}
+            or not is_uint(self.issued_at_ms)
+            or not is_uint(self.expires_at_ms)
+            or self.issued_at_ms > self.expires_at_ms
+        ):
+            raise ValueError("single_call_intent_invalid")
+        return CanonicalSingleCallIntent(
+            task_type=self.task_type,
+            model_id=self.model_id,
+            prompt_digest=self.prompt_digest,
+            prompt_token_upper_bound=positive_int(self.prompt_token_upper_bound),
+            output_use=self.output_use,
+            nonce=self.nonce,
+            issued_at_ms=self.issued_at_ms,
+            expires_at_ms=self.expires_at_ms,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "task_type": self.task_type,
+            "model_id": self.model_id,
+            "prompt_digest": self.prompt_digest,
+            "prompt_token_upper_bound": self.prompt_token_upper_bound,
+            "output_use": self.output_use,
+            "nonce": self.nonce,
+            "issued_at_ms": self.issued_at_ms,
+            "expires_at_ms": self.expires_at_ms,
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalSingleCallAdmission:
+    admission_id: str
+    model_control_evidence_id: str
+    model_control_digest: str
+    endpoint_route_evidence_id: str
+    endpoint_record_digest: str
+    policy_id: str
+    intent_id: str
+    route_contract_digest: str
+    model_id: str
+    endpoint_tag: str
+    provider_order: tuple[str, ...]
+    allow_fallbacks: bool
+    require_parameters: bool
+    data_collection: str
+    require_zdr: bool
+    enforce_distillable_text: bool
+    reasoning_effort: str
+    omitted_sampling_parameters: tuple[str, ...]
+    mandatory_request_parameters: tuple[str, ...]
+    endpoint_status: int
+    accepted_endpoint_statuses: tuple[int, ...]
+    endpoint_status_policy_accepted: bool
+    prompt_token_upper_bound: int
+    max_completion_tokens: int
+    context_length: int
+    max_response_bytes: int
+    prompt_price: str
+    completion_price: str
+    prompt_price_per_million: str
+    completion_price_per_million: str
+    request_price: str
+    request_price_present: bool
+    request_price_schema_policy: str
+    request_price_schema_policy_digest: str
+    request_price_schema_policy_accepted: bool
+    model_summary_prompt_price: str
+    model_summary_completion_price: str
+    price_reconciliation: str
+    reserved_upper_cost: str
+    request_control: Mapping[str, Any]
+    output_use: str
+    output_training_permission: bool
+    issued_at_ms: int
+    fresh_until_ms: int
+    max_calls: int
+    halted_reasons: tuple[str, ...]
+    provider: str = field(init=False, default="openrouter")
+    gateway_base_url: str = field(init=False, default=GATEWAY_BASE_URL)
+    http_method: str = field(init=False, default=HTTP_METHOD)
+    request_path: str = field(init=False, default=REQUEST_PATH)
+    trust_class: str = field(init=False, default=TRUST_CLASS)
+    runtime_authority: str = field(init=False, default=RUNTIME_AUTHORITY)
+    schema_version: str = field(init=False, default=SCHEMA_VERSION)
+
+    def to_dict(self) -> dict[str, Any]:
+        result = {
+            key: getattr(self, key)
+            for key in ADMISSION_KEYS
+            if key not in {
+                "provider_order", "omitted_sampling_parameters",
+                "mandatory_request_parameters",
+                "accepted_endpoint_statuses",
+                "halted_reasons", "request_control",
+            }
+        }
+        result["provider_order"] = list(self.provider_order)
+        result["omitted_sampling_parameters"] = list(self.omitted_sampling_parameters)
+        result["mandatory_request_parameters"] = list(
+            self.mandatory_request_parameters
+        )
+        result["accepted_endpoint_statuses"] = list(self.accepted_endpoint_statuses)
+        result["halted_reasons"] = list(self.halted_reasons)
+        result["request_control"] = mutable(self.request_control)
+        return result
+
+
+def canonical_price(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("single_call_policy_invalid")
+    try:
+        decimal = Decimal(value)
+    except InvalidOperation:
+        raise ValueError("single_call_policy_invalid") from None
+    if not decimal.is_finite() or decimal < 0 or decimal > Decimal("1000000000"):
+        raise ValueError("single_call_policy_invalid")
+    canonical = decimal_text(decimal)
+    if value != canonical:
+        raise ValueError("single_call_policy_invalid")
+    return canonical
+
+
+def positive_int(value: Any) -> int:
+    if type(value) is not int or not 0 < value <= _MAX_TOKEN_BOUND:
+        raise ValueError("single_call_policy_invalid")
+    return value
+
+
+def unique_tokens(values: Any) -> tuple[str, ...]:
+    if not isinstance(values, tuple) or not values:
+        raise ValueError("single_call_policy_invalid")
+    result = tuple(sorted(values))
+    if len(result) != len(set(result)) or not all(valid_token(item) for item in result):
+        raise ValueError("single_call_policy_invalid")
+    return result
+
+
+def valid_token(value: Any) -> bool:
+    return isinstance(value, str) and _TOKEN.fullmatch(value) is not None
+
+
+def valid_model(value: Any) -> bool:
+    return isinstance(value, str) and _MODEL_ID.fullmatch(value) is not None
+
+
+def is_uint(value: Any) -> bool:
+    return type(value) is int and 0 <= value < 2**63
+
+
+def decimal_text(value: Decimal) -> str:
+    return format(value.normalize(), "f")
+
+
+def frozen(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType({
+        key: frozen(item) if isinstance(item, Mapping)
+        else tuple(item) if isinstance(item, list)
+        else item
+        for key, item in value.items()
+    })
+
+
+def mutable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: mutable(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [mutable(item) for item in value]
+    return value
+
+
+def content_id(prefix: str, value: object) -> str:
+    return f"{prefix}:{digest_payload(value)[7:]}"
+
+
+def digest_payload(value: object) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _validate_policy_scalars(policy: CanonicalSingleCallJobPolicy) -> None:
+    if (
+        policy.schema_version != POLICY_SCHEMA_VERSION
+        or not valid_token(policy.task_type)
+        or not valid_model(policy.model_id)
+        or not valid_token(policy.endpoint_tag)
+        or not valid_token(policy.reasoning_effort)
+        or policy.data_collection != "deny"
+        or type(policy.require_zdr) is not bool
+        or type(policy.enforce_distillable_text) is not bool
+        or policy.output_use not in {"evaluation_only", "training"}
+        or policy.max_calls != 1
+        or not is_uint(policy.expires_at_ms)
+    ):
+        raise ValueError("single_call_policy_invalid")
+
+
+def _response_bytes(value: Any) -> int:
+    result = positive_int(value)
+    if result > _MAX_RESPONSE_BYTES:
+        raise ValueError("single_call_policy_invalid")
+    return result
+
+
+def _accepted_statuses(value: Any) -> tuple[int, ...]:
+    if (
+        not isinstance(value, tuple)
+        or value != (0,)
+        or any(type(item) is not int for item in value)
+    ):
+        raise ValueError("single_call_policy_invalid")
+    return (0,)
+
+
+__all__ = [
+    "ADMISSION_ID_PATTERN",
+    "ADMISSION_KEYS",
+    "CanonicalSingleCallAdmission",
+    "CanonicalSingleCallIntent",
+    "CanonicalSingleCallJobPolicy",
+    "GATEWAY_BASE_URL",
+    "HALTED_REASONS",
+    "HTTP_METHOD",
+    "MANDATORY_REQUEST_PARAMETERS",
+    "OMITTED_SAMPLING_PARAMETERS",
+    "PRICE_RECONCILIATION",
+    "PUBLIC_PRICING_SCHEMA_POLICY",
+    "REQUEST_PATH",
+    "RUNTIME_AUTHORITY",
+    "SCHEMA_VERSION",
+    "TRUST_CLASS",
+    "content_id",
+    "decimal_text",
+    "digest_payload",
+    "frozen",
+    "is_uint",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_openrouter_endpoint_payload_projection.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_openrouter_endpoint_payload_projection.py
@@ -1,0 +1,366 @@
+"""Strict bounded projection of supplied OpenRouter endpoint-list payloads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping, Sequence
+
+
+MAX_ENDPOINT_RESPONSE_BYTES = 2 * 1024 * 1024
+MAX_ENDPOINT_RECORDS = 256
+MAX_TOKEN_BOUND = 100_000_000
+DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}\Z")
+PAYLOAD_ID_PATTERN = re.compile(r"openrouter_endpoint_payload:[0-9a-f]{64}\Z")
+MODEL_ID_PATTERN = re.compile(
+    r"[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?/"
+    r"[a-z0-9](?:[a-z0-9._-]{0,126}[a-z0-9])?(?::free)?\Z"
+)
+ENDPOINT_TAG_PATTERN = re.compile(
+    r"[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?"
+    r"(?:/[a-z0-9](?:[a-z0-9._-]{0,62}[a-z0-9])?)?\Z"
+)
+_TOKEN = re.compile(r"[a-z0-9][a-z0-9._:-]{0,63}\Z")
+_PRICE = re.compile(r"(?:0|[1-9][0-9]*)(?:\.[0-9]+)?\Z")
+_ROOT_KEYS = frozenset("id name created description architecture endpoints".split())
+_ENDPOINT_KEYS = frozenset(
+    """name model_id model_name context_length pricing provider_name tag
+    quantization max_completion_tokens max_prompt_tokens supported_parameters
+    uptime_last_30m uptime_last_5m uptime_last_1d supports_implicit_caching
+    latency_last_30m throughput_last_30m""".split()
+)
+_OPTIONAL_PRICES = frozenset(
+    """request internal_reasoning input_cache_read input_cache_write
+    input_cache_write_1h web_search audio audio_output image image_output
+    image_token input_audio_cache""".split()
+)
+_PRICING_KEYS = _OPTIONAL_PRICES | {
+    "prompt",
+    "completion",
+    "discount",
+    "overrides",
+}
+_ENDPOINT_STATUS_CODES = frozenset((0, -1, -2, -3, -5, -10))
+
+
+def parse_and_sanitize_openrouter_endpoint_payload(
+    raw: bytes, *, requested_model_id: str
+) -> dict[str, Any]:
+    if not isinstance(raw, bytes):
+        raise ValueError("endpoint_payload_json_invalid")
+    if len(raw) > MAX_ENDPOINT_RESPONSE_BYTES:
+        raise ValueError("endpoint_payload_too_large")
+    try:
+        parsed = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_unique_object,
+            parse_constant=_invalid_constant,
+        )
+        _bound_json(parsed)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError, RecursionError):
+        raise ValueError("endpoint_payload_json_invalid") from None
+    data = _validated_root(parsed, requested_model_id)
+    endpoints = [_sanitize_endpoint(item, requested_model_id) for item in data["endpoints"]]
+    tags = [item["tag"] for item in endpoints]
+    if len(tags) != len(set(tags)):
+        raise ValueError("endpoint_duplicate_tag")
+    return {
+        "model_id": requested_model_id,
+        "endpoints": sorted(endpoints, key=lambda item: item["tag"]),
+    }
+
+
+def endpoint_payload_id(payload: Mapping[str, Any]) -> str:
+    return content_id("openrouter_endpoint_payload", payload)
+
+
+def sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def digest_payload(value: object) -> str:
+    return sha256_bytes(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+    )
+
+
+def content_id(prefix: str, value: object) -> str:
+    return f"{prefix}:{digest_payload(value)[7:]}"
+
+
+def valid_model_id(value: Any) -> bool:
+    return isinstance(value, str) and MODEL_ID_PATTERN.fullmatch(value) is not None
+
+
+def valid_endpoint_tag(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and ENDPOINT_TAG_PATTERN.fullmatch(value) is not None
+    )
+
+
+def is_uint(value: Any) -> bool:
+    return type(value) is int and 0 <= value < 2**63
+
+
+def _validated_root(parsed: Any, requested_model_id: str) -> Mapping[str, Any]:
+    if not valid_model_id(requested_model_id) or not isinstance(parsed, Mapping):
+        raise ValueError("endpoint_payload_top_level_invalid")
+    data = parsed.get("data")
+    if not isinstance(data, Mapping) or not _ROOT_KEYS.issubset(data):
+        raise ValueError("endpoint_payload_top_level_invalid")
+    if data["id"] != requested_model_id:
+        raise ValueError("endpoint_payload_model_mismatch")
+    if not _bounded_text(data["name"], 256) or not _bounded_text(
+        data["description"], 4096
+    ):
+        raise ValueError("endpoint_payload_top_level_invalid")
+    if not is_uint(data["created"]):
+        raise ValueError("endpoint_payload_top_level_invalid")
+    _validate_architecture(data["architecture"])
+    endpoints = data["endpoints"]
+    if not isinstance(endpoints, list) or len(endpoints) > MAX_ENDPOINT_RECORDS:
+        raise ValueError("endpoint_record_limit_exceeded")
+    return data
+
+
+def _validate_architecture(value: Any) -> None:
+    required = {
+        "tokenizer", "instruct_type", "modality",
+        "input_modalities", "output_modalities",
+    }
+    if not isinstance(value, Mapping) or not required.issubset(value):
+        raise ValueError("endpoint_payload_top_level_invalid")
+    for key in ("tokenizer", "instruct_type", "modality"):
+        if value[key] is not None and not _bounded_text(value[key], 128):
+            raise ValueError("endpoint_payload_top_level_invalid")
+    for key in ("input_modalities", "output_modalities"):
+        if not _token_list(value[key], maximum=16):
+            raise ValueError("endpoint_payload_top_level_invalid")
+
+
+def _sanitize_endpoint(raw: Any, requested_model_id: str) -> dict[str, Any]:
+    if not isinstance(raw, Mapping) or not _ENDPOINT_KEYS.issubset(raw):
+        raise ValueError("endpoint_record_invalid")
+    if raw["model_id"] != requested_model_id:
+        raise ValueError("endpoint_record_invalid")
+    if not _bounded_text(raw["name"], 256) or not _bounded_text(raw["model_name"], 256):
+        raise ValueError("endpoint_record_invalid")
+    if not _bounded_text(raw["provider_name"], 128) or not valid_endpoint_tag(raw["tag"]):
+        raise ValueError("endpoint_record_invalid")
+    context = _positive_tokens(raw["context_length"])
+    prompt_cap = _nullable_positive_tokens(raw["max_prompt_tokens"])
+    completion_cap = _nullable_positive_tokens(raw["max_completion_tokens"])
+    if prompt_cap is not None and prompt_cap > context:
+        raise ValueError("endpoint_record_invalid")
+    if completion_cap is not None and completion_cap > context:
+        raise ValueError("endpoint_record_invalid")
+    pricing, unsafe = _pricing(raw["pricing"])
+    result = _project_endpoint(
+        raw, requested_model_id, context, prompt_cap, completion_cap, pricing, unsafe
+    )
+    if "status" in raw:
+        status = raw["status"]
+        if type(status) is not int or status not in _ENDPOINT_STATUS_CODES:
+            raise ValueError("endpoint_record_invalid")
+        result["status"] = status
+    return result
+
+
+def _project_endpoint(
+    raw, model_id, context, prompt_cap, completion_cap, pricing, unsafe
+) -> dict[str, Any]:
+    parameters = _parameters(raw["supported_parameters"])
+    _validate_metrics(raw)
+    quantization = raw["quantization"]
+    if quantization is not None and not _TOKEN.fullmatch(str(quantization)):
+        raise ValueError("endpoint_record_invalid")
+    return {
+        "model_id": model_id,
+        "tag": raw["tag"],
+        "provider_name": raw["provider_name"],
+        "context_length": context,
+        "max_prompt_tokens": prompt_cap,
+        "max_completion_tokens": completion_cap,
+        "pricing": pricing,
+        "unsafe_cost_dimensions": list(unsafe),
+        "supported_parameters": list(parameters),
+        "quantization": quantization,
+        "supports_implicit_caching": _strict_bool(raw["supports_implicit_caching"]),
+    }
+
+
+def _pricing(value: Any) -> tuple[dict[str, Any], tuple[str, ...]]:
+    if not isinstance(value, Mapping) or not {"prompt", "completion"}.issubset(value):
+        raise ValueError("endpoint_record_invalid")
+    if not set(value).issubset(_PRICING_KEYS):
+        raise ValueError("endpoint_record_invalid")
+    result = {
+        "prompt": _canonical_price(value["prompt"]),
+        "completion": _canonical_price(value["completion"]),
+    }
+    unsafe: list[str] = []
+    for key in sorted(_OPTIONAL_PRICES.intersection(value)):
+        price = _canonical_price(value[key])
+        result[key] = price
+        if price != "0":
+            unsafe.append(key)
+    _project_discount_and_overrides(value, result, unsafe)
+    return result, tuple(sorted(unsafe))
+
+
+def _project_discount_and_overrides(
+    source: Mapping[str, Any], result: dict[str, Any], unsafe: list[str]
+) -> None:
+    if "discount" in source:
+        discount = _canonical_fraction(source["discount"])
+        result["discount"] = discount
+        if discount != "0":
+            unsafe.append("discount")
+    if "overrides" in source:
+        overrides = source["overrides"]
+        if not isinstance(overrides, list) or len(overrides) > 32:
+            raise ValueError("endpoint_record_invalid")
+        result["overrides_count"] = len(overrides)
+        if overrides:
+            unsafe.append("overrides")
+
+
+def _validate_metrics(raw: Mapping[str, Any]) -> None:
+    for key in ("uptime_last_30m", "uptime_last_5m", "uptime_last_1d"):
+        value = raw[key]
+        if value is not None and (
+            type(value) not in (int, float)
+            or not math.isfinite(value)
+            or not 0 <= value <= 100
+        ):
+            raise ValueError("endpoint_record_invalid")
+    for key in ("latency_last_30m", "throughput_last_30m"):
+        _validate_percentiles(raw[key])
+
+
+def _validate_percentiles(value: Any) -> None:
+    if value is None:
+        return
+    if not isinstance(value, Mapping) or set(value) != {"p50", "p75", "p90", "p99"}:
+        raise ValueError("endpoint_record_invalid")
+    if any(
+        type(item) not in (int, float) or not math.isfinite(item) or item < 0
+        for item in value.values()
+    ):
+        raise ValueError("endpoint_record_invalid")
+
+
+def _parameters(value: Any) -> tuple[str, ...]:
+    if not _token_list(value, maximum=64):
+        raise ValueError("endpoint_record_invalid")
+    result = tuple(sorted(value))
+    if len(set(result)) != len(result):
+        raise ValueError("endpoint_record_invalid")
+    return result
+
+
+def _canonical_price(value: Any) -> str:
+    if not isinstance(value, str) or not _PRICE.fullmatch(value):
+        raise ValueError("endpoint_record_invalid")
+    try:
+        decimal = Decimal(value)
+    except InvalidOperation:
+        raise ValueError("endpoint_record_invalid") from None
+    if decimal < 0 or decimal > Decimal("1000"):
+        raise ValueError("endpoint_record_invalid")
+    return format(decimal.normalize(), "f")
+
+
+def _canonical_fraction(value: Any) -> str:
+    if type(value) not in (int, float) or not math.isfinite(value):
+        raise ValueError("endpoint_record_invalid")
+    decimal = Decimal(str(value))
+    if decimal < 0 or decimal > 1:
+        raise ValueError("endpoint_record_invalid")
+    return format(decimal.normalize(), "f")
+
+
+def _bound_json(value: Any, depth: int = 0) -> None:
+    if depth > 12:
+        raise ValueError("json_depth")
+    if isinstance(value, str) and len(value) > 4096:
+        raise ValueError("json_string")
+    if isinstance(value, list):
+        if len(value) > 4096:
+            raise ValueError("json_array")
+        for item in value:
+            _bound_json(item, depth + 1)
+    elif isinstance(value, Mapping):
+        if len(value) > 256:
+            raise ValueError("json_object")
+        for key, item in value.items():
+            if not isinstance(key, str) or len(key) > 128:
+                raise ValueError("json_key")
+            _bound_json(item, depth + 1)
+
+
+def _unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate_key")
+        result[key] = value
+    return result
+
+
+def _invalid_constant(_value: str) -> None:
+    raise ValueError("invalid_constant")
+
+
+def _positive_tokens(value: Any) -> int:
+    if type(value) is not int or not 0 < value <= MAX_TOKEN_BOUND:
+        raise ValueError("endpoint_record_invalid")
+    return value
+
+
+def _nullable_positive_tokens(value: Any) -> int | None:
+    return None if value is None else _positive_tokens(value)
+
+
+def _strict_bool(value: Any) -> bool:
+    if type(value) is not bool:
+        raise ValueError("endpoint_record_invalid")
+    return value
+
+
+def _token_list(value: Any, maximum: int) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) <= maximum
+        and all(isinstance(item, str) and _TOKEN.fullmatch(item) for item in value)
+    )
+
+
+def _bounded_text(value: Any, maximum: int) -> bool:
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= maximum
+        and value.isascii()
+        and all(character.isprintable() for character in value)
+    )
+
+
+__all__ = [
+    "DIGEST_PATTERN",
+    "MAX_ENDPOINT_RESPONSE_BYTES",
+    "PAYLOAD_ID_PATTERN",
+    "content_id",
+    "digest_payload",
+    "endpoint_payload_id",
+    "is_uint",
+    "parse_and_sanitize_openrouter_endpoint_payload",
+    "sha256_bytes",
+    "valid_endpoint_tag",
+    "valid_model_id",
+]

--- a/modules/ai_intelligence/ai_gateway/src/model_openrouter_endpoint_route_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/src/model_openrouter_endpoint_route_evidence.py
@@ -1,0 +1,380 @@
+"""Immutable lineage for supplied OpenRouter endpoint route controls."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from .model_openrouter_endpoint_payload_projection import (
+    DIGEST_PATTERN,
+    MAX_ENDPOINT_RESPONSE_BYTES,
+    PAYLOAD_ID_PATTERN,
+    content_id,
+    digest_payload,
+    endpoint_payload_id,
+    is_uint,
+    parse_and_sanitize_openrouter_endpoint_payload,
+    sha256_bytes,
+    valid_endpoint_tag,
+    valid_model_id,
+)
+
+
+PROVIDER = "openrouter"
+ENDPOINT_ID = "openrouter_model_endpoints_api_v1"
+OBSERVATION_SCHEMA = "openrouter_endpoint_observation_receipt.v1"
+ROUTE_SCHEMA = "openrouter_endpoint_route_evidence.v1"
+DEFAULT_ENDPOINT_FRESHNESS_MS = 900_000
+TRUST_CLASS = "provider_asserted_endpoint_route_controls"
+OBSERVATION_TRUST_CLASS = "provider_asserted_endpoint_observation"
+_RECEIPT_ID = re.compile(r"openrouter_endpoint_observation_receipt:[0-9a-f]{64}\Z")
+_EVIDENCE_ID = re.compile(r"openrouter_endpoint_route_evidence:[0-9a-f]{64}\Z")
+_OBSERVATION_KEYS = frozenset(
+    """schema_version receipt_id provider endpoint_id requested_model_id
+    request_envelope_digest response_body_digest response_byte_count payload_id
+    observed_at_ms fresh_until_ms http_status trust_class""".split()
+)
+_EVIDENCE_KEYS = frozenset(
+    """schema_version evidence_id provider endpoint_id observation_receipt_id
+    request_envelope_digest response_body_digest payload_id observed_at_ms
+    fresh_until_ms model_id endpoint_tag provider_name context_length
+    max_prompt_tokens_present max_prompt_tokens max_completion_tokens_present
+    max_completion_tokens prompt_price completion_price request_price_present
+    request_price unsafe_cost_dimensions supported_parameters status_present
+    status quantization_present quantization supports_implicit_caching
+    endpoint_record_digest source_control trust_class""".split()
+)
+
+
+@dataclass(frozen=True)
+class EndpointObservationReceipt:
+    receipt_id: str
+    requested_model_id: str
+    request_envelope_digest: str
+    response_body_digest: str
+    response_byte_count: int
+    payload_id: str
+    observed_at_ms: int
+    fresh_until_ms: int
+    http_status: int
+    provider: str = field(init=False, default=PROVIDER)
+    endpoint_id: str = field(init=False, default=ENDPOINT_ID)
+    trust_class: str = field(init=False, default=OBSERVATION_TRUST_CLASS)
+    schema_version: str = field(init=False, default=OBSERVATION_SCHEMA)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "receipt_id": self.receipt_id,
+            "provider": self.provider,
+            "endpoint_id": self.endpoint_id,
+            "requested_model_id": self.requested_model_id,
+            "request_envelope_digest": self.request_envelope_digest,
+            "response_body_digest": self.response_body_digest,
+            "response_byte_count": self.response_byte_count,
+            "payload_id": self.payload_id,
+            "observed_at_ms": self.observed_at_ms,
+            "fresh_until_ms": self.fresh_until_ms,
+            "http_status": self.http_status,
+            "trust_class": self.trust_class,
+        }
+
+
+@dataclass(frozen=True)
+class OpenRouterEndpointRouteEvidence:
+    evidence_id: str
+    observation_receipt_id: str
+    request_envelope_digest: str
+    response_body_digest: str
+    payload_id: str
+    observed_at_ms: int
+    fresh_until_ms: int
+    model_id: str
+    endpoint_tag: str
+    provider_name: str
+    context_length: int
+    max_prompt_tokens_present: bool
+    max_prompt_tokens: int | None
+    max_completion_tokens_present: bool
+    max_completion_tokens: int | None
+    prompt_price: str
+    completion_price: str
+    request_price_present: bool
+    request_price: str | None
+    unsafe_cost_dimensions: tuple[str, ...]
+    supported_parameters: tuple[str, ...]
+    status_present: bool
+    status: int | None
+    quantization_present: bool
+    quantization: str | None
+    supports_implicit_caching: bool
+    endpoint_record_digest: str
+    source_control: Mapping[str, Any]
+    provider: str = field(init=False, default=PROVIDER)
+    endpoint_id: str = field(init=False, default=ENDPOINT_ID)
+    trust_class: str = field(init=False, default=TRUST_CLASS)
+    schema_version: str = field(init=False, default=ROUTE_SCHEMA)
+
+    def to_dict(self) -> dict[str, Any]:
+        values = {
+            key: getattr(self, key)
+            for key in _EVIDENCE_KEYS
+            if key not in {"unsafe_cost_dimensions", "supported_parameters", "source_control"}
+        }
+        values["unsafe_cost_dimensions"] = list(self.unsafe_cost_dimensions)
+        values["supported_parameters"] = list(self.supported_parameters)
+        values["source_control"] = _mutable(self.source_control)
+        return values
+
+
+def build_endpoint_observation_receipt(
+    *,
+    requested_model_id: str,
+    request_envelope_digest: str,
+    response_body_digest: str,
+    response_byte_count: int,
+    payload_id: str,
+    observed_at_ms: int,
+    http_status: int,
+) -> EndpointObservationReceipt:
+    body = _observation_body(
+        requested_model_id=requested_model_id,
+        request_envelope_digest=request_envelope_digest,
+        response_body_digest=response_body_digest,
+        response_byte_count=response_byte_count,
+        payload_id=payload_id,
+        observed_at_ms=observed_at_ms,
+        http_status=http_status,
+    )
+    body["receipt_id"] = content_id("openrouter_endpoint_observation_receipt", body)
+    return rehydrate_endpoint_observation_receipt(body)
+
+
+def rehydrate_endpoint_observation_receipt(
+    payload: Mapping[str, Any],
+) -> EndpointObservationReceipt:
+    if not isinstance(payload, Mapping) or set(payload) != _OBSERVATION_KEYS:
+        raise ValueError("endpoint_observation_invalid")
+    if payload.get("schema_version") != OBSERVATION_SCHEMA:
+        raise ValueError("endpoint_observation_invalid")
+    body = _observation_body(**{
+        key: payload[key]
+        for key in (
+            "requested_model_id", "request_envelope_digest",
+            "response_body_digest", "response_byte_count", "payload_id",
+            "observed_at_ms", "http_status",
+        )
+    })
+    expected = content_id("openrouter_endpoint_observation_receipt", body)
+    if payload.get("receipt_id") != expected or dict(payload) != {**body, "receipt_id": expected}:
+        raise ValueError("endpoint_observation_invalid")
+    return EndpointObservationReceipt(
+        receipt_id=expected,
+        requested_model_id=body["requested_model_id"],
+        request_envelope_digest=body["request_envelope_digest"],
+        response_body_digest=body["response_body_digest"],
+        response_byte_count=body["response_byte_count"],
+        payload_id=body["payload_id"],
+        observed_at_ms=body["observed_at_ms"],
+        fresh_until_ms=body["fresh_until_ms"],
+        http_status=body["http_status"],
+    )
+
+
+def build_openrouter_endpoint_route_evidence(
+    *,
+    raw: bytes,
+    observation_receipt: EndpointObservationReceipt,
+    endpoint_tag: str,
+    now_ms: int,
+) -> OpenRouterEndpointRouteEvidence:
+    receipt = _validated_observation(observation_receipt, raw, now_ms)
+    payload = parse_and_sanitize_openrouter_endpoint_payload(
+        raw, requested_model_id=receipt.requested_model_id
+    )
+    if endpoint_payload_id(payload) != receipt.payload_id:
+        raise ValueError("endpoint_observation_invalid")
+    record = _select_route(payload["endpoints"], endpoint_tag)
+    values = _evidence_values(receipt, record)
+    identity = {
+        "schema_version": ROUTE_SCHEMA,
+        "provider": PROVIDER,
+        "endpoint_id": ENDPOINT_ID,
+        **values,
+        "trust_class": TRUST_CLASS,
+    }
+    evidence_id = content_id("openrouter_endpoint_route_evidence", identity)
+    source_control = _frozen(values.pop("source_control"))
+    return OpenRouterEndpointRouteEvidence(
+        evidence_id=evidence_id, source_control=source_control, **values
+    )
+
+
+def rehydrate_openrouter_endpoint_route_evidence(
+    payload: Mapping[str, Any],
+    *,
+    raw: bytes,
+    observation_receipt: EndpointObservationReceipt,
+    now_ms: int,
+) -> OpenRouterEndpointRouteEvidence:
+    if not isinstance(payload, Mapping) or set(payload) != _EVIDENCE_KEYS:
+        raise ValueError("endpoint_route_evidence_invalid")
+    if not _EVIDENCE_ID.fullmatch(str(payload.get("evidence_id"))):
+        raise ValueError("endpoint_route_evidence_invalid")
+    try:
+        expected = build_openrouter_endpoint_route_evidence(
+            raw=raw,
+            observation_receipt=observation_receipt,
+            endpoint_tag=payload.get("endpoint_tag"),  # type: ignore[arg-type]
+            now_ms=now_ms,
+        )
+    except ValueError as exc:
+        if str(exc) in {"endpoint_observation_stale", "endpoint_observation_future"}:
+            raise
+        raise ValueError("endpoint_route_evidence_invalid") from None
+    if dict(payload) != expected.to_dict():
+        raise ValueError("endpoint_route_evidence_invalid")
+    return expected
+
+
+def _frozen(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _frozen(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_frozen(item) for item in value)
+    return value
+
+
+def _mutable(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _mutable(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_mutable(item) for item in value]
+    return value
+
+
+def _observation_body(**values: Any) -> dict[str, Any]:
+    if not valid_model_id(values.get("requested_model_id")):
+        raise ValueError("endpoint_observation_invalid")
+    if not all(
+        DIGEST_PATTERN.fullmatch(str(values.get(key)))
+        for key in ("request_envelope_digest", "response_body_digest")
+    ):
+        raise ValueError("endpoint_observation_invalid")
+    size, observed, status = (
+        values.get("response_byte_count"),
+        values.get("observed_at_ms"),
+        values.get("http_status"),
+    )
+    if (
+        not is_uint(size)
+        or size > MAX_ENDPOINT_RESPONSE_BYTES
+        or not is_uint(observed)
+        or status != 200
+        or not PAYLOAD_ID_PATTERN.fullmatch(str(values.get("payload_id")))
+    ):
+        raise ValueError("endpoint_observation_invalid")
+    return {
+        "schema_version": OBSERVATION_SCHEMA,
+        "provider": PROVIDER,
+        "endpoint_id": ENDPOINT_ID,
+        "requested_model_id": values["requested_model_id"],
+        "request_envelope_digest": values["request_envelope_digest"],
+        "response_body_digest": values["response_body_digest"],
+        "response_byte_count": size,
+        "payload_id": values["payload_id"],
+        "observed_at_ms": observed,
+        "fresh_until_ms": observed + DEFAULT_ENDPOINT_FRESHNESS_MS,
+        "http_status": 200,
+        "trust_class": OBSERVATION_TRUST_CLASS,
+    }
+
+
+def _validated_observation(
+    receipt: EndpointObservationReceipt, raw: bytes, now_ms: int
+) -> EndpointObservationReceipt:
+    if not isinstance(receipt, EndpointObservationReceipt) or not is_uint(now_ms):
+        raise ValueError("endpoint_observation_invalid")
+    item = rehydrate_endpoint_observation_receipt(receipt.to_dict())
+    if now_ms < item.observed_at_ms:
+        raise ValueError("endpoint_observation_future")
+    if now_ms > item.fresh_until_ms:
+        raise ValueError("endpoint_observation_stale")
+    if len(raw) != item.response_byte_count or sha256_bytes(raw) != item.response_body_digest:
+        raise ValueError("endpoint_observation_invalid")
+    return item
+
+
+def _evidence_values(receipt, record) -> dict[str, Any]:
+    return {
+        "observation_receipt_id": receipt.receipt_id,
+        "request_envelope_digest": receipt.request_envelope_digest,
+        "response_body_digest": receipt.response_body_digest,
+        "payload_id": receipt.payload_id,
+        "observed_at_ms": receipt.observed_at_ms,
+        "fresh_until_ms": receipt.fresh_until_ms,
+        "model_id": record["model_id"],
+        "endpoint_tag": record["tag"],
+        "provider_name": record["provider_name"],
+        "context_length": record["context_length"],
+        "max_prompt_tokens_present": True,
+        "max_prompt_tokens": record["max_prompt_tokens"],
+        "max_completion_tokens_present": True,
+        "max_completion_tokens": record["max_completion_tokens"],
+        "prompt_price": record["pricing"]["prompt"],
+        "completion_price": record["pricing"]["completion"],
+        "request_price_present": "request" in record["pricing"],
+        "request_price": record["pricing"].get("request"),
+        "unsafe_cost_dimensions": tuple(record["unsafe_cost_dimensions"]),
+        "supported_parameters": tuple(record["supported_parameters"]),
+        "status_present": "status" in record,
+        "status": record.get("status"),
+        "quantization_present": True,
+        "quantization": record["quantization"],
+        "supports_implicit_caching": record["supports_implicit_caching"],
+        "endpoint_record_digest": digest_payload(record),
+        "source_control": _source_control(record),
+    }
+
+
+def _source_control(record: Mapping[str, Any]) -> dict[str, Any]:
+    result = {
+        key: record[key]
+        for key in (
+            "model_id", "tag", "context_length", "max_prompt_tokens",
+            "max_completion_tokens", "pricing", "unsafe_cost_dimensions",
+            "supported_parameters", "quantization", "supports_implicit_caching",
+        )
+    }
+    if "status" in record:
+        result["status"] = record["status"]
+    return result
+
+
+def _select_route(
+    endpoints: Sequence[Mapping[str, Any]], endpoint_tag: str
+) -> Mapping[str, Any]:
+    if not valid_endpoint_tag(endpoint_tag):
+        raise ValueError("endpoint_route_missing")
+    matches = [item for item in endpoints if item["tag"] == endpoint_tag]
+    if len(matches) != 1:
+        raise ValueError("endpoint_route_missing")
+    if any(item["tag"].startswith(endpoint_tag + "/") for item in endpoints):
+        raise ValueError("endpoint_tag_prefix_collision")
+    return matches[0]
+
+
+__all__ = [
+    "DEFAULT_ENDPOINT_FRESHNESS_MS",
+    "EndpointObservationReceipt",
+    "OpenRouterEndpointRouteEvidence",
+    "build_endpoint_observation_receipt",
+    "build_openrouter_endpoint_route_evidence",
+    "endpoint_payload_id",
+    "parse_and_sanitize_openrouter_endpoint_payload",
+    "rehydrate_endpoint_observation_receipt",
+    "rehydrate_openrouter_endpoint_route_evidence",
+    "sha256_bytes",
+]

--- a/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
+++ b/modules/ai_intelligence/ai_gateway/tests/TestModLog.md
@@ -1,5 +1,50 @@
 # AI Gateway TestModLog
 
+## 2026-07-24 - OpenRouter endpoint-route single-call admission phase B2A
+
+Scope: offline adversarial verification of externally supplied endpoint
+observation, exact route evidence, and one-call evaluation eligibility.
+
+- Binds exact raw bytes, request/response digests, payload/record IDs,
+  observation freshness, model identity, and one unambiguous endpoint tag.
+- Preserves nullable caps/status/quantization separately from omission and
+  rejects malformed recognized values, duplicate keys, non-finite JSON,
+  duplicate tags, prefix collisions, and oversized payloads.
+- Rejects every unknown pricing key, including zero-valued forward additions;
+  additive cost-schema drift is never dropped or inferred free.
+- Restricts status projection to official values `0, -1, -2, -3, -5, -10`,
+  retains known negative evidence, and requires a present value accepted by the
+  trusted exact `(0,)` job policy.
+- Rejects unknown caps, unsupported controls, mismatched identities/intents,
+  stale/future evidence, requested ZDR, output training, unsafe cost
+  dimensions, price-cap violations, and context/token overflow.
+- Proves exact Decimal reconciliation and reservation, exact immutable POST
+  route controls, response-byte binding, rehydration, and explicit HALTED
+  reasons with `runtime_authority=eligibility_only`.
+- Rejects reasoning-only and max-tokens-only weakened policies even when both
+  evidence sources match the weakened subset. The policy and admission bind the
+  exact emitted-control set independently.
+- Proves the Chat Completions wire-control mapping has exactly `max_tokens`,
+  `reasoning`, and `provider`, excludes internal `max_completion_tokens`, and
+  retains the same value in the separate admission/budget field.
+- Rejects explicit `supports_max_tokens=false`; proves omitted/unknown and true
+  claims can proceed only with exact endpoint/model `max_tokens` evidence.
+- Preserves present versus absent request pricing, binds the named PublicPricing
+  optional-request absence-as-zero policy and digest, and rejects recomputed-ID
+  tampering of presence, proof, or digest.
+- Binds `endpoint_status_policy_accepted` through policy/admission IDs and
+  rehydration while proving that omitted, negative, forward-unknown, and
+  policy-tampered status evidence fails closed. The proof is not availability.
+- Enrolls all four production modules in protected-authority import, network
+  purity, source-line, and WSP_62 AST function guards.
+
+Initial amendment RED: `8 failed, 20 passed`; emitted-control/request-price
+amendment RED: `9 failed, 25 passed`; integration wire-key RED: `2 failed, 34
+passed`. Post-rebase focused endpoint/admission: `65 passed`; combined protected
+catalog/execution-control: `134 passed`; full AI Gateway: `712 passed, 2
+skipped`. Ruff and WSP_97 v1.1 validation passed. All fixtures and transports
+were offline; no provider, model, network, or credential call occurred.
+
 ## 2026-07-24 - OpenRouter model execution-control evidence phase B1
 
 Scope: offline adversarial coverage of optional provider-control projection and

--- a/modules/ai_intelligence/ai_gateway/tests/fixtures/openrouter_endpoints_k3_success.json
+++ b/modules/ai_intelligence/ai_gateway/tests/fixtures/openrouter_endpoints_k3_success.json
@@ -1,0 +1,48 @@
+{
+  "data": {
+    "id": "moonshotai/kimi-k3",
+    "name": "Kimi K3",
+    "created": 1784764800,
+    "description": "Offline provider-asserted endpoint fixture.",
+    "architecture": {
+      "tokenizer": "Other",
+      "instruct_type": null,
+      "modality": "text->text",
+      "input_modalities": [
+        "text"
+      ],
+      "output_modalities": [
+        "text"
+      ]
+    },
+    "endpoints": [
+      {
+        "name": "Moonshot AI: Kimi K3",
+        "model_id": "moonshotai/kimi-k3",
+        "model_name": "Kimi K3",
+        "context_length": 1048576,
+        "pricing": {
+          "prompt": "0.0000030",
+          "completion": "0.000015",
+          "request": "0"
+        },
+        "provider_name": "Moonshot AI",
+        "tag": "moonshotai",
+        "quantization": null,
+        "max_completion_tokens": 131072,
+        "max_prompt_tokens": 917504,
+        "supported_parameters": [
+          "reasoning",
+          "max_tokens"
+        ],
+        "uptime_last_30m": null,
+        "uptime_last_5m": null,
+        "uptime_last_1d": null,
+        "supports_implicit_caching": false,
+        "latency_last_30m": null,
+        "throughput_last_30m": null,
+        "status": 0
+      }
+    ]
+  }
+}

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_single_call_admission.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_autoresearch_single_call_admission.py
@@ -1,0 +1,425 @@
+"""Adversarial offline tests for canonical single-call eligibility admission."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_single_call_admission import (
+    rehydrate_canonical_single_call_admission,
+)
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_single_call_contracts import (
+    digest_payload,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_openrouter_endpoint_route_evidence import (
+    TAG,
+    _admission,
+    _endpoint_sources,
+    _intent,
+    _model_sources,
+    _payload,
+    _policy,
+    _raw,
+)
+
+
+def test_canonical_admission_binds_exact_route_controls_lineage_and_halt() -> None:
+    admission, values = _admission()
+    assert admission.gateway_base_url == "https://openrouter.ai/api/v1"
+    assert admission.http_method == "POST"
+    assert admission.request_path == "/chat/completions"
+    assert admission.endpoint_tag == TAG
+    assert admission.provider_order == (TAG,)
+    assert admission.allow_fallbacks is False
+    assert admission.require_parameters is True
+    assert admission.data_collection == "deny"
+    assert admission.require_zdr is False
+    assert admission.enforce_distillable_text is False
+    assert admission.reasoning_effort == "max"
+    assert admission.prompt_price_per_million == "3"
+    assert admission.completion_price_per_million == "15"
+    assert admission.request_price == "0"
+    assert admission.request_price_present is True
+    assert admission.request_price_schema_policy == (
+        "openrouter_public_pricing_request_optional_absence_as_zero.v1"
+    )
+    assert admission.request_price_schema_policy_accepted is True
+    assert admission.mandatory_request_parameters == (
+        "max_tokens",
+        "reasoning",
+    )
+    assert admission.max_calls == 1
+    assert admission.runtime_authority == "eligibility_only"
+    assert admission.halted_reasons == (
+        "atomic_admission_consumption_missing",
+        "authenticated_endpoint_supply_missing",
+        "authoritative_endpoint_availability_missing",
+        "authoritative_usage_missing",
+        "caller_wiring_absent",
+        "prebuffer_response_bound_missing",
+        "runtime_directory_identity_missing",
+    )
+    assert admission.model_control_evidence_id == values[
+        "model_control_evidence"
+    ].evidence_id
+    assert admission.endpoint_route_evidence_id == values[
+        "endpoint_route_evidence"
+    ].evidence_id
+    assert admission.max_response_bytes == 1_000_000
+    assert admission.max_completion_tokens == 4_096
+    assert admission.reserved_upper_cost == "0.09144"
+    assert admission.endpoint_status == 0
+    assert admission.accepted_endpoint_statuses == (0,)
+    assert admission.endpoint_status_policy_accepted is True
+    assert admission.route_contract_digest == digest_payload(
+        {
+            "gateway_base_url": "https://openrouter.ai/api/v1",
+            "http_method": "POST",
+            "request_path": "/chat/completions",
+            "headers": {
+                "Content-Type": "application/json",
+                "X-OpenRouter-Metadata": "enabled",
+            },
+            "stream": False,
+        }
+    )
+    assert admission.to_dict()["request_control"] == {
+        "max_tokens": 4_096,
+        "reasoning": {"effort": "max"},
+        "provider": {
+            "order": [TAG],
+            "allow_fallbacks": False,
+            "require_parameters": True,
+            "data_collection": "deny",
+            "zdr": False,
+            "max_price": {
+                "prompt": "3",
+                "completion": "15",
+                "request": "0",
+            },
+        },
+    }
+
+
+def test_wire_request_control_has_exact_chat_completions_keys() -> None:
+    admission, _ = _admission()
+    assert set(admission.request_control) == {
+        "max_tokens",
+        "reasoning",
+        "provider",
+    }
+
+
+def test_wire_request_control_never_uses_internal_completion_budget_name() -> None:
+    admission, _ = _admission()
+    assert admission.request_control["max_tokens"] == 4_096
+    assert "max_completion_tokens" not in admission.request_control
+
+
+@pytest.mark.parametrize(
+    "policy_change,intent_change,reason",
+    (
+        ({"model_id": "other/model"}, {}, "single_call_model_mismatch"),
+        ({}, {"model_id": "other/model"}, "single_call_model_mismatch"),
+        ({"max_prompt_tokens": 9_999}, {}, "single_call_prompt_cap_exceeded"),
+        (
+            {"max_completion_tokens": 131_073},
+            {},
+            "single_call_completion_cap_exceeded",
+        ),
+        (
+            {"reasoning_effort": "medium"},
+            {},
+            "single_call_reasoning_effort_unsupported",
+        ),
+        (
+            {"required_parameters": ("reasoning", "tools")},
+            {},
+            "single_call_required_parameters_invalid",
+        ),
+        (
+            {"omitted_sampling_parameters": ("temperature",)},
+            {},
+            "single_call_sampling_policy_invalid",
+        ),
+        ({"data_collection": "allow"}, {}, "single_call_policy_invalid"),
+        ({"require_zdr": True}, {}, "single_call_zdr_evidence_missing"),
+        (
+            {"output_use": "training", "enforce_distillable_text": True},
+            {"output_use": "training"},
+            "single_call_output_training_permission_missing",
+        ),
+    ),
+)
+def test_job_certification_rejects_mismatch_and_unsupported_authority(
+    policy_change: dict, intent_change: dict, reason: str
+) -> None:
+    with pytest.raises(ValueError, match=reason):
+        _admission(policy=_policy(**policy_change), intent=_intent(**intent_change))
+
+
+@pytest.mark.parametrize(
+    "supported_parameters",
+    (("reasoning",), ("max_tokens",)),
+)
+def test_policy_cannot_self_weaken_emitted_request_controls(
+    supported_parameters: tuple[str, ...],
+) -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["supported_parameters"] = list(
+        supported_parameters
+    )
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    candidate, model = _model_sources(
+        supported_parameters=supported_parameters
+    )
+    with pytest.raises(
+        ValueError, match="single_call_required_parameters_invalid"
+    ):
+        _admission(
+            raw=raw,
+            endpoint_observation_receipt=receipt,
+            endpoint_route_evidence=endpoint,
+            model_candidate=candidate,
+            model_control_evidence=model,
+            policy=_policy(required_parameters=supported_parameters),
+        )
+
+
+def test_explicit_false_max_tokens_reasoning_claim_rejects_emitted_cap() -> None:
+    candidate, model = _model_sources(reasoning_supports_max_tokens=False)
+    with pytest.raises(ValueError, match="single_call_max_tokens_contradicted"):
+        _admission(model_candidate=candidate, model_control_evidence=model)
+
+
+@pytest.mark.parametrize("claim", (None, True))
+def test_missing_or_true_max_tokens_claim_uses_exact_parameter_evidence(
+    claim: bool | None,
+) -> None:
+    candidate, model = _model_sources(reasoning_supports_max_tokens=claim)
+    admission, _ = _admission(
+        model_candidate=candidate,
+        model_control_evidence=model,
+    )
+    assert admission.mandatory_request_parameters == (
+        "max_tokens",
+        "reasoning",
+    )
+
+
+def test_null_caps_context_overflow_and_unsafe_price_dimensions_reject() -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["max_prompt_tokens"] = None
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    with pytest.raises(ValueError, match="single_call_endpoint_caps_unknown"):
+        _admission(
+            raw=raw,
+            endpoint_observation_receipt=receipt,
+            endpoint_route_evidence=endpoint,
+        )
+
+    payload = _payload()
+    payload["data"]["endpoints"][0]["max_prompt_tokens"] = 1_048_576
+    payload["data"]["endpoints"][0]["max_completion_tokens"] = 1_048_576
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    with pytest.raises(ValueError, match="single_call_context_cap_exceeded"):
+        _admission(
+            raw=raw,
+            endpoint_observation_receipt=receipt,
+            endpoint_route_evidence=endpoint,
+            policy=_policy(
+                max_prompt_tokens=1_047_000,
+                max_completion_tokens=2_000,
+            ),
+            intent=_intent(prompt_token_upper_bound=1_047_000),
+        )
+
+    payload = _payload()
+    payload["data"]["endpoints"][0]["pricing"]["request"] = "0.01"
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    with pytest.raises(ValueError, match="single_call_pricing_unsupported"):
+        _admission(
+            raw=raw,
+            endpoint_observation_receipt=receipt,
+            endpoint_route_evidence=endpoint,
+        )
+
+
+def test_endpoint_price_supersedes_model_summary_and_respects_policy_caps() -> None:
+    candidate, model = _model_sources(prompt_price="0.000004")
+    admission, _ = _admission(
+        model_candidate=candidate,
+        model_control_evidence=model,
+    )
+    assert admission.model_summary_prompt_price == "0.000004"
+    assert admission.prompt_price == "0.000003"
+    assert admission.price_reconciliation == (
+        "endpoint_specific_supersedes_model_summary"
+    )
+    assert admission.reserved_upper_cost == "0.09144"
+
+    with pytest.raises(ValueError, match="single_call_price_cap_exceeded"):
+        _admission(policy=_policy(max_prompt_price_per_million="2.999999"))
+
+
+def test_request_price_absence_is_preserved_under_named_schema_policy() -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["pricing"].pop("request")
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    admission, _ = _admission(
+        raw=raw,
+        endpoint_observation_receipt=receipt,
+        endpoint_route_evidence=endpoint,
+    )
+    assert admission.request_price_present is False
+    assert admission.request_price == "0"
+    assert admission.request_price_schema_policy_accepted is True
+    assert admission.request_price_schema_policy_digest == digest_payload(
+        {
+            "schema_id": (
+                "openrouter_public_pricing_request_optional_absence_as_zero.v1"
+            ),
+            "required": ["prompt", "completion"],
+            "request_presence": "optional",
+            "absent_request_price": "0",
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("request_price_present", False),
+        ("request_price_schema_policy_accepted", False),
+        ("request_price_schema_policy_digest", "sha256:" + "0" * 64),
+    ),
+)
+def test_request_price_schema_proof_is_rehydration_bound(
+    field: str, value: object
+) -> None:
+    admission, values = _admission()
+    assert admission.request_price_present is True
+    payload = admission.to_dict()
+    payload[field] = value
+    body = {key: value for key, value in payload.items() if key != "admission_id"}
+    payload["admission_id"] = (
+        "canonical_single_call_admission:"
+        + hashlib.sha256(
+            json.dumps(
+                body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+            ).encode("utf-8")
+        ).hexdigest()
+    )
+    with pytest.raises(ValueError, match="single_call_admission_invalid"):
+        rehydrate_canonical_single_call_admission(payload, **values)
+
+
+def test_policy_and_intent_time_and_output_use_mismatch_fail_closed() -> None:
+    with pytest.raises(ValueError, match="single_call_evidence_stale"):
+        _admission(policy=_policy(expires_at_ms=10_000), now_ms=10_001)
+    with pytest.raises(ValueError, match="single_call_evidence_stale"):
+        _admission(intent=_intent(expires_at_ms=10_000), now_ms=10_001)
+    with pytest.raises(ValueError, match="single_call_intent_future"):
+        _admission(intent=_intent(issued_at_ms=10_002), now_ms=10_001)
+    with pytest.raises(ValueError, match="single_call_intent_invalid"):
+        _admission(intent=_intent(output_use="training"))
+
+
+def test_status_is_required_by_job_policy() -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0].pop("status")
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    with pytest.raises(ValueError, match="single_call_endpoint_status_missing"):
+        _admission(
+            raw=raw,
+            endpoint_observation_receipt=receipt,
+            endpoint_route_evidence=endpoint,
+        )
+
+
+@pytest.mark.parametrize("status", (-1, -2, -3, -5, -10))
+def test_known_negative_status_fails_job_policy(status: int) -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["status"] = status
+    raw = _raw(payload)
+    receipt, endpoint = _endpoint_sources(raw)
+    with pytest.raises(
+        ValueError, match="single_call_endpoint_status_not_accepted"
+    ):
+        _admission(
+            raw=raw,
+            endpoint_observation_receipt=receipt,
+            endpoint_route_evidence=endpoint,
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("endpoint_status", -1),
+        ("accepted_endpoint_statuses", [-1]),
+        ("endpoint_status_policy_accepted", False),
+    ),
+)
+def test_endpoint_status_policy_is_exact_and_tamper_bound(
+    field: str, value: object
+) -> None:
+    assert _policy().accepted_endpoint_statuses == (0,)
+    with pytest.raises(ValueError, match="single_call_policy_invalid"):
+        _policy(accepted_endpoint_statuses=(-1,))
+
+    admission, values = _admission()
+    payload = admission.to_dict()
+    payload[field] = value
+    body = {key: value for key, value in payload.items() if key != "admission_id"}
+    payload["admission_id"] = (
+        "canonical_single_call_admission:"
+        + hashlib.sha256(
+            json.dumps(
+                body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+            ).encode("utf-8")
+        ).hexdigest()
+    )
+    with pytest.raises(ValueError, match="single_call_admission_invalid"):
+        rehydrate_canonical_single_call_admission(payload, **values)
+
+
+def test_admission_rehydration_rebuilds_all_sources_and_rejects_recomputed_id() -> None:
+    admission, values = _admission()
+    assert (
+        rehydrate_canonical_single_call_admission(admission.to_dict(), **values)
+        == admission
+    )
+    payload = admission.to_dict()
+    payload["runtime_authority"] = "live"
+    body = {key: value for key, value in payload.items() if key != "admission_id"}
+    payload["admission_id"] = (
+        "canonical_single_call_admission:"
+        + hashlib.sha256(
+            json.dumps(
+                body, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+            ).encode("utf-8")
+        ).hexdigest()
+    )
+    with pytest.raises(ValueError, match="single_call_admission_invalid"):
+        rehydrate_canonical_single_call_admission(payload, **values)
+
+
+def test_availability_job_certification_and_training_permission_are_distinct() -> None:
+    _, endpoint = _endpoint_sources()
+    admission, _ = _admission()
+    assert endpoint.trust_class == "provider_asserted_endpoint_route_controls"
+    assert admission.trust_class == (
+        "trusted_job_policy_over_provider_asserted_route_evidence"
+    )
+    assert admission.output_use == "evaluation_only"
+    assert admission.output_training_permission is False
+    assert admission.runtime_authority == "eligibility_only"

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_endpoint_contract_drift.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_endpoint_contract_drift.py
@@ -1,0 +1,44 @@
+"""Fail-closed tests for endpoint cost and status schema drift."""
+
+from __future__ import annotations
+
+import pytest
+
+from modules.ai_intelligence.ai_gateway.src.model_openrouter_endpoint_route_evidence import (
+    parse_and_sanitize_openrouter_endpoint_payload,
+)
+from modules.ai_intelligence.ai_gateway.tests.test_model_openrouter_endpoint_route_evidence import (
+    K3_ID,
+    _endpoint_sources,
+    _payload,
+    _raw,
+)
+
+
+@pytest.mark.parametrize("value", ("0", "0.000001"))
+def test_unknown_endpoint_pricing_key_is_never_inferred_free(value: str) -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["pricing"]["future_cost_dimension"] = value
+    with pytest.raises(ValueError, match="endpoint_record_invalid"):
+        parse_and_sanitize_openrouter_endpoint_payload(
+            _raw(payload), requested_model_id=K3_ID
+        )
+
+
+@pytest.mark.parametrize("status", (1, -4, -11))
+def test_forward_unknown_endpoint_status_is_rejected(status: int) -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["status"] = status
+    with pytest.raises(ValueError, match="endpoint_record_invalid"):
+        parse_and_sanitize_openrouter_endpoint_payload(
+            _raw(payload), requested_model_id=K3_ID
+        )
+
+
+@pytest.mark.parametrize("status", (-1, -2, -3, -5, -10))
+def test_known_negative_endpoint_status_remains_bounded_evidence(status: int) -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["status"] = status
+    _, evidence = _endpoint_sources(_raw(payload))
+    assert evidence.status_present is True
+    assert evidence.status == status

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_endpoint_route_evidence.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_openrouter_endpoint_route_evidence.py
@@ -1,0 +1,481 @@
+"""Offline adversarial contract for endpoint route evidence and call eligibility."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import FrozenInstanceError, replace
+from pathlib import Path
+
+import pytest
+
+from modules.ai_intelligence.ai_gateway.src.model_autoresearch_single_call_admission import (
+    CanonicalSingleCallIntent,
+    CanonicalSingleCallJobPolicy,
+    build_canonical_single_call_admission,
+)
+from modules.ai_intelligence.ai_gateway.src.model_openrouter_endpoint_route_evidence import (
+    DEFAULT_ENDPOINT_FRESHNESS_MS,
+    build_endpoint_observation_receipt,
+    build_openrouter_endpoint_route_evidence,
+    endpoint_payload_id,
+    parse_and_sanitize_openrouter_endpoint_payload,
+    rehydrate_endpoint_observation_receipt,
+    rehydrate_openrouter_endpoint_route_evidence,
+    sha256_bytes,
+)
+from modules.ai_intelligence.ai_gateway.src.model_provider_catalog_snapshot import (
+    build_candidate_snapshot,
+    build_discovery_invocation,
+    build_discovery_receipt,
+    candidate_snapshot_id,
+    sanitize_openrouter_catalog_payload,
+)
+from modules.ai_intelligence.ai_gateway.src.model_provider_execution_control_evidence import (
+    build_provider_model_execution_control_evidence,
+)
+
+
+ROOT = Path(__file__).resolve().parents[4]
+FIXTURE = Path(__file__).parent / "fixtures/openrouter_endpoints_k3_success.json"
+K3_ID = "moonshotai/kimi-k3"
+TAG = "moonshotai"
+
+
+def _raw(payload: dict | None = None) -> bytes:
+    if payload is None:
+        return FIXTURE.read_bytes()
+    return json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+def _payload() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _endpoint_sources(
+    raw: bytes | None = None,
+    *,
+    observed_at_ms: int = 10_000,
+    tag: str = TAG,
+):
+    raw = _raw() if raw is None else raw
+    sanitized = parse_and_sanitize_openrouter_endpoint_payload(
+        raw, requested_model_id=K3_ID
+    )
+    receipt = build_endpoint_observation_receipt(
+        requested_model_id=K3_ID,
+        request_envelope_digest=sha256_bytes(b"fixed-endpoint-request"),
+        response_body_digest=sha256_bytes(raw),
+        response_byte_count=len(raw),
+        payload_id=endpoint_payload_id(sanitized),
+        observed_at_ms=observed_at_ms,
+        http_status=200,
+    )
+    evidence = build_openrouter_endpoint_route_evidence(
+        raw=raw,
+        observation_receipt=receipt,
+        endpoint_tag=tag,
+        now_ms=observed_at_ms + 1,
+    )
+    return receipt, evidence
+
+
+def _model_sources(
+    *,
+    observed_at_ms: int = 10_000,
+    prompt_price: str = "0.000003",
+    completion_price: str = "0.000015",
+    supported_parameters: tuple[str, ...] = ("reasoning", "max_tokens"),
+    reasoning_supports_max_tokens: bool | None = None,
+):
+    row = {
+        "id": K3_ID,
+        "context_length": 1_048_576,
+        "pricing": {"prompt": prompt_price, "completion": completion_price},
+        "architecture": {
+            "input_modalities": ["text"],
+            "output_modalities": ["text"],
+        },
+        "supported_parameters": list(supported_parameters),
+        "reasoning": {
+            "supported_efforts": ["max", "high", "low"],
+            "default_effort": "max",
+            "default_enabled": True,
+            "mandatory": False,
+        },
+        "top_provider": {
+            "context_length": 1_048_576,
+            "max_completion_tokens": 131_072,
+            "is_moderated": False,
+        },
+    }
+    if reasoning_supports_max_tokens is not None:
+        row["reasoning"]["supports_max_tokens"] = reasoning_supports_max_tokens
+    payload, rejected, counts = sanitize_openrouter_catalog_payload({"data": [row]})
+    snapshot_id = candidate_snapshot_id(payload)
+    raw = _raw({"data": [row]})
+    receipt = build_discovery_receipt(
+        call_id="offline-b2a-model-controls",
+        invocation=build_discovery_invocation(mode="manual"),
+        request_envelope_digest=sha256_bytes(b"fixed-model-request"),
+        attempted=True,
+        outcome="COMPLETED",
+        reason="completed",
+        started_at_ms=observed_at_ms - 1,
+        completed_at_ms=observed_at_ms,
+        http_status=200,
+        response_body_digest=sha256_bytes(raw),
+        response_byte_count=len(raw),
+        candidate_snapshot_id=snapshot_id,
+        accepted_record_count=1,
+        rejected_record_count=rejected,
+        rejection_counts=counts,
+    )
+    candidate = build_candidate_snapshot(
+        catalog_payload=payload,
+        rejected_record_count=rejected,
+        rejection_counts=counts,
+        observed_at_ms=observed_at_ms,
+        observation_receipt=receipt,
+    )
+    evidence = build_provider_model_execution_control_evidence(
+        candidate=candidate, model_id=K3_ID, now_ms=observed_at_ms + 1
+    )
+    return candidate, evidence
+
+
+def _policy(**changes):
+    values = {
+        "task_type": "model_autoresearch",
+        "model_id": K3_ID,
+        "endpoint_tag": TAG,
+        "accepted_endpoint_statuses": (0,),
+        "max_prompt_tokens": 20_000,
+        "max_completion_tokens": 4_096,
+        "max_response_bytes": 1_000_000,
+        "reasoning_effort": "max",
+        "required_parameters": ("max_tokens", "reasoning"),
+        "omitted_sampling_parameters": (
+            "min_p",
+            "seed",
+            "temperature",
+            "top_a",
+            "top_k",
+            "top_p",
+        ),
+        "data_collection": "deny",
+        "require_zdr": False,
+        "output_use": "evaluation_only",
+        "enforce_distillable_text": False,
+        "max_prompt_price_per_million": "3",
+        "max_completion_price_per_million": "15",
+        "max_request_price": "0",
+        "expires_at_ms": 20_000,
+        "max_calls": 1,
+    }
+    values.update(changes)
+    return CanonicalSingleCallJobPolicy(**values).normalized()
+
+
+def _intent(**changes):
+    values = {
+        "task_type": "model_autoresearch",
+        "model_id": K3_ID,
+        "prompt_digest": sha256_bytes(b"fully-wrapped-held-out-prompt"),
+        "prompt_token_upper_bound": 10_000,
+        "output_use": "evaluation_only",
+        "nonce": "b2a-intent-0001",
+        "issued_at_ms": 10_000,
+        "expires_at_ms": 20_000,
+    }
+    values.update(changes)
+    return CanonicalSingleCallIntent(**values).normalized()
+
+
+def _admission(**changes):
+    raw = changes.pop("raw", _raw())
+    receipt, endpoint = _endpoint_sources(raw)
+    candidate, model = _model_sources()
+    values = {
+        "raw_endpoint_payload": raw,
+        "endpoint_observation_receipt": receipt,
+        "endpoint_route_evidence": endpoint,
+        "model_candidate": candidate,
+        "model_control_evidence": model,
+        "policy": _policy(),
+        "intent": _intent(),
+        "now_ms": 10_001,
+    }
+    values.update(changes)
+    return build_canonical_single_call_admission(**values), values
+
+
+def test_endpoint_fixture_is_strictly_projected_and_lineage_bound() -> None:
+    raw = _raw()
+    receipt, evidence = _endpoint_sources(raw)
+    assert evidence.model_id == K3_ID
+    assert evidence.endpoint_tag == TAG
+    assert evidence.provider_name == "Moonshot AI"
+    assert evidence.context_length == 1_048_576
+    assert evidence.max_prompt_tokens_present is True
+    assert evidence.max_prompt_tokens == 917_504
+    assert evidence.max_completion_tokens_present is True
+    assert evidence.max_completion_tokens == 131_072
+    assert evidence.prompt_price == "0.000003"
+    assert evidence.completion_price == "0.000015"
+    assert evidence.request_price_present is True
+    assert evidence.request_price == "0"
+    assert evidence.unsafe_cost_dimensions == ()
+    assert evidence.supported_parameters == ("max_tokens", "reasoning")
+    assert evidence.status_present is True
+    assert evidence.status == 0
+    assert evidence.quantization_present is True
+    assert evidence.quantization is None
+    assert evidence.trust_class == "provider_asserted_endpoint_route_controls"
+    assert receipt.response_body_digest == sha256_bytes(raw)
+    assert rehydrate_endpoint_observation_receipt(receipt.to_dict()) == receipt
+    assert (
+        rehydrate_openrouter_endpoint_route_evidence(
+            evidence.to_dict(),
+            raw=raw,
+            observation_receipt=receipt,
+            now_ms=10_001,
+        )
+        == evidence
+    )
+    with pytest.raises(FrozenInstanceError):
+        evidence.endpoint_tag = "other"  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        evidence.source_control["pricing"]["prompt"] = "0"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "mutation,reason",
+    (
+        (lambda p: p["data"].pop("architecture"), "endpoint_payload_top_level_invalid"),
+        (
+            lambda p: p["data"]["endpoints"][0].pop("max_prompt_tokens"),
+            "endpoint_record_invalid",
+        ),
+        (
+            lambda p: p["data"]["endpoints"][0].update(context_length=True),
+            "endpoint_record_invalid",
+        ),
+        (
+            lambda p: p["data"]["endpoints"][0].update(max_completion_tokens=0),
+            "endpoint_record_invalid",
+        ),
+        (
+            lambda p: p["data"]["endpoints"][0]["pricing"].update(prompt="-1"),
+            "endpoint_record_invalid",
+        ),
+        (
+            lambda p: p["data"]["endpoints"][0].update(tag="Moonshot AI"),
+            "endpoint_record_invalid",
+        ),
+    ),
+)
+def test_required_schema_and_recognized_malformed_values_fail_closed(
+    mutation, reason: str
+) -> None:
+    payload = _payload()
+    mutation(payload)
+    with pytest.raises(ValueError, match=reason):
+        parse_and_sanitize_openrouter_endpoint_payload(
+            _raw(payload), requested_model_id=K3_ID
+        )
+
+
+def test_null_caps_and_optional_status_preserve_presence_semantics() -> None:
+    payload = _payload()
+    endpoint = payload["data"]["endpoints"][0]
+    endpoint["max_prompt_tokens"] = None
+    endpoint["max_completion_tokens"] = None
+    endpoint.pop("status")
+    receipt, evidence = _endpoint_sources(_raw(payload))
+    assert evidence.max_prompt_tokens_present is True
+    assert evidence.max_prompt_tokens is None
+    assert evidence.max_completion_tokens_present is True
+    assert evidence.max_completion_tokens is None
+    assert evidence.status_present is False
+    assert evidence.status is None
+    assert "status" not in evidence.source_control
+    assert receipt.payload_id
+
+
+def test_strict_json_duplicate_keys_nonfinite_and_size_bound_reject() -> None:
+    duplicate = b'{"data":{"id":"moonshotai/kimi-k3","id":"other/model"}}'
+    nonfinite = b'{"data":{"id":NaN}}'
+    oversized = b" " * (2 * 1024 * 1024 + 1)
+    for raw in (duplicate, nonfinite):
+        with pytest.raises(ValueError, match="endpoint_payload_json_invalid"):
+            parse_and_sanitize_openrouter_endpoint_payload(
+                raw, requested_model_id=K3_ID
+            )
+    with pytest.raises(ValueError, match="endpoint_payload_too_large"):
+        parse_and_sanitize_openrouter_endpoint_payload(
+            oversized, requested_model_id=K3_ID
+        )
+
+
+def test_exact_model_identity_duplicate_and_prefix_ambiguous_tags_reject() -> None:
+    payload = _payload()
+    payload["data"]["id"] = "moonshotai/Kimi-k3"
+    with pytest.raises(ValueError, match="endpoint_payload_model_mismatch"):
+        parse_and_sanitize_openrouter_endpoint_payload(
+            _raw(payload), requested_model_id=K3_ID
+        )
+
+    payload = _payload()
+    payload["data"]["endpoints"].append(
+        copy.deepcopy(payload["data"]["endpoints"][0])
+    )
+    with pytest.raises(ValueError, match="endpoint_duplicate_tag"):
+        parse_and_sanitize_openrouter_endpoint_payload(
+            _raw(payload), requested_model_id=K3_ID
+        )
+
+    payload = _payload()
+    variant = copy.deepcopy(payload["data"]["endpoints"][0])
+    variant["tag"] = "moonshotai/turbo"
+    payload["data"]["endpoints"].append(variant)
+    raw = _raw(payload)
+    sanitized = parse_and_sanitize_openrouter_endpoint_payload(
+        raw, requested_model_id=K3_ID
+    )
+    receipt = build_endpoint_observation_receipt(
+        requested_model_id=K3_ID,
+        request_envelope_digest=sha256_bytes(b"fixed-endpoint-request"),
+        response_body_digest=sha256_bytes(raw),
+        response_byte_count=len(raw),
+        payload_id=endpoint_payload_id(sanitized),
+        observed_at_ms=10_000,
+        http_status=200,
+    )
+    with pytest.raises(ValueError, match="endpoint_tag_prefix_collision"):
+        build_openrouter_endpoint_route_evidence(
+            raw=raw,
+            observation_receipt=receipt,
+            endpoint_tag=TAG,
+            now_ms=10_001,
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    (
+        ("request", "0.01"),
+        ("internal_reasoning", "0.000001"),
+        ("input_cache_write", "0.000004"),
+        ("discount", 0.5),
+    ),
+)
+def test_nonzero_secondary_cost_dimensions_are_preserved_as_unsafe(
+    field: str, value: object
+) -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["pricing"][field] = value
+    _, evidence = _endpoint_sources(_raw(payload))
+    assert field in evidence.unsafe_cost_dimensions
+
+
+def test_nonempty_pricing_overrides_are_unsafe() -> None:
+    payload = _payload()
+    payload["data"]["endpoints"][0]["pricing"]["overrides"] = [
+        {"min_prompt_tokens": 1000, "prompt": "0.000006"}
+    ]
+    _, evidence = _endpoint_sources(_raw(payload))
+    assert "overrides" in evidence.unsafe_cost_dimensions
+
+
+def test_observation_and_evidence_stale_future_body_and_id_tamper_reject() -> None:
+    raw = _raw()
+    receipt, evidence = _endpoint_sources(raw)
+    with pytest.raises(ValueError, match="endpoint_observation_stale"):
+        build_openrouter_endpoint_route_evidence(
+            raw=raw,
+            observation_receipt=receipt,
+            endpoint_tag=TAG,
+            now_ms=10_000 + DEFAULT_ENDPOINT_FRESHNESS_MS + 1,
+        )
+    with pytest.raises(ValueError, match="endpoint_observation_future"):
+        build_openrouter_endpoint_route_evidence(
+            raw=raw,
+            observation_receipt=receipt,
+            endpoint_tag=TAG,
+            now_ms=9_999,
+        )
+    with pytest.raises(ValueError, match="endpoint_observation_invalid"):
+        build_openrouter_endpoint_route_evidence(
+            raw=raw + b" ",
+            observation_receipt=receipt,
+            endpoint_tag=TAG,
+            now_ms=10_001,
+        )
+    tampered = replace(evidence, endpoint_record_digest="sha256:" + "0" * 64)
+    with pytest.raises(ValueError, match="endpoint_route_evidence_invalid"):
+        rehydrate_openrouter_endpoint_route_evidence(
+            tampered.to_dict(),
+            raw=raw,
+            observation_receipt=receipt,
+            now_ms=10_001,
+        )
+
+
+def test_unknown_prose_and_secret_shaped_fields_do_not_survive_projection() -> None:
+    payload = _payload()
+    endpoint = payload["data"]["endpoints"][0]
+    endpoint["description"] = "Bearer not-a-real-but-secret-shaped-value"
+    endpoint["api_key"] = "sk-this-value-must-not-survive"
+    _, evidence = _endpoint_sources(_raw(payload))
+    serialized = json.dumps(evidence.to_dict(), sort_keys=True)
+    assert "Bearer" not in serialized
+    assert "api_key" not in serialized
+    assert "sk-this" not in serialized
+
+
+def test_wsp97_receipt_names_only_existing_retrieved_wsp_paths() -> None:
+    receipt_path = (
+        ROOT
+        / "docs/audits/ai_intelligence/"
+        "OPENROUTER_ENDPOINT_ROUTE_SINGLE_CALL_ADMISSION_PHASE_B2A_"
+        "WSP97_EXECUTION_RECEIPT.json"
+    )
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    wsp_paths = receipt["action_evidence"]["retrieve_wsps"]
+    assert wsp_paths
+    assert all(path.startswith("WSP_framework/src/WSP_") for path in wsp_paths)
+    assert all((ROOT / path).is_file() for path in wsp_paths)
+
+
+def test_new_surfaces_are_pure_and_have_no_live_authority_tokens() -> None:
+    paths = (
+        ROOT
+        / "modules/ai_intelligence/ai_gateway/src/"
+        "model_openrouter_endpoint_payload_projection.py",
+        ROOT
+        / "modules/ai_intelligence/ai_gateway/src/"
+        "model_openrouter_endpoint_route_evidence.py",
+        ROOT
+        / "modules/ai_intelligence/ai_gateway/src/"
+        "model_autoresearch_single_call_contracts.py",
+        ROOT
+        / "modules/ai_intelligence/ai_gateway/src/"
+        "model_autoresearch_single_call_admission.py",
+    )
+    forbidden = {
+        "aiohttp",
+        "httpx",
+        "requests",
+        "socket",
+        "subprocess",
+        "AIGateway",
+        "GatewayModelCaller",
+        "call_model",
+        "Authorization",
+        "os.environ",
+    }
+    for path in paths:
+        source = path.read_text(encoding="utf-8")
+        assert not forbidden.intersection(source.split())
+        assert len(source.splitlines()) < 500

--- a/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
+++ b/modules/ai_intelligence/ai_gateway/tests/test_model_provider_catalog_protected_surfaces.py
@@ -13,7 +13,11 @@ IDLE_PROJECTION = (
     / "modules/infrastructure/idle_automation/src/openrouter_catalog_projection.py"
 )
 NEW_MODULE_NAMES = {
+    "model_autoresearch_single_call_admission",
+    "model_autoresearch_single_call_contracts",
     "model_openrouter_direct_discovery",
+    "model_openrouter_endpoint_payload_projection",
+    "model_openrouter_endpoint_route_evidence",
     "model_openrouter_schedule_adapter",
     "model_openrouter_scheduled_discovery",
     "model_provider_catalog_replay_state",
@@ -23,8 +27,12 @@ NEW_MODULE_NAMES = {
     "openrouter_model_catalog_snapshot_once",
 }
 FUNCTION_LIMIT_MODULES = (
+    "model_autoresearch_single_call_admission.py",
+    "model_autoresearch_single_call_contracts.py",
     "model_intelligence_catalog.py",
     "model_openrouter_direct_discovery.py",
+    "model_openrouter_endpoint_payload_projection.py",
+    "model_openrouter_endpoint_route_evidence.py",
     "model_openrouter_schedule_adapter.py",
     "model_openrouter_scheduled_discovery.py",
     "model_provider_catalog_atomic_io.py",
@@ -35,6 +43,10 @@ FUNCTION_LIMIT_MODULES = (
     "model_provider_execution_control_projection.py",
 )
 SOURCE_LINE_LIMITS = {
+    "model_autoresearch_single_call_admission.py": 500,
+    "model_autoresearch_single_call_contracts.py": 500,
+    "model_openrouter_endpoint_payload_projection.py": 500,
+    "model_openrouter_endpoint_route_evidence.py": 500,
     "model_provider_catalog_snapshot.py": 450,
     "model_openrouter_direct_discovery.py": 400,
     "model_provider_catalog_atomic_io.py": 400,
@@ -114,6 +126,10 @@ def test_execution_control_surfaces_have_no_network_or_runtime_authority_imports
         "reddog_provider_call_evidence",
     )
     for name in (
+        "model_autoresearch_single_call_admission.py",
+        "model_autoresearch_single_call_contracts.py",
+        "model_openrouter_endpoint_payload_projection.py",
+        "model_openrouter_endpoint_route_evidence.py",
         "model_provider_execution_control_projection.py",
         "model_provider_execution_control_evidence.py",
     ):


### PR DESCRIPTION
## Outcome

Adds a fail-closed, offline OpenRouter endpoint route-admission contract for exactly one future evaluation call. This slice proves eligibility only; it does not call a provider or authorize runtime execution.

## Scope

- bounds and sanitizes external endpoint payloads
- binds observation and route lineage to exact model/endpoint/provider evidence
- enforces exact status, pricing, context, reasoning, privacy, routing, and response-size controls
- reserves worst-case cost with Decimal arithmetic
- emits exact `/api/v1/chat/completions` request controls: `max_tokens`, `reasoning`, `provider`
- keeps `max_completion_tokens` internal to admission budgeting
- preserves output-use and training-permission separation
- remains `runtime_authority=eligibility_only` with authoritative availability/caller/execution explicitly HALTED
- migrates its execution receipt to WSP_97 v1.1 at exact base `a3c13f05`

No credentials, provider calls, caller wiring, static production model choice, or training use are introduced.

## Evidence

- focused endpoint/admission: 65 passed
- protected/control: 134 passed
- full AI Gateway: 712 passed, 2 skipped
- Ruff, WSP_62, JSON, diff check: passed
- WSP_97 v1.1 repository validation: compliant
- one clean commit directly on current main

Independent adversarial review: APPROVE at `487b4227781e1f47fbab2a6d5401780b3cfb08e5`.