### PR TITLE
feat(reddog): route main through canonical resident client

### DIFF
--- a/main.py
+++ b/main.py
@@ -1854,7 +1854,7 @@ def _reddog_resident_architect_intent_id(
     work_focus: str,
     cycle_bucket: str = "",
 ) -> str:
-    explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "").strip()
+    explicit = os.getenv("REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID", "").strip()
     if explicit:
         return explicit
     payload = {
@@ -1897,180 +1897,66 @@ def _reddog_resident_architect_auto_queue_profile(result: Any) -> str:
     return raw if raw in RESIDENT_QUEUE_PROFILES else ""
 
 
-def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bool:
-    """
-    Optionally run one durable AgentDB resident RedDog architect cycle.
+def _run_reddog_main_resident_client(
+    *,
+    repo_root: Path,
+    authenticated_principal: str,
+    authorized_foundups: tuple[str, ...],
+    foundup_id: str,
+    work_focus: str,
+    client_request_id: str,
+    explicit_intent_id: str,
+    runtime_defaults: Mapping[str, Any],
+    cancel_requested: bool,
+    retry_requested: bool,
+) -> Any:
+    """Delegate one main-host request to the transport-neutral runtime module."""
 
-    This is the resident RedDog runtime bridge for main.py. It submits a
-    reddog_intent.v1 request to the durable AgentDB cycle, lets OpenClaw claim
-    read-only audit/research tasks, persists the backend architect
-    determination, and exposes the intent ID for the downstream FIX promotion
-    handoff. It performs no source mutation, shell work, worktree operations,
-    PR creation, HoloIndex re-index, Hermes dispatch, PatternMemory promotion,
-    or live FoundUp enqueue.
-
-    Env:
-        REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE=1           Auto-run resident cycle when low-level flag unset
-        REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE            Explicit enable/disable override
-        REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS=24         New intent cadence; 0 disables cadence
-        REDDOG_RESIDENT_ARCHITECT_CYCLE_BUCKET             Optional explicit cadence bucket
-        REDDOG_RESIDENT_ARCHITECT_NOW_ISO                  Optional deterministic runtime clock
-        REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=0 Block startup if rejected
-        REDDOG_RESIDENT_ARCHITECT_INTENT_ID                Optional stable intent ID
-        REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS               Work focus submitted to RedDog
-        REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF            Principal reference, default 012
-        REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID               FoundUp scope, default foundups_agent
-        REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS               Max OpenClaw claims, default 8
-        REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS          Cycle timeout, default 60
-        REDDOG_RESIDENT_ARCHITECT_RETRY=0                  Retry failed/timed-out cycle; cancelled is terminal
-        REDDOG_RESIDENT_ARCHITECT_CANCEL=0                 Cancel running cycle
-        REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF=1        Auto-arm safe FIX handoff after accepted FIX
-        REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE        Optional downstream queue profile, default draft-PR
-        REDDOG_RESIDENT_BRAIN_CONTEXT=1                     Attach read-only Brain artifact state metadata
-        REDDOG_RESIDENT_BRAIN_STATE_PATH                    Optional Brain artifact state JSON override
-        REDDOG_RESIDENT_BREADCRUMBS_CONTEXT=1               Attach read-only AgentDB breadcrumb metadata
-        REDDOG_RESIDENT_BREADCRUMBS_PATH                    Optional breadcrumb JSON override
-        REDDOG_RESIDENT_WORKSPACE_MEMORY_NOTES_PATH         Optional workspace memory note JSON
-        REDDOG_RESIDENT_MEMORY_MAX_RECORDS=20               Max breadcrumb/workspace records supplied
-        REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT           Outside-repo root for binding artifacts
-        REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH Exact audit binding artifact
-        REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH Exact architect binding artifact
-        REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH             Approved external snapshot JSON
-        REDDOG_AUTHORITATIVE_WORK_STATE_PATH               Existing work-state JSON
-        HOLOINDEX_FRESHNESS_RECEIPT                        Existing HoloIndex receipt
-        HOLOINDEX_SSD_PATH                                 HoloIndex SSD path
-    """
-
-    if not _reddog_resident_architect_cycle_requested():
-        logger.info("[REDDOG-RESIDENT-CYCLE] Startup preflight disabled")
-        return True
-
-    audit_runtime_binding, architect_runtime_binding, binding_reason = (
-        _reddog_resident_model_runtime_bindings_from_env(repo_root)
+    from modules.communication.moltbot_bridge.src.reddog_main_resident_architect_cycle_bootstrap import (
+        run_main_resident_client,
     )
-    if binding_reason:
-        logger.error("[REDDOG-RESIDENT-CYCLE] Runtime model binding preflight failed: %s", binding_reason)
-        print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL reason={binding_reason}")
-        return False
 
-    enforced = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0") != "0"
-    principal_ref = os.getenv("REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF", "012").strip() or "012"
-    foundup_id = os.getenv("REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID", "foundups_agent").strip() or "foundups_agent"
-    work_focus = (
-        os.getenv("REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS", "").strip()
-        or "main.py resident RedDog architect cycle"
-    )
-    explicit_intent_id = os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "").strip()
-    cycle_bucket = "" if explicit_intent_id else _reddog_resident_architect_cycle_bucket()
-    intent_id = _reddog_resident_architect_intent_id(
-        principal_ref=principal_ref,
+    return run_main_resident_client(
+        repo_root=repo_root,
+        authenticated_principal=authenticated_principal,
+        authorized_foundups=authorized_foundups,
         foundup_id=foundup_id,
         work_focus=work_focus,
-        cycle_bucket=cycle_bucket,
+        client_request_id=client_request_id,
+        explicit_intent_id=explicit_intent_id,
+        runtime_defaults=runtime_defaults,
+        cancel_requested=cancel_requested,
+        retry_requested=retry_requested,
     )
-    brain_state = _reddog_resident_brain_state_from_artifacts()
-    breadcrumbs = _reddog_resident_breadcrumbs_from_runtime(work_focus=work_focus, foundup_id=foundup_id)
-    workspace_memory_notes = _reddog_resident_workspace_memory_notes_from_env()
-    memory_context = {
-        "brain_available": bool(brain_state),
-        "brain_record_count": int(brain_state.get("record_count", 0)) if brain_state else 0,
-        "breadcrumbs_count": len(breadcrumbs),
-        "workspace_memory_notes_count": len(workspace_memory_notes),
-    }
-    memory_context["memory_context_digest"] = _reddog_digest_payload(memory_context)
-    red_dog_intent = {
-        "schema_version": "reddog_intent.v1",
-        "intent_id": intent_id,
-        "principal_ref": principal_ref,
-        "foundup_id": foundup_id,
-        "work_focus": work_focus,
-        "cycle_bucket": cycle_bucket,
-        "requested_authority": "read_only_audit",
-        "origin": "main.py",
-        "submits_executable_authority": False,
-        "memory_context": memory_context,
-    }
 
-    try:
-        from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
-            run_reddog_resident_architect_durable_agentdb_cycle,
-        )
 
-        result = run_reddog_resident_architect_durable_agentdb_cycle(
-            repo_root=repo_root,
-            red_dog_intent=red_dog_intent,
-            work_state_path=os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
-            holoindex_receipt_path=os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
-            holoindex_ssd_path=os.getenv("HOLOINDEX_SSD_PATH", ""),
-            requested_operation="main_resident_architect_cycle",
-            prompt_text=work_focus,
-            breadcrumbs=breadcrumbs,
-            brain_state=brain_state,
-            workspace_memory_notes=workspace_memory_notes,
-            external_research_retriever=_reddog_external_research_retriever_from_env(),
-            audit_model_runtime_binding_receipt=audit_runtime_binding,
-            architect_model_runtime_binding_receipt=architect_runtime_binding,
-            max_claims=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS", 8),
-            timeout_seconds=_reddog_positive_int_env("REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS", 60),
-            cancel_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_CANCEL", "0") != "0",
-            retry_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_RETRY", "0") != "0",
-        )
-    except Exception as exc:
-        logger.error(f"[REDDOG-RESIDENT-CYCLE] Startup runtime failed: {exc}")
-        if enforced:
-            print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL error={type(exc).__name__}")
-            return False
-        print(f"[REDDOG-RESIDENT-CYCLE] preflight=WARN error={type(exc).__name__}")
-        return True
+def run_reddog_resident_architect_durable_cycle_preflight(repo_root: Path) -> bool:
+    """Run one resident cycle through the decomposed moltbot bootstrap."""
 
-    status = "PASS" if result.accepted else "WARN"
-    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
-    completed = int(result.task_status_counts.get("completed", 0))
-    auto_fix_handoff = (
-        result.accepted
-        and str(result.architect_action or "").strip().upper() == "FIX"
-        and os.getenv("REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF", "1") != "0"
-        and "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+    from modules.communication.moltbot_bridge.src.reddog_main_resident_architect_cycle_bootstrap import (
+        MainResidentArchitectHooks,
+        run_main_resident_architect_cycle_preflight,
     )
-    auto_queue_profile = _reddog_resident_architect_auto_queue_profile(result)
-    print(
-        f"[REDDOG-RESIDENT-CYCLE] preflight={status} status={result.status} "
-        f"intent={result.intent_id} cycle={result.cycle_id} snapshot={result.snapshot_id or '(none)'} "
-        f"swarm={result.swarm_id or '(none)'} tasks={len(result.task_ids)} completed={completed} "
-        f"claims={len(result.openclaw_claims)} recovered={result.recovered_existing_cycle} "
-        f"duplicate={result.duplicate_intent_reused} architect_action={result.architect_action or '(none)'} "
-        f"architect_next_slice={result.architect_next_slice or '(none)'} "
-        f"architect_determination={result.architect_determination_id or '(none)'} "
-        f"queue_candidates={result.queue_candidate_count} auto_fix_handoff={auto_fix_handoff} "
-        f"auto_queue_profile={auto_queue_profile or '(none)'} "
-        f"brain_records={memory_context['brain_record_count']} "
-        f"breadcrumbs={memory_context['breadcrumbs_count']} "
-        f"workspace_memory={memory_context['workspace_memory_notes_count']} reasons={reasons}"
-    )
-    print(
-        "[REDDOG-RESIDENT-CYCLE] "
-        f"read_only_authority={result.read_only_authority_only} "
-        f"no_shell={result.no_shell_command_executed} "
-        f"no_repo_mutation={result.no_repo_mutation_performed} "
-        f"no_holoindex_reindex={result.no_holoindex_reindex_performed} "
-        f"no_hermes_dispatch={result.no_hermes_dispatch_performed} "
-        f"no_worktree={result.no_worktree_operation_performed} "
-        f"no_pr={result.no_pr_created} "
-        f"no_pattern_memory={result.no_pattern_memory_promotion_performed} "
-        f"no_live_foundup_enqueue={result.no_live_foundup_enqueue_performed}"
-    )
-    if result.accepted:
-        os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] = result.intent_id
-        if auto_fix_handoff:
-            os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] = "1"
-        if auto_queue_profile:
-            os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] = auto_queue_profile
-        return True
 
