### PR TITLE
docs(holoindex): correct owner death runbook

### DIFF
--- a/modules/infrastructure/foundups_mcp_bridge/HOLO_QUERY_OWNER_RUNBOOK.md
+++ b/modules/infrastructure/foundups_mcp_bridge/HOLO_QUERY_OWNER_RUNBOOK.md
@@ -143,7 +143,7 @@ receipt cannot satisfy this sequence.
 | Backend query times out | Poison owner permanently | Private adapter replaces the owned owner and retries once; external supervisor owns external recovery |
 | Owner startup/health fails after successful refresh | Keep the valid CURRENT receipt but return non-operational | Repair owner lifecycle, then re-run authenticated health; do not needlessly restamp the store |
 | Controlled host exit or cleanup runs | Stop owned process and erase handoff | Treat old token as invalid |
-| Host dies abruptly | Cleanup is not guaranteed; an orphan owner/token can survive until OS/supervisor cleanup | Kill the orphan by verified PID/command, rotate the token, and re-run preflight |
+| Auto-owning host dies abruptly | The v0.4.19+ owner's private stdin watchdog observes EOF and exits; manually launched or pre-v0.4.19 owners have no such proof | Confirm the owned process exited, then re-run authenticated preflight; remediate only a verified legacy/manual owner |
 
 ## Timeout and Transport Boundary
 


### PR DESCRIPTION
Correct the HoloIndex owner lifecycle truth table after #1376. Auto-owned v0.4.19+ owners now exit on supervisor-pipe EOF; manually launched and legacy owners remain outside that guarantee. Documentation-only, no authority or runtime change.