### PR TITLE
feat(holoindex): coordinate exact-SHA post-merge refresh

### DIFF
--- a/holo_index/INTERFACE.md
+++ b/holo_index/INTERFACE.md
@@ -207,6 +207,20 @@ Persistent admission reads only the canonical
 `freshness_receipt_path(ssd)`. An explicit receipt argument must resolve to
 that exact stable-ancestor identity, and a final symlink/reparse point is
 rejected before receipt or backend access.
+`rehydrate_canonical_freshness_proof()` exposes the same gate for a caller
+that already holds an expected 40-character repository SHA. It rejects a
+malformed or mismatched expected SHA before receipt loading and returns only
+the existing `ReadonlyQueryAdmission` binding; it never starts an owner,
+opens Chroma, writes a receipt, or reindexes.
+
+HoloIndex also exposes a separate authority-update lease beside the canonical
+maintenance lease. WRE may hold the outer lease while changing a dedicated
+authority checkout; `MaintenanceSession` independently owns the inner SSD
+writer lease and atomic freshness publication.
+The fixed `.holoindex_authority_blocked` marker is a durable fail-closed
+fallback when neither a newer checkout nor canonical invalidation can be
+published. Only exact regular marker content is recognized for recovery.
+
 Module hints accept only repository-relative components. Traversal, absolute
 paths, links, and reparse points are rejected; nested enumeration has fixed
 entry/depth bounds. Module-domain and WSP discovery fail closed on `cap + 1`

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,17 @@
 # HoloIndex Package ModLog
 
+## [2026-07-26] Exact-SHA post-merge authority primitives
+
+- Added a separate cross-process authority-update lease that can safely wrap
+  the existing `MaintenanceSession` writer lease.
+- Added read-only canonical freshness rehydration for an explicit expected
+  repository SHA, reusing the existing query-admission result and reason
+  codes.
+- Added an exact-content authority blocker marker primitive for durable
+  fail-closed recovery after an unpublishable supersession invalidation.
+- Preserved the authority split: HoloIndex supplies leases and proof;
+  WRE/OpenClaw owns post-merge task coordination and worktree effects.
+
 ## [2026-07-25] CLI catalog deterministic refresh
 
 - Regenerated the tracked CLI catalog and JSON rolodex from current main,

--- a/holo_index/ROADMAP.md
+++ b/holo_index/ROADMAP.md
@@ -1,5 +1,16 @@
 # HoloIndex Development Roadmap
 
+## [2026-07-26] Exact-SHA Post-Merge Authority Coordination
+
+**Complete in this slice:** separate authority-update and SSD-maintenance
+leases can nest without deadlock; read-only exact-HEAD proof rehydration
+reuses canonical admission; WRE/OpenClaw owns fetch, non-rewind checkout
+advancement, durable tasking, and completion. Query paths remain mutation-free.
+
+**Deferred:** a GitHub/CI post-merge event source may replace periodic remote
+observation. It must reuse the same SHA task identity and authority
+transaction, not add another indexer.
+
 ## [2026-07-24] Root-Bound Read Admission P0
 
 **Complete in this slice:** raw persistent CLI search, persistent bundle

--- a/holo_index/maintenance_lock.py
+++ b/holo_index/maintenance_lock.py
@@ -17,6 +17,9 @@ from typing import BinaryIO
 
 
 MAINTENANCE_LOCK_FILENAME = "holoindex_maintenance.lock"
+AUTHORITY_UPDATE_LOCK_FILENAME = "holoindex_authority_update.lock"
+AUTHORITY_BLOCK_MARKER_FILENAME = ".holoindex_authority_blocked"
+AUTHORITY_BLOCK_MARKER_CONTENT = b"holoindex_authority_blocked_v1\n"
 
 
 class MaintenanceLockError(RuntimeError):
@@ -45,6 +48,36 @@ def maintenance_lock_path(ssd_path: Path | str) -> Path:
     """Return the canonical maintenance lease path for a storage root."""
 
     return Path(ssd_path) / "indexes" / MAINTENANCE_LOCK_FILENAME
+
+
+def authority_update_lock_path(ssd_path: Path | str) -> Path:
+    """Return the separate cross-process authority-checkout lease path."""
+    return Path(ssd_path) / "indexes" / AUTHORITY_UPDATE_LOCK_FILENAME
+
+
+def authority_block_marker_path(repo_root: Path | str) -> Path:
+    """Return the fixed fail-closed marker in the authority worktree."""
+    return Path(repo_root) / AUTHORITY_BLOCK_MARKER_FILENAME
+
+
+def authority_block_marker_valid(repo_root: Path | str) -> bool:
+    """Accept only the exact regular marker published by trusted WRE."""
+    marker = authority_block_marker_path(repo_root)
+    try:
+        metadata = marker.lstat()
+        return bool(
+            stat.S_ISREG(metadata.st_mode)
+            and marker.read_bytes() == AUTHORITY_BLOCK_MARKER_CONTENT
+        )
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def acquire_authority_update_lease(
+    ssd_path: Path | str,
+) -> MaintenanceLease:
+    """Acquire the outer authority lease without nesting the SSD writer lease."""
+    return acquire_maintenance_lease(authority_update_lock_path(ssd_path))
 
 
 def _is_contention_error(exc: OSError) -> bool:
@@ -207,12 +240,19 @@ def probe_maintenance_lock(path: Path | str) -> MaintenanceLockProbe:
 
 
 __all__ = [
+    "AUTHORITY_UPDATE_LOCK_FILENAME",
+    "AUTHORITY_BLOCK_MARKER_CONTENT",
+    "AUTHORITY_BLOCK_MARKER_FILENAME",
     "MAINTENANCE_LOCK_FILENAME",
     "MaintenanceLease",
     "MaintenanceLeaseBusy",
     "MaintenanceLockError",
     "MaintenanceLockProbe",
+    "acquire_authority_update_lease",
+    "authority_block_marker_path",
+    "authority_block_marker_valid",
     "acquire_maintenance_lease",
+    "authority_update_lock_path",
     "maintenance_lock_path",
     "probe_maintenance_lock",
 ]

--- a/holo_index/query_admission.py
+++ b/holo_index/query_admission.py
@@ -8,6 +8,7 @@ repository-root, SSD, generation, baseline, or maintenance proof.
 from __future__ import annotations
 
 import os
+import re
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,6 +32,8 @@ from modules.infrastructure.foundups_mcp_bridge.src.holo_query_freshness_gate im
 
 RECEIPT_PATH_MISMATCH_CODE = "HOLOINDEX_FRESHNESS_RECEIPT_PATH_MISMATCH"
 RECEIPT_PATH_MISMATCH_REASON = "freshness_receipt_path_not_canonical"
+EXPECTED_HEAD_INVALID_CODE = "HOLOINDEX_EXPECTED_REPO_HEAD_INVALID"
+EXPECTED_HEAD_INVALID_REASON = "expected_repo_head_sha_invalid"
 WINDOWS_REPARSE_POINT = 0x400
 
 
