### PR TITLE
fix(holoindex): bind owner readiness during startup

### DIFF
--- a/modules/infrastructure/foundups_mcp_bridge/HOLO_QUERY_OWNER_RUNBOOK.md
+++ b/modules/infrastructure/foundups_mcp_bridge/HOLO_QUERY_OWNER_RUNBOOK.md
@@ -122,8 +122,11 @@ The maintenance handshake performs this exact sequence:
    source.
 10. Re-prove the same clean HEAD, reload the atomic receipt, and validate its
     repository/store identities and generation.
-11. Start the private owner bound to that exact SHA and generation; require its
-    authenticated semantic canary.
+11. Start the private owner with the exact SHA, repository-root digest,
+    generation, and receipt digest supplied to one authenticated semantic
+    startup exchange. Retain the actual returned binding with the live process;
+    do not launch a duplicate semantic canary merely to export the
+    process-private handoff.
 
 Refresh/index/proof failures preserve a non-current state and return a stable
 secret-free code. If refresh and receipt publication succeed but subsequent

--- a/modules/infrastructure/foundups_mcp_bridge/ModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/ModLog.md
@@ -1,5 +1,23 @@
 # foundups_mcp_bridge - ModLog
 
+## 2026-07-26 - HoloIndex exact-binding startup proof consolidation
+
+- OBSERVED: exact-HEAD maintenance succeeded, but automatic owner bootstrap
+  intermittently failed because it ran a second semantic health canary after
+  the supervisor had already proved readiness; the duplicate five-second
+  probe passed only 7/10 repeated live starts.
+- The supervisor startup loop now proves the requested repository HEAD,
+  repository-root digest, generation, and freshness-receipt digest in one
+  authoritative authenticated health exchange and retains the actual returned
+  binding with the live process.
+- The process-private handoff validates process liveness, endpoint/token
+  shape, and the retained exact binding without issuing a duplicate semantic
+  query. Ten repeated live starts passed after the correction. Query-time
+  pre/post freshness proof, authentication, loopback restriction, and
+  no-reindex authority remain unchanged.
+- An authenticated ready owner proving a different binding is now a terminal
+  startup rejection instead of consuming the full retry window.
+
 ## 2026-07-25 - HoloIndex parent-process lifecycle correction
 
 - OBSERVED: the blocking stdin watchdog introduced in v0.4.19 allowed the HTTP socket to listen but prevented semantic health from completing beyond 120 seconds on Windows; the same owner without that reader returned CURRENT in about 12 seconds.

--- a/modules/infrastructure/foundups_mcp_bridge/src/holo_query_service_supervisor.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/holo_query_service_supervisor.py
@@ -18,6 +18,7 @@ import socket
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
@@ -38,6 +39,7 @@ DEFAULT_OWNER_STARTUP_TIMEOUT_SECONDS = 300.0
 DEFAULT_OWNER_PROBE_TIMEOUT_SECONDS = 30.0
 DEFAULT_OWNER_PROBE_INTERVAL_SECONDS = 0.5
 PORT_IN_USE_ERROR = "HOLOINDEX_QUERY_SERVICE_PORT_IN_USE"
+BINDING_MISMATCH_ERROR = "HOLOINDEX_QUERY_SERVICE_BINDING_MISMATCH"
 
 
 class HoloQueryServiceSupervisorError(RuntimeError):
@@ -46,6 +48,15 @@ class HoloQueryServiceSupervisorError(RuntimeError):
     def __init__(self, code: str) -> None:
         self.code = code
         super().__init__(code)
+
+
+@dataclass(frozen=True)
+class AuthenticatedOwnerHealthProof:
+    """One authenticated health exchange and its actual owner binding."""
+
+    ready: bool
+    rejection: str
+    binding: tuple[str, str, str, str]
 
 
 def _probe_target_is_private(host: str, token: str) -> bool:
@@ -81,10 +92,12 @@ def _health_contract_ready(
     payload: Mapping[str, object],
     *,
     expected_repo_head_sha: str,
+    expected_repo_root_digest: str,
     expected_generation_id: str,
     expected_receipt_digest: str,
 ) -> bool:
     repo_head_sha = str(payload.get("repo_head_sha") or "")