-    if enforced:
-        print("[REDDOG-RESIDENT-CYCLE] Startup blocked by REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1")
-        return False
-    return True
+    hooks = MainResidentArchitectHooks(
+        cycle_requested=_reddog_resident_architect_cycle_requested,
+        model_runtime_bindings=_reddog_resident_model_runtime_bindings_from_env,
+        cycle_bucket=_reddog_resident_architect_cycle_bucket,
+        client_request_id=_reddog_resident_architect_intent_id,
+        brain_state=_reddog_resident_brain_state_from_artifacts,
+        breadcrumbs=_reddog_resident_breadcrumbs_from_runtime,
+        workspace_memory_notes=_reddog_resident_workspace_memory_notes_from_env,
+        payload_digest=_reddog_digest_payload,
+        external_research_retriever=_reddog_external_research_retriever_from_env,
+        positive_int_env=_reddog_positive_int_env,
+        auto_queue_profile=_reddog_resident_architect_auto_queue_profile,
+        run_client=_run_reddog_main_resident_client,
+    )
+    return run_main_resident_architect_cycle_preflight(
+        repo_root,
+        hooks=hooks,
+        logger=logger,
+    )
 
 
 def _reddog_resident_model_runtime_bindings_from_env(

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -55,9 +55,9 @@ not a second authoritative provider-call identity.
 
 `RedDogResidentArchitectClient` revalidates the authenticated principal, FoundUp scope, grounding receipt, full intent digest, and all nine persisted process-local self-attestations on reconnect. Hash-chained transition history is recomputed internal-integrity telemetry, not signer authority, external authentication, or independently observed effect evidence.
 
-The editor bridge requires host-supplied `REDDOG_AUTHENTICATED_PRINCIPAL_ID` and `REDDOG_AUTHORIZED_FOUNDUP_IDS`, then invokes this canonical client. It cannot call the durable cycle directly.
+The editor bridge and `main.py` resident host require host-supplied `REDDOG_AUTHENTICATED_PRINCIPAL_ID` and `REDDOG_AUTHORIZED_FOUNDUP_IDS`, then invoke this canonical client. The main host first emits a verified `reddog_intent.v2` through `ground_transport_work_focus()` with source `main_resident_host` and origin `main.py`; it cannot call the durable cycle directly. `REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID` controls new-request idempotency, while `REDDOG_RESIDENT_ARCHITECT_INTENT_ID` addresses an existing canonical cycle for status, cancel, or retry.
 
-`CANCELLED` and `DETERMINED` are permanently terminal. Only `FAILED` and `TIMED_OUT` cycles may enter a revision-checked retry, and each retry appends one immutable prior-attempt summary. Legacy v1 rows are accepted only by the canonical cancellation path; they cannot reconnect, resume, or become authority-bearing v2 records.
+`CANCELLED` and `DETERMINED` are permanently terminal. Only `FAILED` and `TIMED_OUT` cycles may enter a revision-checked retry, and each retry appends one immutable prior-attempt summary. Persisted main-host v1 intents in both historical v1 and integrity-valid transitional v2 cycle rows have a main-transport-only status/CAS-cancel compatibility path with exact principal, FoundUp, requested-ID, row-ID, and embedded-ID checks. Historical rows remain status/cancel-only. New v1 submissions and legacy resume remain rejected; no legacy record can become an authority-bearing v2 intent.
 
 Resident model execution requires separate runtime-binding inputs
 for the read-only audit and backend architect surfaces. The audit binding is

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,24 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-25: REDDOG_MAIN_RESIDENT_ARCHITECT_CANONICAL_CLIENT_MIGRATION_REVIEW_REPAIR
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 62, 71, 91, 97
+
+- Prevented status/reconnect operations from re-arming FIX promotion or queue
+  handoff, and confined every reconnect to the explicitly selected FoundUp.
+- Added a bounded, main-transport-only compatibility adapter so persisted
+  read-only `reddog_intent.v1` records in both historical v1 and transitional
+  v2 cycles remain observable and cancellable without allowing legacy submit
+  or resume; requested, top-level record, and embedded intent IDs must match
+  before the CAS target is selected.
+- Preserved exact runtime-model binding receipts added after the original
+  slice base, split legacy control from the canonical client, and extracted
+  the resident bootstrap implementation from `main.py` into decomposed
+  functions under the moltbot runtime owner.
+- Restored the prior root-entrypoint no-growth ceiling after the extraction.
+- Enforced the selected FoundUp against the exported helper's authorized scope
+  before grounding or canonical-client construction.
+
 ## 2026-07-24: HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1
 
 **WSP Protocol**: WSP 00, 15, 22, 50, 62, 81, 97
@@ -185,6 +204,17 @@
   canonical store is cross-process atomic under `.operation`.
 - Production remains permanently CLOSED while independent trust-anchor
   verifiers listed by the governed resolver are absent.
+
+## 2026-07-20: REDDOG_MAIN_RESIDENT_ARCHITECT_CANONICAL_CLIENT_MIGRATION_PHASE1
+
+**WSP Protocol**: WSP 00, 15, 22, 50, 71, 91, 97
+
+- Replaced `main.py`'s legacy `reddog_intent.v1` direct cycle invocation with typed v2 grounding and `RedDogResidentArchitectClient`.
+- Added the explicit `main_resident_host -> main.py` source/origin binding across grounding receipt validation and client transport policy.
+- Required host-authenticated principal and FoundUp scope before the resident runtime can be reached; caller role text and implicit `012` defaults no longer establish identity.
+- Separated stable client request IDs from canonical intent IDs, and routed status, cancel, and retry only through an existing canonical intent.
+- Rejected cancel/retry conflicts and control operations without an intent before client, worker, or model invocation.
+- Removed the durable cycle's legacy main-v1 exception while preserving startup order, menu loading, read-only authority, and downstream FIX handoff behavior.
 
 ## 2026-07-20: REDDOG_RESIDENT_CYCLE_CAS_ATTESTATION_AND_INTENT_BINDING_PHASE1
 

--- a/modules/communication/moltbot_bridge/src/reddog_grounded_target_assignment_continuity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_grounded_target_assignment_continuity.py
@@ -28,7 +28,9 @@ from modules.communication.moltbot_bridge.src.reddog_repo_audit_fallback_groundi
 )
 
 SCHEMA_VERSION = "reddog_grounded_target_receipt.v1"
