### PR TITLE
fix(reddog): preserve main menu when resident bindings are absent

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,7 +1,7 @@
 # ModLog - moltbot_bridge
-
+## 2026-07-27: REDDOG_MAIN_MENU_BINDING_PREFLIGHT_BOUNDARY_FIX
+- Missing or invalid model bindings now stop the resident cycle but block interactive startup only under explicit enforced mode; WARN/FAIL and menu-continuity regressions cover the boundary (WSP 00, 5, 15, 22, 50, 64, 97).
 ## 2026-07-26: OpenClaw exact-SHA HoloIndex maintenance route
-
 - Added a dedicated low-risk maintenance family for post-merge HoloIndex work.
 - OpenClaw now uses an exact-binding CAS claim; competing supervisors cannot
   execute the same SHA task.

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -170,6 +170,10 @@ rejects a missing, malformed, rejected, wrong-surface, or pair-mismatched
 receipt before index/provider access or persistence. Selection receipts alone
 do not authorize either call.
 
+At interactive startup, a missing or invalid binding disables the resident
+cycle without blocking the main menu unless
+`REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED=1`.
+
 Model identities and panel topology come only from the exact validated runtime
 receipt. Same-surface substitution is rejected against task, assignment, WSP
 15, and durable-intent bindings. The runners have no model fallback list.

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_architect_cycle_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_architect_cycle_bootstrap.py
@@ -160,15 +160,17 @@ def run_main_resident_architect_cycle_preflight(
     if not hooks.cycle_requested():
         logger.info("[REDDOG-RESIDENT-CYCLE] Startup preflight disabled")
         return True
+    enforced = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0") != "0"
     audit_binding, architect_binding, binding_reason = hooks.model_runtime_bindings(repo_root)
     if binding_reason:
-        logger.error(
+        log_binding_failure = logger.error if enforced else logger.warning
+        log_binding_failure(
             "[REDDOG-RESIDENT-CYCLE] Runtime model binding preflight failed: %s",
             binding_reason,
         )
-        print(f"[REDDOG-RESIDENT-CYCLE] preflight=FAIL reason={binding_reason}")
-        return False
-    enforced = os.getenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0") != "0"
+        status = "FAIL" if enforced else "WARN"
+        print(f"[REDDOG-RESIDENT-CYCLE] preflight={status} reason={binding_reason}")
+        return not enforced
     scope, scope_reason = _authorized_scope_from_env()
     if scope_reason:
         return _configuration_failure(scope_reason, enforced=enforced, logger=logger)

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,5 +1,6 @@
+## 2026-07-27: Main-menu resident binding preflight regression
+- Proved missing bindings skip the client and return WARN/True by default versus FAIL/False when enforced; the focused startup suite passed 92 tests with one platform skip.
 ## 2026-07-26: Independent assurance capacity admission
-
 - Proved the bootstrap persists assurance admission and yields before bounded
   author or verifier execution.
 - Proved queue-stage workers cannot claim or materialize the bounded coding
@@ -13,7 +14,6 @@
   passing tests and three platform skips before final static validation.
 
 ## 2026-07-25: Daemon self-audit runtime nudge alignment
-
 - Proved current external escalation records produce memory events.
 - Proved the obsolete in-repository JSONL is ignored and an in-repository
   runtime-root injection fails closed.

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -1081,6 +1081,7 @@ def test_main_resident_runtime_artifact_preflight_rejects_before_cycle(
         "REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT": str(runtime_root),
         "REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(audit_path),
         "REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(architect_path),
+        "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "1",
     }
     if case == "absent":
         env.pop("REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH")
@@ -1110,7 +1111,6 @@ def test_main_resident_runtime_artifact_preflight_rejects_before_cycle(
         env["REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH"] = str(
             REPO_ROOT / "main.py"
         )
-
     monkeypatch.setattr(
         main,
         "_reddog_resident_model_runtime_bindings_from_env",
@@ -1158,6 +1158,7 @@ def test_main_resident_runtime_artifact_preflight_rejects_symlink_before_cycle(
         "REDDOG_RESIDENT_MODEL_RUNTIME_BINDING_ROOT": str(runtime_root),
         "REDDOG_READONLY_AUDIT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(audit_path),
         "REDDOG_BACKEND_ARCHITECT_MODEL_RUNTIME_BINDING_RECEIPT_PATH": str(architect_path),
+        "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED": "1",
     }
     monkeypatch.setattr(
         main,
@@ -1175,7 +1176,6 @@ def test_main_resident_runtime_artifact_preflight_rejects_symlink_before_cycle(
     output = capsys.readouterr().out
     assert "reason=model_runtime_binding_artifact_invalid" in output
     assert str(tmp_path) not in output
-
 
 def test_main_preflight_durable_resident_cycle_disabled_is_inert() -> None:
     import main

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_architect_client_migration.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_architect_client_migration.py
@@ -95,6 +95,45 @@ def test_main_preflight_requires_host_authenticated_scope_before_runtime(
     assert "authenticated_scope_missing_or_mismatched" in capsys.readouterr().out
 
 
+@pytest.mark.parametrize(
+    ("enforced", "expected_result", "expected_status"),
+    (
+        (False, True, "WARN"),
+        (True, False, "FAIL"),
+    ),
+)
+def test_missing_runtime_bindings_block_cycle_but_only_enforced_mode_blocks_menu(
+    monkeypatch,
+    capsys,
+    enforced: bool,
+    expected_result: bool,
+    expected_status: str,
+) -> None:
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
+    monkeypatch.setenv(
+        "REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED",
+        "1" if enforced else "0",
+    )
+
+    with (
+        patch.object(
+            main,
+            "_reddog_resident_model_runtime_bindings_from_env",
+            return_value=(None, None, "missing_model_runtime_binding_root"),
+        ),
+        patch.object(main, "_run_reddog_main_resident_client") as runtime,
+    ):
+        assert (
+            main.run_reddog_resident_architect_durable_cycle_preflight(REPO_ROOT)
+            is expected_result
+        )
+
+    runtime.assert_not_called()
+    output = capsys.readouterr().out
+    assert f"[REDDOG-RESIDENT-CYCLE] preflight={expected_status}" in output
+    assert "reason=missing_model_runtime_binding_root" in output
+
+
 def test_main_preflight_rejects_principal_cross_check_mismatch(monkeypatch) -> None:
     monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
     monkeypatch.setenv("REDDOG_AUTHENTICATED_PRINCIPAL_ID", "principal-main-test")

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -251,6 +251,95 @@ def test_main_resident_red_dog_chain_passes_profile_to_downstream_preflights(mon
     ]
 
 
+def test_main_missing_resident_bindings_warns_and_still_loads_menu(monkeypatch):
+    monkeypatch.setenv("OPENCLAW_SECURITY_PREFLIGHT", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "0")
+    monkeypatch.setenv("WRE_DASHBOARD_PREFLIGHT", "0")
+    monkeypatch.setenv("WSP_FRAMEWORK_PREFLIGHT", "0")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_ENABLED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "0")
+
+    passing_preflights = {
+        name: MagicMock(return_value=True)
+        for name in (
+            "run_env_hygiene_preflight",
+            "run_brain_artifact_preflight",
+            "run_ironclaw_runtime_preflight",
+            "run_openclaw_security_preflight",
+            "run_dependency_security_preflight",
+            "run_wre_dashboard_preflight",
+            "run_wsp_framework_preflight",
+            "run_git_main_merge_sentinel_preflight",
+            "run_reddog_authoritative_work_state_refresh_preflight",
+            "run_reddog_architect_fix_promotion_preflight",
+            "run_reddog_wre_queue_consumer_preflight",
+            "run_reddog_resident_queue_orchestration_plan_preflight",
+            "run_reddog_resident_queue_next_stage_dispatch_preflight",
+            "run_reddog_resident_queue_control_loop_preflight",
+            "run_reddog_readonly_operational_bootstrap_preflight",
+            "bootstrap_runtime_dae_launches",
+        )
+    }
+
+    with patch.multiple(main, **passing_preflights), patch.object(
+        main,
+        "_reddog_resident_model_runtime_bindings_from_env",
+        return_value=(None, None, "missing_model_runtime_binding_root"),
+    ), patch.object(main, "_run_reddog_main_resident_client") as resident_client, patch(
+        "modules.infrastructure.cli.src.main_menu.run_main_menu"
+    ) as run_main_menu:
+        main.main()
+
+    resident_client.assert_not_called()
+    run_main_menu.assert_called_once()
+
+
+def test_main_missing_resident_bindings_enforced_stops_before_later_stages(
+    monkeypatch,
+):
+    monkeypatch.setenv("OPENCLAW_SECURITY_PREFLIGHT", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "0")
+    monkeypatch.setenv("WRE_DASHBOARD_PREFLIGHT", "0")
+    monkeypatch.setenv("WSP_FRAMEWORK_PREFLIGHT", "0")
+    monkeypatch.setenv("OPENCLAW_SUPERVISOR_ENABLED", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE", "1")
+    monkeypatch.setenv("REDDOG_RESIDENT_ARCHITECT_DURABLE_CYCLE_ENFORCED", "1")
+
+    pre_resident_preflights = {
+        name: MagicMock(return_value=True)
+        for name in (
+            "run_env_hygiene_preflight",
+            "run_brain_artifact_preflight",
+            "run_ironclaw_runtime_preflight",
+            "run_openclaw_security_preflight",
+            "run_dependency_security_preflight",
+            "run_wre_dashboard_preflight",
+            "run_wsp_framework_preflight",
+            "run_git_main_merge_sentinel_preflight",
+            "run_reddog_authoritative_work_state_refresh_preflight",
+        )
+    }
+    later_stage = MagicMock(return_value=True)
+
+    with patch.multiple(main, **pre_resident_preflights), patch.object(
+        main,
+        "_reddog_resident_model_runtime_bindings_from_env",
+        return_value=(None, None, "missing_model_runtime_binding_root"),
+    ), patch.object(main, "_run_reddog_main_resident_client") as resident_client, patch.object(
+        main,
+        "run_reddog_architect_fix_promotion_preflight",
+        later_stage,
+    ), patch(
+        "modules.infrastructure.cli.src.main_menu.run_main_menu"
+    ) as run_main_menu:
+        main.main()
+
+    resident_client.assert_not_called()
+    later_stage.assert_not_called()
+    run_main_menu.assert_not_called()
+
+
 def test_reddog_queue_control_loop_profile_repeats_serial_and_claim(monkeypatch):
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary
- keep the ordinary interactive menu available when the optional RedDog resident cycle lacks model-runtime bindings
- preserve fail-closed startup when durable-cycle enforcement is enabled
- prove the resident client and later queue stages are never invoked after binding failure

## Validation
- 93 passed, 1 skipped: focused resident bootstrap/main runtime suite
- independent 0102 review: GO
- backend manifest regeneration/check: unchanged digest, 1001 runtime files
- git diff --check: PASS

## Truth boundary
- no resident execution on missing or invalid bindings
- no authority expansion
- no extension runtime or VSIX change
- pre-existing WSP 62 INTERFACE threshold drift reproduced unchanged on main