+    repo_root_digest = str(payload.get("repo_root_digest") or "")
     generation_id = str(payload.get("freshness_generation_id") or "")
     receipt_digest = str(payload.get("freshness_receipt_digest") or "")
     contract_checks = (
@@ -99,14 +112,71 @@ def _health_contract_ready(
         payload.get("index_gap_detected") is False,
         payload.get("no_holoindex_reindex_performed") is True,
         payload.get("retrieval_mode") == "semantic",
-        bool(repo_head_sha and generation_id and receipt_digest),
+        bool(repo_head_sha and repo_root_digest and generation_id and receipt_digest),
     )
     binding_checks = (
         not expected_repo_head_sha or repo_head_sha == expected_repo_head_sha,
+        not expected_repo_root_digest
+        or repo_root_digest == expected_repo_root_digest,
         not expected_generation_id or generation_id == expected_generation_id,
         not expected_receipt_digest or receipt_digest == expected_receipt_digest,
     )
     return all(contract_checks + binding_checks)
+
+
+def _health_binding(payload: Mapping[str, object] | None) -> tuple[str, str, str, str]:
+    value = payload if isinstance(payload, Mapping) else {}
+    return (
+        str(value.get("repo_head_sha") or ""),
+        str(value.get("repo_root_digest") or ""),
+        str(value.get("freshness_generation_id") or ""),
+        str(value.get("freshness_receipt_digest") or ""),
+    )
+
+
+def _authenticated_health_exchange(
+    *,
+    host: str,
+    port: int,
+    token: str,
+    timeout_seconds: float,
+    expected_repo_head_sha: str = "",
+    expected_repo_root_digest: str = "",
+    expected_generation_id: str = "",
+    expected_receipt_digest: str = "",
+) -> AuthenticatedOwnerHealthProof:
+    """Return one authenticated ready/rejection decision with actual binding."""
+    unavailable = AuthenticatedOwnerHealthProof(False, "", ("", "", "", ""))
+    if not _probe_target_is_private(host, token):
+        return unavailable
+    connection = http.client.HTTPConnection(
+        host,
+        int(port),
+        timeout=max(0.01, float(timeout_seconds)),
+    )
+    try:
+        payload = _read_health_payload(connection, token)
+        binding = _health_binding(payload)
+        if payload is not None and _health_contract_ready(
+            payload,
+            expected_repo_head_sha=expected_repo_head_sha,
+            expected_repo_root_digest=expected_repo_root_digest,
+            expected_generation_id=expected_generation_id,
+            expected_receipt_digest=expected_receipt_digest,
+        ):
+            return AuthenticatedOwnerHealthProof(True, "", binding)
+        rejection = _health_rejection_code(payload) or _health_binding_rejection_code(
+            payload,
+            expected_repo_head_sha=expected_repo_head_sha,
+            expected_repo_root_digest=expected_repo_root_digest,
+            expected_generation_id=expected_generation_id,
+            expected_receipt_digest=expected_receipt_digest,
+        )
+        return AuthenticatedOwnerHealthProof(False, rejection, binding)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        return unavailable
+    finally:
+        connection.close()
 
 
 def _authenticated_health_probe(
@@ -116,32 +186,21 @@ def _authenticated_health_probe(
     token: str,
     timeout_seconds: float,
     expected_repo_head_sha: str = "",
+    expected_repo_root_digest: str = "",
     expected_generation_id: str = "",
     expected_receipt_digest: str = "",
 ) -> bool:
-    """Return true only for the exact authenticated owner-ready contract."""
-    if not _probe_target_is_private(host, token):
-        return False
-    connection = http.client.HTTPConnection(
-        host,
-        int(port),
-        timeout=max(0.01, float(timeout_seconds)),
-    )
-    try:
-        payload = _read_health_payload(connection, token)
-        return bool(
-            payload is not None
-            and _health_contract_ready(
-                payload,
-                expected_repo_head_sha=expected_repo_head_sha,
-                expected_generation_id=expected_generation_id,
-                expected_receipt_digest=expected_receipt_digest,
-            )
-        )
-    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
-        return False
-    finally:
-        connection.close()
+    """Compatibility wrapper for one exact authenticated owner-ready proof."""
+    return _authenticated_health_exchange(
+        host=host,
+        port=port,
+        token=token,
+        timeout_seconds=timeout_seconds,
+        expected_repo_head_sha=expected_repo_head_sha,
+        expected_repo_root_digest=expected_repo_root_digest,
+        expected_generation_id=expected_generation_id,
+        expected_receipt_digest=expected_receipt_digest,
+    ).ready
 
 
 def _health_rejection_code(payload: Mapping[str, object] | None) -> str:
@@ -164,20 +223,62 @@ def _health_rejection_code(payload: Mapping[str, object] | None) -> str:
     return error if valid and error in terminal else ""
 
 
-def _authenticated_health_rejection(
-    *, host: str, port: int, token: str, timeout_seconds: float
+def _health_binding_rejection_code(
+    payload: Mapping[str, object] | None,
+    *,
+    expected_repo_head_sha: str,
+    expected_repo_root_digest: str,
+    expected_generation_id: str,
+    expected_receipt_digest: str,
 ) -> str:
-    if not _probe_target_is_private(host, token):
+    """Reject an authenticated ready owner that proves a different binding."""
+    value = payload if isinstance(payload, Mapping) else {}
+    if not _health_contract_ready(
+        value,
+        expected_repo_head_sha="",
+        expected_repo_root_digest="",
+        expected_generation_id="",
+        expected_receipt_digest="",
+    ):
         return ""
-    connection = http.client.HTTPConnection(
-        host, int(port), timeout=max(0.01, float(timeout_seconds))
+    actual = _health_binding(value)
+    expected = (
+        expected_repo_head_sha,
+        expected_repo_root_digest,
+        expected_generation_id,
+        expected_receipt_digest,
     )
-    try:
-        return _health_rejection_code(_read_health_payload(connection, token))
-    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
-        return ""
-    finally:
-        connection.close()
+    return (
+        BINDING_MISMATCH_ERROR
+        if any(
+            wanted and wanted != observed
+            for wanted, observed in zip(expected, actual)
+        )
+        else ""
+    )
+
+
+def _authenticated_health_rejection(
+    *,
+    host: str,
+    port: int,
+    token: str,
+    timeout_seconds: float,
+    expected_repo_head_sha: str = "",
+    expected_repo_root_digest: str = "",
+    expected_generation_id: str = "",
+    expected_receipt_digest: str = "",
+) -> str:
+    return _authenticated_health_exchange(
+        host=host,
+        port=port,
+        token=token,
+        timeout_seconds=timeout_seconds,
+        expected_repo_head_sha=expected_repo_head_sha,
+        expected_repo_root_digest=expected_repo_root_digest,
+        expected_generation_id=expected_generation_id,
+        expected_receipt_digest=expected_receipt_digest,
+    ).rejection
 
 
 def _hidden_process_options() -> dict[str, object]:
@@ -321,6 +422,7 @@ class HoloQueryServiceSupervisor:
         self._process: subprocess.Popen[bytes] | None = None
         self._token = ""
         self._ready = False
+        self._verified_binding: tuple[str, str, str, str] = ("", "", "", "")
         self._atexit_registered = False
 
     @property
@@ -337,6 +439,11 @@ class HoloQueryServiceSupervisor:
             and self._process.poll() is None
             and self._token
         )
+
+    @property
+    def verified_binding(self) -> tuple[str, str, str, str]:
+        """Return the exact binding proven by the successful startup health check."""
+        return self._verified_binding
 
     def _spawn(self) -> subprocess.Popen[bytes]:
         if not self.repo_root.is_dir():
@@ -368,9 +475,28 @@ class HoloQueryServiceSupervisor:
         self._token = token
         return process
 
-    def start(self) -> "HoloQueryServiceSupervisor":
+    def start(
+        self,
+        *,
+        expected_repo_head_sha: str = "",
+        expected_repo_root_digest: str = "",
+        expected_generation_id: str = "",
+        expected_receipt_digest: str = "",
+    ) -> "HoloQueryServiceSupervisor":
         """Start, authenticate, and prove the owner ready or fail closed."""
-        if self.is_ready:
+        requested_binding = (
+            expected_repo_head_sha,
+            expected_repo_root_digest,
+            expected_generation_id,
+            expected_receipt_digest,
+        )
+        if self.is_ready and all(
+            not requested or requested == verified
+            for requested, verified in zip(
+                requested_binding,
+                self._verified_binding,
+            )
+        ):
             return self
         self.stop()
         self._process = self._spawn()
@@ -386,27 +512,27 @@ class HoloQueryServiceSupervisor:
                     raise HoloQueryServiceSupervisorError(
                         "HOLOINDEX_QUERY_SERVICE_STARTUP_TIMEOUT"
                     )
-                if _authenticated_health_probe(
+                proof = _authenticated_health_exchange(
                     host=OWNER_HOST,
                     port=self.port,
                     token=self._token,
                     timeout_seconds=min(self.probe_timeout_seconds, remaining),
-                ):
+                    expected_repo_head_sha=expected_repo_head_sha,
+                    expected_repo_root_digest=expected_repo_root_digest,
+                    expected_generation_id=expected_generation_id,
+                    expected_receipt_digest=expected_receipt_digest,
+                )
+                if proof.ready:
                     if self._process.poll() is not None:
                         raise HoloQueryServiceSupervisorError(
                             "HOLOINDEX_QUERY_SERVICE_EXITED_DURING_STARTUP"
                         )
                     self._ready = True
+                    self._verified_binding = proof.binding
                     self._register_cleanup()
                     return self
-                rejection = _authenticated_health_rejection(
-                    host=OWNER_HOST,
-                    port=self.port,
-                    token=self._token,
-                    timeout_seconds=min(self.probe_timeout_seconds, remaining),
-                )
-                if rejection:
-                    raise HoloQueryServiceSupervisorError(rejection)
+                if proof.rejection:
+                    raise HoloQueryServiceSupervisorError(proof.rejection)
                 time.sleep(min(self.probe_interval_seconds, remaining))
         except BaseException:
             self.stop()
@@ -439,6 +565,7 @@ class HoloQueryServiceSupervisor:
         process, self._process = self._process, None
         self._ready = False
         self._token = ""
+        self._verified_binding = ("", "", "", "")
         if self._atexit_registered:
             atexit.unregister(self.stop)
             self._atexit_registered = False
@@ -458,6 +585,8 @@ class HoloQueryServiceSupervisor:
 
 
 __all__ = [
+    "AuthenticatedOwnerHealthProof",
+    "BINDING_MISMATCH_ERROR",
     "DEFAULT_OWNER_PORT",
     "DEFAULT_OWNER_PROBE_INTERVAL_SECONDS",
     "DEFAULT_OWNER_STARTUP_TIMEOUT_SECONDS",

--- a/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_owner_bootstrap.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_owner_bootstrap.py
@@ -8,9 +8,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
+from holo_index.repository_state import repository_root_digest
 from holo_index.storage_contract import resolve_holoindex_ssd_path
 
 from .holo_query_service_supervisor import (
+    DEFAULT_OWNER_PROBE_TIMEOUT_SECONDS,
     SERVICE_TOKEN_ENV,
     SERVICE_URL_ENV,
     HoloQueryServiceSupervisor,
@@ -31,10 +33,10 @@ AUTO_START_DISABLED_ERROR = "HOLOINDEX_QUERY_SERVICE_AUTO_START_DISABLED"
 BOOTSTRAP_FAILED_ERROR = "HOLOINDEX_QUERY_SERVICE_BOOTSTRAP_FAILED"
 CONFIGURED_INVALID_ERROR = "HOLOINDEX_QUERY_SERVICE_CONFIGURED_INVALID"
 CONFIGURED_UNREADY_ERROR = "HOLOINDEX_QUERY_SERVICE_CONFIGURED_UNREADY"
-# The owner health contract includes one semantic canary. A cold-but-ready
-# local owner has been observed just above one second, so the final binding
-# proof needs a bounded response window distinct from ordinary query latency.
-CONFIGURED_HEALTH_TIMEOUT_SECONDS = 5.0
+# The owner health contract runs a semantic canary. Keep the exact-binding
+# proof aligned with the supervisor rather than imposing a shorter timeout
+# than the query service itself permits.
+CONFIGURED_HEALTH_TIMEOUT_SECONDS = DEFAULT_OWNER_PROBE_TIMEOUT_SECONDS
 MIN_CONFIGURED_TOKEN_CHARS = 32
 QUERY_PATH = "/holoindex/v1/query"
 PHASE1_BIND_HOST = "127.0.0.1"
@@ -42,7 +44,7 @@ PHASE1_BIND_HOST = "127.0.0.1"
 _OWNER_LOCK = threading.RLock()
 _OWNER_SUPERVISOR: HoloQueryServiceSupervisor | None = None
 _OWNER_HANDOFF: tuple[str, str] | None = None
-_OWNER_EXPECTED_BINDING: tuple[str, str, str] = ("", "", "")
+_OWNER_EXPECTED_BINDING: tuple[str, str, str, str] = ("", "", "", "")
 
 
 @dataclass(frozen=True)
@@ -59,6 +61,7 @@ def _configured_owner_health_ready(
     service_url: str,
     token: str,
     expected_repo_head_sha: str = "",
+    expected_repo_root_digest: str = "",
     expected_generation_id: str = "",
     expected_receipt_digest: str = "",
 ) -> bool:
@@ -77,6 +80,8 @@ def _configured_owner_health_ready(
     }
     if expected_repo_head_sha:
         probe_kwargs["expected_repo_head_sha"] = expected_repo_head_sha
+    if expected_repo_root_digest:
+        probe_kwargs["expected_repo_root_digest"] = expected_repo_root_digest
     if expected_generation_id:
         probe_kwargs["expected_generation_id"] = expected_generation_id
     if expected_receipt_digest:
@@ -108,6 +113,7 @@ def _service_endpoint_is_valid(service_url: str) -> bool:
 def _configured_service_result(
     *,
     expected_repo_head_sha: str = "",
+    expected_repo_root_digest: str = "",
     expected_generation_id: str = "",
     expected_receipt_digest: str = "",
 ) -> RedDogHoloIndexOwnerBootstrapResult | None:
@@ -131,6 +137,7 @@ def _configured_service_result(
         service_url=url,
         token=token,
         expected_repo_head_sha=expected_repo_head_sha,
+        expected_repo_root_digest=expected_repo_root_digest,
         expected_generation_id=expected_generation_id,
         expected_receipt_digest=expected_receipt_digest,
     ):
@@ -149,10 +156,11 @@ def _validated_owner_handoff(
     supervisor: HoloQueryServiceSupervisor,
     *,
     expected_repo_head_sha: str = "",
+    expected_repo_root_digest: str = "",
     expected_generation_id: str = "",
     expected_receipt_digest: str = "",
 ) -> tuple[str, str]:
-    """Read and prove a supervisor handoff without exporting its secret."""
+    """Read a handoff whose exact binding was proven during supervisor startup."""
     handoff = supervisor.environment_for_child({})
     service_url = str(handoff.get(SERVICE_URL_ENV) or "").strip()
     token = str(handoff.get(SERVICE_TOKEN_ENV) or "").strip()
@@ -161,12 +169,16 @@ def _validated_owner_handoff(
         or len(token) < MIN_CONFIGURED_TOKEN_CHARS
     ):
         raise HoloQueryServiceSupervisorError(CONFIGURED_INVALID_ERROR)
-    if not _configured_owner_health_ready(
-        service_url=service_url,
-        token=token,
-        expected_repo_head_sha=expected_repo_head_sha,
-        expected_generation_id=expected_generation_id,
-        expected_receipt_digest=expected_receipt_digest,
+    expected_binding = (
+        expected_repo_head_sha,
+        expected_repo_root_digest,
+        expected_generation_id,
+        expected_receipt_digest,
+    )
+    verified_binding = supervisor.verified_binding
+    if not supervisor.is_ready or any(
+        expected and expected != verified
+        for expected, verified in zip(expected_binding, verified_binding)
     ):
         raise HoloQueryServiceSupervisorError(CONFIGURED_UNREADY_ERROR)
     return service_url, token
@@ -201,23 +213,29 @@ def restart_reddog_holoindex_owner(
         supervisor.stop()
         _OWNER_SUPERVISOR = None
         _OWNER_HANDOFF = None
-        _OWNER_EXPECTED_BINDING = ("", "", "")
+        _OWNER_EXPECTED_BINDING = ("", "", "", "")
         restarted = ensure_reddog_holoindex_owner(
             repo_root=repo_root,
             requested=True,
             expected_repo_head_sha=expected[0],
-            expected_generation_id=expected[1],
-            expected_receipt_digest=expected[2],
+            expected_generation_id=expected[2],
+            expected_receipt_digest=expected[3],
         )
         return _OWNER_HANDOFF if restarted.ready else None
 
 
 def _requested_binding(
+    repo_root: Path | str,
     repo_head_sha: str,
     generation_id: str,
     receipt_digest: str,
-) -> tuple[str, str, str]:
-    return repo_head_sha, generation_id, receipt_digest
+) -> tuple[str, str, str, str]:
+    return (
+        repo_head_sha,
+        repository_root_digest(Path(repo_root)),
+        generation_id,
+        receipt_digest,
+    )
 
 
 def _stop_owned_owner() -> None:
@@ -228,12 +246,12 @@ def _stop_owned_owner() -> None:
         supervisor.stop()
     _OWNER_SUPERVISOR = None
     _OWNER_HANDOFF = None
-    _OWNER_EXPECTED_BINDING = ("", "", "")
+    _OWNER_EXPECTED_BINDING = ("", "", "", "")
 
 
 def _reuse_owned_owner(
     *,
-    expected_binding: tuple[str, str, str],
+    expected_binding: tuple[str, str, str, str],
 ) -> RedDogHoloIndexOwnerBootstrapResult | None:
     """Return REUSED only after the live owner matches and reproves binding."""
     global _OWNER_HANDOFF
@@ -254,8 +272,9 @@ def _reuse_owned_owner(
         _OWNER_HANDOFF = _validated_owner_handoff(
             supervisor,
             expected_repo_head_sha=expected_binding[0],
-            expected_generation_id=expected_binding[1],
-            expected_receipt_digest=expected_binding[2],
+            expected_repo_root_digest=expected_binding[1],
+            expected_generation_id=expected_binding[2],
+            expected_receipt_digest=expected_binding[3],
         )
     except Exception:
         _stop_owned_owner()
@@ -266,7 +285,7 @@ def _reuse_owned_owner(
 def _start_owned_owner(
     *,
     repo_root: Path | str,
-    expected_binding: tuple[str, str, str],
+    expected_binding: tuple[str, str, str, str],
 ) -> RedDogHoloIndexOwnerBootstrapResult:
     """Start, authenticate, and retain one process-private owner."""
     global _OWNER_EXPECTED_BINDING, _OWNER_HANDOFF, _OWNER_SUPERVISOR
@@ -277,12 +296,18 @@ def _start_owned_owner(
             repo_root=repo_root,
             ssd_path=ssd_path,
         )
-        supervisor.start()
+        supervisor.start(
+            expected_repo_head_sha=expected_binding[0],
+            expected_repo_root_digest=expected_binding[1],
+            expected_generation_id=expected_binding[2],
+            expected_receipt_digest=expected_binding[3],
+        )
         handoff = _validated_owner_handoff(
             supervisor,
             expected_repo_head_sha=expected_binding[0],
-            expected_generation_id=expected_binding[1],
-            expected_receipt_digest=expected_binding[2],
+            expected_repo_root_digest=expected_binding[1],
+            expected_generation_id=expected_binding[2],
+            expected_receipt_digest=expected_binding[3],
         )
     except HoloQueryServiceSupervisorError as exc:
         if supervisor is not None:
@@ -321,6 +346,7 @@ def ensure_reddog_holoindex_owner(
             status=OWNER_NOT_REQUESTED,
         )
     expected_binding = _requested_binding(
+        repo_root,
         expected_repo_head_sha,
         expected_generation_id,
         expected_receipt_digest,
@@ -331,6 +357,7 @@ def ensure_reddog_holoindex_owner(
             return reused
         configured_result = _configured_service_result(
             expected_repo_head_sha=expected_repo_head_sha,
+            expected_repo_root_digest=expected_binding[1],
             expected_generation_id=expected_generation_id,
             expected_receipt_digest=expected_receipt_digest,
         )
@@ -355,7 +382,7 @@ def cleanup_reddog_holoindex_owner(*, restore_environment: bool = True) -> None:
     with _OWNER_LOCK:
         supervisor, _OWNER_SUPERVISOR = _OWNER_SUPERVISOR, None
         _OWNER_HANDOFF = None
-        _OWNER_EXPECTED_BINDING = ("", "", "")
+        _OWNER_EXPECTED_BINDING = ("", "", "", "")
         if supervisor is not None:
             supervisor.stop()
 

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_supervisor.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_supervisor.py
@@ -89,14 +89,31 @@ def _install_successful_start(
         lambda _host, _port: True,
     )
 
-    def fake_health_probe(**kwargs: Any) -> bool:
+    def fake_health_exchange(**kwargs: Any):
         launch.setdefault("probe_timeouts", []).append(kwargs["timeout_seconds"])
-        return kwargs["token"] == TOKEN
+        launch.setdefault("probe_bindings", []).append(
+            (
+                kwargs["expected_repo_head_sha"],
+                kwargs["expected_repo_root_digest"],
+                kwargs["expected_generation_id"],
+                kwargs["expected_receipt_digest"],
+            )
+        )
+        return supervisor_module.AuthenticatedOwnerHealthProof(
+            ready=kwargs["token"] == TOKEN,
+            rejection="",
+            binding=(
+                kwargs["expected_repo_head_sha"] or ("a" * 40),
+                kwargs["expected_repo_root_digest"] or ("sha256:" + ("d" * 64)),
+                kwargs["expected_generation_id"] or ("sha256:" + ("b" * 64)),
+                kwargs["expected_receipt_digest"] or ("sha256:" + ("c" * 64)),
+            ),
+        )
 
     monkeypatch.setattr(
         supervisor_module,
-        "_authenticated_health_probe",
-        fake_health_probe,
+        "_authenticated_health_exchange",
+        fake_health_exchange,
     )
     monkeypatch.setattr(
         supervisor_module.secrets,
@@ -149,12 +166,42 @@ def test_start_uses_argv_loopback_secret_and_authenticated_health(
     assert options["env"][SERVICE_TOKEN_ENV] == TOKEN
     assert SERVICE_URL_ENV not in options["env"]
     assert launch["probe_timeouts"] == [DEFAULT_OWNER_PROBE_TIMEOUT_SECONDS]
+    assert launch["probe_bindings"] == [("", "", "", "")]
     assert registered
 
     owner.stop()
     assert process.terminated is True
     assert unregistered
     assert owner.is_ready is False
+
+
+def test_start_proves_exact_binding_in_its_single_authoritative_health_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = _FakeProcess()
+    launch = _install_successful_start(monkeypatch, process)
+    monkeypatch.setattr(supervisor_module.atexit, "register", lambda _callback: None)
+    monkeypatch.setattr(supervisor_module.atexit, "unregister", lambda _callback: None)
+    expected = (
+        "a" * 40,
+        "sha256:" + ("d" * 64),
+        "sha256:" + ("b" * 64),
+        "sha256:" + ("c" * 64),
+    )
+
+    owner = HoloQueryServiceSupervisor(repo_root=tmp_path).start(
+        expected_repo_head_sha=expected[0],
+        expected_repo_root_digest=expected[1],
+        expected_generation_id=expected[2],
+        expected_receipt_digest=expected[3],
+    )
+
+    assert owner.is_ready is True
+    assert owner.verified_binding == expected
+    assert launch["probe_bindings"] == [expected]
+    owner.stop()
+    assert owner.verified_binding == ("", "", "", "")
 
 
 def test_start_passes_explicit_ssd_path_and_is_idempotent(
@@ -218,13 +265,10 @@ def test_startup_timeout_terminates_owner_and_never_exposes_token_in_error(
     monkeypatch.setattr(supervisor_module.subprocess, "Popen", fake_popen)
     monkeypatch.setattr(
         supervisor_module,
-        "_authenticated_health_probe",
-        lambda **_kwargs: False,
-    )
-    monkeypatch.setattr(
-        supervisor_module,
-        "_authenticated_health_rejection",
-        lambda **_kwargs: "",
+        "_authenticated_health_exchange",
+        lambda **_kwargs: supervisor_module.AuthenticatedOwnerHealthProof(
+            False, "", ("", "", "", "")
+        ),
     )
     monkeypatch.setattr(
         supervisor_module.secrets,
@@ -269,13 +313,10 @@ def test_startup_stops_immediately_on_authenticated_stale_owner(
     )
     monkeypatch.setattr(
         supervisor_module,
-        "_authenticated_health_probe",
-        lambda **_kwargs: False,
-    )
-    monkeypatch.setattr(
-        supervisor_module,
-        "_authenticated_health_rejection",
-        lambda **_kwargs: "REPO_HEAD_MISMATCH",
+        "_authenticated_health_exchange",
+        lambda **_kwargs: supervisor_module.AuthenticatedOwnerHealthProof(
+            False, "REPO_HEAD_MISMATCH", ("", "", "", "")
+        ),
     )
     monkeypatch.setattr(
         supervisor_module.secrets,
@@ -310,6 +351,48 @@ def test_health_rejection_accepts_only_terminal_authenticated_contract() -> None
     assert supervisor_module._health_rejection_code({**base, "schema_version": "wrong"}) == ""
 
 
+def test_health_rejection_treats_authenticated_ready_binding_mismatch_as_terminal(
+) -> None:
+    payload = {
+        "schema_version": HEALTH_SCHEMA_VERSION,
+        "ok": True,
+        "source": "holoindex",
+        "status": "ready",
+        "loopback_only": True,
+        "freshness": "CURRENT",
+        "error": "",
+        "stale_reasons": [],
+        "index_gap_detected": False,
+        "no_holoindex_reindex_performed": True,
+        "retrieval_mode": "semantic",
+        "repo_head_sha": "a" * 40,
+        "repo_root_digest": "sha256:" + ("d" * 64),
+        "freshness_generation_id": "sha256:" + ("b" * 64),
+        "freshness_receipt_digest": "sha256:" + ("c" * 64),
+    }
+
+    assert (
+        supervisor_module._health_binding_rejection_code(
+            payload,
+            expected_repo_head_sha="d" * 40,
+            expected_repo_root_digest="sha256:" + ("d" * 64),
+            expected_generation_id="sha256:" + ("b" * 64),
+            expected_receipt_digest="sha256:" + ("c" * 64),
+        )
+        == supervisor_module.BINDING_MISMATCH_ERROR
+    )
+    assert (
+        supervisor_module._health_binding_rejection_code(
+            payload,
+            expected_repo_head_sha="a" * 40,
+            expected_repo_root_digest="sha256:" + ("d" * 64),
+            expected_generation_id="sha256:" + ("b" * 64),
+            expected_receipt_digest="sha256:" + ("c" * 64),
+        )
+        == ""
+    )
+
+
 def test_startup_fails_closed_when_spawned_owner_exits(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -341,13 +424,22 @@ def test_startup_fails_if_owner_exits_after_health_response(
         lambda _bytes: TOKEN,
     )
 
-    def exit_during_probe(**_kwargs: Any) -> bool:
+    def exit_during_probe(**_kwargs: Any):
         process.returncode = 9
-        return True
+        return supervisor_module.AuthenticatedOwnerHealthProof(
+            True,
+            "",
+            (
+                "a" * 40,
+                "sha256:" + ("d" * 64),
+                "sha256:" + ("b" * 64),
+                "sha256:" + ("c" * 64),
+            ),
+        )
 
     monkeypatch.setattr(
         supervisor_module,
-        "_authenticated_health_probe",
+        "_authenticated_health_exchange",
         exit_during_probe,
     )
     owner = HoloQueryServiceSupervisor(repo_root=tmp_path)
@@ -512,6 +604,7 @@ def test_health_probe_requires_exact_authenticated_ready_contract() -> None:
                     "no_holoindex_reindex_performed": True,
                     "retrieval_mode": "semantic",
                     "repo_head_sha": "a" * 40,
+                    "repo_root_digest": "sha256:" + ("d" * 64),
                     "freshness_generation_id": "sha256:generation",
                     "freshness_receipt_digest": "sha256:receipt",
                 }
@@ -562,6 +655,7 @@ def test_health_probe_accepts_semantic_response_beyond_legacy_one_second() -> No
                 "no_holoindex_reindex_performed": True,
                 "retrieval_mode": "semantic",
                 "repo_head_sha": "a" * 40,
+                "repo_root_digest": "sha256:" + ("d" * 64),
                 "freshness_generation_id": "sha256:" + "b" * 64,
                 "freshness_receipt_digest": "sha256:" + "c" * 64,
             }
@@ -606,6 +700,7 @@ def _binding_health_handler() -> type[BaseHTTPRequestHandler]:
                     "no_holoindex_reindex_performed": True,
                     "retrieval_mode": "semantic",
                     "repo_head_sha": "a" * 40,
+                    "repo_root_digest": "sha256:" + ("d" * 64),
                     "freshness_generation_id": "sha256:generation",
                     "freshness_receipt_digest": "sha256:receipt",
                 }
@@ -635,6 +730,7 @@ def test_health_probe_rejects_expected_binding_mismatch() -> None:
             token=TOKEN,
             timeout_seconds=1.0,
             expected_repo_head_sha="b" * 40,
+            expected_repo_root_digest="sha256:" + ("d" * 64),
             expected_generation_id="sha256:generation",
         )
         assert not supervisor_module._authenticated_health_probe(
@@ -643,6 +739,16 @@ def test_health_probe_rejects_expected_binding_mismatch() -> None:
             token=TOKEN,
             timeout_seconds=1.0,
             expected_repo_head_sha="a" * 40,
+            expected_repo_root_digest="sha256:" + ("e" * 64),
+            expected_generation_id="sha256:generation",
+        )
+        assert not supervisor_module._authenticated_health_probe(
+            host=OWNER_HOST,
+            port=server.server_address[1],
+            token=TOKEN,
+            timeout_seconds=1.0,
+            expected_repo_head_sha="a" * 40,
+            expected_repo_root_digest="sha256:" + ("d" * 64),
             expected_generation_id="sha256:generation",
             expected_receipt_digest="sha256:other",
         )

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_reddog_holoindex_owner_bootstrap.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_reddog_holoindex_owner_bootstrap.py
@@ -34,14 +34,29 @@ class _FakeSupervisor:
         self.ssd_path = Path(ssd_path)
         self.started = False
         self.stopped = False
+        self.verified_binding = ("", "", "", "")
         self.__class__.instances.append(self)
 
     @property
     def is_ready(self) -> bool:
         return self.started and not self.stopped
 
-    def start(self) -> "_FakeSupervisor":
+    def start(
+        self,
+        *,
+        expected_repo_head_sha: str = "",
+        expected_repo_root_digest: str = "",
+        expected_generation_id: str = "",
+        expected_receipt_digest: str = "",
+    ) -> "_FakeSupervisor":
         self.started = True
+        self.stopped = False
+        self.verified_binding = (
+            expected_repo_head_sha,
+            expected_repo_root_digest,
+            expected_generation_id,
+            expected_receipt_digest,
+        )
         return self
 
     def environment_for_child(
@@ -59,6 +74,7 @@ class _FakeSupervisor:
 
     def stop(self) -> None:
         self.stopped = True
+        self.verified_binding = ("", "", "", "")
 
 
 @pytest.fixture(autouse=True)
@@ -171,7 +187,60 @@ def test_final_binding_probe_allows_bounded_semantic_canary_latency(
         expected_receipt_digest="sha256:" + ("c" * 64),
     )
     assert observed == [bootstrap.CONFIGURED_HEALTH_TIMEOUT_SECONDS]
-    assert 1.1 <= observed[0] <= 5.0
+    assert observed[0] == bootstrap.DEFAULT_OWNER_PROBE_TIMEOUT_SECONDS
+
+
+def test_private_handoff_uses_binding_proven_during_supervisor_startup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    health = Mock(side_effect=AssertionError("handoff must not rerun semantic health"))
+    monkeypatch.setattr(bootstrap, "_configured_owner_health_ready", health)
+    supervisor = _FakeSupervisor(repo_root=tmp_path, ssd_path=tmp_path)
+    supervisor.start(
+        expected_repo_head_sha="a" * 40,
+        expected_repo_root_digest="sha256:" + ("d" * 64),
+        expected_generation_id="sha256:" + ("b" * 64),
+        expected_receipt_digest="sha256:" + ("c" * 64),
+    )
+
+    handoff = bootstrap._validated_owner_handoff(
+        supervisor,
+        expected_repo_head_sha="a" * 40,
+        expected_repo_root_digest="sha256:" + ("d" * 64),
+        expected_generation_id="sha256:" + ("b" * 64),
+        expected_receipt_digest="sha256:" + ("c" * 64),
+    )
+
+    assert handoff == (SAFE_URL, SAFE_TOKEN)
+    health.assert_not_called()
+
+
+def test_private_handoff_fails_closed_when_supervisor_proved_another_binding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    health = Mock(side_effect=AssertionError("handoff must not rerun semantic health"))
+    monkeypatch.setattr(bootstrap, "_configured_owner_health_ready", health)
+    supervisor = _FakeSupervisor(repo_root=tmp_path, ssd_path=tmp_path)
+    supervisor.start(
+        expected_repo_head_sha="d" * 40,
+        expected_repo_root_digest="sha256:" + ("a" * 64),
+        expected_generation_id="sha256:" + ("e" * 64),
+        expected_receipt_digest="sha256:" + ("f" * 64),
+    )
+
+    with pytest.raises(HoloQueryServiceSupervisorError) as exc_info:
+        bootstrap._validated_owner_handoff(
+            supervisor,
+            expected_repo_head_sha="a" * 40,
+            expected_repo_root_digest="sha256:" + ("d" * 64),
+            expected_generation_id="sha256:" + ("b" * 64),
+            expected_receipt_digest="sha256:" + ("c" * 64),
+        )
+
+    assert exc_info.value.code == bootstrap.CONFIGURED_UNREADY_ERROR
+    health.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -233,6 +302,7 @@ def test_configured_service_requires_authenticated_semantic_health(
         service_url=SAFE_URL,
         token=SAFE_TOKEN,
         expected_repo_head_sha="",
+        expected_repo_root_digest=bootstrap.repository_root_digest(tmp_path),
         expected_generation_id="",
         expected_receipt_digest="",
     )
@@ -309,6 +379,47 @@ def test_owner_starts_once_and_reuses_process_lifetime_instance(
         SAFE_URL,
         SAFE_TOKEN,
     )
+
+
+def test_changed_exact_binding_replaces_owned_process_instead_of_reusing_it(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bootstrap, "HoloQueryServiceSupervisor", _FakeSupervisor)
+    first_binding = (
+        "a" * 40,
+        bootstrap.repository_root_digest(tmp_path),
+        "sha256:" + ("b" * 64),
+        "sha256:" + ("c" * 64),
+    )
+    second_binding = (
+        "d" * 40,
+        bootstrap.repository_root_digest(tmp_path),
+        "sha256:" + ("e" * 64),
+        "sha256:" + ("f" * 64),
+    )
+    first = bootstrap.ensure_reddog_holoindex_owner(
+        repo_root=tmp_path,
+        requested=True,
+        expected_repo_head_sha=first_binding[0],
+        expected_generation_id=first_binding[2],
+        expected_receipt_digest=first_binding[3],
+    )
+    first_owner = _FakeSupervisor.instances[0]
+
+    second = bootstrap.ensure_reddog_holoindex_owner(
+        repo_root=tmp_path,
+        requested=True,
+        expected_repo_head_sha=second_binding[0],
+        expected_generation_id=second_binding[2],
+        expected_receipt_digest=second_binding[3],
+    )
+
+    assert first.status == bootstrap.OWNER_STARTED
+    assert second.status == bootstrap.OWNER_STARTED
+    assert first_owner.stopped is True
+    assert len(_FakeSupervisor.instances) == 2
+    assert _FakeSupervisor.instances[-1].verified_binding == second_binding
 
 
 def test_auto_owner_secret_is_not_inherited_by_unrelated_subprocess(
@@ -393,7 +504,7 @@ def test_private_resolver_does_not_health_probe_a_live_busy_owner(
     assert first.stopped is False
     assert len(_FakeSupervisor.instances) == 1
     assert handoff == (SAFE_URL, SAFE_TOKEN)
-    assert health.call_count == 1
+    health.assert_not_called()
 
 
 def test_explicit_private_restart_replaces_failed_handoff(
@@ -444,7 +555,7 @@ def test_supervisor_failure_returns_only_stable_error_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class FailingSupervisor(_FakeSupervisor):
-        def start(self) -> "_FakeSupervisor":
+        def start(self, **_kwargs) -> "_FakeSupervisor":
             raise HoloQueryServiceSupervisorError(
                 "HOLOINDEX_QUERY_SERVICE_STARTUP_TIMEOUT"
             )


### PR DESCRIPTION
## Summary

- prove repository HEAD, canonical repository-root digest, generation, and freshness-receipt digest in one authenticated supervisor startup exchange
- retain the actual returned binding with the live owner and remove the duplicate semantic canary from process-private handoff
- reject an authenticated ready owner with a conflicting binding immediately instead of consuming the 300-second startup window
- preserve configured-owner validation, query-time pre/post freshness proof, loopback auth, and no-reindex authority

## WSP_97 evidence

- OBSERVED before: exact-HEAD refresh succeeded, but duplicate post-start health passed only 7/10 repeated live starts
- OBSERVED after: 10/10 repeated exact-binding live starts passed
- focused HoloIndex owner/client/preflight regression: 170 passed
- independent review: GO after root binding, single-exchange proof, actual-binding retention, and terminal mismatch hardening
- full bridge suite was not claimed green: environmental live/training tests exceeded five minutes; the exact lingering pytest process was terminated
- git diff check, py_compile, and added-line ASCII/NUL checks passed

## Boundaries

- no indexing authority added to RedDog/query workers
- no extension/runtime model changes
- no unrelated worktree state included
- no HoloIndex receipt or SSD artifact committed