### PR TITLE
fix(reddog): align verifier assurance gates

### DIFF
--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -322,6 +322,25 @@ def _claim_reddog_signed_worker_dispatch_task_once_under_control_lock(
     task_id, context, task_reject = _signed_worker_claimed_task_context(db, task)
     if task_reject is not None:
         return task_reject
+    return _signed_worker_execute_claimed_task(
+        repo_root=repo_root,
+        db=db,
+        task_id=task_id,
+        context=context,
+        signed_worker_runner=signed_worker_runner,
+    )
+
+
+def _signed_worker_execute_claimed_task(
+    *,
+    repo_root: Path,
+    db: Any,
+    task_id: str,
+    context: Mapping[str, Any],
+    signed_worker_runner: Any | None,
+) -> Dict[str, Any]:
+    """Resolve the runner, execute the claimed task, and persist its result."""
+
     effective_runner, runner_reject = _signed_worker_effective_runner(
         repo_root=repo_root, db=db, task_id=task_id, context=context,
         signed_worker_runner=signed_worker_runner,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_slice_verifier_invoke.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_slice_verifier_invoke.py
@@ -93,6 +93,9 @@ def _verifier_request() -> dict:
         "slice_name": "REDDOG_WRE_QUEUE_AUTHORIZED_SLICE_VERIFIER_INVOKE_PHASE1",
         "worker_id": "worker:author",
         "verifier_id": "worker:verifier",
+        "assurance_reservation_id": "assurance-reservation-test",
+        "assurance_reservation_digest": _digest("d"),
+        "verifier_task_id": "reddog-worker-dispatch-independent-verifier",
         "base_sha": BASE_SHA,
         "head_sha": HEAD_SHA,
         "allowed_path_patterns": [


### PR DESCRIPTION
## Summary
- update the direct verifier fixture for mandatory independent-assurance reservation bindings
- decompose the OpenClaw signed-worker control function to satisfy WSP 62 without changing behavior

## Validation
- 59 passed, 4 skipped across verifier, OpenClaw claim-loop, and resident live-canary tests
- python compilation passed
- git diff --check passed

## Boundary
No authority expansion, shell execution, Hermes execution, runtime configuration, or extension changes.