-SOURCE_SURFACES = frozenset({"editor_thin_client", "hermes_thin_client", "api_thin_client"})
+SOURCE_SURFACES = frozenset(
+    {"editor_thin_client", "hermes_thin_client", "api_thin_client", "main_resident_host"}
+)
 SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 REPO_AUDIT_PRUNED_SEGMENTS = frozenset({
     ".agent", ".agents", ".cache", ".chroma", ".claude", ".codex", ".cursor",

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_architect_cycle_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_architect_cycle_bootstrap.py
@@ -1,0 +1,443 @@
+"""Main-host adapter for the canonical resident RedDog architect client."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+
+@dataclass(frozen=True)
+class MainResidentArchitectHooks:
+    """Host-owned dependencies used by the resident bootstrap."""
+
+    cycle_requested: Callable[[], bool]
+    model_runtime_bindings: Callable[
+        [Path],
+        tuple[Mapping[str, Any] | None, Mapping[str, Any] | None, str],
+    ]
+    cycle_bucket: Callable[[], str]
+    client_request_id: Callable[..., str]
+    brain_state: Callable[[], Mapping[str, Any]]
+    breadcrumbs: Callable[..., tuple[Mapping[str, Any], ...]]
+    workspace_memory_notes: Callable[[], tuple[Mapping[str, Any], ...]]
+    payload_digest: Callable[[Any], str]
+    external_research_retriever: Callable[[], Any | None]
+    positive_int_env: Callable[[str, int], int]
+    auto_queue_profile: Callable[[Any], str]
+    run_client: Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class _AuthorizedScope:
+    authenticated_principal: str
+    authorized_foundups: tuple[str, ...]
+    principal_ref: str
+    foundup_id: str
+
+
+@dataclass(frozen=True)
+class _ResidentRequest:
+    work_focus: str
+    explicit_intent_id: str
+    client_request_id: str
+    memory_context: Mapping[str, Any]
+    runtime_defaults: Mapping[str, Any]
+
+
+def _require_authorized_runtime_scope(
+    *,
+    authenticated_principal: str,
+    authorized_foundups: tuple[str, ...],
+    foundup_id: str,
+) -> None:
+    normalized_principal = str(authenticated_principal or "").strip()
+    normalized_foundup = str(foundup_id or "").strip()
+    authorized_shape_valid = isinstance(authorized_foundups, tuple) and all(
+        isinstance(value, str) and value == value.strip() and bool(value)
+        for value in authorized_foundups
+    )
+    if (
+        not normalized_principal
+        or authenticated_principal != normalized_principal
+        or not normalized_foundup
+        or foundup_id != normalized_foundup
+        or not authorized_shape_valid
+        or len(set(authorized_foundups)) != len(authorized_foundups)
+        or normalized_foundup not in authorized_foundups
+    ):
+        raise ValueError("resident_architect_authenticated_scope_missing_or_mismatched")
+
+
+def _resident_client(
+    *,
+    repo_root: Path,
+    authenticated_principal: str,
+    foundup_id: str,
+    runtime_defaults: Mapping[str, Any],
+) -> Any:
+    from modules.communication.moltbot_bridge.src.reddog_resident_architect_client import (
+        RedDogResidentArchitectClient,
+    )
+
+    return RedDogResidentArchitectClient(
+        repo_root=repo_root,
+        authenticated_principal_id=authenticated_principal,
+        authorized_foundup_ids=(foundup_id,),
+        transport="main",
+        runtime_defaults=runtime_defaults,
+    )
+
+
+def run_main_resident_client(
+    *,
+    repo_root: Path,
+    authenticated_principal: str,
+    authorized_foundups: tuple[str, ...],
+    foundup_id: str,
+    work_focus: str,
+    client_request_id: str,
+    explicit_intent_id: str,
+    runtime_defaults: Mapping[str, Any],
+    cancel_requested: bool,
+    retry_requested: bool,
+) -> Any:
+    """Ground and route one main-host request through the canonical client."""
+
+    _require_authorized_runtime_scope(
+        authenticated_principal=authenticated_principal,
+        authorized_foundups=authorized_foundups,
+        foundup_id=foundup_id,
+    )
+    from modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service import (
+        ground_transport_work_focus,
+    )
+
+    if cancel_requested and retry_requested:
+        raise ValueError("resident_architect_cancel_retry_conflict")
+    if (cancel_requested or retry_requested) and not explicit_intent_id:
+        raise ValueError("resident_architect_control_intent_missing")
+    if explicit_intent_id:
+        client = _resident_client(
+            repo_root=repo_root,
+            authenticated_principal=authenticated_principal,
+            foundup_id=foundup_id,
+            runtime_defaults=runtime_defaults,
+        )
+        if cancel_requested:
+            return client.cancel(explicit_intent_id)
+        if retry_requested:
+            return client.resume(explicit_intent_id)
+        return client.status(explicit_intent_id)
+    grounding = ground_transport_work_focus(
+        repo_root=repo_root,
+        work_focus=work_focus,
+        foundup_id=foundup_id,
+        authenticated_principal_id=authenticated_principal,
+        source_surface="main_resident_host",
+        client_request_id=client_request_id,
+    )
+    if not grounding.accepted:
+        raise RuntimeError("grounding_rejected:" + ",".join(grounding.rejection_reasons))
+    client = _resident_client(
+        repo_root=repo_root,
+        authenticated_principal=authenticated_principal,
+        foundup_id=foundup_id,
+        runtime_defaults=runtime_defaults,
+    )
+    return client.submit(grounding.intent)
+
+
+def run_main_resident_architect_cycle_preflight(
+    repo_root: Path,
+    *,
+    hooks: MainResidentArchitectHooks,
+    logger: Any,
+) -> bool:
+    """Run one bounded resident cycle through the canonical client."""
+
+    if not hooks.cycle_requested():
+        logger.info("[REDDOG-RESIDENT-CYCLE] Startup preflight disabled")
+        return True
+    audit_binding, architect_binding, binding_reason = hooks.model_runtime_bindings(repo_root)
+    if binding_reason:
+        logger.error(
+            "[REDDOG-RESIDENT-CYCLE] Runtime model binding preflight failed: %s",
+            binding_reason,
+        )
+        print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL reason={binding_reason}")
+        return False
+    enforced = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0") != "0"
+    scope, scope_reason = _authorized_scope_from_env()
+    if scope_reason:
+        return _configuration_failure(scope_reason, enforced=enforced, logger=logger)
+    assert scope is not None
+    request = _resident_request_from_env(
+        scope=scope,
+        audit_binding=audit_binding,
+        architect_binding=architect_binding,
+        hooks=hooks,
+    )
+    try:
+        result = _invoke_request(repo_root, scope=scope, request=request, hooks=hooks)
+    except Exception as exc:
+        logger.error("[REDDOG-RESIDENT-CYCLE] Startup runtime failed: %s", exc)
+        if enforced:
+            print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL error={type(exc).__name__}")
+            return False
+        print(f"[REDDOG-RESIDENT-CYCLE] preflight=WARN error={type(exc).__name__}")
+        return True
+    return _report_result(
+        result,
+        request=request,
+        enforced=enforced,
+        auto_queue_profile=hooks.auto_queue_profile,
+    )
+
+
+def _authorized_scope_from_env() -> tuple[_AuthorizedScope | None, str]:
+    authenticated = os.getenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "").strip()
+    authorized = tuple(
+        item.strip()
+        for item in os.getenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", "").split(",")
+        if item.strip()
+    )
+    principal_ref = (
+        os.getenv("REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF", "").strip()
+        or authenticated
+    )
+    foundup_id = os.getenv("REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID", "").strip()
+    if not foundup_id and len(authorized) == 1:
+        foundup_id = authorized[0]
+    if (
+        not authenticated
+        or not authorized
+        or principal_ref != authenticated
+        or foundup_id not in authorized
+    ):
+        return None, "resident_architect_authenticated_scope_missing_or_mismatched"
+    return (
+        _AuthorizedScope(
+            authenticated_principal=authenticated,
+            authorized_foundups=authorized,
+            principal_ref=principal_ref,
+            foundup_id=foundup_id,
+        ),
+        "",
+    )
+
+
+def _resident_request_from_env(
+    *,
+    scope: _AuthorizedScope,
+    audit_binding: Mapping[str, Any] | None,
+    architect_binding: Mapping[str, Any] | None,
+    hooks: MainResidentArchitectHooks,
+) -> _ResidentRequest:
+    work_focus = os.getenv("REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS", "").strip() or (
+        "Audit modules/communication/moltbot_bridge/src/"
+        "reddog_resident_architect_durable_agentdb_cycle.py for the main.py "
+        "resident RedDog architect runtime."
+    )
+    explicit_intent_id = os.getenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "").strip()
+    request_override = os.getenv(
+        "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID", ""
+    ).strip()
+    cycle_bucket = "" if request_override else hooks.cycle_bucket()
+    client_request_id = hooks.client_request_id(
+        principal_ref=scope.principal_ref,
+        foundup_id=scope.foundup_id,
+        work_focus=work_focus,
+        cycle_bucket=cycle_bucket,
+    )
+    brain_state = hooks.brain_state()
+    breadcrumbs = hooks.breadcrumbs(
+        work_focus=work_focus,
+        foundup_id=scope.foundup_id,
+    )
+    workspace_notes = hooks.workspace_memory_notes()
+    memory_context = _memory_context(
+        brain_state=brain_state,
+        breadcrumbs=breadcrumbs,
+        workspace_notes=workspace_notes,
+        payload_digest=hooks.payload_digest,
+    )
+    runtime_defaults = _runtime_defaults(
+        work_focus=work_focus,
+        brain_state=brain_state,
+        breadcrumbs=breadcrumbs,
+        workspace_notes=workspace_notes,
+        audit_binding=audit_binding,
+        architect_binding=architect_binding,
+        hooks=hooks,
+    )
+    return _ResidentRequest(
+        work_focus=work_focus,
+        explicit_intent_id=explicit_intent_id,
+        client_request_id=client_request_id,
+        memory_context=memory_context,
+        runtime_defaults=runtime_defaults,
+    )
+
+
+def _runtime_defaults(
+    *,
+    work_focus: str,
+    brain_state: Mapping[str, Any],
+    breadcrumbs: tuple[Mapping[str, Any], ...],
+    workspace_notes: tuple[Mapping[str, Any], ...],
+    audit_binding: Mapping[str, Any] | None,
+    architect_binding: Mapping[str, Any] | None,
+    hooks: MainResidentArchitectHooks,
+) -> Mapping[str, Any]:
+    return {
+        "work_state_path": os.getenv("REDDOG_AUTHORITATIVE_WORK_STATE_PATH", ""),
+        "holoindex_receipt_path": os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", ""),
+        "holoindex_ssd_path": os.getenv("HOLOINDEX_SSD_PATH", ""),
+        "requested_operation": "main_resident_architect_cycle",
+        "prompt_text": work_focus,
+        "breadcrumbs": breadcrumbs,
+        "brain_state": brain_state,
+        "workspace_memory_notes": workspace_notes,
+        "external_research_retriever": hooks.external_research_retriever(),
+        "audit_model_runtime_binding_receipt": audit_binding,
+        "architect_model_runtime_binding_receipt": architect_binding,
+        "max_claims": hooks.positive_int_env(
+            "REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS", 8
+        ),
+        "timeout_seconds": hooks.positive_int_env(
+            "REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS", 60
+        ),
+    }
+
+
+def _invoke_request(
+    repo_root: Path,
+    *,
+    scope: _AuthorizedScope,
+    request: _ResidentRequest,
+    hooks: MainResidentArchitectHooks,
+) -> Any:
+    return hooks.run_client(
+        repo_root=repo_root,
+        authenticated_principal=scope.authenticated_principal,
+        authorized_foundups=scope.authorized_foundups,
+        foundup_id=scope.foundup_id,
+        work_focus=request.work_focus,
+        client_request_id=request.client_request_id,
+        explicit_intent_id=request.explicit_intent_id,
+        runtime_defaults=request.runtime_defaults,
+        cancel_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_CANCEL", "0") != "0",
+        retry_requested=os.getenv("REDDOG_RESIDENT_ARCHITECT_RETRY", "0") != "0",
+    )
+
+
+def _memory_context(
+    *,
+    brain_state: Mapping[str, Any],
+    breadcrumbs: tuple[Mapping[str, Any], ...],
+    workspace_notes: tuple[Mapping[str, Any], ...],
+    payload_digest: Callable[[Any], str],
+) -> Mapping[str, Any]:
+    value = {
+        "brain_available": bool(brain_state),
+        "brain_record_count": int(brain_state.get("record_count", 0))
+        if brain_state
+        else 0,
+        "breadcrumbs_count": len(breadcrumbs),
+        "workspace_memory_notes_count": len(workspace_notes),
+    }
+    value["memory_context_digest"] = payload_digest(value)
+    return value
+
+
+def _configuration_failure(reason: str, *, enforced: bool, logger: Any) -> bool:
+    logger.error("[REDDOG-RESIDENT-CYCLE] Startup runtime failed: %s", reason)
+    if enforced:
+        print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL error={reason}")
+        return False
+    print(f"[REDDOG-RESIDENT-CYCLE] preflight=WARN error={reason}")
+    return True
+
+
+def _report_result(
+    result: Any,
+    *,
+    request: _ResidentRequest,
+    enforced: bool,
+    auto_queue_profile: Callable[[Any], str],
+) -> bool:
+    reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
+    auto_fix = _auto_fix_handoff(result)
+    queue_profile = auto_queue_profile(result) if result.operation == "submit" else ""
+    print(
+        f"[REDDOG-RESIDENT-CYCLE] preflight={'PASS' if result.accepted else 'WARN'} "
+        f"status={result.status} intent={result.intent_id} cycle={result.cycle_id} "
+        f"snapshot={result.snapshot_id or '(none)'} swarm={result.swarm_id or '(none)'} "
+        f"tasks={len(result.task_ids)} completed={int(result.task_status_counts.get('completed', 0))} "
+        f"claims={result.openclaw_claim_count} recovered={result.recovered_existing_cycle} "
+        f"duplicate={result.duplicate_intent_reused} architect_action={result.architect_action or '(none)'} "
+        f"architect_next_slice={result.architect_next_slice or '(none)'} "
+        f"architect_determination={result.determination_id or '(none)'} "
+        f"queue_candidates={result.queue_candidate_count} auto_fix_handoff={auto_fix} "
+        f"auto_queue_profile={queue_profile or '(none)'} "
+        f"brain_records={request.memory_context['brain_record_count']} "
+        f"breadcrumbs={request.memory_context['breadcrumbs_count']} "
+        f"workspace_memory={request.memory_context['workspace_memory_notes_count']} reasons={reasons}"
+    )
+    _report_runtime_boundary(result)
+    if result.accepted:
+        _persist_accepted_controls(result, auto_fix=auto_fix, queue_profile=queue_profile)
+        return True
+    if enforced:
+        print(
+            "[REDDOG-RESIDENT-CYCLE] Startup blocked by "
+            "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1"
+        )
+        return False
+    return True
+
+
+def _auto_fix_handoff(result: Any) -> bool:
+    return bool(
+        result.accepted
+        and result.operation == "submit"
+        and str(result.architect_action or "").strip().upper() == "FIX"
+        and os.getenv("REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF", "1") != "0"
+        and "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+    )
+
+
+def _report_runtime_boundary(result: Any) -> None:
+    print(
+        "[REDDOG-RESIDENT-CYCLE] "
+        f"read_only_authority={result.read_only_authority_only} "
+        f"no_shell={result.client_no_shell_command_executed} "
+        f"no_repo_mutation={result.client_no_repo_mutation_performed} "
+        f"no_holoindex_reindex={result.client_no_holoindex_reindex_performed} "
+        f"no_hermes_dispatch={result.client_no_hermes_execution_performed} "
+        f"no_worktree={result.client_no_worktree_operation_performed} "
+        f"no_pr={result.client_no_pr_created} "
+        "no_pattern_memory=True no_live_foundup_enqueue=True"
+    )
+
+
+def _persist_accepted_controls(
+    result: Any,
+    *,
+    auto_fix: bool,
+    queue_profile: str,
+) -> None:
+    os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] = result.intent_id
+    if auto_fix:
+        os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] = "1"
+    if queue_profile:
+        os.environ["REDDOG_RESIDENT_QUEUE_BINDING_PROFILE"] = queue_profile
+
+
+__all__ = [
+    "MainResidentArchitectHooks",
+    "run_main_resident_architect_cycle_preflight",
+    "run_main_resident_client",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_client.py
@@ -20,6 +20,10 @@ from typing import Any, Callable, Mapping, Optional, Sequence
 from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
     validate_grounded_target_receipt,
 )
+from modules.communication.moltbot_bridge.src.reddog_resident_legacy_main_control import (
+    authorize_legacy_main_record,
+    cancel_legacy_main_record,
+)
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
     AgentDbResidentArchitectCycleStore,
     RUNTIME_BOUNDARY_FIELDS,
@@ -29,7 +33,6 @@ from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_
     STATUS_FAILED,
     STATUS_TIMED_OUT,
     resident_intent_digest,
-    run_reddog_resident_architect_durable_agentdb_cycle,
 )
 
 
@@ -38,11 +41,13 @@ TRANSPORT_TO_SOURCE = {
     "editor": "editor_thin_client",
     "hermes": "hermes_thin_client",
     "api": "api_thin_client",
+    "main": "main_resident_host",
 }
 TRANSPORT_TO_ORIGIN = {
     "editor": "extension",
     "hermes": "hermes_agent",
     "api": "api_client",
+    "main": "main.py",
 }
 RESERVED_RUNTIME_KEYS = frozenset(
     {
@@ -142,7 +147,13 @@ class RedDogResidentArchitectClient:
         self._source_surface = surface
         self._origin = TRANSPORT_TO_ORIGIN[self._transport]
         self._store = cycle_store or AgentDbResidentArchitectCycleStore()
-        self._runner = cycle_runner or run_reddog_resident_architect_durable_agentdb_cycle
+        if cycle_runner is None:
+            from modules.communication.moltbot_bridge.src import (
+                reddog_resident_architect_durable_agentdb_cycle as cycle_module,
+            )
+
+            cycle_runner = cycle_module.run_reddog_resident_architect_durable_agentdb_cycle
+        self._runner = cycle_runner
         self._runtime_defaults = defaults
 
     def submit(self, intent: Mapping[str, Any] | None) -> ResidentClientResponse:
@@ -154,15 +165,56 @@ class RedDogResidentArchitectClient:
 
     def status(self, intent_id: str) -> ResidentClientResponse:
         record, reasons = self._authorized_record(intent_id)
+        legacy_main = False
         if reasons:
-            return self._reject("status", str(intent_id or ""), reasons)
+            record, legacy_reasons = authorize_legacy_main_record(
+                self._store,
+                intent_id,
+                authenticated_principal_id=self._principal,
+                authorized_foundup_ids=self._authorized_foundup_ids,
+                transport=self._transport,
+            )
+            if legacy_reasons:
+                return self._reject("status", str(intent_id or ""), reasons)
+            legacy_main = True
         assert record is not None
-        return self._from_record("status", record, accepted=True, canonical_cycle_used=True)
+        return self._from_record(
+            "status",
+            record,
+            accepted=True,
+            canonical_cycle_used=not legacy_main,
+        )
 
     def cancel(self, intent_id: str) -> ResidentClientResponse:
         record, reasons = self._authorized_record(intent_id)
         legacy_cancel = False
         if reasons:
+            record, legacy_main_reasons = authorize_legacy_main_record(
+                self._store,
+                intent_id,
+                authenticated_principal_id=self._principal,
+                authorized_foundup_ids=self._authorized_foundup_ids,
+                transport=self._transport,
+            )
+            if not legacy_main_reasons:
+                assert record is not None
+                updated, cancel_reasons = cancel_legacy_main_record(
+                    self._store,
+                    record,
+                    authorized_intent_id=str(intent_id or "").strip(),
+                )
+                if cancel_reasons or updated is None:
+                    return self._reject(
+                        "cancel",
+                        str(intent_id or ""),
+                        cancel_reasons or (ResidentClientReason.RUNTIME_FAILED,),
+                    )
+                return self._from_record(
+                    "cancel",
+                    updated,
+                    accepted=False,
+                    canonical_cycle_used=False,
+                )
             record, legacy_reasons = self._authorized_legacy_cancel_record(intent_id)
             if legacy_reasons:
                 return self._reject("cancel", str(intent_id or ""), reasons)
@@ -272,7 +324,12 @@ class RedDogResidentArchitectClient:
             )
         except Exception:
             return self._reject(operation, _intent_id(intent), (ResidentClientReason.RUNTIME_FAILED,))
-        data = result.to_dict() if hasattr(result, "to_dict") else dict(result)
+        if hasattr(result, "to_dict"):
+            data = result.to_dict()
+        elif isinstance(result, Mapping):
+            data = dict(result)
+        else:
+            data = dict(vars(result))
         legacy_cancelled = bool(
             legacy_cancel
             and str(data.get("status") or "") == STATUS_CANCELLED

--- a/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_architect_durable_agentdb_cycle.py
@@ -1081,12 +1081,7 @@ def _intent_bound_model_runtime_bindings(
 def _validate_intent(intent: Mapping[str, Any]) -> tuple[str, ...]:
     reasons: list[str] = []
     schema = intent.get("schema_version") if isinstance(intent, Mapping) else None
-    main_v1 = bool(
-        schema == "reddog_intent.v1"
-        and intent.get("origin") == "main.py"
-        and intent.get("requested_authority") == "read_only_audit"
-    )
-    if not isinstance(intent, Mapping) or (schema != "reddog_intent.v2" and not main_v1):
+    if not isinstance(intent, Mapping) or schema != "reddog_intent.v2":
         reasons.append(ResidentCycleReason.INTENT_INVALID)
     if not str(intent.get("intent_id") or "").strip():
         reasons.append(ResidentCycleReason.INTENT_INVALID)

--- a/modules/communication/moltbot_bridge/src/reddog_resident_legacy_main_control.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_legacy_main_control.py
@@ -1,0 +1,245 @@
+"""Bounded status/cancel compatibility for persisted main-host v1 intents."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping, Optional, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    RUNTIME_BOUNDARY_FIELDS,
+    STATUS_CANCELLED,
+    STATUS_ENQUEUED,
+    STATUS_RUNNING,
+    STATUS_SUBMITTED,
+    TERMINAL_STATUSES,
+    ResidentArchitectCycleStore,
+    ResidentCycleReason,
+    resident_intent_digest,
+)
+
+
+REQUEST_INVALID = "REJECT_REDDOG_RESIDENT_CLIENT_REQUEST_INVALID"
+PRINCIPAL_MISMATCH = "REJECT_REDDOG_RESIDENT_CLIENT_PRINCIPAL_MISMATCH"
+SOURCE_MISMATCH = "REJECT_REDDOG_RESIDENT_CLIENT_SOURCE_MISMATCH"
+FOUNDUP_SCOPE_MISMATCH = "REJECT_REDDOG_RESIDENT_CLIENT_FOUNDUP_SCOPE_MISMATCH"
+CYCLE_NOT_FOUND = "REJECT_REDDOG_RESIDENT_CLIENT_CYCLE_NOT_FOUND"
+RUNTIME_FAILED = "REJECT_REDDOG_RESIDENT_CLIENT_RUNTIME_FAILED"
+
+
+def authorize_legacy_main_record(
+    store: ResidentArchitectCycleStore,
+    intent_id: str,
+    *,
+    authenticated_principal_id: str,
+    authorized_foundup_ids: Sequence[str],
+    transport: str,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    """Authorize only the historical main.py read-only v1 shape."""
+
+    value = str(intent_id or "").strip()
+    record = store.load_cycle_by_intent(value) if value else None
+    if not isinstance(record, Mapping):
+        return None, (CYCLE_NOT_FOUND,)
+    intent = _record_intent(record)
+    reasons: list[str] = []
+    if transport != "main":
+        reasons.append(SOURCE_MISMATCH)
+    cycle_schema = str(record.get("schema_version") or "")
+    if (
+        cycle_schema not in {
+            "reddog_resident_architect_cycle.v1",
+            "reddog_resident_architect_cycle.v2",
+        }
+        or intent.get("schema_version") != "reddog_intent.v1"
+        or intent.get("origin") != "main.py"
+        or intent.get("requested_authority") != "read_only_audit"
+        or intent.get("submits_executable_authority") is not False
+        or str(record.get("intent_id") or "") != value
+        or _intent_id(intent) != value
+    ):
+        reasons.append(REQUEST_INVALID)
+    if _principal_id(intent) != str(authenticated_principal_id or "").strip():
+        reasons.append(PRINCIPAL_MISMATCH)
+    if str(intent.get("foundup_id") or "").strip() not in {
+        str(item).strip() for item in authorized_foundup_ids if str(item).strip()
+    }:
+        reasons.append(FOUNDUP_SCOPE_MISMATCH)
+    if cycle_schema == "reddog_resident_architect_cycle.v2":
+        if str(record.get("intent_digest") or "") != resident_intent_digest(intent):
+            reasons.append(REQUEST_INVALID)
+        if (
+            record.get("_store_integrity_valid") is not True
+            or not _runtime_boundary_is_safe(record)
+        ):
+            reasons.append(RUNTIME_FAILED)
+    elif not _legacy_v1_integrity_is_acceptable(record):
+        reasons.append(RUNTIME_FAILED)
+    unique = tuple(dict.fromkeys(reasons))
+    return (None, unique) if unique else (record, ())
+
+
+def cancel_legacy_main_record(
+    store: ResidentArchitectCycleStore,
+    record: Mapping[str, Any],
+    *,
+    authorized_intent_id: str,
+) -> tuple[Optional[Mapping[str, Any]], tuple[str, ...]]:
+    """CAS-cancel an authorized nonterminal legacy record without resubmission."""
+
+    intent_id = str(authorized_intent_id or "").strip()
+    if (
+        not intent_id
+        or str(record.get("intent_id") or "") != intent_id
+        or _intent_id(_record_intent(record)) != intent_id
+    ):
+        return None, (REQUEST_INVALID,)
+    status = str(record.get("status") or "")
+    if status == STATUS_CANCELLED:
+        return record, ()
+    if status in TERMINAL_STATUSES or status not in {
+        STATUS_SUBMITTED,
+        STATUS_ENQUEUED,
+        STATUS_RUNNING,
+    }:
+        return None, (RUNTIME_FAILED,)
+    transitioned = store.transition_cycle(
+        intent_id,
+        expected_revision=int(
+            record.get("record_revision")
+            if record.get("record_revision") is not None
+            else record.get("_store_revision") or 0
+        ),
+        expected_statuses=(status,),
+        updates={
+            "status": STATUS_CANCELLED,
+            "rejection_reasons": [ResidentCycleReason.CANCELLED],
+        },
+    )
+    updated = transitioned.get("record") if isinstance(transitioned, Mapping) else None
+    if (
+        transitioned.get("ok") is not True
+        or not isinstance(updated, Mapping)
+        or str(updated.get("intent_id") or "") != intent_id
+        or _intent_id(_record_intent(updated)) != intent_id
+    ):
+        return None, (RUNTIME_FAILED,)
+    return updated, ()
+
+
+def _record_intent(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    intent = record.get("intent")
+    return dict(intent) if isinstance(intent, Mapping) else {}
+
+
+def _intent_id(intent: Mapping[str, Any]) -> str:
+    return str(intent.get("intent_id") or "")
+
+
+def _principal_id(intent: Mapping[str, Any]) -> str:
+    return str(
+        intent.get("principal_id")
+        or intent.get("principal_ref")
+        or intent.get("origin_principal")
+        or ""
+    ).strip()
+
+
+def _runtime_boundary_is_safe(record: Mapping[str, Any]) -> bool:
+    return all(record.get(key) is True for key in RUNTIME_BOUNDARY_FIELDS)
+
+
+def _legacy_v1_integrity_is_acceptable(record: Mapping[str, Any]) -> bool:
+    """Recognize only the historical read-only row shape for status/cancel."""
+
+    if (
+        str(record.get("cycle_id") or "") == ""
+        or record.get("read_only_authority_only") is not True
+        or str(record.get("status") or "")
+        not in {
+            STATUS_SUBMITTED,
+            STATUS_ENQUEUED,
+            STATUS_RUNNING,
+            *TERMINAL_STATUSES,
+        }
+        or "intent_digest" in record
+    ):
+        return False
+    if any(record.get(field) is False for field in RUNTIME_BOUNDARY_FIELDS if field in record):
+        return False
+    if any(
+        record.get(field) is True
+        for field in (
+            "shell_command_executed",
+            "repo_mutation_performed",
+            "holoindex_reindex_performed",
+            "hermes_dispatch_performed",
+            "worktree_operation_performed",
+            "pr_created",
+            "merge_performed",
+        )
+    ):
+        return False
+    if "record_revision" in record:
+        return (
+            record.get("_store_integrity_valid") is True
+            or _legacy_cancel_transition_is_valid(record)
+        )
+    return int(record.get("_store_revision", -1)) >= 0 and not record.get(
+        "transition_history"
+    )
+
+
+def _legacy_cancel_transition_is_valid(record: Mapping[str, Any]) -> bool:
+    history = record.get("transition_history")
+    if (
+        record.get("status") != STATUS_CANCELLED
+        or int(record.get("record_revision", -1)) != 1
+        or int(record.get("_store_revision", -1)) != 1
+        or not isinstance(history, list)
+        or len(history) != 1
+        or not isinstance(history[0], Mapping)
+    ):
+        return False
+    entry = dict(history[0])
+    receipt_id = str(entry.pop("receipt_id", ""))
+    expected_updates = {
+        "status": STATUS_CANCELLED,
+        "rejection_reasons": [ResidentCycleReason.CANCELLED],
+    }
+    state_for_digest = dict(record)
+    state_for_digest.pop("transition_history", None)
+    state_for_digest.pop("_store_integrity_valid", None)
+    state_for_digest.pop("_store_revision", None)
+    return bool(
+        entry.get("schema_version") == "reddog_resident_cycle_transition.v1"
+        and entry.get("intent_id") == record.get("intent_id")
+        and entry.get("cycle_id") == record.get("cycle_id")
+        and entry.get("from_status")
+        in {STATUS_SUBMITTED, STATUS_ENQUEUED, STATUS_RUNNING}
+        and entry.get("to_status") == STATUS_CANCELLED
+        and entry.get("from_revision") == 0
+        and entry.get("to_revision") == 1
+        and entry.get("previous_receipt_id") == ""
+        and entry.get("authority") == "observational_internal_integrity_only"
+        and entry.get("updates_digest") == _digest(expected_updates)
+        and entry.get("result_state_digest") == _digest(state_for_digest)
+        and receipt_id == _digest(entry)
+    )
+
+
+def _digest(payload: Any) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "authorize_legacy_main_record",
+    "cancel_legacy_main_record",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_transport_neutral_grounding_service.py
+++ b/modules/communication/moltbot_bridge/src/reddog_transport_neutral_grounding_service.py
@@ -49,6 +49,7 @@ SOURCE_TO_ORIGIN = {
     "editor_thin_client": "extension",
     "hermes_thin_client": "hermes_agent",
     "api_thin_client": "api_client",
+    "main_resident_host": "main.py",
 }
 
 ACTION_RE = re.compile(

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,18 @@
+## 2026-07-25: Main resident canonical-client review repair
+
+- Added regressions proving status cannot re-arm FIX/queue handoff and
+  status/cancel/resume clients receive only the selected FoundUp scope.
+- Added a real SQLite AgentDB regression for the exact pre-#1310
+  `cycle.v1 + main intent.v1` shape: authenticated status and CAS-cancel pass,
+  while resume remains rejected.
+- Preserved exact audit/architect runtime-binding receipt assertions after
+  rebasing onto the current resident runtime.
+- Extracted the 201-line root preflight into decomposed moltbot-owned
+  functions and asserted the root adapter and critical bootstrap functions
+  remain below their WSP 62 thresholds.
+- Validation after review repair: 159 focused tests passed with one platform
+  skip, including exact WSP 62 no-growth coverage.
+
 ## 2026-07-24: HOLOINDEX_QUERY_ROOT_ADMISSION_P0_PHASE1
 
 - Added direct regressions for pre-backend foreign-root denial and rejection
@@ -134,6 +149,14 @@
   post-run assertions to the permanent production-CLOSED verifier boundary.
 - Reconciled current resident fixtures with independently confined runtime
   roots and canonical governed artifact packs; refreshed exact no-growth gates.
+
+## 2026-07-20: Main resident canonical-client migration
+
+- Added main-host v2 grounding/source/origin round-trip coverage.
+- Added fail-closed tests for missing/mismatched host scope, cancel/retry conflicts, control without an existing intent, and grounding failure before client construction.
+- Proved explicit intent status bypasses new grounding and `main.py` no longer references the durable cycle runner directly.
+- Rejected the removed `reddog_intent.v1` main-host compatibility shape.
+- Validation: 125 focused canonical-client, grounding, durable-cycle, and main startup tests passed before independent review.
 
 ## 2026-07-19: REDDOG_HOLOINDEX_V2_RUNTIME_FIXTURE_MIGRATION_PHASE1
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -80,6 +80,10 @@ OWNER_SERVICE_ENV = {
     "HOLOINDEX_QUERY_SERVICE_TOKEN": "test-owner-service-token-with-strong-length",
     "REDDOG_HOLOINDEX_AUTO_MAINTENANCE": "0",
 }
+MAIN_RESIDENT_AUTH_ENV = {
+    "REDDOG_AUTHENTICATED_PRINCIPAL_ID": "principal-main-test",
+    "REDDOG_AUTHORIZED_FOUNDUP_IDS": "foundups_agent",
+}
 
 
 @pytest.fixture(autouse=True)
@@ -1198,7 +1202,7 @@ def test_main_preflight_durable_resident_cycle_product_mode_runs_by_default(caps
         "run_reddog_resident_architect_durable_agentdb_cycle",
         return_value=_resident_cycle_result(),
     ) as mocked:
-        with patch.dict("os.environ", {}, clear=True):
+        with patch.dict("os.environ", MAIN_RESIDENT_AUTH_ENV, clear=True):
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
             assert os.environ["REDDOG_RESIDENT_ARCHITECT_INTENT_ID"] == "sha256:intent-main-resident"
             assert os.environ["REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF"] == "1"
@@ -1209,7 +1213,7 @@ def test_main_preflight_durable_resident_cycle_product_mode_runs_by_default(caps
 
     kwargs = mocked.call_args.kwargs
     assert kwargs["requested_operation"] == "main_resident_architect_cycle"
-    assert kwargs["prompt_text"] == "main.py resident RedDog architect cycle"
+    assert "reddog_resident_architect_durable_agentdb_cycle.py" in kwargs["prompt_text"]
     assert kwargs["audit_model_runtime_binding_receipt"]["runtime_surface"] == (
         "reddog_readonly_audit_worker"
     )
@@ -1221,9 +1225,11 @@ def test_main_preflight_durable_resident_cycle_product_mode_runs_by_default(caps
         != kwargs["architect_model_runtime_binding_receipt"]["receipt_id"]
     )
     assert kwargs["external_research_retriever"] is None
-    assert kwargs["red_dog_intent"]["requested_authority"] == "read_only_audit"
+    assert kwargs["red_dog_intent"]["schema_version"] == "reddog_intent.v2"
+    assert kwargs["red_dog_intent"]["source_surface"] == "main_resident_host"
+    assert kwargs["red_dog_intent"]["origin"] == "main.py"
     assert kwargs["red_dog_intent"]["submits_executable_authority"] is False
-    assert kwargs["red_dog_intent"]["cycle_bucket"].startswith("24h:")
+    assert kwargs["red_dog_intent"]["client_request_id"].startswith("sha256:")
     output = capsys.readouterr().out
     assert "[REDDOG-RESIDENT-CYCLE] preflight=PASS" in output
     assert "no_repo_mutation=True" in output
@@ -1260,11 +1266,12 @@ def test_main_preflight_durable_resident_cycle_explicit_enable_overrides_product
     ) as mocked:
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE": "0",
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
-            },
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_PRODUCT_MODE": "0",
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
+                },
             clear=True,
         ):
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
@@ -1283,8 +1290,9 @@ def test_main_preflight_durable_resident_cycle_uses_stable_cadence_bucket() -> N
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
                 "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
             },
             clear=True,