@@ -126,10 +129,12 @@ def _evaluate_gate(
     gate: HoloQueryFreshnessGate,
     root: Path,
     repository_state_reader: Callable[[Path], Any] | None,
+    expected_repo_head_sha: str = "",
 ) -> ReadonlyQueryAdmission:
     error, head_sha = gate.repository_error(
         repository_state_reader or read_repository_state,
         root,
+        expected_repo_head_sha,
     )
     if error:
         return ReadonlyQueryAdmission(
@@ -186,9 +191,59 @@ def evaluate_readonly_query_admission(
     return _evaluate_gate(gate, root, repository_state_reader)
 
 
+def rehydrate_canonical_freshness_proof(
+    *,
+    repo_root: Path | str,
+    ssd_path: Path | str,
+    expected_repo_head_sha: str,
+    repository_state_reader: Callable[[Path], Any] | None = None,
+    receipt_loader: Callable[[Path], Any] | None = None,
+    freshness_evaluator: Callable[..., Any] | None = None,
+    maintenance_probe: Callable[[Path], Any] | None = None,
+) -> ReadonlyQueryAdmission:
+    """Rehydrate one canonical exact-HEAD proof without opening the index owner."""
+    root = Path(repo_root).resolve(strict=False)
+    ssd = Path(ssd_path).resolve(strict=False)
+    expected_sha = str(expected_repo_head_sha or "").strip().lower()
+    if re.fullmatch(r"[0-9a-f]{40}", expected_sha) is None:
+        return ReadonlyQueryAdmission(
+            False,
+            EXPECTED_HEAD_INVALID_CODE,
+            (EXPECTED_HEAD_INVALID_REASON,),
+            "UNKNOWN",
+            {},
+        )
+    canonical_receipt, invalid_receipt = _canonical_receipt_binding(ssd, None)
+    if invalid_receipt:
+        return ReadonlyQueryAdmission(
+            False,
+            RECEIPT_PATH_MISMATCH_CODE,
+            (RECEIPT_PATH_MISMATCH_REASON,),
+            "UNKNOWN",
+            {},
+        )
+    gate = _build_gate(
+        root,
+        ssd,
+        canonical_receipt,
+        receipt_loader,
+        freshness_evaluator,
+        maintenance_probe,
+    )
+    return _evaluate_gate(
+        gate,
+        root,
+        repository_state_reader,
+        expected_sha,
+    )
+
+
 __all__ = [
+    "EXPECTED_HEAD_INVALID_CODE",
+    "EXPECTED_HEAD_INVALID_REASON",
     "RECEIPT_PATH_MISMATCH_CODE",
     "RECEIPT_PATH_MISMATCH_REASON",
     "ReadonlyQueryAdmission",
     "evaluate_readonly_query_admission",
+    "rehydrate_canonical_freshness_proof",
 ]

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -26,8 +26,13 @@ from holo_index.freshness_receipt import (
     write_freshness_receipt,
 )
 from holo_index.maintenance_lock import (
+    AUTHORITY_BLOCK_MARKER_CONTENT,
     MaintenanceLeaseBusy,
+    acquire_authority_update_lease,
     acquire_maintenance_lease,
+    authority_block_marker_path,
+    authority_block_marker_valid,
+    authority_update_lock_path,
     maintenance_lock_path,
     probe_maintenance_lock,
 )
@@ -782,6 +787,29 @@ def test_acquiring_lease_does_not_rewrite_freshness_receipt(tmp_path: Path) -> N
         assert receipt_path.read_bytes() == before
 
     assert receipt_path.read_bytes() == before
+
+
+def test_authority_and_maintenance_leases_are_distinct_and_can_nest(
+    tmp_path: Path,
+) -> None:
+    assert authority_update_lock_path(tmp_path) != maintenance_lock_path(tmp_path)
+
+    with acquire_authority_update_lease(tmp_path):
+        with acquire_maintenance_lease(maintenance_lock_path(tmp_path)):
+            assert authority_update_lock_path(tmp_path).exists()
+            assert maintenance_lock_path(tmp_path).exists()
+        assert probe_maintenance_lock(maintenance_lock_path(tmp_path)).clear
+
+
+def test_authority_block_marker_requires_exact_regular_content(
+    tmp_path: Path,
+) -> None:
+    marker = authority_block_marker_path(tmp_path)
+    assert not authority_block_marker_valid(tmp_path)
+    marker.write_bytes(b"wrong")
+    assert not authority_block_marker_valid(tmp_path)
+    marker.write_bytes(AUTHORITY_BLOCK_MARKER_CONTENT)
+    assert authority_block_marker_valid(tmp_path)
 
 
 def test_maintenance_invalidation_preserves_only_unplanned_proof(

--- a/holo_index/tests/test_holoindex_query_admission.py
+++ b/holo_index/tests/test_holoindex_query_admission.py
@@ -7,8 +7,12 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import holo_index.query_admission as query_admission
+import pytest
 from holo_index.freshness_receipt import freshness_receipt_path
-from holo_index.query_admission import evaluate_readonly_query_admission
+from holo_index.query_admission import (
+    evaluate_readonly_query_admission,
+    rehydrate_canonical_freshness_proof,
+)
 from modules.infrastructure.foundups_mcp_bridge.tests.test_holo_query_service import (
     _receipt,
 )
@@ -206,6 +210,64 @@ def test_exact_clean_generation_is_admitted(tmp_path: Path) -> None:
     assert result.error == ""
     assert result.reasons == ()
     assert result.freshness == "CURRENT"
+
+
+def test_rehydration_rejects_expected_head_mismatch_before_receipt_read(
+    tmp_path: Path,
+) -> None:
+    reads: list[Path] = []
+    result = rehydrate_canonical_freshness_proof(
+        repo_root=tmp_path / "repo",
+        ssd_path=tmp_path / "ssd",
+        expected_repo_head_sha=SHA,
+        repository_state_reader=_clean_repository("b" * 40),
+        receipt_loader=lambda path: reads.append(Path(path)),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is False
+    assert result.error == "REPO_HEAD_MISMATCH"
+    assert reads == []
+
+
+def test_rehydration_rejects_malformed_expected_head_before_any_read(
+    tmp_path: Path,
+) -> None:
+    reads: list[Path] = []
+    result = rehydrate_canonical_freshness_proof(
+        repo_root=tmp_path / "repo",
+        ssd_path=tmp_path / "ssd",
+        expected_repo_head_sha="not-a-sha",
+        repository_state_reader=lambda _path: pytest.fail("must not read repo"),
+        receipt_loader=lambda path: reads.append(Path(path)),
+        maintenance_probe=lambda _path: pytest.fail("must not probe lock"),
+    )
+
+    assert result.allowed is False
+    assert result.error == "HOLOINDEX_EXPECTED_REPO_HEAD_INVALID"
+    assert reads == []
+
+
+def test_rehydration_returns_canonical_generation_binding(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    ssd_path = tmp_path / "ssd"
+    _write_receipt(ssd_path, repo_root=repo_root)
+
+    result = rehydrate_canonical_freshness_proof(
+        repo_root=repo_root,
+        ssd_path=ssd_path,
+        expected_repo_head_sha=SHA,
+        repository_state_reader=_clean_repository(),
+        maintenance_probe=_clear_maintenance,
+    )
+
+    assert result.allowed is True
+    assert result.binding["repo_head_sha"] == SHA
+    assert result.binding["freshness_generation_id"].startswith("sha256:")
+    assert result.binding["freshness_receipt_digest"].startswith("sha256:")
 
 
 def test_explicit_noncanonical_receipt_is_rejected_before_any_read(

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -707,6 +707,20 @@ Current operational rule:
 - when the repair budget is exhausted, the supervisor escalates instead of retrying indefinitely
 - the supervisor advances a DAEmon follow cursor every cycle so repair decisions are tied to observed runtime history
 - IronClaw runtime readiness is validated at startup before resident/runtime bootstrap when IronClaw is the selected backend
+- optional post-merge HoloIndex observation runs on one background worker;
+  OpenClaw claims each exact-SHA task with compare-and-swap semantics and the
+  domain executor owns atomic completion
+- the one-use claim ID and context digest are passed explicitly through
+  `execute_task`; CLI or in-process calls without that capability stop before
+  the authority transaction
+
+Post-merge HoloIndex configuration:
+
+- `HOLOINDEX_POSTMERGE_COORDINATOR_ENABLED=1` enables the observer.
+- `HOLOINDEX_POSTMERGE_COORDINATOR_INTERVAL_SEC` sets its bounded polling
+  interval (minimum 30 seconds).
+- `REDDOG_HOLOINDEX_AUTHORITY_REPO_ROOT` selects the absolute dedicated clean
+  authority worktree.
 
 ### PQN Runtime Control
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,21 @@
 # ModLog - moltbot_bridge
 
+## 2026-07-26: OpenClaw exact-SHA HoloIndex maintenance route
+
+- Added a dedicated low-risk maintenance family for post-merge HoloIndex work.
+- OpenClaw now uses an exact-binding CAS claim; competing supervisors cannot
+  execute the same SHA task.
+- Each claim carries an immutable context digest and one-use execution ID;
+  direct or duplicate invocation is rejected before authority effects.
+- OpenClaw passes that capability explicitly through `run_task`; the executor
+  will not recover it implicitly from AgentDB for an untrusted caller.
+- The domain executor owns atomic finalization, so generic `run_task`
+  completion/failure writes cannot split the receipt transaction.
+- Dispatch exceptions immediately release the exact claim into retryable
+  failure; process crashes are recovered by the coordinator's bounded lease.
+- Moved remote polling to one bounded background worker so the supervisor
+  observation loop never waits on `git fetch`.
+
 ## 2026-07-25: Independent assurance capacity admission
 
 - Inserted a durable assurance-capacity gate between worktree creation and

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -129,8 +129,10 @@ These remain deferred until the FoundUp Memex POC and MVP contracts are proven.
   root/SSD/HEAD/generation/baseline/maintenance admission proof before backend
   construction. P1 store namespaces and legacy metadata migration remain owned
   by the HoloIndex roadmap.
-- Complete post-merge activation at the exact merge SHA before treating the
-  persistent semantic store as CURRENT.
+- Completed Phase 1 exact-SHA post-merge activation: durable AgentDB task,
+  OpenClaw CAS claim, authority/SSD leases, atomic completion, and canonical
+  receipt rehydration. CI/webhook-triggered enqueue remains a future event
+  source; the current resident observer is opt-in and bounded.
 - Bind resident governed work orders to process-private owner handoffs without
   adding an indexing surface to the supported query adapter; OS permissions
   remain a separate deployment control.

--- a/modules/communication/moltbot_bridge/scripts/run_task.py
+++ b/modules/communication/moltbot_bridge/scripts/run_task.py
@@ -22,7 +22,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 sys.path.insert(0, str(REPO_ROOT))
@@ -35,6 +35,7 @@ def execute_task(
     repo_root: Path | None = None,
     *,
     signed_worker_runner: Any | None = None,
+    execution_claim: Mapping[str, str] | None = None,
 ) -> Dict[str, Any]:
     """
     Execute a single autonomous task from AgentDB.
@@ -103,10 +104,17 @@ def execute_task(
     if (
         not result["ok"]
         and result["detail"] == "no_executor_matched"
-        and source == "startup_maintenance_gate"
+        and source
+        in {
+            "startup_maintenance_gate",
+            "holoindex_postmerge_coordinator",
+        }
     ):
         startup_result = _try_startup_maintenance_dispatch(
-            repo_root, task_id, context
+            repo_root,
+            task_id,
+            context,
+            execution_claim=execution_claim,
         )
         if startup_result is not None:
             result = startup_result
@@ -141,7 +149,14 @@ def execute_task(
             result["ok"] = False
             result["detail"] = json.dumps(persist_result, default=str)[:1000]
 
-    if result["ok"]:
+    if result.get("finalization_owned"):
+        logger.info(
+            "[RUN_TASK] Task %s finalization owned by executor=%s (%dms)",
+            task_id,
+            result["executor"],
+            elapsed_ms,
+        )
+    elif result["ok"]:
         db.complete_autonomous_task(task_id)
         logger.info("[RUN_TASK] Task %s completed (executor=%s, %dms)", task_id, result["executor"], elapsed_ms)
         if _emit_start is not None and emit_success:
@@ -488,6 +503,7 @@ def _dispatch_holoindex_maintenance(repo_root: Path) -> Dict[str, Any]:
             "error": result.error,
             "repo_head_sha": result.repo_head_sha,
             "generation_id": result.generation_id,
+            "freshness_receipt_digest": result.freshness_receipt_digest,
             "freshness_reasons": list(result.freshness_reasons),
         }
         return {
@@ -601,7 +617,11 @@ def _run_training_batch() -> Dict[str, Any]:
 
 
 def _try_startup_maintenance_dispatch(
-    repo_root: Path, task_id: str, context: dict
+    repo_root: Path,
+    task_id: str,
+    context: dict,
+    *,
+    execution_claim: Mapping[str, str] | None = None,
 ) -> Dict[str, Any] | None:
     """
     Execute startup maintenance tasks queued by startup_maintenance_gate.
@@ -614,6 +634,24 @@ def _try_startup_maintenance_dispatch(
 
     Returns structured result or None if not a recognized startup task.
     """
+    if (
+        context.get("source") == "holoindex_postmerge_coordinator"
+        and task_id.startswith("holoindex_postmerge_refresh:")
+    ):
+        from modules.infrastructure.idle_automation.src.holoindex_postmerge_executor import (
+            execute_holoindex_postmerge_task,
+        )
+
+        logger.info(
+            "[RUN_TASK] Post-merge dispatch: exact-SHA HoloIndex maintenance"
+        )
+        return execute_holoindex_postmerge_task(
+            repo_root=repo_root,
+            task_id=task_id,
+            context=context,
+            execution_claim=execution_claim,
+        )
+
     if task_id == "startup_refresh_holo_index":
         logger.info("[RUN_TASK] Startup dispatch: HoloIndex maintenance handshake")
         return _dispatch_holoindex_maintenance(repo_root)

--- a/modules/communication/moltbot_bridge/src/openclaw_maintenance_selector.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_maintenance_selector.py
@@ -15,8 +15,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -49,9 +47,16 @@ ALLOWED_TASK_FAMILIES = {
     "startup_maintenance": {
         "description": "Startup maintenance gate tasks",
         "risk": "low",
-        "sources": ["startup_maintenance_gate"],  # Maps to run_task.py dispatch path 4
+        "sources": ["startup_maintenance_gate"],
         "required_skills": [],
         "executor": "startup_maintenance_dispatch",
+    },
+    "holoindex_postmerge": {
+        "description": "Exact-SHA post-merge HoloIndex authority maintenance",
+        "risk": "low",
+        "sources": ["holoindex_postmerge_coordinator"],
+        "required_skills": ["holo-search"],
+        "executor": "holoindex_postmerge_dispatch",
     },
 }
 
@@ -315,6 +320,7 @@ def _get_verification_method(family: str) -> str:
         "self_audit_fix": "check_audit_event_resolved",
         "grant_review": "check_task_completed_in_agentdb",
         "startup_maintenance": "check_task_completed_in_agentdb",
+        "holoindex_postmerge": "check_exact_sha_completion_receipt",
     }
     return verification_methods.get(family, "check_task_completed")
 

--- a/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/src/openclaw_supervisor.py
@@ -28,6 +28,7 @@ import threading
 import time
 import uuid
 from collections import deque
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
@@ -1938,6 +1939,9 @@ class OpenClawSupervisor:
         self._self_audit_loop: Any | None = None
         self._event_cursor = 0
         self._restart_attempts: Deque[float] = deque()
+        self._holoindex_postmerge_last_poll = 0.0
+        self._holoindex_postmerge_executor: ThreadPoolExecutor | None = None
+        self._holoindex_postmerge_future: Future[Any] | None = None
 
         # Unified from Supervisor24x7 (P1 2026-03-22)
         self.metrics = SupervisorMetrics()
@@ -2007,6 +2011,13 @@ class OpenClawSupervisor:
     def stop(self) -> None:
         self._stop_event.set()
         self._stop_self_audit()
+        if self._holoindex_postmerge_executor is not None:
+            self._holoindex_postmerge_executor.shutdown(
+                wait=False,
+                cancel_futures=True,
+            )
+            self._holoindex_postmerge_executor = None
+            self._holoindex_postmerge_future = None
 
     def get_metrics(self) -> Dict[str, Any]:
         """Return telemetry metrics (WSP 91 observability)."""
@@ -2331,6 +2342,67 @@ class OpenClawSupervisor:
     #  OBSERVE — poll broker, observer, git, self-audit                   #
     # ------------------------------------------------------------------ #
 
+    def _observe_holoindex_postmerge(self, obs: Dict[str, Any]) -> None:
+        """Collect or schedule one non-blocking post-merge coordination poll."""
+        future = self._holoindex_postmerge_future
+        if future is not None and future.done():
+            try:
+                obs["holoindex_postmerge"] = future.result().to_dict()
+            except Exception as exc:
+                logger.warning(
+                    "[SUPERVISOR] HoloIndex post-merge coordination failed: %s",
+                    type(exc).__name__,
+                )
+                obs["holoindex_postmerge"] = {
+                    "accepted": False,
+                    "status": "REJECTED",
+                    "rejection_reasons": ["coordinator_exception"],
+                }
+            finally:
+                self._holoindex_postmerge_future = None
+
+        postmerge_enabled = os.getenv(
+            "HOLOINDEX_POSTMERGE_COORDINATOR_ENABLED",
+            os.getenv("OPENCLAW_MAINTENANCE_ENABLED", "0"),
+        ) == "1"
+        if not postmerge_enabled or self._holoindex_postmerge_future is not None:
+            return
+        try:
+            interval = max(
+                float(
+                    os.getenv(
+                        "HOLOINDEX_POSTMERGE_COORDINATOR_INTERVAL_SEC",
+                        "300",
+                    )
+                ),
+                30.0,
+            )
+        except ValueError:
+            interval = 300.0
+        current = time.monotonic()
+        if (
+            self._holoindex_postmerge_last_poll > 0.0
+            and current - self._holoindex_postmerge_last_poll < interval
+        ):
+            return
+
+        from modules.infrastructure.idle_automation.src.holoindex_postmerge_coordinator import (
+            coordinate_holoindex_postmerge,
+        )
+
+        self._holoindex_postmerge_last_poll = current
+        if self._holoindex_postmerge_executor is None:
+            self._holoindex_postmerge_executor = ThreadPoolExecutor(
+                max_workers=1,
+                thread_name_prefix="holoindex-postmerge",
+            )
+        self._holoindex_postmerge_future = (
+            self._holoindex_postmerge_executor.submit(
+                coordinate_holoindex_postmerge,
+                repo_root=self.repo_root,
+            )
+        )
+
     def _observe(self) -> Dict[str, Any]:
         broker = self._get_broker()
         observer = self._get_observer()
@@ -2356,6 +2428,8 @@ class OpenClawSupervisor:
             },
             "self_audit_event_count": 0,
         }
+
+        self._observe_holoindex_postmerge(obs)
 
         # Poll DaemonSelfAuditLoop for real events (ported from Supervisor24x7)
         # NOTE: scan_once() returns int (count of events), not an iterable
@@ -2749,30 +2823,113 @@ class OpenClawSupervisor:
             task_id = task.get("task_id")
             family = task.get("family", "unknown")
             result: Dict[str, Any] = {"ok": False, "error": "unknown"}
+            db = None
+            claimed = False
+            claim_id = ""
+            claim_binding_digest = ""
             try:
                 from modules.infrastructure.database.src.agent_db import AgentDB
 
                 db = AgentDB()
                 if task_id:
-                    db.assign_autonomous_task(task_id, "openclaw_supervisor")
+                    if family == "holoindex_postmerge":
+                        from modules.infrastructure.idle_automation.src.holoindex_postmerge_contract import (
+                            SCHEMA_VERSION as POSTMERGE_SCHEMA_VERSION,
+                            SOURCE as POSTMERGE_SOURCE,
+                        )
 
-                    # Dispatch via run_task.execute_task() (same as autonomous tasks)
-                    from modules.communication.moltbot_bridge.scripts.run_task import (
-                        execute_task,
-                    )
+                        persisted = db.get_autonomous_task_by_id(task_id)
+                        context = (
+                            persisted.get("context")
+                            if isinstance(persisted, dict)
+                            else None
+                        )
+                        if isinstance(context, dict):
+                            claim_id = db.claim_holoindex_postmerge_task(
+                                task_id,
+                                "openclaw_supervisor",
+                                expected_source=POSTMERGE_SOURCE,
+                                expected_schema_version=POSTMERGE_SCHEMA_VERSION,
+                                expected_target_repo_head_sha=str(
+                                    context.get("target_repo_head_sha") or ""
+                                ),
+                                expected_authority_root_digest=str(
+                                    context.get("authority_root_digest") or ""
+                                ),
+                            )
+                            claimed = bool(claim_id)
+                            if claimed:
+                                claimed_task = db.get_autonomous_task_by_id(
+                                    task_id
+                                )
+                                claimed_context = (
+                                    claimed_task.get("context")
+                                    if isinstance(claimed_task, dict)
+                                    else None
+                                )
+                                if isinstance(claimed_context, dict):
+                                    claim_binding_digest = str(
+                                        claimed_context.get(
+                                            "claim_binding_digest"
+                                        )
+                                        or ""
+                                    )
+                    else:
+                        claimed = db.assign_autonomous_task(
+                            task_id,
+                            "openclaw_supervisor",
+                        )
+                    if not claimed:
+                        result = {
+                            "ok": False,
+                            "status": "claim_rejected",
+                            "error": "maintenance_task_claim_rejected",
+                            "family": family,
+                        }
+                    else:
+                        # Dispatch via run_task.execute_task() (same as autonomous tasks)
+                        from modules.communication.moltbot_bridge.scripts.run_task import (
+                            execute_task,
+                        )
 
-                    task_result = execute_task(task_id, repo_root=self.repo_root)
-                    result = {
-                        "ok": task_result.get("ok", False),
-                        "status": "completed" if task_result.get("ok") else "task_failed",
-                        "executor": task_result.get("executor", "unknown"),
-                        "detail": task_result.get("detail", "")[:1000],
-                        "execution_time_ms": task_result.get("execution_time_ms", 0),
-                        "family": family,
-                    }
+                        task_result = execute_task(
+                            task_id,
+                            repo_root=self.repo_root,
+                            execution_claim=(
+                                {
+                                    "claim_id": claim_id,
+                                    "claim_binding_digest": (
+                                        claim_binding_digest
+                                    ),
+                                }
+                                if family == "holoindex_postmerge"
+                                else None
+                            ),
+                        )
+                        result = {
+                            "ok": task_result.get("ok", False),
+                            "status": "completed" if task_result.get("ok") else "task_failed",
+                            "executor": task_result.get("executor", "unknown"),
+                            "detail": task_result.get("detail", "")[:1000],
+                            "execution_time_ms": task_result.get("execution_time_ms", 0),
+                            "family": family,
+                        }
                 else:
                     result = {"ok": False, "error": "no_task_id", "family": family}
             except Exception as exc:
+                if (
+                    db is not None
+                    and claimed
+                    and task_id
+                    and family == "holoindex_postmerge"
+                ):
+                    db.fail_holoindex_postmerge_task(
+                        task_id,
+                        "openclaw_supervisor",
+                        claim_id=claim_id,
+                        claim_binding_digest=claim_binding_digest,
+                        status="failed",
+                    )
                 result = {"ok": False, "status": "execute_error", "error": str(exc)[:500], "family": family}
 
             self._action_reporter(

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_supervisor.py
@@ -1726,6 +1726,80 @@ def test_maintenance_loop_e2e_self_audit_via_agentdb(tmp_path, monkeypatch):
     assert "self_audit" in result["action_result"]["executor"]
 
 
+def test_postmerge_dispatch_exception_releases_claim_to_retry(tmp_path):
+    task_id = "holoindex_postmerge_refresh:" + ("a" * 40)
+    context = {
+        "schema_version": "holoindex_postmerge_coordination_v1",
+        "source": "holoindex_postmerge_coordinator",
+        "target_repo_head_sha": "a" * 40,
+        "authority_root_digest": "sha256:" + ("b" * 64),
+    }
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=MagicMock(),
+        observer=MagicMock(),
+        action_reporter=lambda *_args: None,
+    )
+    plan = {
+        "action": "execute_maintenance_task",
+        "task": {
+            "task_id": task_id,
+            "family": "holoindex_postmerge",
+        },
+    }
+
+    with (
+        patch(
+            "modules.infrastructure.database.src.agent_db.AgentDB"
+        ) as mock_db_class,
+        patch(
+            "modules.communication.moltbot_bridge.scripts.run_task.execute_task",
+            side_effect=RuntimeError("interrupted"),
+        ) as mock_execute,
+    ):
+        mock_db = MagicMock()
+        mock_db_class.return_value = mock_db
+        claimed_context = {
+            **context,
+            "claim_id": "hpmc_test",
+            "claim_binding_digest": "sha256:" + ("c" * 64),
+        }
+        mock_db.get_autonomous_task_by_id.side_effect = [
+            {
+                "task_id": task_id,
+                "status": "pending",
+                "context": context,
+            },
+            {
+                "task_id": task_id,
+                "status": "assigned",
+                "context": claimed_context,
+            },
+        ]
+        mock_db.claim_holoindex_postmerge_task.return_value = "hpmc_test"
+        mock_db.fail_holoindex_postmerge_task.return_value = True
+
+        result = supervisor._execute(plan)
+
+    assert result["ok"] is False
+    assert result["status"] == "execute_error"
+    mock_execute.assert_called_once_with(
+        task_id,
+        repo_root=tmp_path,
+        execution_claim={
+            "claim_id": "hpmc_test",
+            "claim_binding_digest": "sha256:" + ("c" * 64),
+        },
+    )
+    mock_db.fail_holoindex_postmerge_task.assert_called_once_with(
+        task_id,
+        "openclaw_supervisor",
+        claim_id="hpmc_test",
+        claim_binding_digest="sha256:" + ("c" * 64),
+        status="failed",
+    )
+
+
 def test_supervisor_action_reporter_recursively_redacts_nested_secrets(tmp_path):
     reports = []
     supervisor = OpenClawSupervisor(
@@ -1789,3 +1863,63 @@ def test_supervisor_pattern_memory_receives_redacted_context_only(tmp_path):
     assert "second-cookie-secret" not in serialized
     assert "pattern-memory-token" not in serialized
     assert "[REDACTED]" in serialized
+def test_observe_polls_postmerge_coordinator_when_maintenance_enabled(
+    tmp_path,
+    monkeypatch,
+):
+    from modules.infrastructure.idle_automation.src import (
+        holoindex_postmerge_coordinator,
+    )
+
+    broker = MagicMock()
+    broker.get_runtime_status.return_value = {
+        "registered": True,
+        "running": True,
+        "state": "running",
+    }
+    observer = MagicMock()
+    observer.get_live_status.return_value = {"registered": True}
+    observer.follow_events.return_value = {
+        "events": [],
+        "next_cursor": 0,
+        "latest_sequence_id": 0,
+    }
+    monkeypatch.setenv("OPENCLAW_MAINTENANCE_ENABLED", "1")
+    calls = []
+    monkeypatch.setattr(
+        holoindex_postmerge_coordinator,
+        "coordinate_holoindex_postmerge",
+        lambda **kwargs: (
+            calls.append(kwargs)
+            or type(
+                "Result",
+                (),
+                {
+                    "to_dict": lambda self: {
+                        "accepted": True,
+                        "status": "QUEUED",
+                    }
+                },
+            )()
+        ),
+    )
+    supervisor = OpenClawSupervisor(
+        repo_root=tmp_path,
+        broker=broker,
+        observer=observer,
+    )
+    monkeypatch.setattr(
+        supervisor,
+        "_git_summary",
+        lambda: {"branch": "main", "dirty_files": 0},
+    )
+
+    first = supervisor._observe()
+    assert supervisor._holoindex_postmerge_future is not None
+    supervisor._holoindex_postmerge_future.result(timeout=2)
+    second = supervisor._observe()
+
+    assert "holoindex_postmerge" not in first
+    assert second["holoindex_postmerge"]["status"] == "QUEUED"
+    assert calls == [{"repo_root": tmp_path.resolve()}]
+    supervisor.stop()

--- a/modules/communication/moltbot_bridge/tests/test_reddog_holoindex_maintenance_dispatch.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_holoindex_maintenance_dispatch.py
@@ -24,6 +24,7 @@ def _result(*, ready: bool):
         error="" if ready else "HOLOINDEX_MAINTENANCE_REQUIRED",
         repo_head_sha="a" * 40,
         generation_id="sha256:generation" if ready else "",
+        freshness_receipt_digest="sha256:receipt" if ready else "",
         freshness_reasons=() if ready else ("missing_freshness_receipt",),
     )
 
@@ -99,7 +100,7 @@ def test_exact_startup_route_precedes_generic_wre_skill(
     monkeypatch.setattr(
         run_task,
         "_try_startup_maintenance_dispatch",
-        lambda *_args: {
+        lambda *_args, **_kwargs: {
             "ok": True,
             "detail": "verified",
             "executor": "startup:holo_index",
@@ -119,3 +120,64 @@ def test_exact_startup_route_precedes_generic_wre_skill(
     )
     assert result["ok"] is True
     assert result["executor"] == "startup:holo_index"
+
+
+def test_postmerge_task_routes_to_exact_sha_executor(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from modules.infrastructure.idle_automation.src import (
+        holoindex_postmerge_executor,
+    )
+
+    task_id = "holoindex_postmerge_refresh:" + ("a" * 40)
+
+    class FakeDB:
+        def get_autonomous_tasks(self, **_kwargs):
+            return [
+                {
+                    "task_id": task_id,
+                    "description": "exact SHA refresh",
+                    "required_skills": ["holo-search"],
+                    "context": {
+                        "source": "holoindex_postmerge_coordinator",
+                        "target_repo_head_sha": "a" * 40,
+                        "claim_id": "hpmc_test",
+                        "claim_binding_digest": "sha256:" + ("c" * 64),
+                    },
+                }
+            ]
+
+        def complete_autonomous_task(self, _task_id):
+            raise AssertionError("domain executor owns atomic finalization")
+
+    monkeypatch.setattr(agent_db, "AgentDB", FakeDB)
+    monkeypatch.setattr(
+        holoindex_postmerge_executor,
+        "execute_holoindex_postmerge_task",
+        lambda **kwargs: {
+            "ok": kwargs["task_id"] == task_id,
+            "detail": "verified",
+            "executor": "wre:holoindex_postmerge",
+            "finalization_owned": True,
+        },
+    )
+    monkeypatch.setattr(
+        run_task,
+        "_try_wre_dispatch",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("generic WRE must not preempt post-merge maintenance")
+        ),
+    )
+
+    result = execute_task(
+        task_id,
+        repo_root=tmp_path,
+        execution_claim={
+            "claim_id": "hpmc_test",
+            "claim_binding_digest": "sha256:" + ("c" * 64),
+        },
+    )
+
+    assert result["ok"] is True
+    assert result["executor"] == "wre:holoindex_postmerge"

--- a/modules/infrastructure/database/INTERFACE.md
+++ b/modules/infrastructure/database/INTERFACE.md
@@ -87,6 +87,26 @@ task to have completed successfully. Admission rejects any author already
 claimed by another worker, and terminal completion revalidates the immutable
 admission digest.
 
+### Exact-SHA HoloIndex Maintenance Transactions
+
+- `create_autonomous_task_if_absent(...) -> bool`
+- `claim_holoindex_postmerge_task(...) -> bool`
+- `fail_holoindex_postmerge_task(...) -> bool`
+- `reclaim_expired_holoindex_postmerge_task(...) -> bool`
+- `commit_holoindex_postmerge_completion(...) -> bool`
+
+The claim is a `pending -> assigned` compare-and-swap over the exact serialized
+context. It publishes a one-use claim ID, canonical context digest, and
+expiry in the same transaction. The executor must atomically consume that
+claim through `assigned -> executing` before any effect. Completion is one
+database transaction: validate the executing claim and request digest, insert
+the completion event, resolve the request, and mark the task completed.
+Both terminal updates compare the exact serialized task context and request
+payload observed in that transaction.
+Competing claims and partial completion writes fail closed.
+Expired claims are reclaimed only by exact worker and assignment timestamp,
+then re-enter the coordinator's bounded retry path.
+
 ## SQLite Audit API
 File: `modules/infrastructure/database/src/sqlite_audit.py`
 

--- a/modules/infrastructure/database/ModLog.md
+++ b/modules/infrastructure/database/ModLog.md
@@ -1,5 +1,17 @@
 # Database Module - ModLog
 
+## Entry: Exact-SHA HoloIndex Maintenance CAS and Atomic Completion
+**Date**: 2026-07-26
+**What Changed**: Added insert-only task creation, an exact-binding CAS claim,
+bounded retry/requeue transitions, and one transactional HoloIndex
+task/request/completion finalizer, one-use executing claims, and
+exact-timestamp assignment reclaim.
+**Why**: Multiple resident OpenClaw supervisors must not execute or partially
+finalize the same post-merge index refresh.
+**Impact**: One claimant wins; completion receipts cannot exist independently
+of the completed task and resolved request.
+**WSP References**: WSP 00, WSP 15, WSP 22, WSP 78, WSP 97
+
 ## Entry: Independent Assurance Capacity Reservation Primitive
 **Date**: 2026-07-25
 **What Changed**: Added a dedicated AgentDB reservation table and transactional APIs for independent verifier capacity.

--- a/modules/infrastructure/database/src/agent_db.py
+++ b/modules/infrastructure/database/src/agent_db.py
@@ -43,6 +43,39 @@ _ASSURANCE_REQUIRED_FIELDS = (
     "reserved_at",
     "expires_at",
 )
+
+_POSTMERGE_CLAIM_KEYS = frozenset(
+    {
+        "claim_id",
+        "claim_binding_digest",
+        "claim_expires_at",
+    }
+)
+
+
+def _postmerge_claim_binding_digest(
+    *,
+    task_id: str,
+    agent_id: str,
+    context: Mapping[str, Any],
+) -> str:
+    base_context = {
+        str(key): value
+        for key, value in context.items()
+        if key not in _POSTMERGE_CLAIM_KEYS
+    }
+    payload = {
+        "task_id": task_id,
+        "agent_id": agent_id,
+        "context": base_context,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
 _ASSURANCE_REQUEST_SCHEMA_VERSION = "reddog_assurance_capacity_request.v1"
 _ASSURANCE_MAX_LEASE = timedelta(hours=6)
 _ASSURANCE_MAX_RENEWALS = 3
@@ -1111,6 +1144,23 @@ class AgentDB:
 
         return results
 
+    def get_coordination_event_by_id(self, event_id: str) -> Optional[Dict[str, Any]]:
+        """Get one coordination event with parsed JSON fields."""
+        results = self.db.execute_query(
+            "SELECT * FROM agents_coordination_events WHERE event_id = ?",
+            (event_id,),
+        )
+        if not results:
+            return None
+        row = dict(results[0])
+        for field in ["target_agents", "payload"]:
+            if row.get(field) and isinstance(row[field], str):
+                try:
+                    row[field] = json.loads(row[field])
+                except json.JSONDecodeError:
+                    row[field] = None
+        return row
+
     def resolve_coordination_event(self, event_id: str, status: str = "completed") -> bool:
         """Mark coordination event as resolved."""
         return self.db.execute_write('''
@@ -1152,6 +1202,38 @@ class AgentDB:
                 origin_continuity_id
             ))
             return True
+        except Exception:
+            return False
+
+    def create_autonomous_task_if_absent(
+        self,
+        task_id: str,
+        description: str,
+        required_skills: List[str],
+        estimated_complexity: float,
+        priority_score: float,
+        context: Dict[str, Any] = None,
+        origin_continuity_id: str = None,
+    ) -> bool:
+        """Insert a task without replacing concurrent or already-claimed state."""
+        try:
+            return self.db.execute_write(
+                """
+                INSERT OR IGNORE INTO agents_autonomous_tasks
+                (task_id, description, required_skills, estimated_complexity,
+                 priority_score, context, origin_continuity_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task_id,
+                    description,
+                    json.dumps(required_skills),
+                    estimated_complexity,
+                    priority_score,
+                    json.dumps(context) if context else None,
+                    origin_continuity_id,
+                ),
+            ) > 0
         except Exception:
             return False
 
@@ -1202,6 +1284,394 @@ class AgentDB:
             WHERE task_id = ?
         ''', (agent_id, datetime.now().isoformat(), task_id)) > 0
 
+    def claim_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        expected_source: str,
+        expected_schema_version: str,
+        expected_target_repo_head_sha: str,
+        expected_authority_root_digest: str,
+        lease_seconds: int = 7500,
+    ) -> str:
+        """Claim one exact-SHA task and return its immutable claim ID."""
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT status, assigned_to, context
+                    FROM agents_autonomous_tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if row is None:
+                    return ""
+                raw_context = str(row.get("context") or "")
+                context = self._parse_task_context(dict(row))
+                target_sha = str(context.get("target_repo_head_sha") or "")
+                authority_digest = str(
+                    context.get("authority_root_digest") or ""
+                )
+                if (
+                    str(row.get("status") or "") != "pending"
+                    or str(row.get("assigned_to") or "").strip()
+                    or context.get("source") != expected_source
+                    or context.get("schema_version") != expected_schema_version
+                    or target_sha != expected_target_repo_head_sha
+                    or task_id != f"holoindex_postmerge_refresh:{target_sha}"
+                    or len(target_sha) != 40
+                    or any(char not in "0123456789abcdef" for char in target_sha)
+                    or authority_digest != expected_authority_root_digest
+                    or not authority_digest.startswith("sha256:")
+                    or len(authority_digest) != 71
+                    or any(
+                        char not in "0123456789abcdef"
+                        for char in authority_digest[7:]
+                    )
+                    or lease_seconds < 1
+                ):
+                    return ""
+                claim_id = "hpmc_" + uuid.uuid4().hex
+                claim_digest = _postmerge_claim_binding_digest(
+                    task_id=task_id,
+                    agent_id=agent_id,
+                    context=context,
+                )
+                now = datetime.now(timezone.utc)
+                claimed_context = dict(context)
+                claimed_context.update(
+                    {
+                        "claim_id": claim_id,
+                        "claim_binding_digest": claim_digest,
+                        "claim_expires_at": (
+                            now + timedelta(seconds=lease_seconds)
+                        ).isoformat(),
+                    }
+                )
+                claimed = conn.execute(
+                    """
+                    UPDATE agents_autonomous_tasks
+                    SET assigned_to = ?, assigned_at = ?, status = 'assigned',
+                        context = ?
+                    WHERE task_id = ?
+                      AND status = 'pending'
+                      AND (assigned_to IS NULL OR assigned_to = '')
+                      AND context = ?
+                    """,
+                    (
+                        agent_id,
+                        now.isoformat(),
+                        json.dumps(claimed_context),
+                        task_id,
+                        raw_context,
+                    ),
+                ).rowcount
+                return claim_id if claimed == 1 else ""
+        except Exception:
+            return ""
+
+    def start_holoindex_postmerge_execution(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        claim_id: str,
+        claim_binding_digest: str,
+    ) -> bool:
+        """Consume one exact claim before any post-merge authority effect."""
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT status, assigned_to, context
+                    FROM agents_autonomous_tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if row is None:
+                    return False
+                raw_context = str(row.get("context") or "")
+                context = self._parse_task_context(dict(row))
+                recomputed = _postmerge_claim_binding_digest(
+                    task_id=task_id,
+                    agent_id=agent_id,
+                    context=context,
+                )
+                expires_raw = str(context.get("claim_expires_at") or "")
+                try:
+                    expires_at = datetime.fromisoformat(
+                        expires_raw.replace("Z", "+00:00")
+                    )
+                    if expires_at.tzinfo is None:
+                        expires_at = expires_at.replace(tzinfo=timezone.utc)
+                except ValueError:
+                    return False
+                if (
+                    str(row.get("status") or "") != "assigned"
+                    or str(row.get("assigned_to") or "") != agent_id
+                    or context.get("claim_id") != claim_id
+                    or context.get("claim_binding_digest")
+                    != claim_binding_digest
+                    or recomputed != claim_binding_digest
+                    or datetime.now(timezone.utc) >= expires_at
+                ):
+                    return False
+                started = conn.execute(
+                    """
+                    UPDATE agents_autonomous_tasks
+                    SET status = 'executing'
+                    WHERE task_id = ?
+                      AND status = 'assigned'
+                      AND assigned_to = ?
+                      AND context = ?
+                    """,
+                    (task_id, agent_id, raw_context),
+                ).rowcount
+                return started == 1
+        except Exception:
+            return False
+
+    def fail_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        claim_id: str,
+        claim_binding_digest: str,
+        status: str = "failed",
+    ) -> bool:
+        """Finalize a claimed post-merge task into a bounded failure state."""
+        if status not in {"failed", "superseded"}:
+            return False
+        try:
+            with self.db.get_connection() as conn:
+                row = conn.execute(
+                    """
+                    SELECT status, assigned_to, context
+                    FROM agents_autonomous_tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+                if row is None:
+                    return False
+                raw_context = str(row.get("context") or "")
+                context = self._parse_task_context(dict(row))
+                if (
+                    str(row.get("status") or "")
+                    not in {"assigned", "executing"}
+                    or str(row.get("assigned_to") or "") != agent_id
+                    or context.get("claim_id") != claim_id
+                    or context.get("claim_binding_digest")
+                    != claim_binding_digest
+                    or _postmerge_claim_binding_digest(
+                        task_id=task_id,
+                        agent_id=agent_id,
+                        context=context,
+                    )
+                    != claim_binding_digest
+                ):
+                    return False
+                finalized = conn.execute(
+                    """
+                    UPDATE agents_autonomous_tasks
+                    SET status = ?, completed_at = ?
+                    WHERE task_id = ?
+                      AND status IN ('assigned', 'executing')
+                      AND assigned_to = ?
+                      AND context = ?
+                    """,
+                    (
+                        status,
+                        datetime.now(timezone.utc).isoformat(),
+                        task_id,
+                        agent_id,
+                        raw_context,
+                    ),
+                ).rowcount
+                return finalized == 1
+        except Exception:
+            return False
+
+    def reclaim_expired_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        expected_assigned_at: str,
+    ) -> bool:
+        """CAS one expired assignment into retryable failure."""
+        return (
+            self.db.execute_write(
+                """
+            UPDATE agents_autonomous_tasks
+            SET status = 'failed', completed_at = ?
+            WHERE task_id = ?
+              AND status IN ('assigned', 'executing')
+                  AND assigned_to = ?
+                  AND assigned_at = ?
+                """,
+                (
+                    datetime.now(timezone.utc).isoformat(),
+                    task_id,
+                    agent_id,
+                    expected_assigned_at,
+                ),
+            )
+            == 1
+        )
+
+    def commit_holoindex_postmerge_completion(
+        self,
+        *,
+        task_id: str,
+        agent_id: str,
+        request_event_id: str,
+        request_payload_digest: str,
+        completion_event_id: str,
+        completion_payload: Dict[str, Any],
+        claim_id: str,
+        claim_binding_digest: str,
+    ) -> bool:
+        """Atomically publish post-merge proof and finalize its task/request."""
+        try:
+            with self.db.get_connection() as conn:
+                task = conn.execute(
+                    """
+                    SELECT status, assigned_to, context
+                    FROM agents_autonomous_tasks
+                    WHERE task_id = ?
+                    """,
+                    (task_id,),
+                ).fetchone()
+                request = conn.execute(
+                    """
+                    SELECT resolution_status, payload
+                    FROM agents_coordination_events
+                    WHERE event_id = ?
+                    """,
+                    (request_event_id,),
+                ).fetchone()
+                existing = conn.execute(
+                    """
+                    SELECT payload
+                    FROM agents_coordination_events
+                    WHERE event_id = ?
+                    """,
+                    (completion_event_id,),
+                ).fetchone()
+                expected_payload_json = json.dumps(completion_payload)
+                task_context_raw = (
+                    str(task.get("context") or "")
+                    if task is not None
+                    else ""
+                )
+                request_payload_raw = (
+                    str(request.get("payload") or "")
+                    if request is not None
+                    else ""
+                )
+                task_context = (
+                    self._parse_task_context(dict(task))
+                    if task is not None
+                    else {}
+                )
+                claim_valid = bool(
+                    task is not None
+                    and task_context.get("claim_id") == claim_id
+                    and task_context.get("claim_binding_digest")
+                    == claim_binding_digest
+                    and _postmerge_claim_binding_digest(
+                        task_id=task_id,
+                        agent_id=agent_id,
+                        context=task_context,
+                    )
+                    == claim_binding_digest
+                )
+
+                if existing is not None:
+                    try:
+                        existing_payload = json.loads(str(existing.get("payload") or ""))
+                    except (TypeError, ValueError):
+                        return False
+                    return bool(
+                        task is not None
+                        and str(task.get("status") or "") == "completed"
+                        and str(task.get("assigned_to") or "") == agent_id
+                        and claim_valid
+                        and request is not None
+                        and str(request.get("resolution_status") or "") == "completed"
+                        and existing_payload == completion_payload
+                    )
+
+                if (
+                    task is None
+                    or str(task.get("status") or "") != "executing"
+                    or str(task.get("assigned_to") or "") != agent_id
+                    or not claim_valid
+                    or request is None
+                    or str(request.get("resolution_status") or "") != "pending"
+                ):
+                    return False
+                try:
+                    request_payload = json.loads(str(request.get("payload") or ""))
+                except (TypeError, ValueError):
+                    return False
+                if (
+                    not isinstance(request_payload, dict)
+                    or request_payload.get("payload_digest") != request_payload_digest
+                ):
+                    return False
+
+                conn.execute(
+                    """
+                    INSERT INTO agents_coordination_events
+                    (event_id, event_type, initiator_agent, target_agents, payload)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        completion_event_id,
+                        "holoindex_postmerge_maintenance_completed",
+                        agent_id,
+                        json.dumps(["wre"]),
+                        expected_payload_json,
+                    ),
+                )
+                request_count = conn.execute(
+                    """
+                    UPDATE agents_coordination_events
+                    SET resolution_status = 'completed'
+                    WHERE event_id = ?
+                      AND resolution_status = 'pending'
+                      AND payload = ?
+                    """,
+                    (request_event_id, request_payload_raw),
+                ).rowcount
+                task_count = conn.execute(
+                    """
+                    UPDATE agents_autonomous_tasks
+                    SET completed_at = ?, status = 'completed'
+                    WHERE task_id = ?
+                      AND status = 'executing'
+                      AND assigned_to = ?
+                      AND context = ?
+                    """,
+                    (
+                        datetime.now().isoformat(),
+                        task_id,
+                        agent_id,
+                        task_context_raw,
+                    ),
+                ).rowcount
+                if request_count != 1 or task_count != 1:
+                    raise RuntimeError("holoindex_postmerge_completion_conflict")
+                return True
+        except Exception:
+            return False
+
     def complete_autonomous_task(self, task_id: str) -> bool:
         """Mark autonomous task as completed."""
         return self.db.execute_write('''
@@ -1209,6 +1679,47 @@ class AgentDB:
             SET completed_at = ?, status = 'completed'
             WHERE task_id = ?
         ''', (datetime.now().isoformat(), task_id)) > 0
+
+    def schedule_autonomous_task_retry(
+        self,
+        task_id: str,
+        *,
+        context: Dict[str, Any],
+        retry_not_before: str,
+    ) -> bool:
+        """Move a failed task into a durable bounded retry wait state."""
+        return self.db.execute_write(
+            """
+            UPDATE agents_autonomous_tasks
+            SET status = 'retry_wait',
+                context = ?,
+                retry_not_before = ?,
+                assigned_to = NULL,
+                assigned_at = NULL
+            WHERE task_id = ? AND status = 'failed'
+            """,
+            (json.dumps(context), retry_not_before, task_id),
+        ) > 0
+
+    def requeue_autonomous_task(
+        self,
+        task_id: str,
+        *,
+        expected_status: str = "retry_wait",
+    ) -> bool:
+        """Requeue a task only from the caller's exact expected state."""
+        return self.db.execute_write(
+            """
+            UPDATE agents_autonomous_tasks
+            SET status = 'pending',
+                retry_not_before = NULL,
+                assigned_to = NULL,
+                assigned_at = NULL,
+                completed_at = NULL
+            WHERE task_id = ? AND status = ?
+            """,
+            (task_id, expected_status),
+        ) > 0
 
     # ============================================================================
     # INDEPENDENT ASSURANCE CAPACITY RESERVATIONS

--- a/modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py
+++ b/modules/infrastructure/database/tests/test_agent_db_schema_compatibility.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import sqlite3
 import tempfile
+import threading
 from pathlib import Path
 
 from modules.infrastructure.database.src.agent_db import AgentDB
@@ -94,6 +96,278 @@ def test_agent_db_returns_recent_breadcrumb_agents() -> None:
 
         assert "0102" in recent_agents
         assert "0201" in recent_agents
+    finally:
+        DatabaseManager.reset_for_tests()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_agent_db_persists_coordination_events_and_bounded_task_retry() -> None:
+    temp_dir = Path(tempfile.mkdtemp())
+    db_path = temp_dir / "postmerge_foundups.db"
+    try:
+        _reset_database(db_path)
+        agent_db = AgentDB()
+        assert agent_db.create_coordination_event(
+            "event-1",
+            "holoindex_postmerge_maintenance",
+            "wre",
+            ["openclaw_supervisor"],
+            {"target_repo_head_sha": "a" * 40},
+        )
+        event = agent_db.get_coordination_event_by_id("event-1")
+        assert event is not None
+        assert event["target_agents"] == ["openclaw_supervisor"]
+        assert event["payload"]["target_repo_head_sha"] == "a" * 40
+
+        assert agent_db.create_autonomous_task(
+            task_id="task-1",
+            description="maintenance",
+            required_skills=["holo-search"],
+            estimated_complexity=3.0,
+            priority_score=19.0,
+            context={"retry_count": 0},
+        )
+        assert not agent_db.create_autonomous_task_if_absent(
+            task_id="task-1",
+            description="must not replace",
+            required_skills=[],
+            estimated_complexity=0.0,
+            priority_score=0.0,
+            context={"retry_count": 99},
+        )
+        assert agent_db.get_autonomous_task_by_id("task-1")["context"] == {
+            "retry_count": 0
+        }
+        agent_db.db.execute_write(
+            "UPDATE agents_autonomous_tasks SET status = 'failed' WHERE task_id = ?",
+            ("task-1",),
+        )
+        retry_context = {"retry_count": 1, "retry_not_before": "2026-07-26T00:00:00Z"}
+        assert agent_db.schedule_autonomous_task_retry(
+            "task-1",
+            context=retry_context,
+            retry_not_before=retry_context["retry_not_before"],
+        )
+        waiting = agent_db.get_autonomous_task_by_id("task-1")
+        assert waiting is not None
+        assert waiting["status"] == "retry_wait"
+        assert waiting["context"] == retry_context
+        assert agent_db.requeue_autonomous_task(
+            "task-1", expected_status="retry_wait"
+        )
+        assert agent_db.get_autonomous_task_by_id("task-1")["status"] == "pending"
+        assert not agent_db.requeue_autonomous_task(
+            "task-1", expected_status="retry_wait"
+        )
+    finally:
+        DatabaseManager.reset_for_tests()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_holoindex_postmerge_claim_and_completion_are_atomic() -> None:
+    temp_dir = Path(tempfile.mkdtemp())
+    db_path = temp_dir / "postmerge_atomic.db"
+    try:
+        _reset_database(db_path)
+        agent_db = AgentDB()
+        task_id = "holoindex_postmerge_refresh:" + ("a" * 40)
+        request_event_id = "holoindex_postmerge_requested:" + ("a" * 40)
+        completion_event_id = "holoindex_postmerge_completed:" + ("a" * 40)
+        authority_digest = "sha256:" + ("b" * 64)
+        request_payload_digest = "sha256:" + ("c" * 64)
+        request_payload = {"payload_digest": request_payload_digest}
+        context = {
+            "schema_version": "holoindex_postmerge_coordination_v1",
+            "source": "holoindex_postmerge_coordinator",
+            "target_repo_head_sha": "a" * 40,
+            "authority_root_digest": authority_digest,
+        }
+        assert agent_db.create_coordination_event(
+            request_event_id,
+            "holoindex_postmerge_maintenance",
+            "wre",
+            ["openclaw_supervisor"],
+            request_payload,
+        )
+        assert agent_db.create_autonomous_task_if_absent(
+            task_id=task_id,
+            description="exact SHA maintenance",
+            required_skills=["holo-search"],
+            estimated_complexity=3.0,
+            priority_score=19.0,
+            context=context,
+        )
+
+        barrier = threading.Barrier(4)
+        claims: list[bool] = []
+        claims_lock = threading.Lock()
+
+        def claim() -> None:
+            barrier.wait()
+            accepted = agent_db.claim_holoindex_postmerge_task(
+                task_id,
+                "openclaw_supervisor",
+                expected_source=context["source"],
+                expected_schema_version=context["schema_version"],
+                expected_target_repo_head_sha=context["target_repo_head_sha"],
+                expected_authority_root_digest=authority_digest,
+            )
+            with claims_lock:
+                claims.append(bool(accepted))
+
+        threads = [threading.Thread(target=claim) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+        assert claims.count(True) == 1
+        assert claims.count(False) == 3
+        claimed_task = agent_db.get_autonomous_task_by_id(task_id)
+        claim_context = claimed_task["context"]
+        claim_id = str(claim_context["claim_id"])
+        claim_binding_digest = str(
+            claim_context["claim_binding_digest"]
+        )
+        assert agent_db.start_holoindex_postmerge_execution(
+            task_id,
+            "openclaw_supervisor",
+            claim_id=claim_id,
+            claim_binding_digest=claim_binding_digest,
+        )
+        assert not agent_db.start_holoindex_postmerge_execution(
+            task_id,
+            "openclaw_supervisor",
+            claim_id=claim_id,
+            claim_binding_digest=claim_binding_digest,
+        )
+
+        completion_payload = {
+            "schema_version": "holoindex_postmerge_coordination_v1",
+            "payload_digest": "sha256:" + ("d" * 64),
+        }
+        assert not agent_db.commit_holoindex_postmerge_completion(
+            task_id=task_id,
+            agent_id="openclaw_supervisor",
+            request_event_id=request_event_id,
+            request_payload_digest="sha256:" + ("0" * 64),
+            completion_event_id=completion_event_id,
+            completion_payload=completion_payload,
+            claim_id=claim_id,
+            claim_binding_digest=claim_binding_digest,
+        )
+        assert agent_db.get_autonomous_task_by_id(task_id)["status"] == "executing"
+        assert (
+            agent_db.get_coordination_event_by_id(request_event_id)[
+                "resolution_status"
+            ]
+            == "pending"
+        )
+        assert agent_db.get_coordination_event_by_id(completion_event_id) is None
+
+        assert agent_db.commit_holoindex_postmerge_completion(
+            task_id=task_id,
+            agent_id="openclaw_supervisor",
+            request_event_id=request_event_id,
+            request_payload_digest=request_payload_digest,
+            completion_event_id=completion_event_id,
+            completion_payload=completion_payload,
+            claim_id=claim_id,
+            claim_binding_digest=claim_binding_digest,
+        )
+        assert agent_db.commit_holoindex_postmerge_completion(
+            task_id=task_id,
+            agent_id="openclaw_supervisor",
+            request_event_id=request_event_id,
+            request_payload_digest=request_payload_digest,
+            completion_event_id=completion_event_id,
+            completion_payload=completion_payload,
+            claim_id=claim_id,
+            claim_binding_digest=claim_binding_digest,
+        )
+        assert agent_db.get_autonomous_task_by_id(task_id)["status"] == "completed"
+        assert (
+            agent_db.get_coordination_event_by_id(request_event_id)[
+                "resolution_status"
+            ]
+            == "completed"
+        )
+        assert (
+            agent_db.get_coordination_event_by_id(completion_event_id)["payload"]
+            == completion_payload
+        )
+    finally:
+        DatabaseManager.reset_for_tests()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_holoindex_postmerge_assignment_reclaim_is_compare_and_swap() -> None:
+    temp_dir = Path(tempfile.mkdtemp())
+    db_path = temp_dir / "postmerge_reclaim.db"
+    try:
+        _reset_database(db_path)
+        agent_db = AgentDB()
+        task_id = "holoindex_postmerge_refresh:" + ("a" * 40)
+        context = {
+            "schema_version": "holoindex_postmerge_coordination_v1",
+            "source": "holoindex_postmerge_coordinator",
+            "target_repo_head_sha": "a" * 40,
+            "authority_root_digest": "sha256:" + ("b" * 64),
+        }
+        assert agent_db.create_autonomous_task_if_absent(
+            task_id=task_id,
+            description="exact SHA maintenance",
+            required_skills=["holo-search"],
+            estimated_complexity=3.0,
+            priority_score=19.0,
+            context=context,
+        )
+        claim_id = agent_db.claim_holoindex_postmerge_task(
+            task_id,
+            "openclaw_supervisor",
+            expected_source=context["source"],
+            expected_schema_version=context["schema_version"],
+            expected_target_repo_head_sha=context["target_repo_head_sha"],
+            expected_authority_root_digest=context["authority_root_digest"],
+        )
+        assert claim_id
+        assigned = agent_db.get_autonomous_task_by_id(task_id)
+        assigned_at = str(assigned["assigned_at"])
+        claim_context = dict(assigned["context"])
+        tampered_context = dict(claim_context)
+        tampered_context["target_repo_head_sha"] = "b" * 40
+        agent_db.db.execute_write(
+            "UPDATE agents_autonomous_tasks SET context = ? WHERE task_id = ?",
+            (json.dumps(tampered_context), task_id),
+        )
+        assert not agent_db.start_holoindex_postmerge_execution(
+            task_id,
+            "openclaw_supervisor",
+            claim_id=claim_id,
+            claim_binding_digest=str(
+                claim_context["claim_binding_digest"]
+            ),
+        )
+        agent_db.db.execute_write(
+            "UPDATE agents_autonomous_tasks SET context = ? WHERE task_id = ?",
+            (json.dumps(claim_context), task_id),
+        )
+
+        assert not agent_db.reclaim_expired_holoindex_postmerge_task(
+            task_id,
+            "openclaw_supervisor",
+            expected_assigned_at="wrong",
+        )
+        assert agent_db.reclaim_expired_holoindex_postmerge_task(
+            task_id,
+            "openclaw_supervisor",
+            expected_assigned_at=assigned_at,
+        )
+        assert agent_db.get_autonomous_task_by_id(task_id)["status"] == "failed"
+        assert not agent_db.reclaim_expired_holoindex_postmerge_task(
+            task_id,
+            "openclaw_supervisor",
+            expected_assigned_at=assigned_at,
+        )
     finally:
         DatabaseManager.reset_for_tests()
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/modules/infrastructure/foundups_mcp_bridge/INTERFACE.md
+++ b/modules/infrastructure/foundups_mcp_bridge/INTERFACE.md
@@ -210,6 +210,30 @@ TOCTOU risk. A successful refresh can leave a valid CURRENT receipt even if
 subsequent owner startup/health fails; in that case this operational result is
 still false.
 
+### Exact-SHA Authority Worktree Transaction
+
+`advance_reddog_holoindex_authority()` is the trusted WRE effect boundary for
+post-merge refresh. It acquires a separate cross-process authority-update
+lease, fetches and proves the requested `origin/main` SHA, rejects non-forward
+updates, stops the process-owned query service, switches the dedicated clean
+worktree in detached mode, and invokes the existing maintenance handshake.
+Before any Git effect it re-derives the authority-root digest and common Git
+directory under that lease, rejecting any path substitution since queuing.
+The inner `MaintenanceSession` remains responsible for SSD invalidation,
+refresh, final receipt publication, and its own writer lease.
+
+If main advances during refresh, the owner is stopped and the authority
+checkout advances to the newer unindexed HEAD (or the current generation is
+explicitly invalidated). No stale completion is published.
+If both advancement and canonical invalidation fail, a fixed authority
+blocker marker makes repository-state admission fail closed; only the same
+leased transaction may clear it after switching to the exact target.
+
+`rehydrate_canonical_freshness_proof()` is read-only. It starts no owner and
+opens no persistent index; it reuses canonical query admission to prove exact
+HEAD, repo/SSD identity, baseline collections, maintenance-lock state,
+generation, and receipt digest.
+
 For model-backed cross-lane audits, HoloIndex supplies candidate discovery and
 an exact receipt HEAD while the worker directly reads only its allowlisted
 paths. The worker re-proves that clean exact HEAD after the direct reads and a

--- a/modules/infrastructure/foundups_mcp_bridge/ModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # foundups_mcp_bridge - ModLog
 
+## 2026-07-26 - HoloIndex authority update transaction
+
+- Added a distinct cross-process authority-update lease around exact-SHA,
+  non-rewind detached worktree updates.
+- Re-derives the queued authority-root digest and shared Git identity inside
+  that lease before any fetch, switch, owner, or index effect.
+- Reused the existing trusted maintenance handshake and `MaintenanceSession`
+  for SSD mutation and atomic freshness publication.
+- Added fail-closed supersession cleanup so a newly stale owner is stopped and
+  no completion is published for an obsolete SHA.
+- Added a durable authority blocker marker when both newer-HEAD advancement
+  and canonical receipt invalidation fail.
+
 ## 2026-07-26 - HoloIndex exact-binding startup proof consolidation
 
 - OBSERVED: exact-HEAD maintenance succeeded, but automatic owner bootstrap

--- a/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_authority_transaction.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_authority_transaction.py
@@ -1,0 +1,448 @@
+"""Cross-process exact-SHA authority worktree maintenance transaction."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from holo_index.freshness_receipt import BASELINE_QUERY_COLLECTIONS
+from holo_index.maintenance_lock import (
+    AUTHORITY_BLOCK_MARKER_CONTENT,
+    AUTHORITY_BLOCK_MARKER_FILENAME,
+    MaintenanceLeaseBusy,
+    MaintenanceLockError,
+    acquire_authority_update_lease,
+    authority_block_marker_path,
+    authority_block_marker_valid,
+)
+from holo_index.maintenance_session import MaintenanceSession, MaintenanceSessionError
+from holo_index.repository_state import read_repository_state, repository_root_digest
+from holo_index.storage_contract import resolve_holoindex_ssd_path
+
+from .reddog_holoindex_maintenance_handshake import (
+    RedDogHoloIndexOperationalResult,
+    ensure_reddog_holoindex_operational,
+)
+from .reddog_holoindex_owner_bootstrap import cleanup_reddog_holoindex_owner
+
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_PROCESS_LOCK = threading.Lock()
+
+GitRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class RedDogHoloIndexAuthorityTransactionResult:
+    """Secret-free exact-SHA authority transaction result."""
+
+    ready: bool
+    status: str
+    target_repo_head_sha: str = ""
+    observed_origin_main_sha: str = ""
+    generation_id: str = ""
+    freshness_receipt_digest: str = ""
+    refreshed: bool = False
+    error: str = ""
+
+
+def _default_git_runner(
+    argv: Sequence[str], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+        check=False,
+        shell=False,
+    )
+
+
+def _run_git(
+    runner: GitRunner,
+    root: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return runner(("git", *args), root)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def _fetch_origin_main(runner: GitRunner, root: Path) -> tuple[str, str]:
+    fetched = _run_git(runner, root, "fetch", "--quiet", "origin", "main")
+    if fetched is None or fetched.returncode != 0:
+        return "", "origin_main_fetch_failed"
+    resolved = _run_git(runner, root, "rev-parse", "FETCH_HEAD")
+    sha = str(resolved.stdout or "").strip().lower() if resolved else ""
+    if (
+        resolved is None
+        or resolved.returncode != 0
+        or _SHA_RE.fullmatch(sha) is None
+    ):
+        return "", "origin_main_sha_unproven"
+    return sha, ""
+
+
+def _is_ancestor(
+    runner: GitRunner,
+    root: Path,
+    ancestor_sha: str,
+    descendant_sha: str,
+) -> bool:
+    if ancestor_sha == descendant_sha:
+        return True
+    result = _run_git(
+        runner,
+        root,
+        "merge-base",
+        "--is-ancestor",
+        ancestor_sha,
+        descendant_sha,
+    )
+    return result is not None and result.returncode == 0
+
+
+def _common_git_dir(
+    runner: GitRunner,
+    root: Path,
+) -> Path | None:
+    result = _run_git(
+        runner,
+        root,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    value = str(result.stdout or "").strip() if result else ""
+    if result is None or result.returncode != 0 or not value:
+        return None
+    path = Path(value)
+    return (path if path.is_absolute() else root / path).resolve(strict=False)
+
+
+def _authority_binding_valid(
+    *,
+    runner: GitRunner,
+    workspace_root: Path,
+    authority_root: Path,
+    expected_digest: str,
+) -> bool:
+    if (
+        not expected_digest
+        or authority_root == workspace_root
+        or not authority_root.is_dir()
+        or not (authority_root / ".git").exists()
+    ):
+        return False
+    workspace_common = _common_git_dir(runner, workspace_root)
+    authority_common = _common_git_dir(runner, authority_root)
+    if workspace_common is None or authority_common is None:
+        return False
+    return bool(
+        os.path.normcase(str(workspace_common))
+        == os.path.normcase(str(authority_common))
+        and repository_root_digest(authority_root) == expected_digest
+    )
+
+
+def _switch_exact_sha(runner: GitRunner, root: Path, target_sha: str) -> bool:
+    switched = _run_git(
+        runner,
+        root,
+        "switch",
+        "--detach",
+        "--quiet",
+        target_sha,
+    )
+    if switched is None or switched.returncode != 0:
+        return False
+    state = read_repository_state(root)
+    return bool(state.head_sha == target_sha)
+
+
+def _block_marker_path(root: Path) -> Path:
+    return authority_block_marker_path(root)
+
+
+def _valid_block_marker(root: Path) -> bool:
+    return authority_block_marker_valid(root)
+
+
+def _publish_block_marker(root: Path) -> bool:
+    temporary_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=f"{AUTHORITY_BLOCK_MARKER_FILENAME}.",
+            suffix=".tmp",
+            dir=root,
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            handle.write(AUTHORITY_BLOCK_MARKER_CONTENT)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, _block_marker_path(root))
+        return _valid_block_marker(root)
+    except OSError:
+        return False
+    finally:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _clear_block_marker(root: Path) -> bool:
+    marker = _block_marker_path(root)
+    if not marker.exists():
+        return True
+    if not _valid_block_marker(root):
+        return False
+    try:
+        marker.unlink()
+    except OSError:
+        return False
+    return not marker.exists()
+
+
+def _marker_is_only_dirty_path(runner: GitRunner, root: Path) -> bool:
+    status_result = _run_git(
+        runner,
+        root,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    )
+    if status_result is None or status_result.returncode != 0:
+        return False
+    entries = [
+        line.strip()
+        for line in str(status_result.stdout or "").splitlines()
+        if line.strip()
+    ]
+    return entries == [f"?? {AUTHORITY_BLOCK_MARKER_FILENAME}"]
+
+
+def _invalidate_generation(
+    *,
+    repo_root: Path,
+    ssd_path: Path,
+    source: str,
+) -> bool:
+    try:
+        session = MaintenanceSession.begin(
+            ssd_path=ssd_path,
+            repo_root=repo_root,
+            planned_collections=BASELINE_QUERY_COLLECTIONS,
+            source=source,
+        )
+    except (MaintenanceLockError, MaintenanceSessionError, OSError, ValueError):
+        return False
+    session.close()
+    return True
+
+
+def advance_reddog_holoindex_authority(
+    *,
+    workspace_root: Path | str,
+    repo_root: Path | str,
+    target_repo_head_sha: str,
+    expected_authority_root_digest: str,
+    environ: Mapping[str, str] | None = None,
+    git_runner: GitRunner = _default_git_runner,
+    ensure_operational: Callable[..., Any] = ensure_reddog_holoindex_operational,
+    cleanup_owner: Callable[[], None] = cleanup_reddog_holoindex_owner,
+    lease_factory: Callable[[Path | str], Any] = acquire_authority_update_lease,
+) -> RedDogHoloIndexAuthorityTransactionResult:
+    """Advance one clean authority checkout and prove its exact-HEAD index."""
+    workspace = Path(workspace_root).resolve(strict=False)
+    root = Path(repo_root).resolve(strict=False)
+    target_sha = str(target_repo_head_sha or "").strip().lower()
+    if _SHA_RE.fullmatch(target_sha) is None:
+        return RedDogHoloIndexAuthorityTransactionResult(
+            False,
+            "REJECTED",
+            error="target_repo_head_sha_invalid",
+        )
+    env = os.environ if environ is None else environ
+    ssd_path = resolve_holoindex_ssd_path(environ=env)
+
+    try:
+        with _PROCESS_LOCK, lease_factory(ssd_path):
+            if not _authority_binding_valid(
+                runner=git_runner,
+                workspace_root=workspace,
+                authority_root=root,
+                expected_digest=expected_authority_root_digest,
+            ):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    error="authority_root_binding_invalid",
+                )
+            initial_state = read_repository_state(root)
+            recovering_block = _valid_block_marker(root)
+            if not initial_state.proven_clean and not (
+                recovering_block and _marker_is_only_dirty_path(git_runner, root)
+            ):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    error="authority_root_dirty",
+                )
+            observed_sha, fetch_error = _fetch_origin_main(git_runner, root)
+            if fetch_error or observed_sha != target_sha:
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "SUPERSEDED" if observed_sha else "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=observed_sha,
+                    error=fetch_error or "target_superseded",
+                )
+            if not _is_ancestor(
+                git_runner,
+                root,
+                initial_state.head_sha,
+                target_sha,
+            ):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=observed_sha,
+                    error="authority_non_forward_update_rejected",
+                )
+
+            cleanup_owner()
+            if not _switch_exact_sha(git_runner, root, target_sha):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=observed_sha,
+                    error="authority_worktree_update_failed",
+                )
+            if recovering_block and not _clear_block_marker(root):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=observed_sha,
+                    error="authority_block_marker_clear_failed",
+                )
+            switched_state = read_repository_state(root)
+            if (
+                not switched_state.proven_clean
+                or switched_state.head_sha != target_sha
+            ):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=observed_sha,
+                    error="authority_worktree_post_switch_invalid",
+                )
+            operational: RedDogHoloIndexOperationalResult = ensure_operational(
+                repo_root=root,
+                requested=True,
+                auto_maintenance=True,
+                environ=env,
+            )
+            if (
+                not operational.ready
+                or operational.repo_head_sha != target_sha
+                or not operational.generation_id
+                or not operational.freshness_receipt_digest
+            ):
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=observed_sha,
+                    error=operational.error
+                    or "holoindex_operational_proof_invalid",
+                )
+
+            latest_sha, latest_error = _fetch_origin_main(git_runner, root)
+            if latest_error or latest_sha != target_sha:
+                cleanup_owner()
+                safe_invalidation = False
+                if (
+                    not latest_error
+                    and _SHA_RE.fullmatch(latest_sha)
+                    and _is_ancestor(git_runner, root, target_sha, latest_sha)
+                    and _switch_exact_sha(git_runner, root, latest_sha)
+                ):
+                    safe_invalidation = True
+                if not safe_invalidation:
+                    safe_invalidation = _invalidate_generation(
+                        repo_root=root,
+                        ssd_path=ssd_path,
+                        source="postmerge_target_superseded",
+                    )
+                durable_blocked = (
+                    safe_invalidation or _publish_block_marker(root)
+                )
+                return RedDogHoloIndexAuthorityTransactionResult(
+                    False,
+                    "SUPERSEDED" if safe_invalidation else "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    observed_origin_main_sha=latest_sha,
+                    error=(
+                        latest_error
+                        or (
+                            "target_superseded"
+                            if safe_invalidation
+                            else (
+                                "target_superseded_invalidation_failed"
+                                if durable_blocked
+                                else "target_superseded_fail_closed_marker_failed"
+                            )
+                        )
+                    ),
+                )
+
+            return RedDogHoloIndexAuthorityTransactionResult(
+                True,
+                "REFRESHED" if operational.refreshed else "READY",
+                target_repo_head_sha=target_sha,
+                observed_origin_main_sha=latest_sha,
+                generation_id=operational.generation_id,
+                freshness_receipt_digest=operational.freshness_receipt_digest,
+                refreshed=bool(operational.refreshed),
+            )
+    except MaintenanceLeaseBusy:
+        return RedDogHoloIndexAuthorityTransactionResult(
+            False,
+            "BUSY",
+            target_repo_head_sha=target_sha,
+            error="authority_update_lease_busy",
+        )
+    except (MaintenanceLockError, OSError, ValueError):
+        return RedDogHoloIndexAuthorityTransactionResult(
+            False,
+            "REJECTED",
+            target_repo_head_sha=target_sha,
+            error="authority_update_lease_failed",
+        )
+
+
+__all__ = [
+    "RedDogHoloIndexAuthorityTransactionResult",
+    "advance_reddog_holoindex_authority",
+]

--- a/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_maintenance_handshake.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_maintenance_handshake.py
@@ -86,6 +86,7 @@ class RedDogHoloIndexOperationalResult:
     error: str = ""
     repo_head_sha: str = ""
     generation_id: str = ""
+    freshness_receipt_digest: str = ""
     freshness_reasons: tuple[str, ...] = ()
 
 
@@ -198,12 +199,17 @@ def _run_full_refresh(
 def _ready_result(
     *, refreshed: bool, state: RepositoryState, receipt: HoloIndexFreshnessReceipt
 ) -> RedDogHoloIndexOperationalResult:
+    binding = generation_binding_from_receipt(
+        receipt,
+        receipt_path=freshness_receipt_path(receipt.ssd_path),
+    )
     return RedDogHoloIndexOperationalResult(
         ready=True,
         status=OPERATIONAL_REFRESHED if refreshed else OPERATIONAL_READY,
         refreshed=refreshed,
         repo_head_sha=state.head_sha,
         generation_id=receipt.generation_id,
+        freshness_receipt_digest=str(binding["freshness_receipt_digest"]),
     )
 
 

--- a/modules/infrastructure/idle_automation/INTERFACE.md
+++ b/modules/infrastructure/idle_automation/INTERFACE.md
@@ -21,6 +21,31 @@ wsp_cycle(input="interface", log=True)
 
 ## Primary Interface
 
+### Exact-SHA HoloIndex Post-Merge Coordination
+
+`coordinate_holoindex_postmerge()` observes `origin/main` from a configured
+clean authority worktree and creates one insert-only AgentDB task per commit
+SHA. It never indexes during query handling and never creates or repairs the
+authority worktree.
+
+The OpenClaw executor must first claim the task through
+`AgentDB.claim_holoindex_postmerge_task()`. The claim CAS binds the serialized
+task context to a one-use claim ID; the effect adapter must consume it through
+`assigned -> executing` and validate the request event before invoking the
+trusted authority transaction. Successful completion is committed
+atomically with the request resolution and exact generation receipt.
+`CURRENT` is returned only after the canonical read-only admission gate
+rehydrates the same HEAD, generation, and freshness-receipt digest.
+Claims have a 7500-second lease, covering the bounded 7200-second maintenance
+timeout plus margin. A crashed or interrupted worker is reclaimed
+by exact assignment timestamp and enters the existing bounded retry policy.
+
+Runtime configuration:
+
+- `REDDOG_HOLOINDEX_AUTHORITY_REPO_ROOT`: absolute dedicated worktree.
+- `HOLOINDEX_POSTMERGE_COORDINATOR_ENABLED=1`: enable periodic observation.
+- `HOLOINDEX_POSTMERGE_COORDINATOR_INTERVAL_SEC`: minimum 30 seconds.
+
 ### Class: IdleAutomationDAE
 
 ```python

--- a/modules/infrastructure/idle_automation/ModLog.md
+++ b/modules/infrastructure/idle_automation/ModLog.md
@@ -12,6 +12,28 @@ This log tracks changes specific to the **idle_automation** module in the **infr
 
 ## MODLOG ENTRIES
 
+### 2026-07-26 - Exact-SHA HoloIndex Post-Merge WRE Coordinator
+
+**WSP Protocol:** WSP 00, WSP 15, WSP 22, WSP 50, WSP 62, WSP 87, WSP 97
+
+- Added a durable one-task-per-main-SHA coordinator and exact OpenClaw
+  maintenance route without query-time indexing.
+- Added CAS claim, bounded retry, supersession, and atomic task/request/proof
+  completion semantics.
+- Added a bounded assignment lease so process interruption cannot leave a
+  post-merge task permanently assigned.
+- Added a separate authority-update lease around clean non-rewind detached
+  checkout updates while retaining `MaintenanceSession` as the canonical SSD
+  writer and receipt transaction.
+- Allows recovery only when the trusted blocker marker is the sole dirty
+  authority path; all other dirty worktree states remain rejected.
+- Required canonical exact-HEAD admission proof before reporting `CURRENT`;
+  self-hashed AgentDB events alone are never operational authority.
+- Moved network polling off the synchronous supervisor observation path.
+
+**WSP_15 MPS:** Complexity 4 + Importance 5 + Deferability 5 + Impact 5 = 19
+(P0).
+
 ### 2026-07-24 - Daily OpenRouter Catalog Schedule POC
 
 **WSP Protocol:** WSP 00, WSP 15, WSP 22, WSP 62, WSP 97

--- a/modules/infrastructure/idle_automation/README.md
+++ b/modules/infrastructure/idle_automation/README.md
@@ -16,6 +16,11 @@ wsp_cycle(input="012", log=True)
 
 The Idle Automation module provides autonomous background tasks that execute when the system enters idle states. This includes automatic Git commits, social media posting, and system maintenance tasks.
 
+System maintenance includes an opt-in exact-SHA HoloIndex coordinator. It
+observes `origin/main` off the supervisor's synchronous path, queues one
+durable OpenClaw task per SHA, and delegates all indexing to the trusted
+authority-worktree transaction. Query workers remain read-only.
+
 ## WSP Compliance
 
 - **WSP 3**: Infrastructure domain - system automation and maintenance

--- a/modules/infrastructure/idle_automation/ROADMAP.md
+++ b/modules/infrastructure/idle_automation/ROADMAP.md
@@ -29,6 +29,10 @@ wsp_cycle(input="idle_automation", log=True)
 - **Daily OpenRouter Catalog Refresh POC**: Exact daily claim, default-off final
   boundary, trusted external evidence root, replay-protected six-key adapter
   projection, and fail-closed exact-token finalization
+- **Exact-SHA HoloIndex Post-Merge Maintenance**: Non-blocking OpenClaw
+  observation, one durable task per `origin/main` SHA, CAS worker claim,
+  cross-process authority/SSD leases, non-rewind checkout update, atomic
+  completion, and canonical receipt rehydration
 
 ### WSP 62 Near-Term Remediation
 

--- a/modules/infrastructure/idle_automation/src/holoindex_postmerge_contract.py
+++ b/modules/infrastructure/idle_automation/src/holoindex_postmerge_contract.py
@@ -1,0 +1,360 @@
+"""Immutable contract and trusted helpers for post-merge HoloIndex work."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from holo_index.repository_state import (
+    read_repository_state,
+    repository_root_digest,
+)
+from holo_index.maintenance_lock import (
+    AUTHORITY_BLOCK_MARKER_FILENAME,
+    authority_block_marker_valid,
+)
+
+
+SCHEMA_VERSION = "holoindex_postmerge_coordination_v1"
+TASK_PREFIX = "holoindex_postmerge_refresh:"
+REQUEST_EVENT_PREFIX = "holoindex_postmerge_requested:"
+COMPLETION_EVENT_PREFIX = "holoindex_postmerge_completed:"
+SOURCE = "holoindex_postmerge_coordinator"
+CLAIM_AGENT_ID = "openclaw_supervisor"
+AUTHORITY_REPO_ROOT_ENV = "REDDOG_HOLOINDEX_AUTHORITY_REPO_ROOT"
+MAX_RETRIES = 3
+RETRY_DELAY_SECONDS = 300
+ASSIGNMENT_LEASE_SECONDS = 7500
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class AgentDbPort(Protocol):
+    def get_autonomous_task_by_id(self, task_id: str) -> dict[str, Any] | None: ...
+
+    def create_autonomous_task_if_absent(
+        self,
+        task_id: str,
+        description: str,
+        required_skills: list[str],
+        estimated_complexity: float,
+        priority_score: float,
+        context: dict[str, Any] | None = None,
+        origin_continuity_id: str | None = None,
+    ) -> bool: ...
+
+    def create_coordination_event(
+        self,
+        event_id: str,
+        event_type: str,
+        initiator_agent: str,
+        target_agents: list[str],
+        payload: dict[str, Any],
+    ) -> bool: ...
+
+    def get_coordination_event_by_id(self, event_id: str) -> dict[str, Any] | None: ...
+
+    def schedule_autonomous_task_retry(
+        self,
+        task_id: str,
+        *,
+        context: dict[str, Any],
+        retry_not_before: str,
+    ) -> bool: ...
+
+    def requeue_autonomous_task(
+        self,
+        task_id: str,
+        *,
+        expected_status: str,
+    ) -> bool: ...
+
+    def claim_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        expected_source: str,
+        expected_schema_version: str,
+        expected_target_repo_head_sha: str,
+        expected_authority_root_digest: str,
+        lease_seconds: int = 900,
+    ) -> str: ...
+
+    def start_holoindex_postmerge_execution(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        claim_id: str,
+        claim_binding_digest: str,
+    ) -> bool: ...
+
+    def fail_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        claim_id: str,
+        claim_binding_digest: str,
+        status: str = "failed",
+    ) -> bool: ...
+
+    def reclaim_expired_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        expected_assigned_at: str,
+    ) -> bool: ...
+
+    def commit_holoindex_postmerge_completion(
+        self,
+        *,
+        task_id: str,
+        agent_id: str,
+        request_event_id: str,
+        request_payload_digest: str,
+        completion_event_id: str,
+        completion_payload: dict[str, Any],
+        claim_id: str,
+        claim_binding_digest: str,
+    ) -> bool: ...
+
+
+GitRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class HoloIndexPostMergeCoordinationResult:
+    accepted: bool
+    status: str
+    target_repo_head_sha: str = ""
+    task_id: str = ""
+    authority_root_digest: str = ""
+    generation_id: str = ""
+    freshness_receipt_digest: str = ""
+    rejection_reasons: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        value = asdict(self)
+        value["rejection_reasons"] = list(self.rejection_reasons)
+        return value
+
+
+def _canonical_digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("ascii")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _default_git_runner(
+    argv: Sequence[str], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+        check=False,
+        shell=False,
+    )
+
+
+def _git_output(
+    runner: GitRunner,
+    cwd: Path,
+    *args: str,
+) -> tuple[str, str]:
+    try:
+        completed = runner(("git", *args), cwd)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return "", "git_command_failed"
+    output = str(completed.stdout or "").strip()
+    if completed.returncode != 0 or not output:
+        return "", "git_command_failed"
+    return output, ""
+
+
+def _fetch_origin_main(runner: GitRunner, repo_root: Path) -> tuple[str, str]:
+    try:
+        fetched = runner(("git", "fetch", "--quiet", "origin", "main"), repo_root)
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return "", "origin_main_fetch_failed"
+    if fetched.returncode != 0:
+        return "", "origin_main_fetch_failed"
+    head, error = _git_output(runner, repo_root, "rev-parse", "FETCH_HEAD")
+    normalized = head.lower()
+    if error or _SHA_RE.fullmatch(normalized) is None:
+        return "", "origin_main_sha_unproven"
+    return normalized, ""
+
+
+def _authority_root(
+    workspace_root: Path,
+    environment: Mapping[str, str],
+) -> tuple[Path | None, str]:
+    configured = str(environment.get(AUTHORITY_REPO_ROOT_ENV, "") or "").strip()
+    if configured:
+        candidate = Path(configured)
+        if not candidate.is_absolute():
+            return None, "authority_root_not_absolute"
+        return candidate.resolve(strict=False), ""
+    return (
+        workspace_root.parent / f"{workspace_root.name}-holo-authority"
+    ).resolve(strict=False), ""
+
+
+def _common_git_dir(
+    runner: GitRunner,
+    repo_root: Path,
+) -> tuple[Path | None, str]:
+    value, error = _git_output(
+        runner,
+        repo_root,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    )
+    if error:
+        return None, "git_common_dir_unproven"
+    path = Path(value)
+    return (
+        path if path.is_absolute() else repo_root / path
+    ).resolve(strict=False), ""
+
+
+def _validate_authority_root(
+    workspace_root: Path,
+    authority_root: Path,
+    runner: GitRunner,
+) -> tuple[str, tuple[str, ...]]:
+    reasons: list[str] = []
+    if (
+        authority_root == workspace_root
+        or not authority_root.is_dir()
+        or not (authority_root / ".git").exists()
+    ):
+        reasons.append("authority_root_invalid")
+    workspace_common, workspace_error = _common_git_dir(runner, workspace_root)
+    authority_common, authority_error = _common_git_dir(runner, authority_root)
+    if workspace_error or authority_error:
+        reasons.append("authority_git_identity_unproven")
+    elif os.path.normcase(str(workspace_common)) != os.path.normcase(
+        str(authority_common)
+    ):
+        reasons.append("authority_root_unrelated")
+    authority_state = read_repository_state(authority_root)
+    marker_recovery = bool(
+        authority_block_marker_valid(authority_root)
+        and _marker_is_only_dirty_path(runner, authority_root)
+    )
+    if not authority_state.proven_clean and not marker_recovery:
+        reasons.append("authority_root_dirty")
+    digest = repository_root_digest(authority_root) if not reasons else ""
+    return digest, tuple(dict.fromkeys(reasons))
+
+
+def _marker_is_only_dirty_path(
+    runner: GitRunner,
+    authority_root: Path,
+) -> bool:
+    value, error = _git_output(
+        runner,
+        authority_root,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    )
+    if error:
+        return False
+    entries = [line.strip() for line in value.splitlines() if line.strip()]
+    return entries == [f"?? {AUTHORITY_BLOCK_MARKER_FILENAME}"]
+
+
+def _event_payload(
+    *,
+    target_repo_head_sha: str,
+    authority_root_digest: str,
+    status: str,
+    generation_id: str = "",
+    freshness_receipt_digest: str = "",
+) -> dict[str, Any]:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "target_repo_head_sha": target_repo_head_sha,
+        "authority_root_digest": authority_root_digest,
+        "status": status,
+        "generation_id": generation_id,
+        "freshness_receipt_digest": freshness_receipt_digest,
+    }
+    payload["payload_digest"] = _canonical_digest(payload)
+    return payload
+
+
+def _event_payload_valid(
+    event: Mapping[str, Any] | None,
+    *,
+    target_repo_head_sha: str,
+    authority_root_digest: str,
+    expected_status: str,
+) -> bool:
+    if not isinstance(event, Mapping):
+        return False
+    payload = event.get("payload")
+    if not isinstance(payload, Mapping):
+        return False
+    unsigned = dict(payload)
+    claimed = str(unsigned.pop("payload_digest", "") or "")
+    base_valid = bool(
+        claimed
+        and claimed == _canonical_digest(unsigned)
+        and unsigned.get("schema_version") == SCHEMA_VERSION
+        and unsigned.get("target_repo_head_sha") == target_repo_head_sha
+        and unsigned.get("authority_root_digest") == authority_root_digest
+        and unsigned.get("status") == expected_status
+    )
+    if not base_valid:
+        return False
+    if expected_status == "COMPLETED":
+        return all(
+            isinstance(unsigned.get(field), str)
+            and re.fullmatch(r"sha256:[0-9a-f]{64}", unsigned[field]) is not None
+            for field in ("generation_id", "freshness_receipt_digest")
+        )
+    return True
+
+
+def _load_db(db: AgentDbPort | None) -> AgentDbPort:
+    if db is not None:
+        return db
+    from modules.infrastructure.database.src.agent_db import AgentDB
+
+    return AgentDB()
+
+
+__all__ = [
+    "AUTHORITY_REPO_ROOT_ENV",
+    "CLAIM_AGENT_ID",
+    "COMPLETION_EVENT_PREFIX",
+    "HoloIndexPostMergeCoordinationResult",
+    "MAX_RETRIES",
+    "REQUEST_EVENT_PREFIX",
+    "RETRY_DELAY_SECONDS",
+    "SCHEMA_VERSION",
+    "SOURCE",
+    "TASK_PREFIX",
+]

--- a/modules/infrastructure/idle_automation/src/holoindex_postmerge_coordinator.py
+++ b/modules/infrastructure/idle_automation/src/holoindex_postmerge_coordinator.py
@@ -1,0 +1,417 @@
+"""Durable exact-SHA HoloIndex maintenance coordination.
+
+The coordinator is a WRE-owned control-plane adapter. It detects the current
+``origin/main`` SHA, creates one idempotent AgentDB maintenance task for that
+SHA, and lets OpenClaw execute the existing trusted HoloIndex maintenance
+handshake in a dedicated clean authority worktree.
+
+It never indexes during a query and never creates an authority worktree.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .holoindex_postmerge_contract import (
+    ASSIGNMENT_LEASE_SECONDS,
+    AUTHORITY_REPO_ROOT_ENV,
+    CLAIM_AGENT_ID,
+    COMPLETION_EVENT_PREFIX,
+    MAX_RETRIES,
+    REQUEST_EVENT_PREFIX,
+    RETRY_DELAY_SECONDS,
+    SCHEMA_VERSION,
+    SOURCE,
+    TASK_PREFIX,
+    AgentDbPort,
+    GitRunner,
+    HoloIndexPostMergeCoordinationResult,
+    _authority_root,
+    _default_git_runner,
+    _event_payload,
+    _event_payload_valid,
+    _fetch_origin_main,
+    _load_db,
+    _validate_authority_root,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def coordinate_holoindex_postmerge(
+    *,
+    repo_root: Path | str,
+    db: AgentDbPort | None = None,
+    environment: Mapping[str, str] | None = None,
+    git_runner: GitRunner = _default_git_runner,
+    now: Callable[[], datetime] = _utc_now,
+    prove_operational: Callable[..., Any] | None = None,
+) -> HoloIndexPostMergeCoordinationResult:
+    """Queue or reconcile one exact-``origin/main`` maintenance task."""
+
+    workspace = Path(repo_root).resolve(strict=False)
+    env = os.environ if environment is None else environment
+    authority, authority_error = _authority_root(workspace, env)
+    if authority is None:
+        return HoloIndexPostMergeCoordinationResult(
+            False, "REJECTED", rejection_reasons=(authority_error,)
+        )
+    authority_digest, authority_reasons = _validate_authority_root(
+        workspace, authority, git_runner
+    )
+    if authority_reasons:
+        return HoloIndexPostMergeCoordinationResult(
+            False,
+            "REJECTED",
+            rejection_reasons=authority_reasons,
+        )
+    target_sha, target_error = _fetch_origin_main(git_runner, authority)
+    if target_error:
+        return HoloIndexPostMergeCoordinationResult(
+            False,
+            "REJECTED",
+            authority_root_digest=authority_digest,
+            rejection_reasons=(target_error,),
+        )
+
+    database = _load_db(db)
+    task_id = TASK_PREFIX + target_sha
+    request_event_id = REQUEST_EVENT_PREFIX + target_sha
+    completion_event_id = COMPLETION_EVENT_PREFIX + target_sha
+    completion = database.get_coordination_event_by_id(completion_event_id)
+    if completion is not None:
+        if not _event_payload_valid(
+            completion,
+            target_repo_head_sha=target_sha,
+            authority_root_digest=authority_digest,
+            expected_status="COMPLETED",
+        ):
+            return HoloIndexPostMergeCoordinationResult(
+                False,
+                "REJECTED",
+                target_repo_head_sha=target_sha,
+                task_id=task_id,
+                authority_root_digest=authority_digest,
+                rejection_reasons=("completion_event_invalid",),
+            )
+        task = database.get_autonomous_task_by_id(task_id)
+        request = database.get_coordination_event_by_id(request_event_id)
+        if (
+            task is None
+            or str(task.get("status") or "") != "completed"
+            or str(task.get("assigned_to") or "") != CLAIM_AGENT_ID
+            or not _event_payload_valid(
+                request,
+                target_repo_head_sha=target_sha,
+                authority_root_digest=authority_digest,
+                expected_status="REQUESTED",
+            )
+            or str(request.get("resolution_status") or "") != "completed"
+        ):
+            return HoloIndexPostMergeCoordinationResult(
+                False,
+                "REJECTED",
+                target_repo_head_sha=target_sha,
+                task_id=task_id,
+                authority_root_digest=authority_digest,
+                rejection_reasons=("completion_transaction_incomplete",),
+            )
+        payload = completion["payload"]
+        from holo_index.storage_contract import resolve_holoindex_ssd_path
+
+        if prove_operational is None:
+            from holo_index.query_admission import (
+                rehydrate_canonical_freshness_proof,
+            )
+
+            prove_operational = rehydrate_canonical_freshness_proof
+        ssd_path = resolve_holoindex_ssd_path(environ=env)
+        proof = prove_operational(
+            repo_root=authority,
+            ssd_path=ssd_path,
+            expected_repo_head_sha=target_sha,
+        )
+        proof_binding = getattr(proof, "binding", {})
+        binding = proof_binding if isinstance(proof_binding, Mapping) else {}
+        if (
+            getattr(proof, "allowed", False) is not True
+            or binding.get("repo_head_sha") != target_sha
+            or binding.get("freshness_generation_id")
+            != payload.get("generation_id")
+            or binding.get("freshness_receipt_digest")
+            != payload.get("freshness_receipt_digest")
+        ):
+            return HoloIndexPostMergeCoordinationResult(
+                False,
+                "REJECTED",
+                target_repo_head_sha=target_sha,
+                task_id=task_id,
+                authority_root_digest=authority_digest,
+                rejection_reasons=("completion_operational_proof_invalid",),
+            )
+        return HoloIndexPostMergeCoordinationResult(
+            True,
+            "CURRENT",
+            target_repo_head_sha=target_sha,
+            task_id=task_id,
+            authority_root_digest=authority_digest,
+            generation_id=str(payload.get("generation_id") or ""),
+            freshness_receipt_digest=str(
+                payload.get("freshness_receipt_digest") or ""
+            ),
+        )
+
+    request = database.get_coordination_event_by_id(request_event_id)
+    if request is None:
+        request_payload = _event_payload(
+            target_repo_head_sha=target_sha,
+            authority_root_digest=authority_digest,
+            status="REQUESTED",
+        )
+        if not database.create_coordination_event(
+            request_event_id,
+            "holoindex_postmerge_maintenance",
+            "wre",
+            ["openclaw_supervisor"],
+            request_payload,
+        ):
+            request = database.get_coordination_event_by_id(request_event_id)
+            if not _event_payload_valid(
+                request,
+                target_repo_head_sha=target_sha,
+                authority_root_digest=authority_digest,
+                expected_status="REQUESTED",
+            ):
+                return HoloIndexPostMergeCoordinationResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    task_id=task_id,
+                    authority_root_digest=authority_digest,
+                    rejection_reasons=("request_event_conflict",),
+                )
+    elif not _event_payload_valid(
+        request,
+        target_repo_head_sha=target_sha,
+        authority_root_digest=authority_digest,
+        expected_status="REQUESTED",
+    ):
+        return HoloIndexPostMergeCoordinationResult(
+            False,
+            "REJECTED",
+            target_repo_head_sha=target_sha,
+            task_id=task_id,
+            authority_root_digest=authority_digest,
+            rejection_reasons=("request_event_invalid",),
+        )
+
+    task = database.get_autonomous_task_by_id(task_id)
+    if task is None:
+        context = {
+            "schema_version": SCHEMA_VERSION,
+            "source": SOURCE,
+            "target_repo_head_sha": target_sha,
+            "authority_root_digest": authority_digest,
+            "request_event_id": request_event_id,
+            "retry_count": 0,
+        }
+        created = database.create_autonomous_task_if_absent(
+            task_id=task_id,
+            description=f"Refresh canonical HoloIndex for origin/main {target_sha}",
+            required_skills=["holo-search"],
+            estimated_complexity=3.0,
+            priority_score=19.0,
+            context=context,
+        )
+        if not created:
+            task = database.get_autonomous_task_by_id(task_id)
+            if task is None:
+                return HoloIndexPostMergeCoordinationResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    task_id=task_id,
+                    authority_root_digest=authority_digest,
+                    rejection_reasons=("maintenance_task_create_failed",),
+                )
+        status = "QUEUED" if created else str(task.get("status") or "pending").upper()
+    if task is not None:
+        status = str(task.get("status") or "pending")
+        context = task.get("context")
+        if (
+            not isinstance(context, Mapping)
+            or context.get("target_repo_head_sha") != target_sha
+            or context.get("authority_root_digest") != authority_digest
+            or context.get("source") != SOURCE
+        ):
+            return HoloIndexPostMergeCoordinationResult(
+                False,
+                "REJECTED",
+                target_repo_head_sha=target_sha,
+                task_id=task_id,
+                authority_root_digest=authority_digest,
+                rejection_reasons=("maintenance_task_binding_invalid",),
+            )
+        retry_count = int(context.get("retry_count") or 0)
+        if status in {"assigned", "executing"}:
+            assigned_at_raw = str(task.get("assigned_at") or "")
+            try:
+                assigned_at = datetime.fromisoformat(
+                    assigned_at_raw.replace("Z", "+00:00")
+                )
+                if assigned_at.tzinfo is None:
+                    assigned_at = assigned_at.replace(tzinfo=UTC)
+                lease_expired = now() >= assigned_at + timedelta(
+                    seconds=ASSIGNMENT_LEASE_SECONDS
+                )
+            except ValueError:
+                lease_expired = True
+            if lease_expired:
+                reclaimed = database.reclaim_expired_holoindex_postmerge_task(
+                    task_id,
+                    CLAIM_AGENT_ID,
+                    expected_assigned_at=assigned_at_raw,
+                )
+                if reclaimed:
+                    status = "failed"
+                else:
+                    concurrent = database.get_autonomous_task_by_id(task_id)
+                    concurrent_status = str(
+                        (concurrent or {}).get("status") or ""
+                    )
+                    if concurrent_status not in {
+                        "failed",
+                        "pending",
+                        "retry_wait",
+                        "completed",
+                    }:
+                        return HoloIndexPostMergeCoordinationResult(
+                            False,
+                            "REJECTED",
+                            target_repo_head_sha=target_sha,
+                            task_id=task_id,
+                            authority_root_digest=authority_digest,
+                            rejection_reasons=(
+                                "maintenance_assignment_reclaim_failed",
+                            ),
+                        )
+                    status = concurrent_status
+        if status == "failed":
+            if retry_count >= MAX_RETRIES:
+                return HoloIndexPostMergeCoordinationResult(
+                    False,
+                    "RETRY_EXHAUSTED",
+                    target_repo_head_sha=target_sha,
+                    task_id=task_id,
+                    authority_root_digest=authority_digest,
+                    rejection_reasons=("maintenance_retry_exhausted",),
+                )
+            retry_at = now() + timedelta(seconds=RETRY_DELAY_SECONDS)
+            retry_context = dict(context)
+            retry_context["retry_count"] = retry_count + 1
+            retry_context["retry_not_before"] = retry_at.isoformat()
+            if not database.schedule_autonomous_task_retry(
+                task_id,
+                context=retry_context,
+                retry_not_before=retry_at.isoformat(),
+            ):
+                concurrent = database.get_autonomous_task_by_id(task_id)
+                if not concurrent or concurrent.get("status") != "retry_wait":
+                    return HoloIndexPostMergeCoordinationResult(
+                        False,
+                        "REJECTED",
+                        target_repo_head_sha=target_sha,
+                        task_id=task_id,
+                        authority_root_digest=authority_digest,
+                        rejection_reasons=("maintenance_retry_schedule_failed",),
+                    )
+            status = "RETRY_WAIT"
+        elif status == "retry_wait":
+            raw_retry = str(context.get("retry_not_before") or "")
+            try:
+                retry_at = datetime.fromisoformat(raw_retry.replace("Z", "+00:00"))
+                if retry_at.tzinfo is None:
+                    retry_at = retry_at.replace(tzinfo=UTC)
+            except ValueError:
+                return HoloIndexPostMergeCoordinationResult(
+                    False,
+                    "REJECTED",
+                    target_repo_head_sha=target_sha,
+                    task_id=task_id,
+                    authority_root_digest=authority_digest,
+                    rejection_reasons=("retry_schedule_invalid",),
+                )
+            if now() >= retry_at:
+                if not database.requeue_autonomous_task(
+                    task_id,
+                    expected_status="retry_wait",
+                ):
+                    concurrent = database.get_autonomous_task_by_id(task_id)
+                    if not concurrent or concurrent.get("status") != "pending":
+                        return HoloIndexPostMergeCoordinationResult(
+                            False,
+                            "REJECTED",
+                            target_repo_head_sha=target_sha,
+                            task_id=task_id,
+                            authority_root_digest=authority_digest,
+                            rejection_reasons=("maintenance_requeue_failed",),
+                        )
+                status = "REQUEUED"
+            else:
+                status = "RETRY_WAIT"
+        elif status == "completed":
+            status = "WAITING_COMPLETION_RECEIPT"
+        else:
+            status = status.upper()
+
+    return HoloIndexPostMergeCoordinationResult(
+        True,
+        status,
+        target_repo_head_sha=target_sha,
+        task_id=task_id,
+        authority_root_digest=authority_digest,
+    )
+
+
+def execute_holoindex_postmerge_task(
+    *,
+    repo_root: Path | str,
+    task_id: str,
+    context: Mapping[str, Any],
+    execution_claim: Mapping[str, str] | None = None,
+    db: AgentDbPort | None = None,
+    environment: Mapping[str, str] | None = None,
+    authority_transaction: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Compatibility import for the separately owned effect adapter."""
+    from .holoindex_postmerge_executor import (
+        execute_holoindex_postmerge_task as execute,
+    )
+
+    return execute(
+        repo_root=repo_root,
+        task_id=task_id,
+        context=context,
+        execution_claim=execution_claim,
+        db=db,
+        environment=environment,
+        authority_transaction=authority_transaction,
+    )
+
+
+__all__ = [
+    "AUTHORITY_REPO_ROOT_ENV",
+    "COMPLETION_EVENT_PREFIX",
+    "HoloIndexPostMergeCoordinationResult",
+    "REQUEST_EVENT_PREFIX",
+    "SCHEMA_VERSION",
+    "SOURCE",
+    "TASK_PREFIX",
+    "coordinate_holoindex_postmerge",
+    "execute_holoindex_postmerge_task",
+]

--- a/modules/infrastructure/idle_automation/src/holoindex_postmerge_executor.py
+++ b/modules/infrastructure/idle_automation/src/holoindex_postmerge_executor.py
@@ -1,0 +1,351 @@
+"""Trusted execution adapter for exact-SHA post-merge HoloIndex maintenance."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from .holoindex_postmerge_contract import (
+    CLAIM_AGENT_ID,
+    COMPLETION_EVENT_PREFIX,
+    REQUEST_EVENT_PREFIX,
+    SCHEMA_VERSION,
+    SOURCE,
+    TASK_PREFIX,
+    AgentDbPort,
+    _authority_root,
+    _event_payload,
+    _event_payload_valid,
+    _load_db,
+    _SHA_RE,
+)
+
+
+EXECUTOR_ID = "wre:holoindex_postmerge"
+
+
+def _result(
+    *,
+    ok: bool,
+    detail: str,
+    structured_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "ok": ok,
+        "detail": detail[:1000],
+        "executor": EXECUTOR_ID,
+        "structured_result": dict(structured_result),
+        "finalization_owned": True,
+    }
+
+
+def _validate_task_binding(
+    task_id: str,
+    context: Mapping[str, Any],
+) -> tuple[str, str]:
+    target_sha = str(context.get("target_repo_head_sha") or "").lower()
+    valid = (
+        context.get("schema_version") == SCHEMA_VERSION
+        and context.get("source") == SOURCE
+        and _SHA_RE.fullmatch(target_sha) is not None
+        and task_id == TASK_PREFIX + target_sha
+    )
+    return target_sha, "" if valid else "postmerge_task_binding_invalid"
+
+
+def _fail_claimed_task(
+    database: AgentDbPort,
+    *,
+    task_id: str,
+    context: Mapping[str, Any],
+    status: str,
+    reasons: list[str],
+    superseded_by: str = "",
+) -> dict[str, Any]:
+    finalized = database.fail_holoindex_postmerge_task(
+        task_id,
+        CLAIM_AGENT_ID,
+        claim_id=str(context.get("claim_id") or ""),
+        claim_binding_digest=str(
+            context.get("claim_binding_digest") or ""
+        ),
+        status=status,
+    )
+    normalized = reasons or ["postmerge_unknown_failure"]
+    if not finalized:
+        normalized.append("task_failure_finalization_failed")
+    structured = {
+        "ready": False,
+        "status": status.upper(),
+        "rejection_reasons": normalized,
+    }
+    if superseded_by:
+        structured["superseded_by"] = superseded_by
+    return _result(
+        ok=False,
+        detail=",".join(normalized),
+        structured_result=structured,
+    )
+
+
+def _validate_request_event(
+    *,
+    database: AgentDbPort,
+    context: Mapping[str, Any],
+    target_sha: str,
+    authority_digest: str,
+) -> tuple[str, str]:
+    request_event_id = str(context.get("request_event_id") or "")
+    if request_event_id != REQUEST_EVENT_PREFIX + target_sha:
+        return "", "request_event_binding_invalid"
+    request_event = database.get_coordination_event_by_id(request_event_id)
+    if not _event_payload_valid(
+        request_event,
+        target_repo_head_sha=target_sha,
+        authority_root_digest=authority_digest,
+        expected_status="REQUESTED",
+    ):
+        return "", "request_event_invalid"
+    payload = request_event.get("payload")
+    return str(payload.get("payload_digest") or ""), ""
+
+
+def _persist_completion(
+    *,
+    database: AgentDbPort,
+    task_id: str,
+    context: Mapping[str, Any],
+    target_sha: str,
+    authority_digest: str,
+    transaction_result: Any,
+) -> tuple[str, str]:
+    request_digest, request_error = _validate_request_event(
+        database=database,
+        context=context,
+        target_sha=target_sha,
+        authority_digest=authority_digest,
+    )
+    if request_error:
+        return "", request_error
+    completion_payload = _event_payload(
+        target_repo_head_sha=target_sha,
+        authority_root_digest=authority_digest,
+        status="COMPLETED",
+        generation_id=transaction_result.generation_id,
+        freshness_receipt_digest=transaction_result.freshness_receipt_digest,
+    )
+    completion_event_id = COMPLETION_EVENT_PREFIX + target_sha
+    committed = database.commit_holoindex_postmerge_completion(
+        task_id=task_id,
+        agent_id=CLAIM_AGENT_ID,
+        request_event_id=REQUEST_EVENT_PREFIX + target_sha,
+        request_payload_digest=request_digest,
+        completion_event_id=completion_event_id,
+        completion_payload=completion_payload,
+        claim_id=str(context.get("claim_id") or ""),
+        claim_binding_digest=str(
+            context.get("claim_binding_digest") or ""
+        ),
+    )
+    return (
+        (completion_event_id, "")
+        if committed
+        else ("", "completion_transaction_failed")
+    )
+
+
+def execute_holoindex_postmerge_task(
+    *,
+    repo_root: Path | str,
+    task_id: str,
+    context: Mapping[str, Any],
+    execution_claim: Mapping[str, str] | None = None,
+    db: AgentDbPort | None = None,
+    environment: Mapping[str, str] | None = None,
+    authority_transaction: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Execute one already-claimed task through the trusted authority transaction."""
+    database = _load_db(db)
+    workspace = Path(repo_root).resolve(strict=False)
+    env = os.environ if environment is None else environment
+    persisted = database.get_autonomous_task_by_id(task_id)
+    persisted_context = (
+        persisted.get("context") if isinstance(persisted, Mapping) else None
+    )
+    if (
+        not isinstance(persisted_context, Mapping)
+        or dict(persisted_context) != dict(context)
+    ):
+        return _result(
+            ok=False,
+            detail="postmerge_persisted_context_mismatch",
+            structured_result={
+                "ready": False,
+                "status": "REJECTED",
+                "rejection_reasons": [
+                    "postmerge_persisted_context_mismatch"
+                ],
+            },
+        )
+    context = persisted_context
+    claim = execution_claim if isinstance(execution_claim, Mapping) else {}
+    if (
+        str(claim.get("claim_id") or "")
+        != str(context.get("claim_id") or "")
+        or str(claim.get("claim_binding_digest") or "")
+        != str(context.get("claim_binding_digest") or "")
+    ):
+        return _result(
+            ok=False,
+            detail="postmerge_execution_claim_missing_or_mismatched",
+            structured_result={
+                "ready": False,
+                "status": "REJECTED",
+                "rejection_reasons": [
+                    "postmerge_execution_claim_missing_or_mismatched"
+                ],
+            },
+        )
+    target_sha, binding_error = _validate_task_binding(task_id, context)
+    if binding_error:
+        return _fail_claimed_task(
+            database,
+            task_id=task_id,
+            context=context,
+            status="failed",
+            reasons=[binding_error],
+        )
+    authority, authority_error = _authority_root(workspace, env)
+    authority_digest = str(context.get("authority_root_digest") or "")
+    if authority is None:
+        return _fail_claimed_task(
+            database,
+            task_id=task_id,
+            context=context,
+            status="failed",
+            reasons=[authority_error],
+        )
+    if not authority_digest:
+        return _fail_claimed_task(
+            database,
+            task_id=task_id,
+            context=context,
+            status="failed",
+            reasons=["authority_root_digest_missing"],
+        )
+
+    _, request_error = _validate_request_event(
+        database=database,
+        context=context,
+        target_sha=target_sha,
+        authority_digest=authority_digest,
+    )
+    if request_error:
+        return _fail_claimed_task(
+            database,
+            task_id=task_id,
+            context=context,
+            status="failed",
+            reasons=[request_error],
+        )
+    claim_id = str(context.get("claim_id") or "")
+    claim_binding_digest = str(
+        context.get("claim_binding_digest") or ""
+    )
+    if not database.start_holoindex_postmerge_execution(
+        task_id,
+        CLAIM_AGENT_ID,
+        claim_id=claim_id,
+        claim_binding_digest=claim_binding_digest,
+    ):
+        return _result(
+            ok=False,
+            detail="postmerge_execution_claim_rejected",
+            structured_result={
+                "ready": False,
+                "status": "REJECTED",
+                "rejection_reasons": [
+                    "postmerge_execution_claim_rejected"
+                ],
+            },
+        )
+
+    if authority_transaction is None:
+        from modules.infrastructure.foundups_mcp_bridge.src.reddog_holoindex_authority_transaction import (
+            advance_reddog_holoindex_authority,
+        )
+
+        authority_transaction = advance_reddog_holoindex_authority
+    transaction = authority_transaction(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=target_sha,
+        expected_authority_root_digest=authority_digest,
+        environ=env,
+    )
+    if not transaction.ready:
+        status = "superseded" if transaction.status == "SUPERSEDED" else "failed"
+        result = _fail_claimed_task(
+            database,
+            task_id=task_id,
+            context=context,
+            status=status,
+            reasons=[transaction.error or "authority_transaction_failed"],
+            superseded_by=str(transaction.observed_origin_main_sha or ""),
+        )
+        if (
+            transaction.observed_origin_main_sha
+            and transaction.observed_origin_main_sha != target_sha
+        ):
+            from .holoindex_postmerge_coordinator import (
+                coordinate_holoindex_postmerge,
+            )
+
+            follow_up = coordinate_holoindex_postmerge(
+                repo_root=workspace,
+                db=database,
+                environment=env,
+            )
+            result["structured_result"]["follow_up"] = follow_up.to_dict()
+        return result
+
+    completion_event_id, persistence_error = _persist_completion(
+        database=database,
+        task_id=task_id,
+        context=context,
+        target_sha=target_sha,
+        authority_digest=authority_digest,
+        transaction_result=transaction,
+    )
+    if persistence_error:
+        return _fail_claimed_task(
+            database,
+            task_id=task_id,
+            context=context,
+            status="failed",
+            reasons=[persistence_error],
+        )
+
+    structured = {
+        "ready": True,
+        "status": transaction.status,
+        "refreshed": transaction.refreshed,
+        "repo_head_sha": target_sha,
+        "generation_id": transaction.generation_id,
+        "freshness_receipt_digest": transaction.freshness_receipt_digest,
+        "completion_event_id": completion_event_id,
+    }
+    return _result(
+        ok=True,
+        detail=json.dumps(structured, sort_keys=True),
+        structured_result=structured,
+    )
+
+
+__all__ = [
+    "CLAIM_AGENT_ID",
+    "EXECUTOR_ID",
+    "execute_holoindex_postmerge_task",
+]

--- a/modules/infrastructure/idle_automation/tests/test_holoindex_postmerge_coordinator.py
+++ b/modules/infrastructure/idle_automation/tests/test_holoindex_postmerge_coordinator.py
@@ -1,0 +1,1117 @@
+"""Exact-SHA HoloIndex post-merge coordinator regressions."""
+
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Sequence
+
+import pytest
+
+from modules.infrastructure.idle_automation.src import (
+    holoindex_postmerge_coordinator as coordinator,
+)
+from modules.infrastructure.idle_automation.src import (
+    holoindex_postmerge_contract as contract,
+)
+from modules.infrastructure.idle_automation.src import (
+    holoindex_postmerge_executor as executor,
+)
+from modules.infrastructure.foundups_mcp_bridge.src import (
+    reddog_holoindex_authority_transaction as authority_transaction,
+)
+
+
+HEAD = "a" * 40
+NEWER_HEAD = "b" * 40
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.tasks: dict[str, dict[str, Any]] = {}
+        self.events: dict[str, dict[str, Any]] = {}
+
+    def get_autonomous_task_by_id(self, task_id: str):
+        task = self.tasks.get(task_id)
+        return dict(task) if task else None
+
+    def create_autonomous_task(self, **kwargs):
+        task_id = kwargs["task_id"]
+        if task_id in self.tasks:
+            return False
+        self.tasks[task_id] = {
+            **kwargs,
+            "status": "pending",
+        }
+        return True
+
+    def create_autonomous_task_if_absent(self, **kwargs):
+        return self.create_autonomous_task(**kwargs)
+
+    def create_coordination_event(
+        self,
+        event_id: str,
+        event_type: str,
+        initiator_agent: str,
+        target_agents: list[str],
+        payload: dict[str, Any],
+    ):
+        if event_id in self.events:
+            return False
+        self.events[event_id] = {
+            "event_id": event_id,
+            "event_type": event_type,
+            "initiator_agent": initiator_agent,
+            "target_agents": list(target_agents),
+            "payload": dict(payload),
+            "resolution_status": "pending",
+        }
+        return True
+
+    def get_coordination_event_by_id(self, event_id: str):
+        event = self.events.get(event_id)
+        return dict(event) if event else None
+
+    def resolve_coordination_event(self, event_id: str, status: str = "completed"):
+        if event_id not in self.events:
+            return False
+        self.events[event_id]["resolution_status"] = status
+        return True
+
+    def schedule_autonomous_task_retry(
+        self,
+        task_id: str,
+        *,
+        context: dict[str, Any],
+        retry_not_before: str,
+    ):
+        task = self.tasks.get(task_id)
+        if not task or task.get("status") != "failed":
+            return False
+        task["status"] = "retry_wait"
+        task["context"] = dict(context)
+        task["retry_not_before"] = retry_not_before
+        return True
+
+    def requeue_autonomous_task(
+        self, task_id: str, *, expected_status: str
+    ):
+        task = self.tasks.get(task_id)
+        if not task or task.get("status") != expected_status:
+            return False
+        task["status"] = "pending"
+        return True
+
+    def claim_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        expected_source: str,
+        expected_schema_version: str,
+        expected_target_repo_head_sha: str,
+        expected_authority_root_digest: str,
+    ):
+        task = self.tasks.get(task_id)
+        context = task.get("context") if task else None
+        if (
+            not task
+            or task.get("status") != "pending"
+            or task.get("assigned_to")
+            or not isinstance(context, dict)
+            or context.get("source") != expected_source
+            or context.get("schema_version") != expected_schema_version
+            or context.get("target_repo_head_sha")
+            != expected_target_repo_head_sha
+            or context.get("authority_root_digest")
+            != expected_authority_root_digest
+        ):
+            return False
+        task["status"] = "assigned"
+        task["assigned_to"] = agent_id
+        task["assigned_at"] = datetime.now(UTC).isoformat()
+        claimed_context = dict(context)
+        claimed_context.update(
+            {
+                "claim_id": "hpmc_test",
+                "claim_binding_digest": "sha256:" + ("c" * 64),
+                "claim_expires_at": (
+                    datetime.now(UTC)
+                    + timedelta(seconds=coordinator.ASSIGNMENT_LEASE_SECONDS)
+                ).isoformat(),
+            }
+        )
+        task["context"] = claimed_context
+        return "hpmc_test"
+
+    def start_holoindex_postmerge_execution(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        claim_id: str,
+        claim_binding_digest: str,
+    ):
+        task = self.tasks.get(task_id)
+        context = task.get("context") if task else None
+        if (
+            not task
+            or task.get("status") != "assigned"
+            or task.get("assigned_to") != agent_id
+            or not isinstance(context, dict)
+            or context.get("claim_id") != claim_id
+            or context.get("claim_binding_digest") != claim_binding_digest
+        ):
+            return False
+        task["status"] = "executing"
+        return True
+
+    def fail_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        claim_id: str,
+        claim_binding_digest: str,
+        status: str = "failed",
+    ):
+        task = self.tasks.get(task_id)
+        context = task.get("context") if task else None
+        if (
+            not task
+            or task.get("status") not in {"assigned", "executing"}
+            or task.get("assigned_to") != agent_id
+            or not isinstance(context, dict)
+            or context.get("claim_id") != claim_id
+            or context.get("claim_binding_digest") != claim_binding_digest
+        ):
+            return False
+        task["status"] = status
+        return True
+
+    def reclaim_expired_holoindex_postmerge_task(
+        self,
+        task_id: str,
+        agent_id: str,
+        *,
+        expected_assigned_at: str,
+    ):
+        task = self.tasks.get(task_id)
+        if (
+            not task
+            or task.get("status") not in {"assigned", "executing"}
+            or task.get("assigned_to") != agent_id
+            or task.get("assigned_at") != expected_assigned_at
+        ):
+            return False
+        task["status"] = "failed"
+        return True
+
+    def commit_holoindex_postmerge_completion(
+        self,
+        *,
+        task_id: str,
+        agent_id: str,
+        request_event_id: str,
+        request_payload_digest: str,
+        completion_event_id: str,
+        completion_payload: dict[str, Any],
+        claim_id: str,
+        claim_binding_digest: str,
+    ):
+        task = self.tasks.get(task_id)
+        request = self.events.get(request_event_id)
+        context = task.get("context") if task else None
+        if (
+            not task
+            or task.get("status") != "executing"
+            or task.get("assigned_to") != agent_id
+            or not isinstance(context, dict)
+            or context.get("claim_id") != claim_id
+            or context.get("claim_binding_digest") != claim_binding_digest
+            or not request
+            or request.get("resolution_status") != "pending"
+            or request["payload"].get("payload_digest") != request_payload_digest
+            or completion_event_id in self.events
+        ):
+            return False
+        self.events[completion_event_id] = {
+            "event_id": completion_event_id,
+            "event_type": "holoindex_postmerge_maintenance_completed",
+            "initiator_agent": agent_id,
+            "target_agents": ["wre"],
+            "payload": dict(completion_payload),
+            "resolution_status": "pending",
+        }
+        request["resolution_status"] = "completed"
+        task["status"] = "completed"
+        return True
+
+
+class FakeGit:
+    def __init__(self, heads: Sequence[str] = (HEAD,)) -> None:
+        self.heads = list(heads)
+        self.calls: list[tuple[tuple[str, ...], Path]] = []
+        self.switch_target = ""
+
+    def __call__(self, argv: Sequence[str], cwd: Path):
+        normalized = tuple(argv)
+        self.calls.append((normalized, Path(cwd)))
+        if normalized[:3] == ("git", "fetch", "--quiet"):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if normalized == ("git", "rev-parse", "FETCH_HEAD"):
+            value = self.heads.pop(0) if len(self.heads) > 1 else self.heads[0]
+            return SimpleNamespace(returncode=0, stdout=value + "\n", stderr="")
+        if normalized[-2:] == (
+            "--path-format=absolute",
+            "--git-common-dir",
+        ):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=str(Path(cwd).parent / "common.git") + "\n",
+                stderr="",
+            )
+        if normalized[:4] == ("git", "switch", "--detach", "--quiet"):
+            self.switch_target = normalized[4]
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if normalized[:3] == ("git", "merge-base", "--is-ancestor"):
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if normalized[:3] == ("git", "status", "--porcelain=v1"):
+            marker = Path(cwd) / ".holoindex_authority_blocked"
+            output = "?? .holoindex_authority_blocked\n" if marker.exists() else ""
+            return SimpleNamespace(returncode=0, stdout=output, stderr="")
+        raise AssertionError(f"unexpected git command: {normalized}")
+
+
+@pytest.fixture
+def roots(tmp_path: Path):
+    workspace = tmp_path / "Foundups-Agent"
+    authority = tmp_path / "Foundups-Agent-holo-authority"
+    workspace.mkdir()
+    authority.mkdir()
+    (workspace / ".git").write_text("gitdir: common\n", encoding="utf-8")
+    (authority / ".git").write_text("gitdir: common\n", encoding="utf-8")
+    return workspace, authority
+
+
+def _state(head: str = HEAD, *, clean: bool = True):
+    return SimpleNamespace(
+        head_sha=head,
+        proven_clean=clean,
+        error="" if clean else "dirty",
+    )
+
+
+def _patch_state(
+    monkeypatch: pytest.MonkeyPatch,
+    authority: Path,
+    git: FakeGit,
+    *,
+    authority_clean: bool = True,
+) -> None:
+    def read_state(path: Path):
+        if Path(path) == authority:
+            return _state(git.switch_target or HEAD, clean=authority_clean)
+        return _state(HEAD)
+
+    monkeypatch.setattr(contract, "read_repository_state", read_state)
+    monkeypatch.setattr(authority_transaction, "read_repository_state", read_state)
+
+
+def _environment(authority: Path) -> dict[str, str]:
+    return {coordinator.AUTHORITY_REPO_ROOT_ENV: str(authority)}
+
+
+def _claim(db: FakeDB, task_id: str) -> None:
+    context = db.tasks[task_id]["context"]
+    assert db.claim_holoindex_postmerge_task(
+        task_id,
+        executor.CLAIM_AGENT_ID,
+        expected_source=coordinator.SOURCE,
+        expected_schema_version=coordinator.SCHEMA_VERSION,
+        expected_target_repo_head_sha=context["target_repo_head_sha"],
+        expected_authority_root_digest=context["authority_root_digest"],
+    )
+
+
+def _execution_claim(db: FakeDB, task_id: str) -> dict[str, str]:
+    context = db.tasks[task_id]["context"]
+    return {
+        "claim_id": str(context["claim_id"]),
+        "claim_binding_digest": str(context["claim_binding_digest"]),
+    }
+
+
+def _transaction_result(
+    *,
+    ready: bool = True,
+    status: str = "REFRESHED",
+    observed_sha: str = HEAD,
+    error: str = "",
+):
+    return SimpleNamespace(
+        ready=ready,
+        status=status,
+        refreshed=status == "REFRESHED",
+        error=error,
+        target_repo_head_sha=HEAD,
+        repo_head_sha=HEAD,
+        observed_origin_main_sha=observed_sha,
+        generation_id="sha256:" + ("1" * 64) if ready else "",
+        freshness_receipt_digest="sha256:" + ("2" * 64) if ready else "",
+    )
+
+
+def test_exact_sha_task_is_queued_once(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+
+    first = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+    second = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+
+    assert first.accepted and first.status == "QUEUED"
+    assert second.accepted and second.status == "PENDING"
+    assert tuple(db.tasks) == (coordinator.TASK_PREFIX + HEAD,)
+    context = db.tasks[first.task_id]["context"]
+    assert context["target_repo_head_sha"] == HEAD
+    assert context["authority_root_digest"] == first.authority_root_digest
+
+
+def test_tampered_completion_event_fails_closed(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+    db.events[coordinator.COMPLETION_EVENT_PREFIX + HEAD] = {
+        "payload": {
+            "schema_version": coordinator.SCHEMA_VERSION,
+            "target_repo_head_sha": HEAD,
+            "authority_root_digest": queued.authority_root_digest,
+            "status": "COMPLETED",
+            "generation_id": "forged",
+            "freshness_receipt_digest": "forged",
+            "payload_digest": "sha256:" + ("0" * 64),
+        }
+    }
+
+    result = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+
+    assert result.accepted is False
+    assert result.rejection_reasons == ("completion_event_invalid",)
+
+
+def test_failed_task_enters_bounded_retry_then_requeues(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+    start = datetime(2026, 7, 26, tzinfo=UTC)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        now=lambda: start,
+    )
+    db.tasks[queued.task_id]["status"] = "failed"
+
+    waiting = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        now=lambda: start,
+    )
+    assert waiting.status == "RETRY_WAIT"
+    assert db.tasks[queued.task_id]["context"]["retry_count"] == 1
+
+    requeued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        now=lambda: start + timedelta(seconds=coordinator.RETRY_DELAY_SECONDS + 1),
+    )
+    assert requeued.status == "REQUEUED"
+    assert db.tasks[queued.task_id]["status"] == "pending"
+
+
+def test_expired_assignment_is_reclaimed_into_bounded_retry(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+    start = datetime(2026, 7, 26, tzinfo=UTC)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        now=lambda: start,
+    )
+    _claim(db, queued.task_id)
+    db.tasks[queued.task_id]["assigned_at"] = (
+        start
+        - timedelta(seconds=coordinator.ASSIGNMENT_LEASE_SECONDS + 1)
+    ).isoformat()
+
+    result = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        now=lambda: start,
+    )
+
+    assert result.status == "RETRY_WAIT"
+    assert db.tasks[queued.task_id]["status"] == "retry_wait"
+    assert db.tasks[queued.task_id]["context"]["retry_count"] == 1
+
+
+def test_execution_rejects_context_before_any_effect(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    db.tasks[coordinator.TASK_PREFIX + HEAD] = {
+        "status": "assigned",
+        "assigned_to": executor.CLAIM_AGENT_ID,
+        "context": {},
+    }
+    effects: list[str] = []
+
+    result = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=coordinator.TASK_PREFIX + HEAD,
+        context={
+            "schema_version": coordinator.SCHEMA_VERSION,
+            "source": coordinator.SOURCE,
+            "target_repo_head_sha": NEWER_HEAD,
+        },
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=lambda **_kwargs: effects.append("authority"),
+    )
+
+    assert result["ok"] is False
+    assert result["detail"] == "postmerge_persisted_context_mismatch"
+    assert effects == []
+    assert db.tasks[coordinator.TASK_PREFIX + HEAD]["status"] == "assigned"
+
+
+def test_valid_execution_updates_authority_and_persists_proof(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit((HEAD, HEAD))
+    _patch_state(monkeypatch, authority, git)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+    _claim(db, queued.task_id)
+    transaction_calls: list[dict[str, Any]] = []
+
+    def run_transaction(**kwargs):
+        transaction_calls.append(kwargs)
+        return _transaction_result()
+
+    missing_claim = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=run_transaction,
+    )
+    assert missing_claim["ok"] is False
+    assert (
+        missing_claim["detail"]
+        == "postmerge_execution_claim_missing_or_mismatched"
+    )
+    assert transaction_calls == []
+
+    result = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        execution_claim=_execution_claim(db, queued.task_id),
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=run_transaction,
+    )
+
+    assert result["ok"] is True
+    assert result["executor"] == "wre:holoindex_postmerge"
+    assert result["finalization_owned"] is True
+    assert db.tasks[queued.task_id]["status"] == "completed"
+    completion = db.events[coordinator.COMPLETION_EVENT_PREFIX + HEAD]
+    assert completion["payload"]["generation_id"] == "sha256:" + ("1" * 64)
+    assert (
+        completion["payload"]["freshness_receipt_digest"]
+        == "sha256:" + ("2" * 64)
+    )
+    assert (
+        db.events[coordinator.REQUEST_EVENT_PREFIX + HEAD]["resolution_status"]
+        == "completed"
+    )
+    assert transaction_calls == [
+        {
+            "workspace_root": workspace,
+            "repo_root": authority,
+            "target_repo_head_sha": HEAD,
+            "expected_authority_root_digest": queued.authority_root_digest,
+            "environ": _environment(authority),
+        }
+    ]
+    duplicate = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        execution_claim=_execution_claim(db, queued.task_id),
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=run_transaction,
+    )
+    assert duplicate["ok"] is False
+    assert duplicate["detail"] == "postmerge_execution_claim_rejected"
+    assert len(transaction_calls) == 1
+
+
+def test_invalid_request_event_blocks_authority_effect(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+    _claim(db, queued.task_id)
+    db.events[coordinator.REQUEST_EVENT_PREFIX + HEAD]["payload"][
+        "payload_digest"
+    ] = "sha256:" + ("0" * 64)
+    effects: list[str] = []
+
+    result = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        execution_claim=_execution_claim(db, queued.task_id),
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=lambda **_kwargs: effects.append("authority"),
+    )
+
+    assert result["ok"] is False
+    assert "request_event_invalid" in result["detail"]
+    assert effects == []
+
+
+def test_origin_main_advance_after_refresh_blocks_completion(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    setup_git = FakeGit()
+    _patch_state(monkeypatch, authority, setup_git)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=setup_git,
+    )
+    _claim(db, queued.task_id)
+    monkeypatch.setattr(
+        coordinator,
+        "coordinate_holoindex_postmerge",
+        lambda **_kwargs: coordinator.HoloIndexPostMergeCoordinationResult(
+            True,
+            "QUEUED",
+            target_repo_head_sha=NEWER_HEAD,
+        ),
+    )
+
+    result = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        execution_claim=_execution_claim(db, queued.task_id),
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=lambda **_kwargs: _transaction_result(
+            ready=False,
+            status="SUPERSEDED",
+            observed_sha=NEWER_HEAD,
+            error="target_superseded",
+        ),
+    )
+
+    assert result["ok"] is False
+    assert result["detail"] == "target_superseded"
+    assert coordinator.COMPLETION_EVENT_PREFIX + HEAD not in db.events
+    assert db.tasks[queued.task_id]["status"] == "superseded"
+    assert result["structured_result"]["follow_up"]["status"] == "QUEUED"
+
+
+def test_dirty_or_unrelated_authority_never_queues(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git, authority_clean=False)
+
+    result = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+
+    assert result.accepted is False
+    assert "authority_root_dirty" in result.rejection_reasons
+    assert db.tasks == {}
+
+
+def test_completion_requires_canonical_operational_proof(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, authority = roots
+    db = FakeDB()
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+    _claim(db, queued.task_id)
+    completed = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        execution_claim=_execution_claim(db, queued.task_id),
+        db=db,
+        environment=_environment(authority),
+        authority_transaction=lambda **_kwargs: _transaction_result(),
+    )
+    assert completed["ok"] is True
+
+    current = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        prove_operational=lambda **_kwargs: SimpleNamespace(
+            allowed=True,
+            binding={
+                "repo_head_sha": HEAD,
+                "freshness_generation_id": "sha256:" + ("1" * 64),
+                "freshness_receipt_digest": "sha256:" + ("2" * 64),
+            },
+        ),
+    )
+    assert current.accepted is True
+    assert current.status == "CURRENT"
+
+    rejected = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+        prove_operational=lambda **_kwargs: SimpleNamespace(
+            allowed=True,
+            binding={
+                "repo_head_sha": HEAD,
+                "freshness_generation_id": "sha256:" + ("3" * 64),
+                "freshness_receipt_digest": "sha256:" + ("2" * 64),
+            },
+        ),
+    )
+    assert rejected.accepted is False
+    assert rejected.rejection_reasons == (
+        "completion_operational_proof_invalid",
+    )
+
+
+class _Lease:
+    def __init__(self, effects: list[str]) -> None:
+        self.effects = effects
+
+    def __enter__(self):
+        self.effects.append("lease_enter")
+        return self
+
+    def __exit__(self, *_args):
+        self.effects.append("lease_exit")
+
+
+def test_authority_transaction_holds_lease_through_switch_and_refresh(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+    git = FakeGit((HEAD, HEAD))
+    _patch_state(monkeypatch, authority, git)
+    effects: list[str] = []
+
+    result = authority_transaction.advance_reddog_holoindex_authority(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=HEAD,
+        expected_authority_root_digest=(
+            authority_transaction.repository_root_digest(authority)
+        ),
+        environ={"HOLOINDEX_SSD_PATH": str(tmp_path / "ssd")},
+        git_runner=git,
+        cleanup_owner=lambda: effects.append("cleanup"),
+        ensure_operational=lambda **_kwargs: (
+            effects.append("refresh") or SimpleNamespace(
+                ready=True,
+                status="REFRESHED",
+                refreshed=True,
+                error="",
+                repo_head_sha=HEAD,
+                generation_id="sha256:" + ("1" * 64),
+                freshness_receipt_digest="sha256:" + ("2" * 64),
+            )
+        ),
+        lease_factory=lambda _path: _Lease(effects),
+    )
+
+    assert result.ready is True
+    assert effects == ["lease_enter", "cleanup", "refresh", "lease_exit"]
+    assert git.switch_target == HEAD
+
+
+def test_authority_transaction_rejects_non_forward_update(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+
+    def read_state(_path: Path):
+        return _state(NEWER_HEAD)
+
+    monkeypatch.setattr(authority_transaction, "read_repository_state", read_state)
+
+    class NonAncestorGit(FakeGit):
+        def __call__(self, argv: Sequence[str], cwd: Path):
+            if tuple(argv)[:3] == ("git", "merge-base", "--is-ancestor"):
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            return super().__call__(argv, cwd)
+
+    git = NonAncestorGit()
+    result = authority_transaction.advance_reddog_holoindex_authority(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=HEAD,
+        expected_authority_root_digest=(
+            authority_transaction.repository_root_digest(authority)
+        ),
+        environ={"HOLOINDEX_SSD_PATH": str(tmp_path / "ssd")},
+        git_runner=git,
+        ensure_operational=lambda **_kwargs: pytest.fail("must not refresh"),
+        cleanup_owner=lambda: pytest.fail("must not stop owner"),
+        lease_factory=lambda _path: _Lease([]),
+    )
+
+    assert result.ready is False
+    assert result.error == "authority_non_forward_update_rejected"
+
+
+def test_authority_transaction_supersession_stops_owner_and_advances_checkout(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+    git = FakeGit((HEAD, NEWER_HEAD))
+    _patch_state(monkeypatch, authority, git)
+    effects: list[str] = []
+
+    result = authority_transaction.advance_reddog_holoindex_authority(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=HEAD,
+        expected_authority_root_digest=(
+            authority_transaction.repository_root_digest(authority)
+        ),
+        environ={"HOLOINDEX_SSD_PATH": str(tmp_path / "ssd")},
+        git_runner=git,
+        cleanup_owner=lambda: effects.append("cleanup"),
+        ensure_operational=lambda **_kwargs: _transaction_result(),
+        lease_factory=lambda _path: _Lease(effects),
+    )
+
+    assert result.ready is False
+    assert result.status == "SUPERSEDED"
+    assert result.observed_origin_main_sha == NEWER_HEAD
+    assert effects == [
+        "lease_enter",
+        "cleanup",
+        "cleanup",
+        "lease_exit",
+    ]
+    assert git.switch_target == NEWER_HEAD
+
+
+def test_supersession_invalidation_failure_leaves_durable_block_marker(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+
+    class LatestSwitchFails(FakeGit):
+        def __call__(self, argv: Sequence[str], cwd: Path):
+            if (
+                tuple(argv)[:4] == ("git", "switch", "--detach", "--quiet")
+                and tuple(argv)[4] == NEWER_HEAD
+            ):
+                return SimpleNamespace(returncode=1, stdout="", stderr="")
+            return super().__call__(argv, cwd)
+
+    git = LatestSwitchFails((HEAD, NEWER_HEAD))
+    _patch_state(monkeypatch, authority, git)
+    monkeypatch.setattr(
+        authority_transaction,
+        "_invalidate_generation",
+        lambda **_kwargs: False,
+    )
+
+    result = authority_transaction.advance_reddog_holoindex_authority(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=HEAD,
+        expected_authority_root_digest=(
+            authority_transaction.repository_root_digest(authority)
+        ),
+        environ={"HOLOINDEX_SSD_PATH": str(tmp_path / "ssd")},
+        git_runner=git,
+        cleanup_owner=lambda: None,
+        ensure_operational=lambda **_kwargs: _transaction_result(),
+        lease_factory=lambda _path: _Lease([]),
+    )
+
+    marker = authority / ".holoindex_authority_blocked"
+    assert result.ready is False
+    assert result.status == "REJECTED"
+    assert result.error == "target_superseded_invalidation_failed"
+    assert marker.read_text(encoding="ascii") == "holoindex_authority_blocked_v1\n"
+
+
+def test_authority_transaction_recovers_its_own_block_marker(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+    marker = authority / ".holoindex_authority_blocked"
+    marker.write_bytes(b"holoindex_authority_blocked_v1\n")
+    git = FakeGit((HEAD, HEAD))
+
+    def read_state(_path: Path):
+        return _state(
+            git.switch_target or HEAD,
+            clean=not marker.exists(),
+        )
+
+    monkeypatch.setattr(authority_transaction, "read_repository_state", read_state)
+    result = authority_transaction.advance_reddog_holoindex_authority(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=HEAD,
+        expected_authority_root_digest=(
+            authority_transaction.repository_root_digest(authority)
+        ),
+        environ={"HOLOINDEX_SSD_PATH": str(tmp_path / "ssd")},
+        git_runner=git,
+        cleanup_owner=lambda: None,
+        ensure_operational=lambda **_kwargs: SimpleNamespace(
+            ready=True,
+            status="READY",
+            refreshed=False,
+            error="",
+            repo_head_sha=HEAD,
+            generation_id="sha256:" + ("1" * 64),
+            freshness_receipt_digest="sha256:" + ("2" * 64),
+        ),
+        lease_factory=lambda _path: _Lease([]),
+    )
+
+    assert result.ready is True
+    assert not marker.exists()
+
+
+def test_coordinator_queues_and_executes_block_marker_recovery(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+    marker = authority / ".holoindex_authority_blocked"
+    marker.write_bytes(b"holoindex_authority_blocked_v1\n")
+    git = FakeGit((NEWER_HEAD, NEWER_HEAD, NEWER_HEAD))
+
+    def read_state(path: Path):
+        if Path(path) == authority:
+            return _state(
+                git.switch_target or HEAD,
+                clean=not marker.exists(),
+            )
+        return _state(HEAD)
+
+    monkeypatch.setattr(contract, "read_repository_state", read_state)
+    monkeypatch.setattr(authority_transaction, "read_repository_state", read_state)
+    db = FakeDB()
+    queued = coordinator.coordinate_holoindex_postmerge(
+        repo_root=workspace,
+        db=db,
+        environment=_environment(authority),
+        git_runner=git,
+    )
+    assert queued.accepted is True
+    assert queued.target_repo_head_sha == NEWER_HEAD
+    _claim(db, queued.task_id)
+
+    def run_transaction(**kwargs):
+        return authority_transaction.advance_reddog_holoindex_authority(
+            **kwargs,
+            git_runner=git,
+            cleanup_owner=lambda: None,
+            ensure_operational=lambda **_inner: SimpleNamespace(
+                ready=True,
+                status="REFRESHED",
+                refreshed=True,
+                error="",
+                repo_head_sha=NEWER_HEAD,
+                generation_id="sha256:" + ("1" * 64),
+                freshness_receipt_digest="sha256:" + ("2" * 64),
+            ),
+            lease_factory=lambda _path: _Lease([]),
+        )
+
+    executed = coordinator.execute_holoindex_postmerge_task(
+        repo_root=workspace,
+        task_id=queued.task_id,
+        context=db.tasks[queued.task_id]["context"],
+        execution_claim=_execution_claim(db, queued.task_id),
+        db=db,
+        environment={
+            **_environment(authority),
+            "HOLOINDEX_SSD_PATH": str(tmp_path / "ssd"),
+        },
+        authority_transaction=run_transaction,
+    )
+
+    assert executed["ok"] is True
+    assert db.tasks[queued.task_id]["status"] == "completed"
+    assert not marker.exists()
+
+
+def test_authority_transaction_rejects_substituted_authority_binding(
+    roots,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace, authority = roots
+    git = FakeGit()
+    _patch_state(monkeypatch, authority, git)
+
+    result = authority_transaction.advance_reddog_holoindex_authority(
+        workspace_root=workspace,
+        repo_root=authority,
+        target_repo_head_sha=HEAD,
+        expected_authority_root_digest="sha256:" + ("0" * 64),
+        environ={"HOLOINDEX_SSD_PATH": str(tmp_path / "ssd")},
+        git_runner=git,
+        ensure_operational=lambda **_kwargs: pytest.fail("must not refresh"),
+        cleanup_owner=lambda: pytest.fail("must not stop owner"),
+        lease_factory=lambda _path: _Lease([]),
+    )
+
+    assert result.ready is False
+    assert result.error == "authority_root_binding_invalid"
+    assert not any(call[:3] == ("git", "fetch", "--quiet") for call, _ in git.calls)
+
+
+def test_postmerge_runtime_has_no_shell_or_destructive_git_path() -> None:
+    source_paths = (
+        Path(contract.__file__),
+        Path(coordinator.__file__),
+        Path(executor.__file__),
+        Path(authority_transaction.__file__),
+    )
+    combined = "\n".join(
+        path.read_text(encoding="utf-8") for path in source_paths
+    )
+    assert "reset --hard" not in combined
+    assert '"pull"' not in combined
+    assert '"checkout"' not in combined
+    for path in source_paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                assert not (
+                    isinstance(node.func, ast.Name)
+                    and node.func.id in {"eval", "exec"}
+                )
+                for keyword in node.keywords:
+                    if keyword.arg == "shell":
+                        assert isinstance(keyword.value, ast.Constant)
+                        assert keyword.value.value is False

--- a/modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py
+++ b/modules/infrastructure/idle_automation/tests/test_startup_maintenance_gate.py
@@ -336,6 +336,7 @@ class TestStartupTaskExecution:
                 error="",
                 repo_head_sha="a" * 40,
                 generation_id=f"sha256:{'b' * 64}",
+                freshness_receipt_digest=f"sha256:{'c' * 64}",
                 freshness_reasons=(),
             ),
         ) as mock_ensure:
@@ -360,6 +361,7 @@ class TestStartupTaskExecution:
             "error": "",
             "repo_head_sha": "a" * 40,
             "generation_id": f"sha256:{'b' * 64}",
+            "freshness_receipt_digest": f"sha256:{'c' * 64}",
             "freshness_reasons": [],
         }
         assert result["structured_result"] == expected_receipt


### PR DESCRIPTION
## Summary
- queue one durable AgentDB maintenance task per origin/main SHA
- require one-use OpenClaw claim capability and atomic task/request/proof completion
- advance a dedicated authority worktree under a cross-process lease and canonical freshness proof
- recover crashes, supersession, and failed invalidation without query-time reindexing

## Verification
- 193 impacted tests passed
- Ruff passed on all changed Python files
- py_compile passed
- git diff --check clean
- two independent WSP_97 reviews: GO, no blocker/major findings

## Truth boundary
- no query-time HoloIndex mutation
- no reset --hard, pull, checkout, shell=True, eval, or exec
- post-merge maintenance remains WRE/OpenClaw owned