@@ -1292,8 +1300,9 @@ def test_main_preflight_durable_resident_cycle_uses_stable_cadence_bucket() -> N
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T18:00:00+00:00",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T18:00:00+00:00",
                 "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
             },
             clear=True,
@@ -1302,7 +1311,7 @@ def test_main_preflight_durable_resident_cycle_uses_stable_cadence_bucket() -> N
 
     first = calls[0]["red_dog_intent"]
     second = calls[1]["red_dog_intent"]
-    assert first["cycle_bucket"] == second["cycle_bucket"]
+    assert first["client_request_id"] == second["client_request_id"]
     assert first["intent_id"] == second["intent_id"]
 
 
@@ -1317,8 +1326,9 @@ def test_main_preflight_durable_resident_cycle_rolls_intent_after_cadence() -> N
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
                 "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
             },
             clear=True,
@@ -1326,8 +1336,9 @@ def test_main_preflight_durable_resident_cycle_rolls_intent_after_cadence() -> N
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-18T09:00:01+00:00",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-18T09:00:01+00:00",
                 "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "24",
             },
             clear=True,
@@ -1336,7 +1347,7 @@ def test_main_preflight_durable_resident_cycle_rolls_intent_after_cadence() -> N
 
     first = calls[0]["red_dog_intent"]
     second = calls[1]["red_dog_intent"]
-    assert first["cycle_bucket"] != second["cycle_bucket"]
+    assert first["client_request_id"] != second["client_request_id"]
     assert first["intent_id"] != second["intent_id"]
 
 
@@ -1350,17 +1361,18 @@ def test_main_preflight_durable_resident_cycle_explicit_intent_disables_cadence_
     ) as mocked:
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:explicit-intent",
-                "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "explicit-request",
+                    "REDDOG_RESIDENT_ARCHITECT_NOW_ISO": "2026-07-17T09:00:00+00:00",
             },
             clear=True,
         ):
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
 
     intent = mocked.call_args.kwargs["red_dog_intent"]
-    assert intent["intent_id"] == "sha256:explicit-intent"
-    assert intent["cycle_bucket"] == ""
+    assert intent["schema_version"] == "reddog_intent.v2"
+    assert intent["client_request_id"] == "explicit-request"
 
 
 def test_main_preflight_durable_resident_cycle_can_disable_cadence_for_legacy_sticky_intent() -> None:
@@ -1373,13 +1385,13 @@ def test_main_preflight_durable_resident_cycle_can_disable_cadence_for_legacy_st
     ) as mocked:
         with patch.dict(
             "os.environ",
-            {"REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "0"},
+                {**MAIN_RESIDENT_AUTH_ENV, "REDDOG_RESIDENT_ARCHITECT_CADENCE_HOURS": "0"},
             clear=True,
         ):
             assert main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT) is True
 
     intent = mocked.call_args.kwargs["red_dog_intent"]
-    assert intent["cycle_bucket"] == ""
+    assert intent["schema_version"] == "reddog_intent.v2"
 
 
 def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_path, capsys) -> None:
@@ -1394,12 +1406,16 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
     ) as mocked:
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "0",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
-                "REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS": "resident main cycle",
-                "REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF": "012",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "0",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
+                    "REDDOG_RESIDENT_ARCHITECT_WORK_FOCUS": (
+                        "Audit modules/communication/moltbot_bridge/src/"
+                        "reddog_resident_architect_client.py."
+                    ),
+                    "REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF": "principal-main-test",
                 "REDDOG_RESIDENT_ARCHITECT_FOUNDUP_ID": "foundups_agent",
                 "REDDOG_RESIDENT_ARCHITECT_MAX_CLAIMS": "2",
                 "REDDOG_RESIDENT_ARCHITECT_TIMEOUT_SECONDS": "30",
@@ -1424,15 +1440,16 @@ def test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled(tmp_pat
     assert kwargs["holoindex_receipt_path"] == "O:/state/holo_receipt.json"
     assert kwargs["holoindex_ssd_path"] == "E:/HoloIndex"
     assert kwargs["requested_operation"] == "main_resident_architect_cycle"
-    assert kwargs["prompt_text"] == "resident main cycle"
+    assert "reddog_resident_architect_client.py" in kwargs["prompt_text"]
     assert kwargs["max_claims"] == 2
     assert kwargs["timeout_seconds"] == 30
     assert kwargs["external_research_retriever"] is not None
     intent = kwargs["red_dog_intent"]
-    assert intent["schema_version"] == "reddog_intent.v1"
-    assert intent["intent_id"] == "sha256:intent-main-resident"
+    assert intent["schema_version"] == "reddog_intent.v2"
+    assert intent["source_surface"] == "main_resident_host"
+    assert intent["origin"] == "main.py"
+    assert intent["principal_ref"] == "principal-main-test"
     assert intent["submits_executable_authority"] is False
-    assert intent["requested_authority"] == "read_only_audit"
     output = capsys.readouterr().out
     assert "[REDDOG-RESIDENT-CYCLE] preflight=PASS" in output
     assert "tasks=2" in output
@@ -1486,9 +1503,10 @@ def test_main_preflight_durable_resident_cycle_supplies_memory_context(tmp_path,
     ) as mocked:
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_BRAIN_STATE_PATH": str(brain_state),
                 "REDDOG_RESIDENT_BREADCRUMBS_PATH": str(breadcrumbs),
                 "REDDOG_RESIDENT_WORKSPACE_MEMORY_NOTES_PATH": str(workspace_notes),
@@ -1504,12 +1522,6 @@ def test_main_preflight_durable_resident_cycle_supplies_memory_context(tmp_path,
     assert kwargs["breadcrumbs"][0]["breadcrumb_id"] == "crumb-1"
     assert len(kwargs["workspace_memory_notes"]) == 1
     assert kwargs["workspace_memory_notes"][0]["note_id"] == "note-1"
-    intent_memory = kwargs["red_dog_intent"]["memory_context"]
-    assert intent_memory["brain_available"] is True
-    assert intent_memory["brain_record_count"] == 7
-    assert intent_memory["breadcrumbs_count"] == 2
-    assert intent_memory["workspace_memory_notes_count"] == 1
-    assert intent_memory["memory_context_digest"].startswith("sha256:")
     output = capsys.readouterr().out
     assert "brain_records=7" in output
     assert "breadcrumbs=2" in output
@@ -1526,9 +1538,10 @@ def test_main_preflight_durable_resident_cycle_memory_context_can_be_disabled() 
     ) as mocked:
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_BRAIN_CONTEXT": "0",
                 "REDDOG_RESIDENT_BREADCRUMBS_CONTEXT": "0",
             },
@@ -1540,10 +1553,6 @@ def test_main_preflight_durable_resident_cycle_memory_context_can_be_disabled() 
     assert kwargs["brain_state"] is None
     assert kwargs["breadcrumbs"] == ()
     assert kwargs["workspace_memory_notes"] == ()
-    intent_memory = kwargs["red_dog_intent"]["memory_context"]
-    assert intent_memory["brain_available"] is False
-    assert intent_memory["breadcrumbs_count"] == 0
-    assert intent_memory["workspace_memory_notes_count"] == 0
 
 
 def test_main_preflight_resident_cycle_respects_explicit_queue_profile(tmp_path) -> None:
@@ -1558,9 +1567,10 @@ def test_main_preflight_resident_cycle_respects_explicit_queue_profile(tmp_path)
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
@@ -1582,9 +1592,10 @@ def test_main_preflight_resident_cycle_can_disable_auto_queue_profile(tmp_path) 
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE": "0",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
@@ -1606,9 +1617,10 @@ def test_main_preflight_resident_cycle_rejects_invalid_auto_queue_profile(tmp_pa
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_ARCHITECT_AUTO_QUEUE_PROFILE": "unsafe_profile",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
@@ -1633,9 +1645,10 @@ def test_main_preflight_resident_cycle_requires_fix_queue_candidate_for_auto_pro
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
             clear=True,
@@ -1650,9 +1663,10 @@ def test_main_preflight_resident_cycle_requires_fix_queue_candidate_for_auto_pro
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
             clear=True,
@@ -1673,9 +1687,10 @@ def test_main_preflight_resident_cycle_respects_auto_fix_handoff_opt_out(tmp_pat
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_ARCHITECT_AUTO_FIX_HANDOFF": "0",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
@@ -1697,9 +1712,10 @@ def test_main_preflight_resident_cycle_does_not_override_explicit_fix_handoff(tm
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
                 "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
                 "REDDOG_EXTERNAL_RESEARCH_SNAPSHOT_PATH": str(external_snapshot),
             },
@@ -1719,10 +1735,11 @@ def test_main_preflight_resident_cycle_reject_is_nonblocking_by_default(capsys) 
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "0",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "0",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
             },
             clear=True,
         ):
@@ -1743,10 +1760,11 @@ def test_main_preflight_resident_cycle_reject_blocks_when_enforced(capsys) -> No
     ):
         with patch.dict(
             "os.environ",
-            {
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
-                "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "1",
-                "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-main-resident",
+                {
+                    **MAIN_RESIDENT_AUTH_ENV,
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "1",
+                    "REDDOG_RESIDENT_ARCHITECT_CLIENT_REQUEST_ID": "request-main-resident",
             },
             clear=True,
         ):

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_architect_client_migration.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_architect_client_migration.py
@@ -1,0 +1,375 @@
+"""Security regressions for main.py canonical resident-client migration."""
+
+from __future__ import annotations
+
+import inspect
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+import main
+from modules.communication.moltbot_bridge.src import (
+    reddog_main_resident_architect_cycle_bootstrap as resident_main_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    ResidentCycleReason,
+    run_reddog_resident_architect_durable_agentdb_cycle,
+)
+from modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service import (
+    TransportGroundingResult,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+MAIN_AUTH_ENV = {
+    "REDDOG_AUTHENTICATED_PRINCIPAL_ID": "principal-main-test",
+    "REDDOG_AUTHORIZED_FOUNDUP_IDS": "foundups_agent",
+}
+
+
+def _model_runtime_bindings() -> tuple[dict[str, str], dict[str, str], str]:
+    return (
+        {"runtime_surface": "reddog_readonly_audit_worker"},
+        {"runtime_surface": "reddog_backend_architect"},
+        "",
+    )
+
+
+def _runtime_defaults() -> dict[str, object]:
+    return {"requested_operation": "main_resident_architect_cycle"}
+
+
+def _status_fix_response() -> SimpleNamespace:
+    return SimpleNamespace(
+        accepted=True,
+        operation="status",
+        status="DETERMINED",
+        intent_id="sha256:existing",
+        cycle_id="sha256:cycle",
+        snapshot_id="sha256:snapshot",
+        swarm_id="sha256:swarm",
+        task_ids=("task-1",),
+        task_status_counts={"completed": 1},
+        openclaw_claim_count=1,
+        recovered_existing_cycle=True,
+        duplicate_intent_reused=True,
+        architect_action="FIX",
+        architect_next_slice="REDDOG_NEXT_PHASE1",
+        determination_id="sha256:determination",
+        queue_candidate_count=1,
+        rejection_reasons=(),
+        read_only_authority_only=True,
+        client_no_shell_command_executed=True,
+        client_no_repo_mutation_performed=True,
+        client_no_holoindex_reindex_performed=True,
+        client_no_hermes_execution_performed=True,
+        client_no_worktree_operation_performed=True,
+        client_no_pr_created=True,
+    )
+
+
+def test_main_preflight_requires_host_authenticated_scope_before_runtime(
+    monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
+    monkeypatch.delenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", raising=False)
+    monkeypatch.delenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", raising=False)
+
+    with (
+        patch.object(
+            main,
+            "_reddog_resident_model_runtime_bindings_from_env",
+            return_value=_model_runtime_bindings(),
+        ),
+        patch.object(main, "_run_reddog_main_resident_client") as runtime,
+    ):
+        assert (
+            main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT)
+            is True
+        )
+
+    runtime.assert_not_called()
+    assert "authenticated_scope_missing_or_mismatched" in capsys.readouterr().out
+
+
+def test_main_preflight_rejects_principal_cross_check_mismatch(monkeypatch) -> None:
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
+    monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-main-test")
+    monkeypatch.setenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", "foundups_agent")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_PRINCIPAL_REF", "forged-principal")
+
+    with (
+        patch.object(
+            main,
+            "_reddog_resident_model_runtime_bindings_from_env",
+            return_value=_model_runtime_bindings(),
+        ),
+        patch.object(main, "_run_reddog_main_resident_client") as runtime,
+    ):
+        assert (
+            main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT)
+            is True
+        )
+
+    runtime.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("cancel_requested", "retry_requested", "explicit_intent_id", "reason"),
+    (
+        (True, True, "sha256:existing", "resident_architect_cancel_retry_conflict"),
+        (True, False, "", "resident_architect_control_intent_missing"),
+        (False, True, "", "resident_architect_control_intent_missing"),
+    ),
+)
+def test_control_operations_fail_before_client(
+    cancel_requested: bool,
+    retry_requested: bool,
+    explicit_intent_id: str,
+    reason: str,
+) -> None:
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_client."
+        "RedDogResidentArchitectClient"
+    ) as client:
+        with pytest.raises(ValueError, match=reason):
+            main._run_reddog_main_resident_client(
+                repo_root=REPO_ROOT,
+                authenticated_principal="principal-main-test",
+                authorized_foundups=("foundups_agent",),
+                foundup_id="foundups_agent",
+                work_focus="Audit main resident RedDog.",
+                client_request_id="request-1",
+                explicit_intent_id=explicit_intent_id,
+                runtime_defaults=_runtime_defaults(),
+                cancel_requested=cancel_requested,
+                retry_requested=retry_requested,
+            )
+    client.assert_not_called()
+
+
+def test_exported_helper_rejects_unauthorized_foundup_before_runtime() -> None:
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src.reddog_resident_architect_client."
+            "RedDogResidentArchitectClient"
+        ) as client,
+        patch(
+            "modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service."
+            "ground_transport_work_focus"
+        ) as grounding,
+    ):
+        with pytest.raises(
+            ValueError,
+            match="resident_architect_authenticated_scope_missing_or_mismatched",
+        ):
+            resident_main_bootstrap.run_main_resident_client(
+                repo_root=REPO_ROOT,
+                authenticated_principal="principal-main-test",
+                authorized_foundups=("foundup-a",),
+                foundup_id="foundup-b",
+                work_focus="Audit main resident RedDog.",
+                client_request_id="request-1",
+                explicit_intent_id="",
+                runtime_defaults=_runtime_defaults(),
+                cancel_requested=False,
+                retry_requested=False,
+            )
+
+    client.assert_not_called()
+    grounding.assert_not_called()
+
+
+def test_grounding_failure_never_constructs_client() -> None:
+    rejected = TransportGroundingResult(
+        schema_version="reddog_transport_grounding_result.v1",
+        accepted=False,
+        rejection_reasons=("grounding_failed",),
+    )
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service."
+            "ground_transport_work_focus",
+            return_value=rejected,
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src.reddog_resident_architect_client."
+            "RedDogResidentArchitectClient"
+        ) as client,
+    ):
+        with pytest.raises(RuntimeError, match="grounding_rejected:grounding_failed"):
+            main._run_reddog_main_resident_client(
+                repo_root=REPO_ROOT,
+                authenticated_principal="principal-main-test",
+                authorized_foundups=("foundups_agent",),
+                foundup_id="foundups_agent",
+                work_focus="Audit missing evidence.",
+                client_request_id="request-1",
+                explicit_intent_id="",
+                runtime_defaults=_runtime_defaults(),
+                cancel_requested=False,
+                retry_requested=False,
+            )
+    client.assert_not_called()
+
+
+def test_explicit_intent_routes_status_without_grounding() -> None:
+    expected = SimpleNamespace(accepted=True, intent_id="sha256:existing")
+    client_instance = Mock()
+    client_instance.status.return_value = expected
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src.reddog_resident_architect_client."
+            "RedDogResidentArchitectClient",
+            return_value=client_instance,
+        ) as client_class,
+        patch(
+            "modules.communication.moltbot_bridge.src.reddog_transport_neutral_grounding_service."
+            "ground_transport_work_focus"
+        ) as grounding,
+    ):
+        result = main._run_reddog_main_resident_client(
+            repo_root=REPO_ROOT,
+            authenticated_principal="principal-main-test",
+            authorized_foundups=("foundups_agent", "second_foundup"),
+            foundup_id="foundups_agent",
+            work_focus="Audit main resident RedDog.",
+            client_request_id="request-1",
+            explicit_intent_id="sha256:existing",
+            runtime_defaults=_runtime_defaults(),
+            cancel_requested=False,
+            retry_requested=False,
+        )
+
+    assert result is expected
+    client_class.assert_called_once_with(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-main-test",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="main",
+        runtime_defaults=_runtime_defaults(),
+    )
+    client_instance.status.assert_called_once_with("sha256:existing")
+    grounding.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("cancel_requested", "retry_requested", "method_name"),
+    (
+        (True, False, "cancel"),
+        (False, True, "resume"),
+    ),
+)
+def test_control_reconnects_bind_to_selected_foundup_only(
+    cancel_requested: bool,
+    retry_requested: bool,
+    method_name: str,
+) -> None:
+    expected = SimpleNamespace(accepted=True, intent_id="sha256:existing")
+    client_instance = Mock()
+    getattr(client_instance, method_name).return_value = expected
+    with patch(
+        "modules.communication.moltbot_bridge.src.reddog_resident_architect_client."
+        "RedDogResidentArchitectClient",
+        return_value=client_instance,
+    ) as client_class:
+        result = main._run_reddog_main_resident_client(
+            repo_root=REPO_ROOT,
+            authenticated_principal="principal-main-test",
+            authorized_foundups=("foundups_agent", "second_foundup"),
+            foundup_id="foundups_agent",
+            work_focus="Audit main resident RedDog.",
+            client_request_id="request-1",
+            explicit_intent_id="sha256:existing",
+            runtime_defaults=_runtime_defaults(),
+            cancel_requested=cancel_requested,
+            retry_requested=retry_requested,
+        )
+
+    assert result is expected
+    client_class.assert_called_once_with(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-main-test",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="main",
+        runtime_defaults=_runtime_defaults(),
+    )
+    getattr(client_instance, method_name).assert_called_once_with("sha256:existing")
+
+
+def test_status_reconnect_cannot_rearm_fix_handoff(monkeypatch) -> None:
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
+    monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-main-test")
+    monkeypatch.setenv("REDDOG_AUTHORIZED_FOUNDUP_IDS", "foundups_agent")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_INTENT_ID", "sha256:existing")
+    monkeypatch.delenv("REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF", raising=False)
+    monkeypatch.delenv("REDDOG_RESIDENT_QUEUE_BINDING_PROFILE", raising=False)
+
+    with (
+        patch.object(
+            main,
+            "_reddog_resident_model_runtime_bindings_from_env",
+            return_value=_model_runtime_bindings(),
+        ),
+        patch.object(
+            main,
+            "_run_reddog_main_resident_client",
+            return_value=_status_fix_response(),
+        ),
+    ):
+        assert (
+            main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT)
+            is True
+        )
+
+    assert "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF" not in os.environ
+    assert "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE" not in os.environ
+
+
+def test_new_legacy_main_v1_submission_is_rejected() -> None:
+    result = run_reddog_resident_architect_durable_agentdb_cycle(
+        repo_root=REPO_ROOT,
+        red_dog_intent={
+            "schema_version": "reddog_intent.v1",
+            "intent_id": "sha256:new-legacy-main-intent",
+            "origin": "main.py",
+            "principal_ref": "principal-main-test",
+            "foundup_id": "foundups_agent",
+            "work_focus": "Legacy main submission must not be accepted.",
+            "requested_authority": "read_only_audit",
+            "submits_executable_authority": False,
+        },
+    )
+
+    assert result.accepted is False
+    assert ResidentCycleReason.INTENT_INVALID in result.rejection_reasons
+
+
+def test_main_preflight_source_has_no_direct_cycle_runner_reference() -> None:
+    source = inspect.getsource(
+        main.run_reddog_resident_architect_durable_cycle_preflight
+    )
+    source += inspect.getsource(main._run_reddog_main_resident_client)
+    source += inspect.getsource(resident_main_bootstrap.run_main_resident_client)
+    source += inspect.getsource(resident_main_bootstrap._resident_client)
+    assert "run_reddog_resident_architect_durable_agentdb_cycle" not in source
+    assert "RedDogResidentArchitectClient" in source
+    assert "ground_transport_work_focus" in source
+
+
+def test_main_preflight_is_thin_and_bootstrap_functions_are_decomposed() -> None:
+    assert len(
+        inspect.getsource(
+            main.run_reddog_resident_architect_durable_cycle_preflight
+        ).splitlines()
+    ) <= 40
+    for name in (
+        "run_main_resident_architect_cycle_preflight",
+        "run_main_resident_client",
+        "_resident_request_from_env",
+        "_report_result",
+    ):
+        assert len(inspect.getsource(getattr(resident_main_bootstrap, name)).splitlines()) <= 75

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_client.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_client.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import ast
+import json
 from pathlib import Path
 
+from modules.infrastructure.database.src.agent_db import AgentDB
+from modules.infrastructure.database.src.db_manager import DatabaseManager
 from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
     SCHEMA_VERSION as GROUNDING_SCHEMA_VERSION,
     canonical_digest,
@@ -14,6 +17,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_architect_client i
     ResidentClientReason,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
+    AgentDbResidentArchitectCycleStore,
     resident_intent_digest,
 )
 
@@ -104,6 +108,27 @@ class _Store:
         self.records[intent_id] = record
         return {"ok": True}
 
+    def transition_cycle(
+        self,
+        intent_id,
+        *,
+        expected_revision,
+        expected_statuses,
+        updates,
+        allow_terminal_retry=False,
+    ):
+        del allow_terminal_retry
+        record = dict(self.records[intent_id])
+        if (
+            int(record.get("record_revision", 0)) != int(expected_revision)
+            or str(record.get("status") or "") not in set(expected_statuses)
+        ):
+            return {"ok": False, "reason": "transition_conflict"}
+        record.update(dict(updates))
+        record["record_revision"] = int(expected_revision) + 1
+        self.records[intent_id] = record
+        return {"ok": True, "record": record}
+
     def load_task_ids(self, determination_id):
         return ()
 
@@ -158,6 +183,125 @@ def _client(store=None, runner=None) -> RedDogResidentArchitectClient:
         cycle_store=store or _Store(),
         cycle_runner=runner or _Runner(),
     )
+
+
+def _legacy_main_record(
+    *,
+    principal: str = "principal-012",
+    foundup_id: str = "foundups_agent",
+) -> dict:
+    intent = {
+        "schema_version": "reddog_intent.v1",
+        "intent_id": "sha256:legacy-main-intent",
+        "origin": "main.py",
+        "principal_ref": principal,
+        "foundup_id": foundup_id,
+        "work_focus": "Legacy main resident audit.",
+        "requested_authority": "read_only_audit",
+        "submits_executable_authority": False,
+    }
+    return {
+        "schema_version": "reddog_resident_architect_cycle.v2",
+        "intent_id": intent["intent_id"],
+        "intent_digest": resident_intent_digest(intent),
+        "intent": intent,
+        "cycle_id": "sha256:legacy-main-cycle",
+        "status": "RUNNING",
+        "record_revision": 0,
+        "transition_history": [],
+        "read_only_authority_only": True,
+        "no_shell_command_executed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_worktree_operation_performed": True,
+        "no_pr_created": True,
+        "no_pattern_memory_promotion_performed": True,
+        "no_live_foundup_enqueue_performed": True,
+    }
+
+
+def test_real_agentdb_pre1310_main_cycle_supports_status_and_cas_cancel_only(
+    tmp_path, monkeypatch
+) -> None:
+    DatabaseManager.reset_for_tests()
+    monkeypatch.setenv("FOUNDUPS_DB_ENGINE", "sqlite")
+    monkeypatch.setenv("FOUNDUPS_DB_PATH", str(tmp_path / "legacy-main.db"))
+    db = AgentDB()
+    store = AgentDbResidentArchitectCycleStore(agent_db_factory=lambda: db)
+    store._ensure_table(db)
+    intent_id = "sha256:pre1310-main-intent"
+    intent = {
+        "schema_version": "reddog_intent.v1",
+        "intent_id": intent_id,
+        "origin": "main.py",
+        "principal_ref": "principal-012",
+        "foundup_id": "foundups_agent",
+        "work_focus": "Historical main resident audit.",
+        "cycle_bucket": "24h:legacy",
+        "requested_authority": "read_only_audit",
+        "submits_executable_authority": False,
+        "memory_context": {},
+    }
+    record = {
+        "schema_version": "reddog_resident_architect_cycle.v1",
+        "intent_id": intent_id,
+        "cycle_id": "sha256:pre1310-cycle",
+        "status": "RUNNING",
+        "intent": intent,
+        "snapshot_id": None,
+        "determination_id": None,
+        "swarm_id": None,
+        "task_ids": [],
+        "task_status_counts": {},
+        "openclaw_claims": [],
+        "retry_count": 0,
+        "created_at": "2026-07-01T00:00:00+00:00",
+        "updated_at": "2026-07-01T00:00:00+00:00",
+        "rejection_reasons": [],
+        "read_only_authority_only": True,
+    }
+    with db.db.get_connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO reddog_resident_architect_cycles
+            (intent_id, cycle_id, status, snapshot_id, determination_id, revision, cycle_json, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                intent_id,
+                record["cycle_id"],
+                record["status"],
+                None,
+                None,
+                0,
+                json.dumps(record, sort_keys=True, separators=(",", ":")),
+                record["updated_at"],
+            ),
+        )
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="main",
+        cycle_store=store,
+    )
+
+    status = client.status(intent_id)
+    cancelled = client.cancel(intent_id)
+    persisted = client.status(intent_id)
+    resumed = client.resume(intent_id)
+
+    assert status.accepted is True
+    assert status.status == "RUNNING"
+    assert status.canonical_resident_cycle_used is False
+    assert cancelled.accepted is False
+    assert cancelled.status == "CANCELLED"
+    assert persisted.accepted is True
+    assert persisted.status == "CANCELLED"
+    assert resumed.accepted is False
+    assert resumed.status == "REJECTED"
+    DatabaseManager.reset_for_tests()
 
 
 def test_submit_calls_canonical_cycle_and_returns_readonly_receipt() -> None:
@@ -290,6 +434,93 @@ def test_foundup_outside_host_authorized_scope_never_reaches_cycle() -> None:
     assert result.accepted is False
     assert ResidentClientReason.FOUNDUP_SCOPE_MISMATCH in result.rejection_reasons
     assert runner.calls == []
+
+
+def test_legacy_main_v1_record_supports_status_and_cancel_only() -> None:
+    store = _Store()
+    runner = _Runner()
+    record = _legacy_main_record()
+    store.records[record["intent_id"]] = record
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="main",
+        cycle_store=store,
+        cycle_runner=runner,
+    )
+
+    status = client.status(record["intent_id"])
+    cancelled = client.cancel(record["intent_id"])
+    resumed = client.resume(record["intent_id"])
+
+    assert status.accepted is True
+    assert status.canonical_resident_cycle_used is False
+    assert cancelled.status == "CANCELLED"
+    assert cancelled.canonical_resident_cycle_used is False
+    assert store.records[record["intent_id"]]["status"] == "CANCELLED"
+    assert resumed.accepted is False
+    assert runner.calls == []
+
+
+def test_legacy_main_v1_record_rejects_wrong_principal_or_foundup_scope() -> None:
+    for record in (
+        _legacy_main_record(principal="other-principal"),
+        _legacy_main_record(foundup_id="other_foundup"),
+    ):
+        store = _Store()
+        store.records[record["intent_id"]] = record
+        client = RedDogResidentArchitectClient(
+            repo_root=REPO_ROOT,
+            authenticated_principal_id="principal-012",
+            authorized_foundup_ids=("foundups_agent",),
+            transport="main",
+            cycle_store=store,
+            cycle_runner=_Runner(),
+        )
+
+        assert client.status(record["intent_id"]).accepted is False
+        assert client.cancel(record["intent_id"]).accepted is False
+        assert store.records[record["intent_id"]]["status"] == "RUNNING"
+
+
+def test_legacy_main_v1_record_rejects_non_main_transport() -> None:
+    store = _Store()
+    record = _legacy_main_record()
+    store.records[record["intent_id"]] = record
+
+    result = _client(store=store).status(record["intent_id"])
+
+    assert result.accepted is False
+    assert ResidentClientReason.REQUEST_INVALID in result.rejection_reasons
+
+
+def test_legacy_main_v1_record_rejects_top_level_intent_substitution() -> None:
+    store = _Store()
+    record = _legacy_main_record()
+    requested_intent_id = str(record["intent_id"])
+    record["intent_id"] = "sha256:cross-record-target"
+    store.records[requested_intent_id] = record
+    store.records[record["intent_id"]] = {
+        **_legacy_main_record(),
+        "intent_id": record["intent_id"],
+        "status": "RUNNING",
+    }
+    client = RedDogResidentArchitectClient(
+        repo_root=REPO_ROOT,
+        authenticated_principal_id="principal-012",
+        authorized_foundup_ids=("foundups_agent",),
+        transport="main",
+        cycle_store=store,
+        cycle_runner=_Runner(),
+    )
+
+    status = client.status(requested_intent_id)
+    cancelled = client.cancel(requested_intent_id)
+
+    assert status.accepted is False
+    assert cancelled.accepted is False
+    assert store.records["sha256:cross-record-target"]["status"] == "RUNNING"
 
 
 def test_missing_runtime_boundary_attestation_fails_closed() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_transport_neutral_grounding_service.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_transport_neutral_grounding_service.py
@@ -168,6 +168,31 @@ def test_repo_path_is_verified_and_bound_into_v2_intent() -> None:
     assert validation.accepted is True
 
 
+def test_main_resident_host_builds_verified_v2_intent() -> None:
+    result = ground_transport_work_focus(
+        repo_root=REPO_ROOT,
+        work_focus=(
+            "Audit modules/communication/moltbot_bridge/src/"
+            "reddog_resident_architect_client.py."
+        ),
+        foundup_id="foundups_agent",
+        authenticated_principal_id="principal-main-test",
+        source_surface="main_resident_host",
+        client_request_id="main-request-1",
+    )
+
+    assert result.accepted is True
+    assert result.intent["schema_version"] == "reddog_intent.v2"
+    assert result.intent["source_surface"] == "main_resident_host"
+    assert result.intent["origin"] == "main.py"
+    assert result.intent["principal_ref"] == "principal-main-test"
+    assert validate_grounded_target_receipt(
+        result.grounding_receipt,
+        work_focus=result.intent["work_focus"],
+        expected_source_surface="main_resident_host",
+    ).accepted is True
+
+
 def test_semantic_audit_requires_current_generation_and_corroborated_hits() -> None:
     focus = "Audit resident RedDog transport authority and grounding architecture."
 

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -303,7 +303,7 @@ exemptions:
     reason: >-
       Legacy end-to-end startup integration suite; focused owner-preflight
       stubs are retained while durable-cycle sections are split by contract.
-    threshold_override: 1939
+    threshold_override: 1957
     function_threshold_override: 72
     functions:
       - "test_bootstrap_memex_supply_enriches_enqueued_readonly_audit_tasks"
@@ -312,12 +312,12 @@ exemptions:
       - "test_main_preflight_durable_resident_cycle_supplies_memory_context"
     remediation: "modules/communication/moltbot_bridge/ROADMAP.md#2026-07-18-reddog--holoindex-truth-boundary-follow-ups"
     no_growth_ceiling:
-      file_lines: 1939
+      file_lines: 1957
       functions:
         test_bootstrap_memex_supply_enriches_enqueued_readonly_audit_tasks: 70
         test_main_resident_runtime_artifact_preflight_rejects_before_cycle: 72
-        test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled: 62
-        test_main_preflight_durable_resident_cycle_supplies_memory_context: 68
+        test_main_preflight_runs_durable_resident_agentdb_cycle_when_enabled: 67
+        test_main_preflight_durable_resident_cycle_supplies_memory_context: 63
 
   - <<: *reddog_security_repair
     file: "tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py"
@@ -382,7 +382,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 8790
+    threshold_override: 8820
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -394,7 +394,7 @@ exemptions:
     reason: >-
       Legacy WSP_22 test journal. Current entries record focused validation;
       historical test evidence is not split during a runtime-security slice.
-    threshold_override: 1597
+    threshold_override: 1620
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/wsp_62_exemptions.yaml
+++ b/wsp_62_exemptions.yaml
@@ -37,7 +37,6 @@ exemptions:
       - "run_reddog_readonly_operational_bootstrap_preflight"
       - "run_reddog_authoritative_work_state_refresh_preflight"
       - "run_reddog_wre_queue_consumer_preflight"
-      - "run_reddog_resident_architect_durable_cycle_preflight"
       - "_run_reddog_startup_blocker_diagnostic"
       - "run_reddog_architect_fix_promotion_preflight"
       - "run_reddog_resident_queue_orchestration_plan_preflight"


### PR DESCRIPTION
## Summary
- route `main.py` resident RedDog through typed v2 grounding and the canonical `RedDogResidentArchitectClient`
- require host-authenticated principal plus selected FoundUp scope and preserve exact runtime-model binding receipts
- separate client request idempotency from canonical intent IDs and confine status/cancel/resume to the selected FoundUp
- prevent reconnect/status from re-arming FIX promotion or queue handoff
- retain a bounded main-only status/CAS-cancel path for persisted read-only v1 records while rejecting new v1 submit/resume

## WSP_97 Evidence
- `164 passed, 1 skipped` across client, grounding, main bootstrap, migration, durable cycle, WSP 62, and root bootstrap suites
- WSP 62 exact no-growth gate: `3 passed`
- modular-audit unit suite: `16 passed`
- `git diff --check` clean and focused Python compile clean
- first independent review found three authority defects; all were repaired and regression-tested

## Truth Boundary
- no shell, repository mutation, worktree, PR, merge, Hermes execution, HoloIndex re-index, or PatternMemory authority added
- main remains a read-only resident host; execution still requires downstream signed receipts and valves
- legacy compatibility is observation/CAS-cancel only and is not canonical execution authority

## HoloIndex
No re-index was performed. This slice changes runtime transport and must be queried only after merge through the generation-bound owner path; WRE/CI maintenance is warranted only on a verified stale/index-gap receipt.