### PR TITLE
feat(reddog): gate architect proposals by executability

### DIFF
--- a/main.py
+++ b/main.py
@@ -2123,6 +2123,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         REDDOG_MEMEX_SUPPLY_RECEIPT_PATH                     Outside-repo Memex supply JSON
         REDDOG_AUTHORITY_PROFILE_SOURCE_PATH                 Outside-repo authority seed JSON
         REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH         Outside-repo promoted profile JSON
+        HOLOINDEX_FRESHNESS_RECEIPT                          Current HoloIndex freshness receipt
         REDDOG_RESIDENT_QUEUE_BINDING_PROFILE                Optional profile-derived output path
         REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF=0              Materialize determination/Memex from AgentDB cycle
         REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY=0             Materialize model selection receipt from signed evidence
@@ -2218,6 +2219,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
         repo_root,
         "REDDOG_MODEL_RUNTIME_BINDING_RECEIPT_PATH",
     )
+    holoindex_receipt_path = os.getenv("HOLOINDEX_FRESHNESS_RECEIPT", "")
     model_autoresearch_plan_receipt_path = resident_queue_runtime_file_path(
         os.environ,
         repo_root,
@@ -3005,6 +3007,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             model_selection_receipt_path,
             memex_supply_receipt_path,
             authority_profile_source_path,
+            holoindex_receipt_path,
         )
     ) and bool(authority_profile_path)
     raw_requested = os.getenv("REDDOG_ARCHITECT_FIX_PROMOTION_RUNTIME")
@@ -3030,6 +3033,7 @@ def run_reddog_architect_fix_promotion_preflight(repo_root: Path) -> bool:
             memex_supply_receipt_path=memex_supply_receipt_path,
             authority_profile_source_path=authority_profile_source_path,
             authority_profile_output_path=authority_profile_path,
+            holoindex_receipt_path=holoindex_receipt_path,
             worker_id=os.getenv(
                 "REDDOG_ARCHITECT_FIX_PROMOTION_WORKER_ID",
                 "reddog-main-architect-fix-promotion",

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -2,6 +2,38 @@
 
 ## Public API
 
+### Architect proposal validity and execution readiness
+
+`evaluate_architect_proposal_executability()` runs after backend Fusion output
+validation and before a FIX becomes an architect queue candidate. It requires
+an audit-supported `REUSE_EXISTING`, `EXTEND_EXISTING`, or separately gated
+`CREATE_NEW` decision plus exact paths, tests, policy gates, capabilities,
+expected evidence, and stop conditions.
+
+The resulting
+`reddog_architect_proposal_executability_admission.v1` receipt separates
+proposal validity from current execution readiness. A valid prerequisite slice
+may persist as `BLOCKED_CANDIDATE`; it does not mutate the authoritative queue.
+Model-supplied readiness booleans and capabilities produced by the proposed
+slice are never current authority.
+
+`promote_reddog_architect_fix_to_signed_wsp15_work_order()` canonically
+rehydrates the receipt and rechecks current trust anchors, platform, repository
+HEAD, HoloIndex generation/freshness receipt, authoritative work-state
+revision, snapshot, audit bundle, canonical candidate identity, and WSP 15
+lineage. Only `CANDIDATE` plus `READY` may enter the queue. The authorized base
+is the immutable repository SHA from the admission receipt, not a moving branch
+name. INDEX_GAP blocks ordinary code work; the only phase-one exception is a
+HoloIndex maintenance slice whose exact non-wildcard paths equal the supporting
+direct-read paths.
+
+The receipt's SHA is integrity evidence, not authentication. Production policy
+therefore keeps `architect_proposal_admission_authenticity` unavailable until a
+trusted verifier is implemented. Promotion also remains blocked by the
+code-owned incomplete trust anchors documented in the execution-valve roadmap.
+Tests may inject a complete policy to validate the queue mechanics; callers
+cannot inject that policy into the production promotion seam.
+
 ### Resident queue exact-SHA commit stage
 
 The resident queue runs `exact_sha_commit` after `bounded_worker_pilot` and

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,37 @@
 # ModLog - moltbot_bridge
+## 2026-07-27: REDDOG_ARCHITECT_PROPOSAL_EXECUTABILITY_ADMISSION_PHASE1
+- Added a deterministic post-Fusion proposal admission receipt that binds the
+  audit finding, operational snapshot, repository HEAD, work-state revision,
+  HoloIndex generation/freshness, WSP 15 allocation, reuse decision, paths,
+  tests, policy gates, capabilities, expected evidence, and stop conditions.
+- Separated proposal validity from execution readiness so prerequisite work is
+  retained as `BLOCKED_CANDIDATE` without becoming authoritative queue work.
+- Revalidated current trust anchors, platform, HEAD, HoloIndex freshness
+  receipt, canonical candidate/determination IDs, and work-state revision in
+  the existing signed WSP 15 promotion seam; model readiness claims,
+  underdeclared effect capabilities, and produced capabilities cannot
+  self-authorize.
+- Restricted stale-index admission to direct-read-grounded HoloIndex
+  maintenance whose exact non-wildcard write paths equal the cited direct-read
+  paths; ordinary coding, live Windows canaries, merge, and external effects
+  remain fail closed.
+- Bound claims, queue items, and authority profiles to one immutable base SHA,
+  and held repository-promotion plus profile locks across profile snapshot,
+  prewrite, queue commit, and rollback. Rollback is digest-CAS guarded and
+  reports failure rather than overwriting a newer profile.
+- Required the live HoloIndex query owner to prove the exact repository root,
+  HEAD, generation, and on-disk freshness-receipt digest inside the promotion
+  lock; an arbitrary valid historical receipt path is insufficient.
+- Certified that SHA-bound proposal receipts provide integrity but not
+  authenticity. Production admission remains blocked on a separate trusted
+  proposal-authenticity verifier; no caller-supplied policy can enter the
+  promotion side-effect boundary.
+- Split prompt, contract, and evaluator modules to honor WSP 62 and lowered
+  the inherited architect runtime/test no-growth ceilings (WSP 00, 15, 22, 50,
+  62, 97).
+- Reconciled the stale WSP 62 ceilings left by merged exact-SHA commit PR #1398
+  to its already-landed file and test sizes; no #1398 runtime code was changed.
+
 ## 2026-07-27: REDDOG_RESIDENT_QUEUE_EXACT_SHA_COMMIT_STAGE_PHASE1
 - Inserted an exact-SHA commit stage between the bounded author and the
   independent verifier in the resident RedDog queue.

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -43,6 +43,16 @@ file is at or below the WSP 62 file threshold; do not widen the ceiling.
 
 ## RedDog execution-valve readiness
 
+- Architect proposal admission is complete: audit-supported validity is
+  recorded separately from current execution readiness, and signed WSP 15
+  promotion rechecks the canonical admission receipt, current repository HEAD,
+  HoloIndex freshness receipt, work-state revision, platform, and code-owned
+  trust-anchor capabilities.
+  Valid prerequisite work may remain a blocked candidate; it cannot enter the
+  authoritative queue until a fresh determination observes the capability.
+  SHA-bound proposal receipts are integrity-only; a trusted proposal-admission
+  authenticity verifier remains required before production readiness can ever
+  become `READY`.
 - Phase 1 safety wiring complete locally: token-free canonical supplier,
   bootstrap-to-handler canonical routing, secure use-time reload, signed
   authority re-verification, process-local single-use effect admissions, and

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_candidate_gate.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_candidate_gate.py
@@ -1,0 +1,213 @@
+"""Deterministic candidate and proposal checks before FIX promotion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from holo_index.freshness_receipt import (
+    HoloIndexFreshnessReceipt,
+    evaluate_freshness_for_paths,
+)
+
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_executability_admission import (
+    ArchitectProposalExecutabilityReceipt,
+    EFFECT_REPOSITORY_CODE_CHANGE,
+    reevaluate_architect_proposal_execution_readiness,
+    validate_architect_proposal_executability_receipt,
+)
+
+
+CANDIDATE_MALFORMED = "candidate_malformed"
+PROPOSAL_ADMISSION_INVALID = "proposal_admission_invalid"
+REPO_HEAD_MISMATCH = "repo_head_mismatch"
+HOLOINDEX_BINDING_MISMATCH = "holoindex_binding_mismatch"
+
+
+def validate_architect_fix_candidate(
+    candidate: Mapping[str, Any],
+    determination: Mapping[str, Any],
+    *,
+    schema_version: str,
+) -> tuple[str, ...]:
+    expected_id = _digest(
+        {
+            "source_determination_receipt_id": str(
+                candidate.get("source_determination_receipt_id") or ""
+            ),
+            "slice_id": str(candidate.get("slice_id") or ""),
+            "snapshot_receipt_id": str(
+                determination.get("snapshot_receipt_id") or ""
+            ),
+            "report_bundle_id": str(determination.get("report_bundle_id") or ""),
+            "wsp15_allocation_receipt_id": str(
+                determination.get("wsp15_allocation_receipt_id") or ""
+            ),
+            "proposal_admission_receipt_id": str(
+                candidate.get("proposal_admission_receipt_id") or ""
+            ),
+        }
+    )
+    expected = (
+        candidate
+        and candidate.get("schema_version") == schema_version
+        and str(candidate.get("queue_candidate_id") or "") == expected_id
+        and str(candidate.get("source_determination_receipt_id") or "")
+        == str(determination.get("determination_receipt_id") or "")
+        and str(candidate.get("slice_id") or "")
+        == str(determination.get("next_slice_name") or "")
+        and str(candidate.get("status") or "").upper()
+        in {"CANDIDATE", "BLOCKED_CANDIDATE"}
+        and candidate.get("no_execution_performed") is True
+        and isinstance(candidate.get("wsp15_allocation_receipt"), Mapping)
+        and bool(candidate.get("wsp15_allocation_receipt"))
+    )
+    return () if expected else (CANDIDATE_MALFORMED,)
+
+
+def validate_architect_fix_proposal_admission(
+    *,
+    determination: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    current_work_state: Mapping[str, Any],
+    current_repo_head_sha: str | None,
+    current_holoindex_receipt: Any,
+) -> tuple[ArchitectProposalExecutabilityReceipt | None, tuple[str, ...]]:
+    raw = determination.get("proposal_admission")
+    try:
+        receipt = validate_architect_proposal_executability_receipt(
+            raw if isinstance(raw, Mapping) else {}
+        )
+    except ValueError:
+        return None, (PROPOSAL_ADMISSION_INVALID,)
+    reasons = _lineage_reasons(
+        receipt=receipt,
+        determination=determination,
+        candidate=candidate,
+        current_work_state=current_work_state,
+        current_repo_head_sha=current_repo_head_sha,
+        current_holoindex_receipt=current_holoindex_receipt,
+    )
+    if reevaluate_architect_proposal_execution_readiness(receipt):
+        reasons.append(PROPOSAL_ADMISSION_INVALID)
+    return (
+        receipt if not reasons else None,
+        tuple(dict.fromkeys(reasons)),
+    )
+
+
+def _lineage_reasons(
+    *,
+    receipt: ArchitectProposalExecutabilityReceipt,
+    determination: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    current_work_state: Mapping[str, Any],
+    current_repo_head_sha: str | None,
+    current_holoindex_receipt: Any,
+) -> list[str]:
+    expected = (
+        receipt.accepted is True
+        and receipt.admissible_to_authoritative_queue is True
+        and receipt.action == "FIX"
+        and receipt.target_effect_plane == EFFECT_REPOSITORY_CODE_CHANGE
+        and receipt.slice_id == determination.get("next_slice_name")
+        and _valid_determination_id(determination, receipt)
+        and receipt.snapshot_receipt_id
+        == str(determination.get("snapshot_receipt_id") or "")
+        and receipt.snapshot_content_digest
+        == str(determination.get("snapshot_content_digest") or "")
+        and receipt.report_bundle_id
+        == str(determination.get("report_bundle_id") or "")
+        and receipt.wsp15_allocation_receipt_id
+        == str(determination.get("wsp15_allocation_receipt_id") or "")
+        and receipt.wsp15_allocation_digest
+        == str(determination.get("wsp15_allocation_digest") or "")
+        and receipt.work_state_revision
+        == str(current_work_state.get("revision") or "")
+        and str(candidate.get("status") or "").upper() == "CANDIDATE"
+        and receipt.receipt_id
+        == str(candidate.get("proposal_admission_receipt_id") or "")
+        and _digest(receipt.to_dict())
+        == str(candidate.get("proposal_admission_digest") or "")
+    )
+    reasons = [] if expected else [PROPOSAL_ADMISSION_INVALID]
+    if not current_repo_head_sha or receipt.repo_head_sha != current_repo_head_sha:
+        reasons.append(REPO_HEAD_MISMATCH)
+    if not _current_holoindex_binding_matches(
+        receipt,
+        current_holoindex_receipt=current_holoindex_receipt,
+        current_repo_head_sha=current_repo_head_sha,
+    ):
+        reasons.append(HOLOINDEX_BINDING_MISMATCH)
+    return reasons
+
+
+def _valid_determination_id(
+    determination: Mapping[str, Any],
+    receipt: ArchitectProposalExecutabilityReceipt,
+) -> bool:
+    seed = {
+        "cycle_id": determination.get("cycle_id"),
+        "action": determination.get("action"),
+        "next_slice_name": determination.get("next_slice_name"),
+        "model_result_digest": determination.get("model_result_digest"),
+        "model_selection_digest": determination.get("model_selection_digest"),
+        "provider_call_id": determination.get("provider_call_id"),
+        "provider_call_receipt_id": determination.get("provider_call_receipt_id"),
+        "provider_call_evidence_digest": determination.get(
+            "provider_call_evidence_digest"
+        ),
+        "proposal_admission_receipt_id": receipt.receipt_id,
+    }
+    return str(determination.get("determination_receipt_id") or "") == _digest(seed)
+
+
+def _current_holoindex_binding_matches(
+    receipt: ArchitectProposalExecutabilityReceipt,
+    *,
+    current_holoindex_receipt: Any,
+    current_repo_head_sha: str | None,
+) -> bool:
+    if not isinstance(current_holoindex_receipt, HoloIndexFreshnessReceipt):
+        return False
+    payload = (
+        current_holoindex_receipt.to_dict()
+        if hasattr(current_holoindex_receipt, "to_dict")
+        else current_holoindex_receipt
+    )
+    if not isinstance(payload, Mapping):
+        return False
+    generation_id = str(payload.get("generation_id") or "")
+    if (
+        generation_id != receipt.holoindex_generation_id
+        or _digest(payload) != receipt.holoindex_freshness_receipt_digest
+    ):
+        return False
+    check = evaluate_freshness_for_paths(
+        current_holoindex_receipt,
+        receipt.allowed_paths,
+        expected_repo_head_sha=current_repo_head_sha,
+    )
+    return check.ok or receipt.holoindex_maintenance_exception_applied
+
+
+def _digest(payload: Any) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "CANDIDATE_MALFORMED",
+    "HOLOINDEX_BINDING_MISMATCH",
+    "PROPOSAL_ADMISSION_INVALID",
+    "REPO_HEAD_MISMATCH",
+    "validate_architect_fix_candidate",
+    "validate_architect_fix_proposal_admission",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_promotion_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_promotion_profile.py
@@ -1,0 +1,139 @@
+"""Authority-profile projection for an admitted architect FIX promotion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ArchitectFixPromotionProfileInputs:
+    authority_profile: Mapping[str, Any]
+    determination: Mapping[str, Any]
+    allocation: Mapping[str, Any]
+    model_selection_receipt: Mapping[str, Any]
+    model_selection: Mapping[str, Any]
+    model_selection_digest: str
+    model_runtime_binding_receipt: Mapping[str, Any] | None
+    model_runtime_binding: Mapping[str, Any]
+    model_runtime_binding_digest: str | None
+    memex_supply: Mapping[str, Any]
+    memex_supply_digest: str
+    proposal_admission: Mapping[str, Any]
+    proposal_admission_digest: str
+    work_order_id: str
+    queue_item_id: str
+    claim_id: str
+    holoindex_evidence: Mapping[str, Any]
+
+
+def promoted_authority_profile(
+    inputs: ArchitectFixPromotionProfileInputs,
+) -> Mapping[str, Any]:
+    profile = dict(inputs.authority_profile)
+    binding = _operational_binding(inputs)
+    profile.update(_profile_updates(inputs, binding))
+    if inputs.model_runtime_binding:
+        profile.update(_runtime_binding_fields(
+            inputs.model_runtime_binding_receipt,
+            inputs.model_runtime_binding,
+        ))
+    return profile
+
+
+def _operational_binding(
+    inputs: ArchitectFixPromotionProfileInputs,
+) -> dict[str, Any]:
+    determination = inputs.determination
+    selection = inputs.model_selection
+    runtime = inputs.model_runtime_binding
+    memex = inputs.memex_supply
+    determination_id = str(determination["determination_receipt_id"])
+    binding = {
+        "work_order_id": inputs.work_order_id,
+        "snapshot_receipt_id": str(determination.get("snapshot_receipt_id") or ""),
+        "context_view_id": str(determination.get("context_view_id") or ""),
+        "evidence_bundle_id": str(determination.get("evidence_bundle_id") or ""),
+        "determination_id": determination_id,
+        "readonly_audit_decision_id": determination_id,
+        "architect_determination_receipt_id": determination_id,
+        "queue_item_id": inputs.queue_item_id,
+        "claim_id": inputs.claim_id,
+        "authorized_base_sha": inputs.proposal_admission["repo_head_sha"],
+        "wsp15_allocation_receipt": dict(inputs.allocation),
+        "model_catalog_snapshot_id": selection["catalog_snapshot_id"],
+        "model_selection_receipt_id": selection["receipt_id"],
+        "model_selection_digest": inputs.model_selection_digest,
+        "model_selection_receipt": dict(inputs.model_selection_receipt),
+        "model_runtime_binding_receipt_id": runtime.get("receipt_id", ""),
+        "model_runtime_binding_digest": inputs.model_runtime_binding_digest or "",
+        "memex_supply_receipt_id": memex["receipt_id"],
+        "memex_supply_digest": inputs.memex_supply_digest,
+        "proposal_admission_receipt_id": inputs.proposal_admission["receipt_id"],
+        "proposal_admission_digest": inputs.proposal_admission_digest,
+        "proposal_admission": dict(inputs.proposal_admission),
+        "holoindex_evidence": dict(inputs.holoindex_evidence),
+    }
+    if runtime:
+        binding.update(
+            _runtime_binding_fields(inputs.model_runtime_binding_receipt, runtime)
+        )
+    return binding
+
+
+def _profile_updates(
+    inputs: ArchitectFixPromotionProfileInputs,
+    binding: Mapping[str, Any],
+) -> dict[str, Any]:
+    determination = inputs.determination
+    selection = inputs.model_selection
+    runtime = inputs.model_runtime_binding
+    memex = inputs.memex_supply
+    determination_id = str(determination["determination_receipt_id"])
+    return {
+        "work_order_id": inputs.work_order_id,
+        "base_ref": inputs.proposal_admission["repo_head_sha"],
+        "authorized_base_sha": inputs.proposal_admission["repo_head_sha"],
+        "task_summary": str(
+            inputs.authority_profile.get("task_summary")
+            or f"RedDog architect FIX promotion for {determination.get('next_slice_name')}."
+        ),
+        "wsp15_allocation_receipt": dict(inputs.allocation),
+        "snapshot_receipt_id": binding["snapshot_receipt_id"],
+        "context_view_id": binding["context_view_id"],
+        "evidence_bundle_id": binding["evidence_bundle_id"],
+        "readonly_audit_decision_id": determination_id,
+        "determination_id": determination_id,
+        "model_catalog_snapshot_id": selection["catalog_snapshot_id"],
+        "model_selection_receipt_id": selection["receipt_id"],
+        "model_selection_digest": inputs.model_selection_digest,
+        "model_selection_receipt": dict(inputs.model_selection_receipt),
+        "model_runtime_binding_receipt_id": runtime.get("receipt_id", ""),
+        "model_runtime_binding_digest": inputs.model_runtime_binding_digest or "",
+        "memex_supply_receipt_id": memex["receipt_id"],
+        "memex_supply_digest": inputs.memex_supply_digest,
+        "proposal_admission_receipt_id": inputs.proposal_admission["receipt_id"],
+        "proposal_admission_digest": inputs.proposal_admission_digest,
+        "proposal_admission": dict(inputs.proposal_admission),
+        "operational_context_binding": binding,
+        "holoindex_evidence": dict(inputs.holoindex_evidence),
+    }
+
+
+def _runtime_binding_fields(
+    receipt: Mapping[str, Any] | None,
+    runtime: Mapping[str, Any],
+) -> dict[str, Any]:
+    return {
+        "model_runtime_binding_receipt": dict(receipt or {}),
+        "model_runtime_binding_runtime_surface": runtime["runtime_surface"],
+        "model_runtime_binding_principal_model": runtime["principal_model"],
+        "model_runtime_binding_panel_models": list(runtime["panel_models"]),
+        "model_runtime_binding_role_bindings": list(runtime["role_bindings"]),
+    }
+
+
+__all__ = [
+    "ArchitectFixPromotionProfileInputs",
+    "promoted_authority_profile",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_promotion_records.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_promotion_records.py
@@ -1,0 +1,212 @@
+"""Pure record construction for an admitted RedDog architect FIX promotion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ArchitectFixPromotionRecordInputs:
+    selected_slice: str
+    determination_id: str
+    worker_id: str
+    now_iso: str
+    expires_at: str
+    freshness_receipt_id: str
+    reconciliation_report_id: str
+    proposal_admission_receipt_id: str
+    proposal_admission_digest: str
+    authorized_base_sha: str
+    model_selection_digest: str
+    model_runtime_binding_digest: str
+    memex_supply_digest: str
+    candidate: Mapping[str, Any]
+    allocation: Mapping[str, Any]
+    model_selection: Mapping[str, Any]
+    model_runtime_binding: Mapping[str, Any]
+    memex_supply: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ArchitectFixPromotionRecords:
+    claim_id: str
+    queue_item_id: str
+    claim: Mapping[str, Any]
+    queue_item: Mapping[str, Any]
+    sync_receipt: Mapping[str, Any]
+    evidence_refs: tuple[str, ...]
+
+
+def canonical_digest(payload: Any) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_architect_fix_promotion_records(
+    inputs: ArchitectFixPromotionRecordInputs,
+) -> ArchitectFixPromotionRecords:
+    claim_id = canonical_digest(_claim_seed(inputs))
+    queue_item_id = canonical_digest(_queue_seed(inputs, claim_id))
+    evidence_refs = _evidence_refs(inputs, claim_id)
+    return ArchitectFixPromotionRecords(
+        claim_id=claim_id,
+        queue_item_id=queue_item_id,
+        claim=_claim(inputs, claim_id),
+        queue_item=_queue_item(inputs, claim_id, queue_item_id, evidence_refs),
+        sync_receipt=_sync_receipt(inputs, claim_id, queue_item_id),
+        evidence_refs=evidence_refs,
+    )
+
+
+def _claim_seed(inputs: ArchitectFixPromotionRecordInputs) -> dict[str, Any]:
+    return {
+        "selected_slice": inputs.selected_slice,
+        "determination_receipt_id": inputs.determination_id,
+        **_evidence_receipt_ids(inputs),
+        "worker_id": inputs.worker_id,
+        "claimed_at": inputs.now_iso,
+        "freshness_receipt_id": inputs.freshness_receipt_id,
+        "authorized_base_sha": inputs.authorized_base_sha,
+    }
+
+
+def _queue_seed(
+    inputs: ArchitectFixPromotionRecordInputs,
+    claim_id: str,
+) -> dict[str, Any]:
+    return {
+        "slice_id": inputs.selected_slice,
+        "claim_id": claim_id,
+        "worker_id": inputs.worker_id,
+        "enqueued_at": inputs.now_iso,
+        "determination_receipt_id": inputs.determination_id,
+        "authorized_base_sha": inputs.authorized_base_sha,
+        "wsp15_allocation_receipt_id": inputs.allocation["receipt_id"],
+        **_evidence_receipt_ids(inputs),
+    }
+
+
+def _evidence_receipt_ids(
+    inputs: ArchitectFixPromotionRecordInputs,
+) -> dict[str, str]:
+    return {
+        "model_selection_receipt_id": str(inputs.model_selection["receipt_id"]),
+        "model_runtime_binding_receipt_id": str(
+            inputs.model_runtime_binding.get("receipt_id", "")
+        ),
+        "memex_supply_receipt_id": str(inputs.memex_supply["receipt_id"]),
+        "proposal_admission_receipt_id": inputs.proposal_admission_receipt_id,
+    }
+
+
+def _claim(
+    inputs: ArchitectFixPromotionRecordInputs,
+    claim_id: str,
+) -> dict[str, Any]:
+    return {
+        "claim_id": claim_id,
+        "slice_id": inputs.selected_slice,
+        "worker_id": inputs.worker_id,
+        "lane_id": "reddog_operational",
+        "claimed_at": inputs.now_iso,
+        "expires_at": inputs.expires_at,
+        "reconciliation_report_id": inputs.reconciliation_report_id,
+        "freshness_receipt_id": inputs.freshness_receipt_id,
+        "status": "ACTIVE",
+        "source_determination_receipt_id": inputs.determination_id,
+        "authorized_base_sha": inputs.authorized_base_sha,
+        **_evidence_receipt_ids(inputs),
+    }
+
+
+def _evidence_refs(
+    inputs: ArchitectFixPromotionRecordInputs,
+    claim_id: str,
+) -> tuple[str, ...]:
+    runtime_refs = (
+        [f"model_runtime_binding:{inputs.model_runtime_binding['receipt_id']}"]
+        if inputs.model_runtime_binding
+        else []
+    )
+    refs = [
+        f"claim:{claim_id}",
+        f"freshness:{inputs.freshness_receipt_id}",
+        f"wsp15_allocation:{inputs.allocation['receipt_id']}",
+        f"architect_determination:{inputs.determination_id}",
+        f"proposal_admission:{inputs.proposal_admission_receipt_id}",
+        f"model_selection:{inputs.model_selection['receipt_id']}",
+        *runtime_refs,
+        f"memex_supply:{inputs.memex_supply['receipt_id']}",
+        *[str(ref) for ref in inputs.candidate.get("evidence_refs") or ()],
+    ]
+    return tuple(dict.fromkeys(refs))
+
+
+def _queue_item(
+    inputs: ArchitectFixPromotionRecordInputs,
+    claim_id: str,
+    queue_item_id: str,
+    evidence_refs: tuple[str, ...],
+) -> dict[str, Any]:
+    return {
+        "queue_item_id": queue_item_id,
+        "slice_id": inputs.selected_slice,
+        "claim_id": claim_id,
+        "worker_id": inputs.worker_id,
+        "status": "QUEUED",
+        "enqueued_at": inputs.now_iso,
+        "evidence_refs": list(evidence_refs),
+        "wsp15_allocation_receipt": dict(inputs.allocation),
+        "source_determination_receipt_id": inputs.determination_id,
+        "source_queue_candidate_id": str(
+            inputs.candidate.get("queue_candidate_id") or ""
+        ),
+        "authorized_base_sha": inputs.authorized_base_sha,
+        "proposal_admission_receipt_id": inputs.proposal_admission_receipt_id,
+        "proposal_admission_digest": inputs.proposal_admission_digest,
+        "model_catalog_snapshot_id": inputs.model_selection["catalog_snapshot_id"],
+        "model_selection_receipt_id": inputs.model_selection["receipt_id"],
+        "model_selection_digest": inputs.model_selection_digest,
+        "model_runtime_binding_receipt_id": inputs.model_runtime_binding.get(
+            "receipt_id", ""
+        ),
+        "model_runtime_binding_digest": inputs.model_runtime_binding_digest,
+        "memex_supply_receipt_id": inputs.memex_supply["receipt_id"],
+        "memex_supply_digest": inputs.memex_supply_digest,
+        "no_execution_performed": True,
+    }
+
+
+def _sync_receipt(
+    inputs: ArchitectFixPromotionRecordInputs,
+    claim_id: str,
+    queue_item_id: str,
+) -> dict[str, Any]:
+    return {
+        "sync_id": canonical_digest(
+            {"queue_item_id": queue_item_id, "claim_id": claim_id}
+        ),
+        "status": "WRE_QUEUE_SYNCED",
+        "queue_item_ids": [queue_item_id],
+        "selected_slice": inputs.selected_slice,
+        "rejection_reasons": [],
+        "source": "reddog_architect_fix_wsp15_work_order_promotion.v1",
+        "no_execution_performed": True,
+    }
+
+
+__all__ = [
+    "ArchitectFixPromotionRecordInputs",
+    "ArchitectFixPromotionRecords",
+    "build_architect_fix_promotion_records",
+    "canonical_digest",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -19,7 +19,7 @@ import hashlib
 import json
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Mapping, Optional
+from typing import Any, Callable, Mapping, Optional
 
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_selection import (
     SelectionDecision,
@@ -40,6 +40,23 @@ from modules.communication.moltbot_bridge.src.reddog_backend_architect_determina
     ACTION_FIX,
     ARCHITECT_DETERMINATION_ACCEPT,
     ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_fix_promotion_profile import (
+    ArchitectFixPromotionProfileInputs,
+    promoted_authority_profile,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_fix_candidate_gate import (
+    CANDIDATE_MALFORMED,
+    HOLOINDEX_BINDING_MISMATCH,
+    PROPOSAL_ADMISSION_INVALID,
+    REPO_HEAD_MISMATCH,
+    validate_architect_fix_candidate,
+    validate_architect_fix_proposal_admission,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_fix_promotion_records import (
+    ArchitectFixPromotionRecordInputs,
+    build_architect_fix_promotion_records,
+    canonical_digest as _digest,
 )
 from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt import (
     canonical_reddog_wsp15_allocation_digest,
@@ -75,6 +92,16 @@ class ArchitectFixPromotionReason:
     AUTHORITY_PROFILE_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_AUTHORITY_PROFILE_MISSING"
     AUTHORITY_PROFILE_INCOMPLETE = "REJECT_ARCHITECT_FIX_PROMOTION_AUTHORITY_PROFILE_INCOMPLETE"
     HOLOINDEX_EVIDENCE_MISSING = "REJECT_ARCHITECT_FIX_PROMOTION_HOLOINDEX_EVIDENCE_MISSING"
+    PROPOSAL_ADMISSION_INVALID = (
+        "REJECT_ARCHITECT_FIX_PROMOTION_PROPOSAL_ADMISSION_INVALID"
+    )
+    HOLOINDEX_BINDING_MISMATCH = (
+        "REJECT_ARCHITECT_FIX_PROMOTION_HOLOINDEX_BINDING_MISMATCH"
+    )
+    REPO_HEAD_MISMATCH = "REJECT_ARCHITECT_FIX_PROMOTION_REPO_HEAD_MISMATCH"
+    AUTHORITY_PROFILE_PRECOMMIT_WRITE_FAILED = (
+        "REJECT_ARCHITECT_FIX_PROMOTION_AUTHORITY_PROFILE_PRECOMMIT_WRITE_FAILED"
+    )
     DUPLICATE_QUEUE_ITEM = "REJECT_ARCHITECT_FIX_PROMOTION_DUPLICATE_QUEUE_ITEM"
     STORE_REJECTED = "REJECT_ARCHITECT_FIX_PROMOTION_STORE_REJECTED"
 
@@ -117,6 +144,8 @@ class ArchitectFixPromotionReceipt:
     freshness_receipt_id: str
     wsp15_allocation_receipt_id: str
     wsp15_allocation_digest: str
+    proposal_admission_receipt_id: str
+    proposal_admission_digest: str
     model_catalog_snapshot_id: str
     model_selection_receipt_id: str
     model_selection_digest: str
@@ -190,6 +219,11 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     worker_id: str,
     now_iso: str,
     claim_ttl_seconds: int = 3600,
+    current_repo_head_sha: str | None = None,
+    current_holoindex_receipt: Any = None,
+    authority_profile_precommit_writer: (
+        Callable[[Mapping[str, Any]], None] | None
+    ) = None,
 ) -> ArchitectFixPromotionResult:
     """Commit one architect FIX queue item and return its signer authority profile."""
 
@@ -213,8 +247,28 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     if not candidate:
         reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MISSING)
 
-    candidate_reasons = _validate_candidate(candidate, determination)
-    reasons.extend(candidate_reasons)
+    if CANDIDATE_MALFORMED in validate_architect_fix_candidate(
+        candidate, determination,
+        schema_version=ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+    ):
+        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
+    proposal_admission, proposal_codes = validate_architect_fix_proposal_admission(
+        determination=determination,
+        candidate=candidate,
+        current_work_state=current,
+        current_repo_head_sha=current_repo_head_sha,
+        current_holoindex_receipt=current_holoindex_receipt,
+    )
+    if PROPOSAL_ADMISSION_INVALID in proposal_codes:
+        reasons.append(ArchitectFixPromotionReason.PROPOSAL_ADMISSION_INVALID)
+    if REPO_HEAD_MISMATCH in proposal_codes:
+        reasons.append(ArchitectFixPromotionReason.REPO_HEAD_MISMATCH)
+    if HOLOINDEX_BINDING_MISMATCH in proposal_codes:
+        reasons.append(ArchitectFixPromotionReason.HOLOINDEX_BINDING_MISMATCH)
+    if authority_profile_precommit_writer is None:
+        reasons.append(
+            ArchitectFixPromotionReason.AUTHORITY_PROFILE_PRECOMMIT_WRITE_FAILED
+        )
     allocation = _mapping(candidate.get("wsp15_allocation_receipt"))
     allocation_validation = validate_reddog_wsp15_allocation_receipt(allocation)
     if not allocation_validation.accepted:
@@ -249,6 +303,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     assert freshness_id
     assert selection_payload
     assert memex_payload
+    assert proposal_admission is not None
     assert selected_slice
     now = _parse_iso(now_iso)
     expires_at = (now + timedelta(seconds=int(claim_ttl_seconds))).isoformat()
@@ -256,115 +311,61 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     model_runtime_binding_digest = _digest(model_runtime_binding_receipt) if runtime_binding_payload else None
     memex_supply_digest = _digest(memex_supply_receipt)
     allocation_digest = canonical_reddog_wsp15_allocation_digest(allocation)
+    proposal_admission_digest = _digest(proposal_admission.to_dict())
 
-    claim_seed = {
-        "selected_slice": selected_slice,
-        "determination_receipt_id": determination_id,
-        "model_selection_receipt_id": selection_payload["receipt_id"],
-        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
-        "memex_supply_receipt_id": memex_payload["receipt_id"],
-        "worker_id": worker_id,
-        "claimed_at": now_iso,
-        "freshness_receipt_id": freshness_id,
-    }
-    claim_id = _digest(claim_seed)
-    queue_seed = {
-        "slice_id": selected_slice,
-        "claim_id": claim_id,
-        "worker_id": worker_id,
-        "enqueued_at": now_iso,
-        "determination_receipt_id": determination_id,
-        "wsp15_allocation_receipt_id": allocation["receipt_id"],
-        "model_selection_receipt_id": selection_payload["receipt_id"],
-        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
-        "memex_supply_receipt_id": memex_payload["receipt_id"],
-    }
-    queue_item_id = _digest(queue_seed)
-
-    claim = {
-        "claim_id": claim_id,
-        "slice_id": selected_slice,
-        "worker_id": worker_id,
-        "lane_id": "reddog_operational",
-        "claimed_at": now_iso,
-        "expires_at": expires_at,
-        "reconciliation_report_id": str(current.get("reconciliation_report_id") or determination_id),
-        "freshness_receipt_id": freshness_id,
-        "status": "ACTIVE",
-        "source_determination_receipt_id": determination_id,
-        "model_selection_receipt_id": selection_payload["receipt_id"],
-        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
-        "memex_supply_receipt_id": memex_payload["receipt_id"],
-    }
-    evidence_refs = tuple(
-        dict.fromkeys(
-            [
-                f"claim:{claim_id}",
-                f"freshness:{freshness_id}",
-                f"wsp15_allocation:{allocation['receipt_id']}",
-                f"architect_determination:{determination_id}",
-                f"model_selection:{selection_payload['receipt_id']}",
-                *(
-                    [f"model_runtime_binding:{runtime_binding_payload['receipt_id']}"]
-                    if runtime_binding_payload
-                    else []
-                ),
-                f"memex_supply:{memex_payload['receipt_id']}",
-                *[str(ref) for ref in candidate.get("evidence_refs") or ()],
-            ]
+    records = build_architect_fix_promotion_records(
+        ArchitectFixPromotionRecordInputs(
+            selected_slice=selected_slice,
+            determination_id=determination_id,
+            worker_id=worker_id,
+            now_iso=now_iso,
+            expires_at=expires_at,
+            freshness_receipt_id=freshness_id,
+            reconciliation_report_id=str(
+                current.get("reconciliation_report_id") or determination_id
+            ),
+            proposal_admission_receipt_id=proposal_admission.receipt_id,
+            proposal_admission_digest=proposal_admission_digest,
+            authorized_base_sha=proposal_admission.repo_head_sha,
+            model_selection_digest=model_selection_digest,
+            model_runtime_binding_digest=model_runtime_binding_digest or "",
+            memex_supply_digest=memex_supply_digest,
+            candidate=candidate,
+            allocation=allocation,
+            model_selection=selection_payload,
+            model_runtime_binding=runtime_binding_payload,
+            memex_supply=memex_payload,
         )
     )
-    queue_item = {
-        "queue_item_id": queue_item_id,
-        "slice_id": selected_slice,
-        "claim_id": claim_id,
-        "worker_id": worker_id,
-        "status": "QUEUED",
-        "enqueued_at": now_iso,
-        "evidence_refs": list(evidence_refs),
-        "wsp15_allocation_receipt": dict(allocation),
-        "source_determination_receipt_id": determination_id,
-        "source_queue_candidate_id": str(candidate.get("queue_candidate_id") or ""),
-        "model_catalog_snapshot_id": selection_payload["catalog_snapshot_id"],
-        "model_selection_receipt_id": selection_payload["receipt_id"],
-        "model_selection_digest": model_selection_digest,
-        "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
-        "model_runtime_binding_digest": model_runtime_binding_digest or "",
-        "memex_supply_receipt_id": memex_payload["receipt_id"],
-        "memex_supply_digest": memex_supply_digest,
-        "no_execution_performed": True,
-    }
-    sync_receipt = {
-        "sync_id": _digest({"queue_item_id": queue_item_id, "claim_id": claim_id}),
-        "status": "WRE_QUEUE_SYNCED",
-        "queue_item_ids": [queue_item_id],
-        "selected_slice": selected_slice,
-        "rejection_reasons": [],
-        "source": ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION,
-        "no_execution_performed": True,
-    }
+    claim_id = records.claim_id
+    queue_item_id = records.queue_item_id
 
-    promoted_profile = _promoted_authority_profile(
-        authority_profile=authority_profile,
-        determination=determination,
-        allocation=allocation,
-        model_selection_receipt=model_selection_receipt,
-        model_selection=selection_payload,
-        model_selection_digest=model_selection_digest,
-        model_runtime_binding_receipt=model_runtime_binding_receipt,
-        model_runtime_binding=runtime_binding_payload,
-        model_runtime_binding_digest=model_runtime_binding_digest,
-        memex_supply=memex_payload,
-        memex_supply_digest=memex_supply_digest,
-        queue_item_id=queue_item_id,
-        claim_id=claim_id,
-        holoindex_evidence=holoindex_evidence,
+    promoted_profile = promoted_authority_profile(
+        ArchitectFixPromotionProfileInputs(
+            authority_profile=authority_profile,
+            determination=determination,
+            allocation=allocation,
+            model_selection_receipt=model_selection_receipt,
+            model_selection=selection_payload,
+            model_selection_digest=model_selection_digest,
+            model_runtime_binding_receipt=model_runtime_binding_receipt,
+            model_runtime_binding=runtime_binding_payload,
+            model_runtime_binding_digest=model_runtime_binding_digest,
+            memex_supply=memex_payload,
+            memex_supply_digest=memex_supply_digest,
+            proposal_admission=proposal_admission.to_dict(),
+            proposal_admission_digest=proposal_admission_digest,
+            work_order_id=_work_order_id(queue_item_id),
+            queue_item_id=queue_item_id,
+            claim_id=claim_id,
+            holoindex_evidence=holoindex_evidence,
+        )
     )
     updated = _append_queue_state(
         current,
-        claim=claim,
-        queue_item=queue_item,
-        sync_receipt=sync_receipt,
+        claim=records.claim,
+        queue_item=records.queue_item,
+        sync_receipt=records.sync_receipt,
         promotion_record={
             "schema_version": ARCHITECT_FIX_WSP15_PROMOTION_SCHEMA_VERSION,
             "architect_determination_receipt_id": determination_id,
@@ -373,9 +374,18 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
             "model_selection_receipt_id": selection_payload["receipt_id"],
             "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
             "memex_supply_receipt_id": memex_payload["receipt_id"],
+            "proposal_admission_receipt_id": proposal_admission.receipt_id,
             "created_at": now_iso,
         },
     )
+
+    try:
+        assert authority_profile_precommit_writer is not None
+        authority_profile_precommit_writer(promoted_profile)
+    except Exception:
+        return _reject(
+            [ArchitectFixPromotionReason.AUTHORITY_PROFILE_PRECOMMIT_WRITE_FAILED]
+        )
 
     try:
         committed_revision = work_state_store.commit(updated, expected_revision=current.get("revision"))
@@ -390,6 +400,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         "model_selection_receipt_id": selection_payload["receipt_id"],
         "model_runtime_binding_receipt_id": runtime_binding_payload.get("receipt_id", ""),
         "memex_supply_receipt_id": memex_payload["receipt_id"],
+        "proposal_admission_receipt_id": proposal_admission.receipt_id,
         "committed_revision": committed_revision,
     }
     receipt = ArchitectFixPromotionReceipt(
@@ -405,6 +416,8 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         freshness_receipt_id=freshness_id,
         wsp15_allocation_receipt_id=str(allocation["receipt_id"]),
         wsp15_allocation_digest=allocation_digest,
+        proposal_admission_receipt_id=proposal_admission.receipt_id,
+        proposal_admission_digest=proposal_admission_digest,
         model_catalog_snapshot_id=selection_payload["catalog_snapshot_id"],
         model_selection_receipt_id=selection_payload["receipt_id"],
         model_selection_digest=model_selection_digest,
@@ -437,11 +450,6 @@ def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
-def _digest(payload: Any) -> str:
-    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True, default=str)
-    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
-
-
 def _parse_iso(value: str) -> datetime:
     text = str(value or "").strip()
     if text.endswith("Z"):
@@ -470,27 +478,6 @@ def _freshness_receipt_id(snapshot: Mapping[str, Any]) -> str:
         if receipt_id and receipt.get("fresh") is True and (not preferred or receipt_id == preferred):
             return receipt_id
     return ""
-
-
-def _validate_candidate(candidate: Mapping[str, Any], determination: Mapping[str, Any]) -> list[str]:
-    reasons: list[str] = []
-    if not candidate:
-        return reasons
-    if candidate.get("schema_version") != ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION:
-        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
-    if str(candidate.get("source_determination_receipt_id") or "") != str(
-        determination.get("determination_receipt_id") or ""
-    ):
-        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
-    if str(candidate.get("slice_id") or "") != str(determination.get("next_slice_name") or ""):
-        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
-    if str(candidate.get("status") or "").upper() != "CANDIDATE":
-        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
-    if candidate.get("no_execution_performed") is not True:
-        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
-    if not _mapping(candidate.get("wsp15_allocation_receipt")):
-        reasons.append(ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED)
-    return reasons
 
 
 def _validate_model_selection(selection: Mapping[str, Any], reasons: list[str]) -> Mapping[str, Any]:
@@ -597,141 +584,6 @@ def _duplicate_queue(snapshot: Mapping[str, Any], *, selected_slice: str, determ
         if str(claim.get("slice_id") or "") == selected_slice and str(claim.get("status") or "").upper() == "ACTIVE":
             return True
     return False
-
-
-def _promoted_authority_profile(
-    *,
-    authority_profile: Mapping[str, Any],
-    determination: Mapping[str, Any],
-    allocation: Mapping[str, Any],
-    model_selection_receipt: Mapping[str, Any],
-    model_selection: Mapping[str, Any],
-    model_selection_digest: str,
-    model_runtime_binding_receipt: Mapping[str, Any] | None,
-    model_runtime_binding: Mapping[str, Any],
-    model_runtime_binding_digest: str | None,
-    memex_supply: Mapping[str, Any],
-    memex_supply_digest: str,
-    queue_item_id: str,
-    claim_id: str,
-    holoindex_evidence: Mapping[str, Any],
-) -> Mapping[str, Any]:
-    profile = dict(authority_profile)
-    determination_id = str(determination["determination_receipt_id"])
-    work_order_id = _work_order_id(queue_item_id)
-    binding = _promoted_operational_binding(
-        determination=determination,
-        allocation=allocation,
-        model_selection_receipt=model_selection_receipt,
-        model_selection=model_selection,
-        model_selection_digest=model_selection_digest,
-        model_runtime_binding_receipt=model_runtime_binding_receipt,
-        model_runtime_binding=model_runtime_binding,
-        model_runtime_binding_digest=model_runtime_binding_digest,
-        memex_supply=memex_supply,
-        memex_supply_digest=memex_supply_digest,
-        work_order_id=work_order_id,
-        queue_item_id=queue_item_id,
-        claim_id=claim_id,
-        holoindex_evidence=holoindex_evidence,
-    )
-    profile.update(
-        _promoted_profile_updates(
-            profile=profile,
-            determination=determination,
-            binding=binding,
-            allocation=allocation,
-            model_selection_receipt=model_selection_receipt,
-            model_selection=model_selection,
-            model_selection_digest=model_selection_digest,
-            model_runtime_binding=model_runtime_binding,
-            model_runtime_binding_digest=model_runtime_binding_digest,
-            memex_supply=memex_supply,
-            memex_supply_digest=memex_supply_digest,
-            work_order_id=work_order_id,
-            holoindex_evidence=holoindex_evidence,
-        )
-    )
-    if model_runtime_binding:
-        profile["model_runtime_binding_receipt"] = dict(model_runtime_binding_receipt or {})
-        profile["model_runtime_binding_runtime_surface"] = model_runtime_binding["runtime_surface"]
-        profile["model_runtime_binding_principal_model"] = model_runtime_binding["principal_model"]
-        profile["model_runtime_binding_panel_models"] = list(model_runtime_binding["panel_models"])
-        profile["model_runtime_binding_role_bindings"] = list(model_runtime_binding["role_bindings"])
-    return profile
-
-
-def _promoted_operational_binding(**values: Any) -> dict[str, Any]:
-    determination = values["determination"]
-    model_selection = values["model_selection"]
-    model_runtime_binding = values["model_runtime_binding"]
-    memex_supply = values["memex_supply"]
-    determination_id = str(determination["determination_receipt_id"])
-    binding = {
-        "work_order_id": values["work_order_id"],
-        "snapshot_receipt_id": str(determination.get("snapshot_receipt_id") or ""),
-        "context_view_id": str(determination.get("context_view_id") or ""),
-        "evidence_bundle_id": str(determination.get("evidence_bundle_id") or ""),
-        "determination_id": determination_id,
-        "readonly_audit_decision_id": determination_id,
-        "architect_determination_receipt_id": determination_id,
-        "queue_item_id": values["queue_item_id"],
-        "claim_id": values["claim_id"],
-        "wsp15_allocation_receipt": dict(values["allocation"]),
-        "model_catalog_snapshot_id": model_selection["catalog_snapshot_id"],
-        "model_selection_receipt_id": model_selection["receipt_id"],
-        "model_selection_digest": values["model_selection_digest"],
-        "model_selection_receipt": dict(values["model_selection_receipt"]),
-        "model_runtime_binding_receipt_id": model_runtime_binding.get("receipt_id", ""),
-        "model_runtime_binding_digest": values["model_runtime_binding_digest"] or "",
-        "memex_supply_receipt_id": memex_supply["receipt_id"],
-        "memex_supply_digest": values["memex_supply_digest"],
-        "holoindex_evidence": dict(values["holoindex_evidence"]),
-    }
-    if model_runtime_binding:
-        binding.update(
-            {
-                "model_runtime_binding_receipt": dict(values["model_runtime_binding_receipt"] or {}),
-                "model_runtime_binding_runtime_surface": model_runtime_binding["runtime_surface"],
-                "model_runtime_binding_principal_model": model_runtime_binding["principal_model"],
-                "model_runtime_binding_panel_models": list(model_runtime_binding["panel_models"]),
-                "model_runtime_binding_role_bindings": list(model_runtime_binding["role_bindings"]),
-            }
-        )
-    return binding
-
-
-def _promoted_profile_updates(**values: Any) -> dict[str, Any]:
-    profile = values["profile"]
-    determination = values["determination"]
-    binding = values["binding"]
-    model_selection = values["model_selection"]
-    model_runtime_binding = values["model_runtime_binding"]
-    memex_supply = values["memex_supply"]
-    determination_id = str(determination["determination_receipt_id"])
-    return {
-            "work_order_id": values["work_order_id"],
-            "task_summary": str(
-                profile.get("task_summary")
-                or f"RedDog architect FIX promotion for {determination.get('next_slice_name')}."
-            ),
-            "wsp15_allocation_receipt": dict(values["allocation"]),
-            "snapshot_receipt_id": binding["snapshot_receipt_id"],
-            "context_view_id": binding["context_view_id"],
-            "evidence_bundle_id": binding["evidence_bundle_id"],
-            "readonly_audit_decision_id": determination_id,
-            "determination_id": determination_id,
-            "model_catalog_snapshot_id": model_selection["catalog_snapshot_id"],
-            "model_selection_receipt_id": model_selection["receipt_id"],
-            "model_selection_digest": values["model_selection_digest"],
-            "model_selection_receipt": dict(values["model_selection_receipt"]),
-            "model_runtime_binding_receipt_id": model_runtime_binding.get("receipt_id", ""),
-            "model_runtime_binding_digest": values["model_runtime_binding_digest"] or "",
-            "memex_supply_receipt_id": memex_supply["receipt_id"],
-            "memex_supply_digest": values["memex_supply_digest"],
-            "operational_context_binding": binding,
-            "holoindex_evidence": dict(values["holoindex_evidence"]),
-    }
 
 
 def _work_order_id(queue_item_id: str) -> str:

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_admission_contract.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_admission_contract.py
@@ -1,0 +1,449 @@
+"""Canonical contract for architect proposal validity and readiness receipts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_execution_valve_use_time_authority import (
+    INCOMPLETE_TRUST_ANCHOR_REASONS,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    OperationalContextSnapshot,
+)
+
+
+PROPOSAL_ADMISSION_SCHEMA_VERSION = (
+    "reddog_architect_proposal_executability_admission.v1"
+)
+
+VALIDITY_VALID = "VALID"
+VALIDITY_NEEDS_RESEARCH = "NEEDS_RESEARCH"
+VALIDITY_INVALID = "INVALID"
+PROPOSAL_VALIDITIES = frozenset(
+    {VALIDITY_VALID, VALIDITY_NEEDS_RESEARCH, VALIDITY_INVALID}
+)
+
+READINESS_READY = "READY"
+READINESS_CONFIGURATION_BLOCKED = "CONFIGURATION_BLOCKED"
+READINESS_IMPLEMENTATION_BLOCKED = "IMPLEMENTATION_BLOCKED"
+READINESS_PLATFORM_BLOCKED = "PLATFORM_BLOCKED"
+READINESS_POLICY_BLOCKED = "POLICY_BLOCKED"
+READINESS_EVIDENCE_BLOCKED = "EVIDENCE_BLOCKED"
+EXECUTION_READINESS_STATES = frozenset(
+    {
+        READINESS_READY,
+        READINESS_CONFIGURATION_BLOCKED,
+        READINESS_IMPLEMENTATION_BLOCKED,
+        READINESS_PLATFORM_BLOCKED,
+        READINESS_POLICY_BLOCKED,
+        READINESS_EVIDENCE_BLOCKED,
+    }
+)
+
+REUSE_EXISTING = "REUSE_EXISTING"
+EXTEND_EXISTING = "EXTEND_EXISTING"
+CREATE_NEW = "CREATE_NEW"
+REUSE_DECISIONS = frozenset({REUSE_EXISTING, EXTEND_EXISTING, CREATE_NEW})
+
+EFFECT_NONE = "NONE"
+EFFECT_READ_ONLY_AUDIT = "READ_ONLY_AUDIT"
+EFFECT_CONFIGURATION_ONLY = "CONFIGURATION_ONLY"
+EFFECT_REPOSITORY_CODE_CHANGE = "REPOSITORY_CODE_CHANGE"
+EFFECT_LIVE_WORKTREE_CANARY = "LIVE_WORKTREE_CANARY"
+EFFECT_DRAFT_PR_PUBLISH = "DRAFT_PR_PUBLISH"
+EFFECT_MERGE = "MERGE"
+EFFECT_EXTERNAL = "EXTERNAL_EFFECT"
+TARGET_EFFECT_PLANES = frozenset(
+    {
+        EFFECT_NONE,
+        EFFECT_READ_ONLY_AUDIT,
+        EFFECT_CONFIGURATION_ONLY,
+        EFFECT_REPOSITORY_CODE_CHANGE,
+        EFFECT_LIVE_WORKTREE_CANARY,
+        EFFECT_DRAFT_PR_PUBLISH,
+        EFFECT_MERGE,
+        EFFECT_EXTERNAL,
+    }
+)
+
+CAP_SIGNED_ARTIFACT_MANIFEST = "signed_runtime_artifact_manifest"
+CAP_CONSENSUS_RECEIPT = "verified_consensus_receipt"
+CAP_SOVEREIGN_AUTHORIZATION = "verified_sovereign_authorization"
+CAP_PRINCIPAL_KEY_ATTESTATION = "principal_subject_key_attestation"
+CAP_MODEL_EVIDENCE = "model_signed_evidence_trust"
+CAP_MODEL_SELECTION_EVIDENCE = "model_selection_signed_evidence"
+CAP_MEMEX_EVIDENCE = "memex_supply_signed_evidence"
+CAP_SIGNER_HANDSHAKE = "fresh_signer_peer_handshake"
+CAP_PROPOSAL_AUTHENTICITY = "architect_proposal_admission_authenticity"
+CAP_MERGE_AUTHORITY = "independent_merge_authority"
+CAP_EXTERNAL_EFFECT_AUTHORITY = "external_effect_authority"
+PROPOSAL_AUTHENTICITY_VERIFIER_MISSING = (
+    "architect_proposal_admission_authenticity_verifier_missing"
+)
+
+_TRUST_REASON_CAPABILITY = {
+    "canonical_signed_runtime_artifact_manifest_producer_missing": (
+        CAP_SIGNED_ARTIFACT_MANIFEST
+    ),
+    "canonical_consensus_receipt_verifier_missing": CAP_CONSENSUS_RECEIPT,
+    "canonical_sovereign_authorization_verifier_missing": (
+        CAP_SOVEREIGN_AUTHORIZATION
+    ),
+    "canonical_principal_subject_key_attestation_missing": (
+        CAP_PRINCIPAL_KEY_ATTESTATION
+    ),
+    "canonical_model_signed_evidence_trust_anchor_incomplete": CAP_MODEL_EVIDENCE,
+    "canonical_model_selection_signed_evidence_verifier_missing": (
+        CAP_MODEL_SELECTION_EVIDENCE
+    ),
+    "canonical_memex_supply_signed_evidence_verifier_missing": CAP_MEMEX_EVIDENCE,
+    "canonical_signer_client_peer_handshake_verifier_missing": (
+        CAP_SIGNER_HANDSHAKE
+    ),
+    PROPOSAL_AUTHENTICITY_VERIFIER_MISSING: CAP_PROPOSAL_AUTHENTICITY,
+}
+LIVE_EXECUTION_CAPABILITIES = tuple(sorted(_TRUST_REASON_CAPABILITY.values()))
+
+
+@dataclass(frozen=True)
+class ArchitectProposalAdmissionPolicy:
+    platform: str
+    available_capabilities: tuple[str, ...]
+    missing_capability_reasons: Mapping[str, str]
+    merge_authority_available: bool = False
+    external_effect_authority_available: bool = False
+    live_canary_platforms: tuple[str, ...] = ("linux",)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ArchitectProposalExecutabilityReceipt:
+    schema_version: str
+    receipt_id: str
+    accepted: bool
+    proposal_validity: str
+    execution_readiness: str
+    admissible_to_authoritative_queue: bool
+    action: str
+    slice_id: str | None
+    task_summary_digest: str
+    reuse_decision: str
+    requested_operation: str
+    target_runtime: str
+    target_effect_plane: str
+    allowed_paths: tuple[str, ...]
+    denied_paths: tuple[str, ...]
+    required_tests: tuple[str, ...]
+    required_policy_gates: tuple[str, ...]
+    required_capabilities: tuple[str, ...]
+    produced_capabilities: tuple[str, ...]
+    expected_evidence: tuple[str, ...]
+    stop_conditions: tuple[str, ...]
+    missing_preconditions: tuple[str, ...]
+    decision_reasons: tuple[str, ...]
+    supporting_finding_ids: tuple[str, ...]
+    supporting_direct_read_paths: tuple[str, ...]
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    repo_head_sha: str
+    work_state_revision: str
+    holoindex_generation_id: str
+    holoindex_freshness_receipt_digest: str
+    index_gap_detected: bool
+    direct_read_grounded: bool
+    holoindex_maintenance_exception_applied: bool
+    report_bundle_id: str
+    wsp15_allocation_receipt_id: str
+    wsp15_allocation_digest: str
+    policy_digest: str
+    rejection_reasons: tuple[str, ...]
+    no_queue_mutation_performed: bool = True
+    no_execution_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def current_architect_proposal_admission_policy(
+    *, platform_name: str | None = None
+) -> ArchitectProposalAdmissionPolicy:
+    missing = {
+        _TRUST_REASON_CAPABILITY[reason]: reason
+        for reason in INCOMPLETE_TRUST_ANCHOR_REASONS
+        if reason in _TRUST_REASON_CAPABILITY
+    }
+    # Proposal receipts are SHA-bound integrity records, not authenticated
+    # authority. Keep production admission blocked until a verifier proves the
+    # receipt came from the trusted architect determination runtime.
+    missing[CAP_PROPOSAL_AUTHENTICITY] = (
+        PROPOSAL_AUTHENTICITY_VERIFIER_MISSING
+    )
+    return ArchitectProposalAdmissionPolicy(
+        platform=_normalize_platform(platform_name or sys.platform),
+        available_capabilities=tuple(
+            sorted(set(LIVE_EXECUTION_CAPABILITIES).difference(missing))
+        ),
+        missing_capability_reasons=missing,
+    )
+
+
+def proposal_admission_prompt_policy(
+    *,
+    snapshot: OperationalContextSnapshot,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> Mapping[str, Any]:
+    return {
+        "schema_version": PROPOSAL_ADMISSION_SCHEMA_VERSION,
+        "current_platform": policy.platform,
+        "repo_head_sha": str(snapshot.repo_state.get("head_sha") or ""),
+        "work_state_revision": str(snapshot.work_state.get("revision") or ""),
+        "holoindex_freshness_ok": snapshot.holoindex_state.get("freshness_ok")
+        is True,
+        "holoindex_generation_id": str(
+            snapshot.holoindex_state.get("generation_id") or ""
+        ),
+        "available_capabilities": list(policy.available_capabilities),
+        "missing_capability_reasons": dict(policy.missing_capability_reasons),
+        "live_canary_platforms": list(policy.live_canary_platforms),
+        "merge_authority_available": policy.merge_authority_available,
+        "external_effect_authority_available": (
+            policy.external_effect_authority_available
+        ),
+        "reuse_decisions": sorted(REUSE_DECISIONS),
+        "target_effect_planes": sorted(TARGET_EFFECT_PLANES),
+        "rule": (
+            "Proposal validity and resident execution readiness are separate. "
+            "Never claim missing output capability as already implemented."
+        ),
+    }
+
+
+def validate_architect_proposal_executability_receipt(
+    value: Mapping[str, Any],
+) -> ArchitectProposalExecutabilityReceipt:
+    if not isinstance(value, Mapping):
+        raise ValueError("proposal_admission_receipt_missing")
+    expected = set(ArchitectProposalExecutabilityReceipt.__dataclass_fields__)
+    if set(value) != expected:
+        raise ValueError("proposal_admission_field_set_invalid")
+    data = dict(value)
+    receipt_id = _text(data.pop("receipt_id"))
+    if not _valid_receipt_body(data, receipt_id):
+        raise ValueError("proposal_admission_receipt_invalid")
+    for field in _TUPLE_FIELDS:
+        data[field] = tuple(str(item) for item in data.get(field) or ())
+    return ArchitectProposalExecutabilityReceipt(receipt_id=receipt_id, **data)
+
+
+def reevaluate_architect_proposal_execution_readiness(
+    receipt: ArchitectProposalExecutabilityReceipt,
+    *,
+    policy: ArchitectProposalAdmissionPolicy | None = None,
+) -> tuple[str, ...]:
+    current = policy or current_architect_proposal_admission_policy()
+    effect_capabilities = required_capabilities_for_effect(
+        receipt.target_effect_plane
+    )
+    declared = set(receipt.required_capabilities)
+    unavailable = effect_capabilities.union(declared).difference(
+        current.available_capabilities
+    )
+    reasons: list[str] = [
+        current.missing_capability_reasons.get(
+            capability, f"required_capability_unavailable:{capability}"
+        )
+        for capability in sorted(unavailable)
+    ]
+    if not effect_capabilities.issubset(declared):
+        reasons.append("effect_capability_requirements_underdeclared")
+    if receipt.policy_digest != _digest(current.to_dict()):
+        reasons.append("proposal_admission_policy_binding_stale")
+    if (
+        receipt.index_gap_detected
+        and not receipt.holoindex_maintenance_exception_applied
+    ):
+        reasons.append("proposal_was_grounded_against_index_gap")
+    if _unsupported_live_canary(receipt, current):
+        reasons.append(f"live_canary_platform_unsupported:{current.platform}")
+    if receipt.target_effect_plane == EFFECT_MERGE and not current.merge_authority_available:
+        reasons.append("merge_authority_unavailable")
+    if (
+        receipt.target_effect_plane == EFFECT_EXTERNAL
+        and not current.external_effect_authority_available
+    ):
+        reasons.append("external_effect_authority_unavailable")
+    return tuple(dict.fromkeys(reasons))
+
+
+_TUPLE_FIELDS = (
+    "allowed_paths",
+    "denied_paths",
+    "required_tests",
+    "required_policy_gates",
+    "required_capabilities",
+    "produced_capabilities",
+    "expected_evidence",
+    "stop_conditions",
+    "missing_preconditions",
+    "decision_reasons",
+    "supporting_finding_ids",
+    "supporting_direct_read_paths",
+    "rejection_reasons",
+)
+
+
+def _valid_receipt_body(data: Mapping[str, Any], receipt_id: str) -> bool:
+    expected_admission = (
+        data.get("action") == "FIX"
+        and data.get("proposal_validity") == VALIDITY_VALID
+        and data.get("execution_readiness") == READINESS_READY
+    )
+    attestations = (
+        "no_queue_mutation_performed",
+        "no_execution_performed",
+        "no_repo_mutation_performed",
+        "no_holoindex_reindex_performed",
+    )
+    missing = tuple(data.get("missing_preconditions") or ())
+    rejected = tuple(data.get("rejection_reasons") or ())
+    return (
+        data.get("schema_version") == PROPOSAL_ADMISSION_SCHEMA_VERSION
+        and receipt_id == _digest(data)
+        and data.get("proposal_validity") in PROPOSAL_VALIDITIES
+        and data.get("execution_readiness") in EXECUTION_READINESS_STATES
+        and data.get("reuse_decision") in REUSE_DECISIONS
+        and data.get("target_effect_plane") in TARGET_EFFECT_PLANES
+        and isinstance(data.get("direct_read_grounded"), bool)
+        and isinstance(data.get("holoindex_maintenance_exception_applied"), bool)
+        and _valid_holoindex_maintenance_exception(data)
+        and data.get("accepted")
+        is (data.get("proposal_validity") == VALIDITY_VALID)
+        and data.get("admissible_to_authoritative_queue") is expected_admission
+        and (
+            (data.get("execution_readiness") == READINESS_READY and not missing)
+            or (data.get("execution_readiness") != READINESS_READY and bool(missing))
+        )
+        and (
+            (data.get("proposal_validity") == VALIDITY_VALID and not rejected)
+            or (data.get("proposal_validity") != VALIDITY_VALID and bool(rejected))
+        )
+        and all(data.get(field) is True for field in attestations)
+    )
+
+
+def _valid_holoindex_maintenance_exception(data: Mapping[str, Any]) -> bool:
+    if data.get("holoindex_maintenance_exception_applied") is not True:
+        return True
+    allowed_paths = tuple(str(path) for path in data.get("allowed_paths") or ())
+    evidence_paths = tuple(
+        str(path) for path in data.get("supporting_direct_read_paths") or ()
+    )
+    return (
+        data.get("index_gap_detected") is True
+        and data.get("direct_read_grounded") is True
+        and "HOLOINDEX" in _text(data.get("slice_id")).upper()
+        and data.get("requested_operation")
+        in {"holoindex_maintenance", "index_maintenance"}
+        and bool(allowed_paths)
+        and all(path.startswith("holo_index/") for path in allowed_paths)
+        and all(not any(token in path for token in ("*", "?", "[")) for path in allowed_paths)
+        and set(allowed_paths) == set(evidence_paths)
+    )
+
+
+def required_capabilities_for_effect(effect_plane: str) -> frozenset[str]:
+    if effect_plane not in {
+        EFFECT_REPOSITORY_CODE_CHANGE,
+        EFFECT_LIVE_WORKTREE_CANARY,
+        EFFECT_DRAFT_PR_PUBLISH,
+        EFFECT_MERGE,
+        EFFECT_EXTERNAL,
+    }:
+        return frozenset()
+    values = set(LIVE_EXECUTION_CAPABILITIES)
+    if effect_plane == EFFECT_MERGE:
+        values.add(CAP_MERGE_AUTHORITY)
+    if effect_plane == EFFECT_EXTERNAL:
+        values.add(CAP_EXTERNAL_EFFECT_AUTHORITY)
+    return frozenset(values)
+
+
+def _unsupported_live_canary(
+    receipt: ArchitectProposalExecutabilityReceipt,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> bool:
+    return (
+        receipt.target_effect_plane == EFFECT_LIVE_WORKTREE_CANARY
+        and policy.platform not in policy.live_canary_platforms
+    )
+
+
+def _normalize_platform(value: str) -> str:
+    text = _text(value).lower()
+    if text.startswith("linux"):
+        return "linux"
+    if text.startswith("win"):
+        return "windows"
+    if text.startswith(("darwin", "mac")):
+        return "macos"
+    return text or "unknown"
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "ArchitectProposalAdmissionPolicy",
+    "ArchitectProposalExecutabilityReceipt",
+    "CREATE_NEW",
+    "EFFECT_CONFIGURATION_ONLY",
+    "EFFECT_DRAFT_PR_PUBLISH",
+    "EFFECT_EXTERNAL",
+    "EFFECT_LIVE_WORKTREE_CANARY",
+    "EFFECT_MERGE",
+    "EFFECT_NONE",
+    "EFFECT_READ_ONLY_AUDIT",
+    "EFFECT_REPOSITORY_CODE_CHANGE",
+    "EXECUTION_READINESS_STATES",
+    "EXTEND_EXISTING",
+    "LIVE_EXECUTION_CAPABILITIES",
+    "PROPOSAL_ADMISSION_SCHEMA_VERSION",
+    "PROPOSAL_VALIDITIES",
+    "READINESS_CONFIGURATION_BLOCKED",
+    "READINESS_EVIDENCE_BLOCKED",
+    "READINESS_IMPLEMENTATION_BLOCKED",
+    "READINESS_PLATFORM_BLOCKED",
+    "READINESS_POLICY_BLOCKED",
+    "READINESS_READY",
+    "REUSE_DECISIONS",
+    "REUSE_EXISTING",
+    "TARGET_EFFECT_PLANES",
+    "VALIDITY_INVALID",
+    "VALIDITY_NEEDS_RESEARCH",
+    "VALIDITY_VALID",
+    "current_architect_proposal_admission_policy",
+    "proposal_admission_prompt_policy",
+    "required_capabilities_for_effect",
+    "reevaluate_architect_proposal_execution_readiness",
+    "validate_architect_proposal_executability_receipt",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_executability_admission.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_executability_admission.py
@@ -1,0 +1,631 @@
+"""Deterministic validity and readiness admission for architect proposals."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_admission_contract import (
+    ArchitectProposalAdmissionPolicy,
+    ArchitectProposalExecutabilityReceipt,
+    CREATE_NEW,
+    EFFECT_CONFIGURATION_ONLY,
+    EFFECT_DRAFT_PR_PUBLISH,
+    EFFECT_EXTERNAL,
+    EFFECT_LIVE_WORKTREE_CANARY,
+    EFFECT_MERGE,
+    EFFECT_NONE,
+    EFFECT_READ_ONLY_AUDIT,
+    EFFECT_REPOSITORY_CODE_CHANGE,
+    EXECUTION_READINESS_STATES,
+    EXTEND_EXISTING,
+    LIVE_EXECUTION_CAPABILITIES,
+    PROPOSAL_ADMISSION_SCHEMA_VERSION,
+    PROPOSAL_VALIDITIES,
+    READINESS_CONFIGURATION_BLOCKED,
+    READINESS_EVIDENCE_BLOCKED,
+    READINESS_IMPLEMENTATION_BLOCKED,
+    READINESS_PLATFORM_BLOCKED,
+    READINESS_POLICY_BLOCKED,
+    READINESS_READY,
+    REUSE_DECISIONS,
+    REUSE_EXISTING,
+    TARGET_EFFECT_PLANES,
+    VALIDITY_INVALID,
+    VALIDITY_NEEDS_RESEARCH,
+    VALIDITY_VALID,
+    current_architect_proposal_admission_policy,
+    proposal_admission_prompt_policy,
+    reevaluate_architect_proposal_execution_readiness,
+    required_capabilities_for_effect,
+    validate_architect_proposal_executability_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    OperationalContextSnapshot,
+)
+
+
+@dataclass(frozen=True)
+class _Proposal:
+    action: str
+    slice_id: str | None
+    summary: str
+    reuse_decision: str
+    requested_operation: str
+    target_runtime: str
+    effect_plane: str
+    allowed_paths: tuple[str, ...]
+    denied_paths: tuple[str, ...]
+    required_tests: tuple[str, ...]
+    policy_gates: tuple[str, ...]
+    required_capabilities: tuple[str, ...]
+    produced_capabilities: tuple[str, ...]
+    expected_evidence: tuple[str, ...]
+    stop_conditions: tuple[str, ...]
+    declared_reasons: tuple[str, ...]
+    invalid_path_tokens: bool
+
+
+@dataclass(frozen=True)
+class _Support:
+    finding_ids: tuple[str, ...]
+    conflicts: tuple[str, ...]
+    direct_read_grounded: bool
+    direct_read_paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _Decision:
+    validity: str
+    readiness: str
+    admissible: bool
+    validity_reasons: tuple[str, ...]
+    missing_preconditions: tuple[str, ...]
+
+
+def evaluate_architect_proposal_executability(
+    *,
+    model_output: Mapping[str, Any],
+    snapshot: OperationalContextSnapshot,
+    reports: Sequence[Mapping[str, Any]],
+    report_bundle_id: str | None,
+    wsp15_allocation_receipt: Mapping[str, Any],
+    policy: ArchitectProposalAdmissionPolicy | None = None,
+) -> ArchitectProposalExecutabilityReceipt:
+    """Validate proposal structure and derive current execution readiness."""
+
+    current_policy = policy or current_architect_proposal_admission_policy()
+    proposal = _proposal(model_output)
+    support = _proposal_support(reports=reports, slice_id=proposal.slice_id)
+    decision = _decision(
+        proposal=proposal,
+        snapshot=snapshot,
+        support=support,
+        policy=current_policy,
+    )
+    return _receipt(
+        proposal=proposal,
+        snapshot=snapshot,
+        support=support,
+        decision=decision,
+        report_bundle_id=report_bundle_id,
+        wsp15_allocation_receipt=wsp15_allocation_receipt,
+        policy=current_policy,
+    )
+
+
+def _proposal(value: Mapping[str, Any]) -> _Proposal:
+    return _Proposal(
+        action=_text(value.get("action")).upper(),
+        slice_id=_text(value.get("next_slice_name")) or None,
+        summary=_text(value.get("summary")),
+        reuse_decision=_text(value.get("reuse_decision")).upper(),
+        requested_operation=_text(value.get("requested_operation")).lower(),
+        target_runtime=_text(value.get("target_runtime")).lower(),
+        effect_plane=_text(value.get("target_effect_plane")).upper(),
+        allowed_paths=_normalize_paths(value.get("allowed_paths")),
+        denied_paths=_normalize_paths(value.get("denied_paths")),
+        required_tests=_normalize_texts(value.get("required_tests")),
+        policy_gates=_normalize_texts(value.get("required_policy_gates")),
+        required_capabilities=_normalize_texts(value.get("required_capabilities")),
+        produced_capabilities=_normalize_texts(value.get("produced_capabilities")),
+        expected_evidence=_normalize_texts(value.get("expected_evidence")),
+        stop_conditions=_normalize_texts(value.get("stop_conditions")),
+        declared_reasons=_normalize_texts(value.get("decision_reasons")),
+        invalid_path_tokens=(
+            _has_invalid_paths(value.get("allowed_paths"))
+            or _has_invalid_paths(value.get("denied_paths"))
+        ),
+    )
+
+
+def _decision(
+    *,
+    proposal: _Proposal,
+    snapshot: OperationalContextSnapshot,
+    support: _Support,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> _Decision:
+    reasons = _validity_reasons(proposal, snapshot=snapshot, support=support)
+    validity = _validity(reasons)
+    blockers = _readiness_blockers(
+        proposal=proposal,
+        snapshot=snapshot,
+        support=support,
+        policy=policy,
+    )
+    readiness, missing = _readiness(validity=validity, blockers=blockers)
+    return _Decision(
+        validity=validity,
+        readiness=readiness,
+        admissible=(
+            proposal.action == "FIX"
+            and validity == VALIDITY_VALID
+            and readiness == READINESS_READY
+        ),
+        validity_reasons=reasons,
+        missing_preconditions=missing,
+    )
+
+
+def _validity_reasons(
+    proposal: _Proposal,
+    *,
+    snapshot: OperationalContextSnapshot,
+    support: _Support,
+) -> tuple[str, ...]:
+    reasons = [*_shape_reasons(proposal), *_snapshot_reasons(snapshot)]
+    if proposal.action == "FIX" and not support.finding_ids:
+        reasons.append("proposal_not_supported_by_observed_fix_finding")
+    if proposal.action == "FIX" and support.conflicts:
+        reasons.append("conflicting_audit_finding")
+    required = required_capabilities_for_effect(proposal.effect_plane)
+    if not required.issubset(proposal.required_capabilities):
+        reasons.append("effect_capability_requirements_underdeclared")
+    return _dedupe(reasons)
+
+
+def _shape_reasons(proposal: _Proposal) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if proposal.action == "FIX" and (
+        not proposal.slice_id or not _valid_slice_name(proposal.slice_id)
+    ):
+        reasons.append("slice_id_invalid")
+    if proposal.reuse_decision not in REUSE_DECISIONS:
+        reasons.append("reuse_decision_invalid")
+    if proposal.effect_plane not in TARGET_EFFECT_PLANES:
+        reasons.append("target_effect_plane_invalid")
+    if proposal.action == "STOP" and proposal.effect_plane != EFFECT_NONE:
+        reasons.append("stop_effect_plane_must_be_none")
+    if proposal.action != "STOP" and proposal.effect_plane == EFFECT_NONE:
+        reasons.append("non_stop_effect_plane_missing")
+    if _effectful_contract_incomplete(proposal):
+        reasons.append("effectful_proposal_contract_incomplete")
+    if set(proposal.allowed_paths).intersection(proposal.denied_paths):
+        reasons.append("allowed_denied_path_overlap")
+    if proposal.invalid_path_tokens:
+        reasons.append("repository_path_token_invalid")
+    if (
+        proposal.reuse_decision == CREATE_NEW
+        and proposal.effect_plane != EFFECT_READ_ONLY_AUDIT
+    ):
+        reasons.append("create_new_requires_separate_architecture_gate")
+    return tuple(reasons)
+
+
+def _effectful_contract_incomplete(proposal: _Proposal) -> bool:
+    if proposal.action != "FIX" or proposal.effect_plane == EFFECT_READ_ONLY_AUDIT:
+        return False
+    required = (
+        proposal.requested_operation,
+        proposal.target_runtime,
+        proposal.allowed_paths,
+        proposal.denied_paths,
+        proposal.required_tests,
+        proposal.policy_gates,
+        proposal.expected_evidence,
+        proposal.stop_conditions,
+    )
+    return any(not item for item in required)
+
+
+def _snapshot_reasons(snapshot: OperationalContextSnapshot) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if not snapshot.snapshot_receipt_id or not snapshot.snapshot_content_digest:
+        reasons.append("operational_snapshot_binding_missing")
+    repo_head = _text(snapshot.repo_state.get("head_sha"))
+    if not repo_head or repo_head.lower() == "unknown":
+        reasons.append("repository_head_unknown")
+    if not _text(snapshot.work_state.get("revision")):
+        reasons.append("work_state_revision_missing")
+    return tuple(reasons)
+
+
+def _readiness_blockers(
+    *,
+    proposal: _Proposal,
+    snapshot: OperationalContextSnapshot,
+    support: _Support,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> Mapping[str, tuple[str, ...]]:
+    index_gap = snapshot.holoindex_state.get("freshness_ok") is not True
+    holo_exception = _is_holo_maintenance_proposal(proposal, support)
+    missing = required_capabilities_for_effect(proposal.effect_plane).union(
+        proposal.required_capabilities
+    ).difference(
+        policy.available_capabilities
+    )
+    return {
+        READINESS_EVIDENCE_BLOCKED: (
+            ("holoindex_index_gap",) if index_gap and not holo_exception else ()
+        ),
+        READINESS_PLATFORM_BLOCKED: _platform_blockers(proposal, policy),
+        READINESS_POLICY_BLOCKED: _policy_blockers(proposal, policy),
+        READINESS_CONFIGURATION_BLOCKED: (),
+        READINESS_IMPLEMENTATION_BLOCKED: tuple(
+            policy.missing_capability_reasons.get(
+                capability, f"required_capability_unavailable:{capability}"
+            )
+            for capability in sorted(missing)
+        ),
+    }
+
+
+def _platform_blockers(
+    proposal: _Proposal,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> tuple[str, ...]:
+    if (
+        proposal.effect_plane == EFFECT_LIVE_WORKTREE_CANARY
+        and policy.platform not in policy.live_canary_platforms
+    ):
+        return (f"live_canary_platform_unsupported:{policy.platform}",)
+    return ()
+
+
+def _policy_blockers(
+    proposal: _Proposal,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if proposal.effect_plane == EFFECT_MERGE and not policy.merge_authority_available:
+        reasons.append("merge_authority_unavailable")
+    if (
+        proposal.effect_plane == EFFECT_EXTERNAL
+        and not policy.external_effect_authority_available
+    ):
+        reasons.append("external_effect_authority_unavailable")
+    return tuple(reasons)
+
+
+def _validity(reasons: Sequence[str]) -> str:
+    research_reasons = {
+        "proposal_not_supported_by_observed_fix_finding",
+        "conflicting_audit_finding",
+    }
+    if reasons and all(reason in research_reasons for reason in reasons):
+        return VALIDITY_NEEDS_RESEARCH
+    return VALIDITY_INVALID if reasons else VALIDITY_VALID
+
+
+def _readiness(
+    *,
+    validity: str,
+    blockers: Mapping[str, tuple[str, ...]],
+) -> tuple[str, tuple[str, ...]]:
+    if validity != VALIDITY_VALID:
+        return READINESS_EVIDENCE_BLOCKED, (
+            f"proposal_validity_not_ready:{validity}",
+        )
+    for status in (
+        READINESS_EVIDENCE_BLOCKED,
+        READINESS_PLATFORM_BLOCKED,
+        READINESS_POLICY_BLOCKED,
+        READINESS_CONFIGURATION_BLOCKED,
+        READINESS_IMPLEMENTATION_BLOCKED,
+    ):
+        if blockers[status]:
+            return status, _dedupe(blockers[status])
+    return READINESS_READY, ()
+
+
+def _receipt(
+    *,
+    proposal: _Proposal,
+    snapshot: OperationalContextSnapshot,
+    support: _Support,
+    decision: _Decision,
+    report_bundle_id: str | None,
+    wsp15_allocation_receipt: Mapping[str, Any],
+    policy: ArchitectProposalAdmissionPolicy,
+) -> ArchitectProposalExecutabilityReceipt:
+    payload = {
+        **_receipt_contract(proposal),
+        **_receipt_decision(proposal, decision),
+        **_receipt_bindings(
+            proposal=proposal,
+            support=support,
+            snapshot=snapshot,
+            report_bundle_id=report_bundle_id,
+            wsp15_allocation_receipt=wsp15_allocation_receipt,
+            policy=policy,
+        ),
+        "supporting_finding_ids": list(support.finding_ids),
+        "supporting_direct_read_paths": list(support.direct_read_paths),
+        "rejection_reasons": (
+            [] if decision.validity == VALIDITY_VALID else list(decision.validity_reasons)
+        ),
+        "no_queue_mutation_performed": True,
+        "no_execution_performed": True,
+        "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
+    }
+    return _typed_receipt(payload)
+
+
+def _receipt_contract(proposal: _Proposal) -> dict[str, Any]:
+    return {
+        "schema_version": PROPOSAL_ADMISSION_SCHEMA_VERSION,
+        "action": proposal.action,
+        "slice_id": proposal.slice_id,
+        "task_summary_digest": _digest(proposal.summary),
+        "reuse_decision": proposal.reuse_decision,
+        "requested_operation": proposal.requested_operation,
+        "target_runtime": proposal.target_runtime,
+        "target_effect_plane": proposal.effect_plane,
+        "allowed_paths": list(proposal.allowed_paths),
+        "denied_paths": list(proposal.denied_paths),
+        "required_tests": list(proposal.required_tests),
+        "required_policy_gates": list(proposal.policy_gates),
+        "required_capabilities": list(proposal.required_capabilities),
+        "produced_capabilities": list(proposal.produced_capabilities),
+        "expected_evidence": list(proposal.expected_evidence),
+        "stop_conditions": list(proposal.stop_conditions),
+    }
+
+
+def _receipt_decision(
+    proposal: _Proposal,
+    decision: _Decision,
+) -> dict[str, Any]:
+    produced_warnings = (
+        "produced_capability_is_output_not_current_authority:" + capability
+        for capability in proposal.produced_capabilities
+        if decision.readiness == READINESS_IMPLEMENTATION_BLOCKED
+        and capability in proposal.required_capabilities
+    )
+    return {
+        "accepted": decision.validity == VALIDITY_VALID,
+        "proposal_validity": decision.validity,
+        "execution_readiness": decision.readiness,
+        "admissible_to_authoritative_queue": decision.admissible,
+        "missing_preconditions": list(decision.missing_preconditions),
+        "decision_reasons": list(
+            _dedupe(
+                (
+                    *proposal.declared_reasons,
+                    *decision.validity_reasons,
+                    *decision.missing_preconditions,
+                    *produced_warnings,
+                )
+            )
+        ),
+    }
+
+
+def _receipt_bindings(
+    *,
+    proposal: _Proposal,
+    support: _Support,
+    snapshot: OperationalContextSnapshot,
+    report_bundle_id: str | None,
+    wsp15_allocation_receipt: Mapping[str, Any],
+    policy: ArchitectProposalAdmissionPolicy,
+) -> dict[str, Any]:
+    return {
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+        "snapshot_content_digest": snapshot.snapshot_content_digest,
+        "repo_head_sha": _text(snapshot.repo_state.get("head_sha")),
+        "work_state_revision": _text(snapshot.work_state.get("revision")),
+        "holoindex_generation_id": _text(
+            snapshot.holoindex_state.get("generation_id")
+        ),
+        "holoindex_freshness_receipt_digest": _text(
+            snapshot.holoindex_state.get("receipt_digest")
+        ),
+        "index_gap_detected": snapshot.holoindex_state.get("freshness_ok") is not True,
+        "direct_read_grounded": support.direct_read_grounded,
+        "holoindex_maintenance_exception_applied": (
+            snapshot.holoindex_state.get("freshness_ok") is not True
+            and _is_holo_maintenance_proposal(proposal, support)
+        ),
+        "report_bundle_id": _text(report_bundle_id),
+        "wsp15_allocation_receipt_id": _text(
+            wsp15_allocation_receipt.get("receipt_id")
+        ),
+        "wsp15_allocation_digest": _digest(wsp15_allocation_receipt),
+        "policy_digest": _digest(policy.to_dict()),
+    }
+
+
+def _typed_receipt(payload: Mapping[str, Any]) -> ArchitectProposalExecutabilityReceipt:
+    values = dict(payload)
+    tuple_fields = (
+        "allowed_paths", "denied_paths", "required_tests", "required_policy_gates",
+        "required_capabilities", "produced_capabilities", "expected_evidence",
+        "stop_conditions", "missing_preconditions", "decision_reasons",
+        "supporting_finding_ids", "rejection_reasons",
+        "supporting_direct_read_paths",
+    )
+    for field in tuple_fields:
+        values[field] = tuple(values[field])
+    return ArchitectProposalExecutabilityReceipt(
+        receipt_id=_digest(payload),
+        **values,
+    )
+
+
+def _proposal_support(
+    *,
+    reports: Sequence[Mapping[str, Any]],
+    slice_id: str | None,
+) -> _Support:
+    support: list[str] = []
+    conflicts: list[str] = []
+    direct_read_paths: list[str] = []
+    for report in reports:
+        report_refs = set(_normalize_texts(report.get("evidence_refs")))
+        for finding in _findings(report):
+            if _text(finding.get("next_slice_name")) != _text(slice_id):
+                continue
+            finding_id = _text(finding.get("finding_id"))
+            finding_refs = set(_normalize_texts(finding.get("evidence_refs")))
+            action = _text(finding.get("recommended_action")).upper()
+            observed = _text(finding.get("wsp97_label")).upper() == "OBSERVED"
+            if action == "FIX" and observed and finding_refs and finding_refs.issubset(report_refs):
+                support.append(finding_id)
+                direct_read_paths.extend(
+                    path
+                    for path in (
+                        _repo_path_from_file_evidence(ref)
+                        for ref in finding_refs
+                    )
+                    if path.startswith("holo_index/")
+                )
+            elif action in {"REVISE", "RESEARCH_MORE", "STOP"} and finding_id:
+                conflicts.append(finding_id)
+    paths = _dedupe(direct_read_paths)
+    return _Support(_dedupe(support), _dedupe(conflicts), bool(paths), paths)
+
+
+def _findings(report: Mapping[str, Any]) -> tuple[Mapping[str, Any], ...]:
+    values = report.get("findings")
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        return ()
+    return tuple(value for value in values if isinstance(value, Mapping))
+
+
+def _is_holo_maintenance_proposal(
+    proposal: _Proposal,
+    support: _Support | None = None,
+) -> bool:
+    evidence_paths = set(support.direct_read_paths) if support else set()
+    return (
+        "HOLOINDEX" in _text(proposal.slice_id).upper()
+        and proposal.requested_operation
+        in {"holoindex_maintenance", "index_maintenance"}
+        and bool(proposal.allowed_paths)
+        and all(path.startswith("holo_index/") for path in proposal.allowed_paths)
+        and all(
+            not any(token in path for token in ("*", "?", "["))
+            for path in proposal.allowed_paths
+        )
+        and (support is None or set(proposal.allowed_paths) == evidence_paths)
+    )
+
+
+def _repo_path_from_file_evidence(value: str) -> str:
+    text = _text(value)
+    if not text.startswith("file:"):
+        return ""
+    body = text.removeprefix("file:")
+    for marker in (":sha256:", ":lines:", "#L"):
+        if marker in body:
+            body = body.split(marker, 1)[0]
+    return body.replace("\\", "/")
+
+
+def _normalize_paths(value: Any) -> tuple[str, ...]:
+    return _dedupe(
+        item.replace("\\", "/")
+        for item in _normalize_texts(value)
+        if _valid_repo_path(item.replace("\\", "/"))
+    )
+
+
+def _has_invalid_paths(value: Any) -> bool:
+    paths = _normalize_texts(value)
+    return any(
+        not _valid_repo_path(path.replace("\\", "/")) for path in paths
+    )
+
+
+def _valid_repo_path(path: str) -> bool:
+    parts = path.split("/")
+    return (
+        bool(path)
+        and not path.startswith(("/", "../"))
+        and "\x00" not in path
+        and ":" not in parts[0]
+        and all(part not in {"", ".", ".."} for part in parts)
+    )
+
+
+def _normalize_texts(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return ()
+    return _dedupe(_text(item) for item in value if _text(item))
+
+
+def _dedupe(values: Sequence[str] | Any) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(_text(item) for item in values if _text(item)))
+
+
+def _valid_slice_name(value: str) -> bool:
+    text = _text(value)
+    return (
+        text.endswith("_PHASE1")
+        and text.replace("_", "").isalnum()
+        and text.upper() == text
+    )
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "ArchitectProposalAdmissionPolicy",
+    "ArchitectProposalExecutabilityReceipt",
+    "CREATE_NEW",
+    "EFFECT_CONFIGURATION_ONLY",
+    "EFFECT_DRAFT_PR_PUBLISH",
+    "EFFECT_EXTERNAL",
+    "EFFECT_LIVE_WORKTREE_CANARY",
+    "EFFECT_MERGE",
+    "EFFECT_NONE",
+    "EFFECT_READ_ONLY_AUDIT",
+    "EFFECT_REPOSITORY_CODE_CHANGE",
+    "EXECUTION_READINESS_STATES",
+    "EXTEND_EXISTING",
+    "LIVE_EXECUTION_CAPABILITIES",
+    "PROPOSAL_ADMISSION_SCHEMA_VERSION",
+    "PROPOSAL_VALIDITIES",
+    "READINESS_EVIDENCE_BLOCKED",
+    "READINESS_IMPLEMENTATION_BLOCKED",
+    "READINESS_PLATFORM_BLOCKED",
+    "READINESS_READY",
+    "REUSE_DECISIONS",
+    "REUSE_EXISTING",
+    "TARGET_EFFECT_PLANES",
+    "VALIDITY_NEEDS_RESEARCH",
+    "VALIDITY_VALID",
+    "current_architect_proposal_admission_policy",
+    "evaluate_architect_proposal_executability",
+    "proposal_admission_prompt_policy",
+    "reevaluate_architect_proposal_execution_readiness",
+    "validate_architect_proposal_executability_receipt",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_prompt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_prompt.py
@@ -1,0 +1,177 @@
+"""Prompt schema and shape validation for backend architect proposals."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Sequence
+
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_admission_contract import (
+    ArchitectProposalAdmissionPolicy,
+    proposal_admission_prompt_policy,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
+    OperationalContextSnapshot,
+)
+
+
+VALIDATION_INVALID_OUTPUT = "invalid_model_output"
+VALIDATION_WSP15_MISMATCH = "wsp15_receipt_mismatch"
+
+
+def build_architect_proposal_prompt(
+    *,
+    snapshot: OperationalContextSnapshot,
+    report_bundle_id: str | None,
+    report_views: Sequence[Mapping[str, Any]],
+    wsp15_allocation_receipt: Mapping[str, Any],
+    proposal_admission_policy: ArchitectProposalAdmissionPolicy,
+    max_chars: int,
+) -> str:
+    payload = {
+        "task": "Return one backend RedDog architect determination as strict JSON only.",
+        "required_fields": [
+            "action", "next_slice_name", "summary", "decision_reasons",
+            "evidence_refs", "wsp15_allocation_receipt_id", "reuse_decision",
+            "requested_operation", "target_runtime", "target_effect_plane",
+            "allowed_paths", "denied_paths", "required_tests",
+            "required_policy_gates", "required_capabilities",
+            "produced_capabilities", "expected_evidence", "stop_conditions",
+        ],
+        "rules": _PROMPT_RULES,
+        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
+        "snapshot_content_digest": snapshot.snapshot_content_digest,
+        "work_state_revision": snapshot.work_state.get("revision"),
+        "repo_head_sha": snapshot.repo_state.get("head_sha"),
+        "audit_report_collection": {
+            "accepted": True,
+            "report_count": len(report_views),
+            "bundle_id": report_bundle_id,
+        },
+        "wsp15_allocation_receipt_id": wsp15_allocation_receipt.get("receipt_id"),
+        "proposal_admission_policy": proposal_admission_prompt_policy(
+            snapshot=snapshot,
+            policy=proposal_admission_policy,
+        ),
+        "reports": list(report_views),
+    }
+    return _budgeted_json(payload, max_chars=max_chars)
+
+
+def validate_architect_proposal_output(
+    output: Mapping[str, Any],
+    *,
+    reports: Sequence[Mapping[str, Any]],
+    wsp15_allocation_receipt_id: str | None,
+) -> tuple[str, ...]:
+    if not output:
+        return (VALIDATION_INVALID_OUTPUT,)
+    reasons: list[str] = []
+    action = _text(output.get("action")).upper()
+    next_slice = _text(output.get("next_slice_name"))
+    evidence_refs = _texts(output.get("evidence_refs"))
+    if not _base_shape_valid(output, action=action, next_slice=next_slice):
+        reasons.append(VALIDATION_INVALID_OUTPUT)
+    report_refs = _report_evidence_refs(reports)
+    if not evidence_refs or not set(evidence_refs).issubset(report_refs):
+        reasons.append(VALIDATION_INVALID_OUTPUT)
+    if _text(output.get("wsp15_allocation_receipt_id")) != _text(
+        wsp15_allocation_receipt_id
+    ):
+        reasons.append(VALIDATION_WSP15_MISMATCH)
+    return tuple(dict.fromkeys(reasons))
+
+
+_PROMPT_RULES = [
+    "Use FIX only for one audit-supported proposal; code derives whether it is executable now.",
+    "Use RESEARCH_MORE when evidence is insufficient.",
+    "Use REVISE when a valid direction has implementation, configuration, platform, or policy blockers.",
+    "Use STOP when no next work should be queued.",
+    "Use only evidence_refs present in the supplied audit reports.",
+    "Configuration cannot satisfy a missing implementation trust anchor.",
+    "An INDEX_GAP or unconfirmed defect must not produce FIX.",
+    "Current draft-PR capability is not merge authority.",
+    "Declare every capability required to execute the slice and every capability the slice produces.",
+    "Produced capabilities are outputs, never current authority.",
+    "Specify exact paths, tests, evidence, and stop conditions for effectful work.",
+    "Echo the supplied WSP15 allocation receipt id exactly.",
+]
+
+
+def _base_shape_valid(
+    output: Mapping[str, Any],
+    *,
+    action: str,
+    next_slice: str,
+) -> bool:
+    sequence_fields = (
+        "evidence_refs", "decision_reasons", "allowed_paths", "denied_paths",
+        "required_tests", "required_policy_gates", "required_capabilities",
+        "produced_capabilities", "expected_evidence", "stop_conditions",
+    )
+    actions = {"FIX", "RESEARCH_MORE", "REVISE", "STOP"}
+    return (
+        action in actions
+        and (
+            _valid_slice_name(next_slice)
+            if action in {"FIX", "RESEARCH_MORE", "REVISE"}
+            else not next_slice
+        )
+        and bool(_text(output.get("summary")))
+        and bool(_text(output.get("reuse_decision")))
+        and bool(_text(output.get("requested_operation")))
+        and bool(_text(output.get("target_runtime")))
+        and bool(_text(output.get("target_effect_plane")))
+        and all(_is_sequence(output.get(field)) for field in sequence_fields)
+    )
+
+
+def _report_evidence_refs(reports: Sequence[Mapping[str, Any]]) -> set[str]:
+    refs: set[str] = set()
+    for report in reports:
+        refs.update(_texts(report.get("evidence_refs")))
+        findings = report.get("findings")
+        if not _is_sequence(findings):
+            continue
+        for finding in findings:
+            if isinstance(finding, Mapping):
+                refs.update(_texts(finding.get("evidence_refs")))
+    return refs
+
+
+def _budgeted_json(value: Mapping[str, Any], *, max_chars: int) -> str:
+    text = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    if len(text) > max_chars:
+        raise ValueError("architect_prompt_budget_exceeded")
+    return text
+
+
+def _texts(value: Any) -> tuple[str, ...]:
+    if not _is_sequence(value):
+        return ()
+    return tuple(dict.fromkeys(_text(item) for item in value if _text(item)))
+
+
+def _is_sequence(value: Any) -> bool:
+    return not isinstance(value, (str, bytes)) and isinstance(value, Sequence)
+
+
+def _valid_slice_name(value: str) -> bool:
+    return (
+        value.endswith("_PHASE1")
+        and value.replace("_", "").isalnum()
+        and value.upper() == value
+    )
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+__all__ = [
+    "VALIDATION_INVALID_OUTPUT",
+    "VALIDATION_WSP15_MISMATCH",
+    "build_architect_proposal_prompt",
+    "validate_architect_proposal_output",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/src/reddog_backend_architect_determination_runtime.py
@@ -27,6 +27,18 @@ from modules.communication.moltbot_bridge.src.reddog_context_snapshot_fusion_ass
     FUSION_ASSIGNMENT_GATE_PASSED,
     FusionAssignmentGateDecision,
 )
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_executability_admission import (
+    ArchitectProposalAdmissionPolicy,
+    ArchitectProposalExecutabilityReceipt,
+    current_architect_proposal_admission_policy,
+    evaluate_architect_proposal_executability,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_prompt import (
+    VALIDATION_INVALID_OUTPUT,
+    VALIDATION_WSP15_MISMATCH,
+    build_architect_proposal_prompt,
+    validate_architect_proposal_output,
+)
 from modules.communication.moltbot_bridge.src.reddog_operational_context_snapshot import (
     ContextView,
     EvidenceBundle,
@@ -104,6 +116,9 @@ class ArchitectDeterminationReason:
     MODEL_SELECTION_RECEIPT = "REJECT_ARCHITECT_DETERMINATION_MODEL_SELECTION_RECEIPT"
     MODEL_RUNTIME_BINDING_RECEIPT = "REJECT_ARCHITECT_DETERMINATION_MODEL_RUNTIME_BINDING_RECEIPT"
     PROVIDER_CALL_EVIDENCE = "REJECT_ARCHITECT_DETERMINATION_PROVIDER_CALL_EVIDENCE"
+    PROPOSAL_EXECUTABILITY_ADMISSION = (
+        "REJECT_ARCHITECT_DETERMINATION_PROPOSAL_EXECUTABILITY_ADMISSION"
+    )
 
 
 @dataclass(frozen=True)
@@ -312,6 +327,8 @@ class ArchitectQueueCandidate:
     status: str
     evidence_refs: tuple[str, ...]
     wsp15_allocation_receipt: Mapping[str, Any]
+    proposal_admission_receipt_id: str
+    proposal_admission_digest: str
     no_queue_mutation_performed: bool = True
     no_execution_performed: bool = True
     no_worker_spawn_performed: bool = True
@@ -354,6 +371,7 @@ class ArchitectDeterminationReceipt:
     fusion_quorum_passed: bool
     wsp15_allocation_receipt_id: Optional[str]
     wsp15_allocation_digest: Optional[str]
+    proposal_admission: Optional[ArchitectProposalExecutabilityReceipt]
     queue_candidate: Optional[ArchitectQueueCandidate]
     decision_reasons: tuple[str, ...]
     rejection_reasons: tuple[str, ...]
@@ -579,6 +597,7 @@ def run_reddog_backend_architect_determination_runtime(
     model_runner: ArchitectModelRunner | None = None,
     model_selection_receipt: Mapping[str, Any] | None = None,
     model_runtime_binding_receipt: Mapping[str, Any] | None = None,
+    proposal_admission_policy: ArchitectProposalAdmissionPolicy | None = None,
     now_iso: str | None = None,
     timeout_seconds: int = 60,
 ) -> BackendArchitectDeterminationResult:
@@ -679,13 +698,16 @@ def run_reddog_backend_architect_determination_runtime(
     assert fusion_gate is not None
     assert report_collection is not None
     assert cycle_id is not None
+    proposal_policy = proposal_admission_policy or current_architect_proposal_admission_policy()
     runner = model_runner if model_runner is not None else FoundupsFusionArchitectModelRunner()
     try:
-        prompt = _build_architect_prompt(
+        prompt = build_architect_proposal_prompt(
             snapshot=snapshot,
-            report_collection=report_collection,
-            reports=reports,
+            report_bundle_id=report_bundle_id,
+            report_views=[_report_prompt_view(report) for report in reports],
             wsp15_allocation_receipt=wsp15_allocation_receipt,
+            proposal_admission_policy=proposal_policy,
+            max_chars=DEFAULT_MAX_PROMPT_CHARS,
         )
         context = _build_architect_context(
             context_view=context_view,
@@ -760,36 +782,22 @@ def run_reddog_backend_architect_determination_runtime(
         persist_result = _persist_rejected(receipt)
         return _result(receipt=receipt, persist_result=persist_result)
 
-    provider_call_evidence = _canonical_provider_call_evidence(
-        model_result.provider_call_evidence
-    )
-    model_result = replace(
-        model_result,
-        provider_call_evidence=provider_call_evidence,
-    )
-    if not model_result.ok:
-        reasons.append(ArchitectDeterminationReason.MODEL_FAILURE)
-        reasons.extend(model_result.rejection_reasons)
-    elif not _provider_call_evidence_matches_architect(
-        provider_call_evidence,
+    model_result, assurance_reasons = _validated_model_assurance(
+        model_result=model_result,
         binding=binding,
         cycle_id=cycle_id,
         model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
         model_runtime_binding_digest=model_runtime_binding_digest,
-    ):
-        reasons.append(ArchitectDeterminationReason.PROVIDER_CALL_EVIDENCE)
-    if not _fusion_quorum_passed(model_result.review_packet):
-        reasons.append(ArchitectDeterminationReason.FUSION_QUORUM_NOT_PASSED)
-
-    parsed = _parse_model_output(model_result.content)
-    output_reasons: list[str] = []
-    _validate_model_output(
-        parsed,
-        reports=reports,
-        wsp15_allocation_receipt_id=allocation_receipt_id,
-        output_reasons=output_reasons,
     )
-    reasons.extend(output_reasons)
+    reasons.extend(assurance_reasons)
+    parsed, proposal_admission, proposal_reasons = _validated_proposal(
+        model_result=model_result,
+        snapshot=snapshot,
+        reports=reports,
+        report_bundle_id=report_bundle_id, allocation=wsp15_allocation_receipt,
+        allocation_receipt_id=allocation_receipt_id, policy=proposal_policy,
+    )
+    reasons.extend(proposal_reasons)
     if reasons:
         receipt = _receipt(
             accepted=False,
@@ -812,6 +820,7 @@ def run_reddog_backend_architect_determination_runtime(
             model_selection_digest=model_selection_digest,
             model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
             model_runtime_binding_digest=model_runtime_binding_digest,
+            proposal_admission=proposal_admission,
         )
         persist_result = _persist_rejected(receipt)
         return _result(receipt=receipt, persist_result=persist_result)
@@ -837,16 +846,21 @@ def run_reddog_backend_architect_determination_runtime(
                 if model_result.provider_call_evidence
                 else None
             ),
+            "proposal_admission_receipt_id": (
+                proposal_admission.receipt_id if proposal_admission else None
+            ),
         }
     )
     if action == ACTION_FIX:
         assert next_slice_name is not None
+        assert proposal_admission is not None
         queue_candidate = _queue_candidate(
             source_determination_receipt_id=accepted_receipt_id,
             next_slice_name=next_slice_name,
             snapshot=snapshot,
             report_bundle_id=report_bundle_id,
             wsp15_allocation_receipt=wsp15_allocation_receipt,
+            proposal_admission=proposal_admission,
         )
     receipt = _receipt(
         accepted=True,
@@ -869,6 +883,7 @@ def run_reddog_backend_architect_determination_runtime(
         model_selection_digest=model_selection_digest,
         model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
         model_runtime_binding_digest=model_runtime_binding_digest,
+        proposal_admission=proposal_admission,
         queue_candidate=queue_candidate,
         determination_receipt_id=accepted_receipt_id,
     )
@@ -895,6 +910,7 @@ def run_reddog_backend_architect_determination_runtime(
             model_selection_digest=model_selection_digest,
             model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
             model_runtime_binding_digest=model_runtime_binding_digest,
+            proposal_admission=proposal_admission,
         )
         return _result(receipt=failed, persist_result=persist_result)
     return _result(receipt=receipt, persist_result=persist_result)
@@ -1118,80 +1134,67 @@ def _parse_model_output(content: str) -> Mapping[str, Any]:
     return {}
 
 
-def _validate_model_output(
-    output: Mapping[str, Any],
+def _validated_model_assurance(
     *,
+    model_result: ArchitectModelResult,
+    binding: Mapping[str, Any],
+    cycle_id: str,
+    model_runtime_binding_receipt_id: str | None,
+    model_runtime_binding_digest: str | None,
+) -> tuple[ArchitectModelResult, tuple[str, ...]]:
+    evidence = _canonical_provider_call_evidence(model_result.provider_call_evidence)
+    normalized = replace(model_result, provider_call_evidence=evidence)
+    reasons: list[str] = []
+    if not normalized.ok:
+        reasons.append(ArchitectDeterminationReason.MODEL_FAILURE)
+        reasons.extend(normalized.rejection_reasons)
+    elif not _provider_call_evidence_matches_architect(
+        evidence, binding=binding, cycle_id=cycle_id,
+        model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
+        model_runtime_binding_digest=model_runtime_binding_digest,
+    ):
+        reasons.append(ArchitectDeterminationReason.PROVIDER_CALL_EVIDENCE)
+    if not _fusion_quorum_passed(normalized.review_packet):
+        reasons.append(ArchitectDeterminationReason.FUSION_QUORUM_NOT_PASSED)
+    return normalized, _dedupe(reasons)
+
+
+def _validated_proposal(
+    *,
+    model_result: ArchitectModelResult,
+    snapshot: OperationalContextSnapshot,
     reports: Sequence[Mapping[str, Any]],
-    wsp15_allocation_receipt_id: Optional[str],
-    output_reasons: list[str],
-) -> None:
-    if not output:
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-        return
-    action = str(output.get("action") or "").strip().upper()
-    next_slice = str(output.get("next_slice_name") or "").strip()
-    summary = str(output.get("summary") or "").strip()
-    evidence_refs = _normalize_text_list(output.get("evidence_refs"))
-    model_allocation_id = str(output.get("wsp15_allocation_receipt_id") or "").strip()
-    if action not in ALLOWED_ACTIONS:
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-    if action in {ACTION_FIX, ACTION_RESEARCH_MORE, ACTION_REVISE} and not _valid_slice_name(next_slice):
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-    if action == ACTION_STOP and next_slice:
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-    if not summary:
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-    if not evidence_refs:
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-    report_refs = set(_all_report_evidence_refs(reports))
-    if evidence_refs and not set(evidence_refs).issubset(report_refs):
-        output_reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
-    if not model_allocation_id or model_allocation_id != wsp15_allocation_receipt_id:
-        output_reasons.append(ArchitectDeterminationReason.WSP15_RECEIPT_MISMATCH)
+    report_bundle_id: str | None,
+    allocation: Mapping[str, Any],
+    allocation_receipt_id: str | None,
+    policy: ArchitectProposalAdmissionPolicy,
+) -> tuple[Mapping[str, Any], ArchitectProposalExecutabilityReceipt | None, tuple[str, ...]]:
+    parsed = _parse_model_output(model_result.content)
+    validation = validate_architect_proposal_output(
+        parsed, reports=reports,
+        wsp15_allocation_receipt_id=allocation_receipt_id,
+    )
+    reasons: list[str] = []
+    if VALIDATION_INVALID_OUTPUT in validation:
+        reasons.append(ArchitectDeterminationReason.INVALID_MODEL_OUTPUT)
+    if VALIDATION_WSP15_MISMATCH in validation:
+        reasons.append(ArchitectDeterminationReason.WSP15_RECEIPT_MISMATCH)
+    if reasons:
+        return parsed, None, _dedupe(reasons)
+    admission = evaluate_architect_proposal_executability(
+        model_output=parsed, snapshot=snapshot, reports=reports,
+        report_bundle_id=report_bundle_id, wsp15_allocation_receipt=allocation,
+        policy=policy,
+    )
+    if not admission.accepted:
+        reasons.append(ArchitectDeterminationReason.PROPOSAL_EXECUTABILITY_ADMISSION)
+        reasons.extend(admission.rejection_reasons)
+    return parsed, admission, _dedupe(reasons)
 
 
 def _fusion_quorum_passed(review_packet: Mapping[str, Any]) -> bool:
     quorum = review_packet.get("fusion_panel_quorum")
     return isinstance(quorum, Mapping) and quorum.get("passed") is True
-
-
-def _build_architect_prompt(
-    *,
-    snapshot: OperationalContextSnapshot,
-    report_collection: ReadOnlyAuditReportCollectionResult,
-    reports: Sequence[Mapping[str, Any]],
-    wsp15_allocation_receipt: Mapping[str, Any],
-) -> str:
-    payload = {
-        "task": "Return one backend RedDog architect determination as strict JSON only.",
-        "allowed_actions": list(ALLOWED_ACTIONS),
-        "required_json_fields": [
-            "action",
-            "next_slice_name",
-            "summary",
-            "decision_reasons",
-            "evidence_refs",
-            "wsp15_allocation_receipt_id",
-        ],
-        "rules": [
-            "Use FIX only when exactly one next implementation slice should be queued.",
-            "Use RESEARCH_MORE when evidence is insufficient.",
-            "Use REVISE when prior work should be corrected before new implementation.",
-            "Use STOP when no next work should be queued.",
-            "Use only evidence_refs present in the supplied audit reports.",
-            "Echo the supplied WSP15 allocation receipt id exactly.",
-        ],
-        "snapshot_receipt_id": snapshot.snapshot_receipt_id,
-        "snapshot_content_digest": snapshot.snapshot_content_digest,
-        "report_collection": {
-            "status": report_collection.status,
-            "report_count": report_collection.report_count,
-            "bundle_id": _report_bundle_id(report_collection),
-        },
-        "wsp15_allocation_receipt_id": wsp15_allocation_receipt.get("receipt_id"),
-        "reports": [_report_prompt_view(report) for report in reports],
-    }
-    return _budgeted_canonical_json(payload, max_chars=DEFAULT_MAX_PROMPT_CHARS)
 
 
 def _build_architect_context(
@@ -1228,6 +1231,7 @@ def _queue_candidate(
     snapshot: OperationalContextSnapshot,
     report_bundle_id: Optional[str],
     wsp15_allocation_receipt: Mapping[str, Any],
+    proposal_admission: ArchitectProposalExecutabilityReceipt,
 ) -> ArchitectQueueCandidate:
     payload = {
         "source_determination_receipt_id": source_determination_receipt_id,
@@ -1235,20 +1239,28 @@ def _queue_candidate(
         "snapshot_receipt_id": snapshot.snapshot_receipt_id,
         "report_bundle_id": report_bundle_id,
         "wsp15_allocation_receipt_id": wsp15_allocation_receipt.get("receipt_id"),
+        "proposal_admission_receipt_id": proposal_admission.receipt_id,
     }
     return ArchitectQueueCandidate(
         schema_version=ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
         queue_candidate_id=_digest(payload),
         source_determination_receipt_id=source_determination_receipt_id,
         slice_id=next_slice_name,
-        status="CANDIDATE",
+        status=(
+            "CANDIDATE"
+            if proposal_admission.admissible_to_authoritative_queue
+            else "BLOCKED_CANDIDATE"
+        ),
         evidence_refs=(
             f"architect_determination:{source_determination_receipt_id}",
             f"snapshot:{snapshot.snapshot_receipt_id}",
             f"report_bundle:{report_bundle_id}",
             f"wsp15_allocation:{wsp15_allocation_receipt.get('receipt_id')}",
+            f"proposal_admission:{proposal_admission.receipt_id}",
         ),
         wsp15_allocation_receipt=dict(wsp15_allocation_receipt),
+        proposal_admission_receipt_id=proposal_admission.receipt_id,
+        proposal_admission_digest=_digest(proposal_admission.to_dict()),
     )
 
 
@@ -1310,6 +1322,7 @@ def _receipt(
     model_selection_digest: Optional[str] = None,
     model_runtime_binding_receipt_id: Optional[str] = None,
     model_runtime_binding_digest: Optional[str] = None,
+    proposal_admission: ArchitectProposalExecutabilityReceipt | None = None,
     queue_candidate: ArchitectQueueCandidate | None = None,
     determination_receipt_id: Optional[str] = None,
 ) -> ArchitectDeterminationReceipt:
@@ -1332,12 +1345,8 @@ def _receipt(
         "model_selection_digest": model_selection_digest,
         "model_runtime_binding_receipt_id": model_runtime_binding_receipt_id,
         "model_runtime_binding_digest": model_runtime_binding_digest,
-        "provider_call_id": (
-            model_result.provider_call_evidence.get("call_id") if model_result else None
-        ),
-        "provider_call_receipt_id": (
-            model_result.provider_call_evidence.get("receipt_id") if model_result else None
-        ),
+        "provider_call_id": model_result.provider_call_evidence.get("call_id") if model_result else None,
+        "provider_call_receipt_id": model_result.provider_call_evidence.get("receipt_id") if model_result else None,
         "provider_call_evidence_digest": (
             provider_evidence_digest(model_result.provider_call_evidence)
             if model_result and model_result.provider_call_evidence
@@ -1346,6 +1355,7 @@ def _receipt(
         "fusion_quorum_passed": _fusion_quorum_passed(model_result.review_packet) if model_result else False,
         "wsp15_allocation_receipt_id": allocation_receipt_id,
         "wsp15_allocation_digest": allocation_digest,
+        "proposal_admission_receipt_id": proposal_admission.receipt_id if proposal_admission else None,
         "queue_candidate_id": queue_candidate.queue_candidate_id if queue_candidate else None,
         "decision_reasons": tuple(decision_reasons),
         "rejection_reasons": tuple(rejection_reasons),
@@ -1373,12 +1383,8 @@ def _receipt(
         model_selection_digest=model_selection_digest,
         model_runtime_binding_receipt_id=model_runtime_binding_receipt_id,
         model_runtime_binding_digest=model_runtime_binding_digest,
-        provider_call_id=(
-            model_result.provider_call_evidence.get("call_id") if model_result else None
-        ),
-        provider_call_receipt_id=(
-            model_result.provider_call_evidence.get("receipt_id") if model_result else None
-        ),
+        provider_call_id=model_result.provider_call_evidence.get("call_id") if model_result else None,
+        provider_call_receipt_id=model_result.provider_call_evidence.get("receipt_id") if model_result else None,
         provider_call_evidence_digest=(
             provider_evidence_digest(model_result.provider_call_evidence)
             if model_result and model_result.provider_call_evidence
@@ -1387,6 +1393,7 @@ def _receipt(
         fusion_quorum_passed=_fusion_quorum_passed(model_result.review_packet) if model_result else False,
         wsp15_allocation_receipt_id=allocation_receipt_id,
         wsp15_allocation_digest=allocation_digest,
+        proposal_admission=proposal_admission,
         queue_candidate=queue_candidate,
         decision_reasons=tuple(decision_reasons),
         rejection_reasons=tuple(rejection_reasons),
@@ -1566,14 +1573,6 @@ def _report_digests(reports: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
     return tuple(sorted(digests))
 
 
-def _all_report_evidence_refs(reports: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
-    refs: list[str] = []
-    for report in reports:
-        if isinstance(report, Mapping):
-            refs.extend(_normalize_text_list(report.get("evidence_refs")))
-    return tuple(dict.fromkeys(refs))
-
-
 def _normalize_text_list(value: Any) -> tuple[str, ...]:
     if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
         return ()
@@ -1582,11 +1581,6 @@ def _normalize_text_list(value: Any) -> tuple[str, ...]:
 
 def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(str(value) for value in values if str(value).strip()))
-
-
-def _valid_slice_name(value: str) -> bool:
-    text = str(value or "").strip()
-    return bool(text) and text == text.upper() and all(ch.isalnum() or ch == "_" for ch in text)
 
 
 def _snapshot_expired(valid_until: str, now_iso: str) -> bool:

--- a/modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_architect_fix_promotion_bootstrap.py
@@ -22,6 +22,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+from holo_index.freshness_receipt import load_freshness_receipt, read_git_head_sha
+from holo_index.query_receipt import generation_binding_from_receipt
+
 from modules.communication.moltbot_bridge.src.reddog_architect_fix_signed_wsp15_work_order_promotion import (
     ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT,
     promote_reddog_architect_fix_to_signed_wsp15_work_order,
@@ -31,6 +34,9 @@ from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_re
 )
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
     runtime_operation_lock,
+)
+from modules.infrastructure.foundups_mcp_bridge.src.reddog_holoindex_owner_bootstrap import (
+    verify_reddog_holoindex_owner_binding,
 )
 
 
@@ -80,6 +86,7 @@ def run_reddog_main_architect_fix_promotion_bootstrap(
     memex_supply_receipt_path: Path | str | None,
     authority_profile_source_path: Path | str | None,
     authority_profile_output_path: Path | str | None,
+    holoindex_receipt_path: Path | str | None,
     model_runtime_binding_receipt_path: Path | str | None = None,
     worker_id: str = "reddog-main-architect-fix-promotion",
     now_iso: str | None = None,
@@ -135,6 +142,13 @@ def run_reddog_main_architect_fix_promotion_bootstrap(
         unreadable_reason="malformed_authority_profile_source",
     )
     reasons.extend(profile_reasons)
+    holoindex_file, holoindex_reasons = _resolve_existing_file_outside_repo(
+        root,
+        holoindex_receipt_path,
+        missing_reason="missing_holoindex_freshness_receipt_path",
+        inside_reason="holoindex_freshness_receipt_path_inside_repo",
+    )
+    reasons.extend(holoindex_reasons)
     output_path, output_reasons = _resolve_output_outside_repo(
         root,
         authority_profile_output_path,
@@ -152,31 +166,78 @@ def run_reddog_main_architect_fix_promotion_bootstrap(
     assert model_selection is not None
     assert memex_supply is not None
     assert authority_profile is not None
+    assert holoindex_file is not None
 
     output_probe_reasons = _probe_atomic_output(output_path)
     if output_probe_reasons:
         return _not_ready(output_probe_reasons)
 
     store = AtomicJsonAuthoritativeWorkStateStore(work_state_file)
-    result = promote_reddog_architect_fix_to_signed_wsp15_work_order(
-        architect_determination=determination,
-        work_state_store=store,
-        authority_profile=authority_profile,
-        model_selection_receipt=model_selection,
-        model_runtime_binding_receipt=model_runtime_binding,
-        memex_supply_receipt=memex_supply,
-        worker_id=worker_id,
-        now_iso=now_iso or datetime.now(timezone.utc).isoformat(),
-    )
-    if not result.accepted or result.status != ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT:
-        return _not_ready(result.rejection_reasons or ("architect_fix_promotion_rejected",))
+    with runtime_operation_lock(str(root) + ".architect-fix-promotion"):
+        try:
+            current_holoindex_receipt = load_freshness_receipt(holoindex_file)
+        except Exception:
+            return _not_ready(("malformed_holoindex_freshness_receipt",))
+        current_repo_head_sha = read_git_head_sha(root)
+        owner_binding = generation_binding_from_receipt(
+            current_holoindex_receipt,
+            receipt_path=holoindex_file,
+        )
+        if not verify_reddog_holoindex_owner_binding(
+            repo_root=root,
+            expected_repo_head_sha=current_repo_head_sha,
+            expected_generation_id=current_holoindex_receipt.generation_id,
+            expected_receipt_digest=str(
+                owner_binding.get("freshness_receipt_digest") or ""
+            ),
+        ):
+            return _not_ready(("holoindex_owner_binding_not_current",))
+
+        with runtime_operation_lock(str(output_path) + ".operation"):
+            previous_output = (
+                output_path.read_bytes() if output_path.exists() else None
+            )
+            written_digest: list[str] = []
+
+            def precommit_writer(profile: Mapping[str, Any]) -> None:
+                _write_json_atomic_unlocked(output_path, profile)
+                written_digest[:] = [_file_digest(output_path)]
+
+            result = promote_reddog_architect_fix_to_signed_wsp15_work_order(
+                architect_determination=determination,
+                work_state_store=store,
+                authority_profile=authority_profile,
+                model_selection_receipt=model_selection,
+                model_runtime_binding_receipt=model_runtime_binding,
+                memex_supply_receipt=memex_supply,
+                worker_id=worker_id,
+                now_iso=now_iso or datetime.now(timezone.utc).isoformat(),
+                current_repo_head_sha=current_repo_head_sha,
+                current_holoindex_receipt=current_holoindex_receipt,
+                authority_profile_precommit_writer=precommit_writer,
+            )
+            if (
+                not result.accepted
+                or result.status != ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT
+            ):
+                rollback_failed = bool(
+                    written_digest
+                ) and not _restore_output_unlocked(
+                    output_path,
+                    previous_output,
+                    expected_current_digest=written_digest[0],
+                )
+                rejection_reasons = list(
+                    result.rejection_reasons
+                    or ("architect_fix_promotion_rejected",)
+                )
+                if rollback_failed:
+                    rejection_reasons.append(
+                        "authority_profile_rollback_failed"
+                    )
+                return _not_ready(rejection_reasons)
     if result.authority_profile is None or result.receipt is None:
         return _not_ready(("architect_fix_promotion_missing_profile",))
-
-    try:
-        _write_json_atomic(output_path, result.authority_profile)
-    except Exception:
-        return _not_ready(("authority_profile_output_write_failed",))
 
     return RedDogMainArchitectFixPromotionBootstrapResult(
         accepted=True,
@@ -296,11 +357,6 @@ def _probe_atomic_output(path: Path) -> list[str]:
     return []
 
 
-def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
-    with runtime_operation_lock(str(path) + ".operation"):
-        _write_json_atomic_unlocked(path, payload)
-
-
 def _write_json_atomic_unlocked(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
@@ -312,6 +368,48 @@ def _write_json_atomic_unlocked(path: Path, payload: Mapping[str, Any]) -> None:
     finally:
         if os.path.exists(tmp_name):
             os.unlink(tmp_name)
+
+
+def _file_digest(path: Path) -> str:
+    import hashlib
+
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def _restore_output_unlocked(
+    path: Path,
+    previous: bytes | None,
+    *,
+    expected_current_digest: str,
+) -> bool:
+    if (
+        not expected_current_digest
+        or _file_digest(path) != expected_current_digest
+    ):
+        return False
+    try:
+        if previous is None:
+            path.unlink(missing_ok=True)
+            return True
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".restore", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(previous)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_name, path)
+        finally:
+            if os.path.exists(tmp_name):
+                os.unlink(tmp_name)
+        return True
+    except Exception:
+        return False
 
 
 def _not_ready(reasons: tuple[str, ...] | list[str]) -> RedDogMainArchitectFixPromotionBootstrapResult:

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,19 @@
+## 2026-07-27: Architect proposal executability admission
+- Added adversarial coverage for valid-but-blocked prerequisite slices,
+  produced-capability self-authorization, model readiness forgery, INDEX_GAP
+  handling, HoloIndex maintenance exceptions, Windows live-canary blocking,
+  path traversal, receipt tampering, rehashed capability under-declaration,
+  noncanonical candidate IDs, current-HEAD drift, current-Holo generation
+  drift, exact base-SHA binding, precommit-write atomicity, profile rollback,
+  rollback compare-and-swap, active-owner generation mismatch, work-state
+  revision drift, and mutation-free module imports.
+- Updated backend architect and signed WSP 15 promotion fixtures to carry the
+  canonical proposal-admission lineage while keeping production trust-anchor
+  discovery fail closed.
+- Focused and startup/runtime validation: 276 passed, one platform skip, and
+  one pre-existing Memex assertion deselected after reproducing it on clean
+  `origin/main`. Simulator CI parity passed 302 tests; red-team passed 42.
+
 ## 2026-07-27: Main-menu resident binding preflight regression
 - Proved missing bindings skip the client and return WARN/True by default versus FAIL/False when enforced; the focused startup suite passed 92 tests with one platform skip.
 ## 2026-07-26: Independent assurance capacity admission

--- a/modules/communication/moltbot_bridge/tests/architect_proposal_test_helpers.py
+++ b/modules/communication/moltbot_bridge/tests/architect_proposal_test_helpers.py
@@ -1,0 +1,92 @@
+"""Shared fixtures for architect proposal-admission runtime tests."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_executability_admission import (
+    ArchitectProposalAdmissionPolicy,
+    EFFECT_NONE,
+    EFFECT_READ_ONLY_AUDIT,
+    EFFECT_REPOSITORY_CODE_CHANGE,
+    LIVE_EXECUTION_CAPABILITIES,
+)
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ACTION_FIX,
+)
+
+
+def architect_model_output(
+    allocation: Mapping[str, Any],
+    evidence_ref: str,
+    *,
+    action: str = ACTION_FIX,
+    slice_name: str = "REDDOG_NEXT_RUNTIME_SLICE_PHASE1",
+) -> dict[str, Any]:
+    effect = (
+        EFFECT_REPOSITORY_CODE_CHANGE
+        if action == ACTION_FIX
+        else EFFECT_NONE if action == "STOP" else EFFECT_READ_ONLY_AUDIT
+    )
+    return {
+        "action": action,
+        "next_slice_name": (
+            slice_name if action != "STOP" else None
+        ),
+        "summary": "Verified reports support one next backend runtime slice.",
+        "decision_reasons": ["selected verified P0 runtime gap"],
+        "evidence_refs": [evidence_ref],
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "reuse_decision": "EXTEND_EXISTING",
+        "requested_operation": (
+            "bounded_code_change" if action == ACTION_FIX else "readonly_research"
+        ),
+        "target_runtime": "reddog_resident_queue",
+        "target_effect_plane": effect,
+        "allowed_paths": [
+            "modules/communication/moltbot_bridge/src/reddog_next_runtime_slice.py"
+        ],
+        "denied_paths": [".github/workflows/**", ".env"],
+        "required_tests": [
+            "pytest modules/communication/moltbot_bridge/tests/test_reddog_next_runtime_slice.py"
+        ],
+        "required_policy_gates": ["WSP_50", "WSP_97"],
+        "required_capabilities": (
+            list(LIVE_EXECUTION_CAPABILITIES) if action == ACTION_FIX else []
+        ),
+        "produced_capabilities": [],
+        "expected_evidence": ["exact_sha_test_receipt", "independent_review_receipt"],
+        "stop_conditions": ["stop_before_merge"],
+    }
+
+
+def ready_proposal_policy() -> ArchitectProposalAdmissionPolicy:
+    return ArchitectProposalAdmissionPolicy(
+        platform="linux",
+        available_capabilities=LIVE_EXECUTION_CAPABILITIES,
+        missing_capability_reasons={},
+    )
+
+
+def runtime_kwargs(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    kwargs = {
+        "snapshot": inputs["snapshot"],
+        "context_view": inputs["context_view"],
+        "evidence_bundle": inputs["evidence_bundle"],
+        "fusion_gate": inputs["fusion_gate"],
+        "report_collection": inputs["report_collection"],
+        "reports": inputs["reports"],
+        "proposal_admission_policy": ready_proposal_policy(),
+    }
+    if inputs["architect_runtime_binding"] is not None:
+        kwargs["model_runtime_binding_receipt"] = inputs[
+            "architect_runtime_binding"
+        ]
+    return kwargs
+
+
+__all__ = [
+    "architect_model_output",
+    "ready_proposal_policy",
+    "runtime_kwargs",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -6,6 +6,7 @@ import ast
 import json
 from pathlib import Path
 from typing import Any, Mapping
+from unittest.mock import patch
 
 from modules.ai_intelligence.ai_gateway.src.model_intelligence_catalog import (
     Availability,
@@ -48,6 +49,18 @@ from modules.communication.moltbot_bridge.src.reddog_backend_architect_determina
     ARCHITECT_DETERMINATION_ACCEPT,
     ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
 )
+from modules.communication.moltbot_bridge.src import (
+    reddog_architect_proposal_executability_admission as proposal_admission,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_executability_admission import (
+    LIVE_EXECUTION_CAPABILITIES,
+)
+from modules.communication.moltbot_bridge.tests.architect_proposal_test_helpers import (
+    ready_proposal_policy,
+)
+from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
+    build_fresh_holoindex_receipt,
+)
 from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
     WRE_QUEUE_CONSUMER_DRYRUN_READY,
     plan_reddog_wre_queue_consumer_dry_run,
@@ -69,6 +82,15 @@ MODULE_PATH = (
 )
 NOW = "2026-07-16T00:00:00+00:00"
 SNAPSHOT_ID = "sha256:snapshot-1"
+REPO_HEAD = "sha256:repo-head"
+
+
+def _holo_receipt():
+    return build_fresh_holoindex_receipt(
+        repo_root=REPO_ROOT,
+        head_sha=REPO_HEAD,
+        generated_at=NOW,
+    )
 
 
 def _allocation() -> dict[str, Any]:
@@ -95,32 +117,96 @@ def _work_state() -> dict[str, Any]:
     }
 
 
-def _determination(*, action: str = ACTION_FIX, allocation: Mapping[str, Any] | None = None) -> dict[str, Any]:
-    allocation = allocation or _allocation()
-    determination_id = "sha256:architect-determination-1"
-    candidate = {
-        "schema_version": ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
-        "queue_candidate_id": "sha256:queue-candidate-1",
-        "source_determination_receipt_id": determination_id,
+def _proposal_admission(
+    allocation: Mapping[str, Any],
+    *,
+    admissible: bool = True,
+    readiness: str = "READY",
+) -> dict[str, Any]:
+    holo_receipt = _holo_receipt()
+    policy = ready_proposal_policy()
+    payload = {
+        "schema_version": proposal_admission.PROPOSAL_ADMISSION_SCHEMA_VERSION,
+        "accepted": True,
+        "proposal_validity": "VALID",
+        "execution_readiness": readiness,
+        "admissible_to_authoritative_queue": admissible,
+        "action": ACTION_FIX,
         "slice_id": "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1",
-        "status": "CANDIDATE",
-        "evidence_refs": ["file:docs/audit.md:1"],
-        "wsp15_allocation_receipt": dict(allocation),
+        "task_summary_digest": "sha256:task-summary",
+        "reuse_decision": "EXTEND_EXISTING",
+        "requested_operation": "bounded_code_change",
+        "target_runtime": "reddog_resident_queue",
+        "target_effect_plane": "REPOSITORY_CODE_CHANGE",
+        "allowed_paths": [
+            "modules/communication/moltbot_bridge/src/reddog_next_operational_slice.py"
+        ],
+        "denied_paths": [".github/workflows/**", ".env"],
+        "required_tests": [
+            "pytest modules/communication/moltbot_bridge/tests/test_reddog_next_operational_slice.py"
+        ],
+        "required_policy_gates": ["WSP_50", "WSP_97"],
+        "required_capabilities": list(LIVE_EXECUTION_CAPABILITIES),
+        "produced_capabilities": [],
+        "expected_evidence": ["exact_sha_test_receipt"],
+        "stop_conditions": ["stop_before_merge"],
+        "missing_preconditions": (
+            [] if admissible else ["canonical_signer_client_peer_handshake_verifier_missing"]
+        ),
+        "decision_reasons": [],
+        "supporting_finding_ids": ["repo-code-audit-finding"],
+        "supporting_direct_read_paths": [],
+        "snapshot_receipt_id": SNAPSHOT_ID,
+        "snapshot_content_digest": "sha256:snapshot-content",
+        "repo_head_sha": REPO_HEAD,
+        "work_state_revision": "sha256:work-state-rev-1",
+        "holoindex_generation_id": holo_receipt.generation_id,
+        "holoindex_freshness_receipt_digest": proposal_admission._digest(
+            holo_receipt.to_dict()
+        ),
+        "index_gap_detected": False,
+        "direct_read_grounded": False,
+        "holoindex_maintenance_exception_applied": False,
+        "report_bundle_id": "sha256:report-bundle",
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "wsp15_allocation_digest": canonical_reddog_wsp15_allocation_digest(
+            allocation
+        ),
+        "policy_digest": proposal_admission._digest(policy.to_dict()),
+        "rejection_reasons": [],
         "no_queue_mutation_performed": True,
         "no_execution_performed": True,
-        "no_worker_spawn_performed": True,
-        "no_openclaw_enqueue_performed": True,
-        "no_hermes_dispatch_performed": True,
         "no_repo_mutation_performed": True,
+        "no_holoindex_reindex_performed": True,
     }
-    return {
+    payload["receipt_id"] = proposal_admission._digest(payload)
+    return payload
+
+
+def _determination(
+    *,
+    action: str = ACTION_FIX,
+    allocation: Mapping[str, Any] | None = None,
+    proposal_ready: bool = True,
+) -> dict[str, Any]:
+    allocation = allocation or _allocation()
+    admission = _proposal_admission(
+        allocation,
+        admissible=proposal_ready,
+        readiness="READY" if proposal_ready else "IMPLEMENTATION_BLOCKED",
+    )
+    next_slice = (
+        "REDDOG_NEXT_OPERATIONAL_SLICE_PHASE1"
+        if action == ACTION_FIX
+        else None
+    )
+    base = {
         "schema_version": "reddog_architect_determination_receipt.v1",
-        "determination_receipt_id": determination_id,
         "cycle_id": "sha256:cycle-1",
         "accepted": True,
         "status": ARCHITECT_DETERMINATION_ACCEPT,
         "action": action,
-        "next_slice_name": candidate["slice_id"] if action == ACTION_FIX else None,
+        "next_slice_name": next_slice,
         "summary": "Promote one verified FIX slice.",
         "snapshot_receipt_id": SNAPSHOT_ID,
         "snapshot_content_digest": "sha256:snapshot-content",
@@ -131,13 +217,112 @@ def _determination(*, action: str = ACTION_FIX, allocation: Mapping[str, Any] | 
         "audit_report_digests": ["sha256:report-1"],
         "model_result_digest": "sha256:model-result",
         "model_receipt_id": "model-receipt-1",
+        "model_selection_receipt_id": None,
+        "model_selection_digest": None,
+        "model_runtime_binding_receipt_id": None,
+        "model_runtime_binding_digest": None,
+        "provider_call_id": None,
+        "provider_call_receipt_id": None,
+        "provider_call_evidence_digest": None,
         "fusion_quorum_passed": True,
         "wsp15_allocation_receipt_id": allocation["receipt_id"],
-        "wsp15_allocation_digest": canonical_reddog_wsp15_allocation_digest(allocation),
-        "queue_candidate": candidate if action == ACTION_FIX else None,
+        "wsp15_allocation_digest": canonical_reddog_wsp15_allocation_digest(
+            allocation
+        ),
         "decision_reasons": ["FIX is the next verified bridge."],
         "rejection_reasons": [],
     }
+    determination_id = proposal_admission._digest(
+        {
+            "cycle_id": base["cycle_id"],
+            "action": base["action"],
+            "next_slice_name": base["next_slice_name"],
+            "model_result_digest": base["model_result_digest"],
+            "model_selection_digest": base["model_selection_digest"],
+            "provider_call_id": base["provider_call_id"],
+            "provider_call_receipt_id": base["provider_call_receipt_id"],
+            "provider_call_evidence_digest": base[
+                "provider_call_evidence_digest"
+            ],
+            "proposal_admission_receipt_id": admission["receipt_id"],
+        }
+    )
+    candidate_seed = {
+        "source_determination_receipt_id": determination_id,
+        "slice_id": next_slice,
+        "snapshot_receipt_id": SNAPSHOT_ID,
+        "report_bundle_id": base["report_bundle_id"],
+        "wsp15_allocation_receipt_id": allocation["receipt_id"],
+        "proposal_admission_receipt_id": admission["receipt_id"],
+    }
+    candidate = {
+        "schema_version": ARCHITECT_QUEUE_CANDIDATE_SCHEMA_VERSION,
+        "queue_candidate_id": proposal_admission._digest(candidate_seed),
+        "source_determination_receipt_id": determination_id,
+        "slice_id": next_slice,
+        "status": "CANDIDATE" if proposal_ready else "BLOCKED_CANDIDATE",
+        "evidence_refs": ["file:docs/audit.md:1"],
+        "wsp15_allocation_receipt": dict(allocation),
+        "proposal_admission_receipt_id": admission["receipt_id"],
+        "proposal_admission_digest": promotion._digest(admission),
+        "no_queue_mutation_performed": True,
+        "no_execution_performed": True,
+        "no_worker_spawn_performed": True,
+        "no_openclaw_enqueue_performed": True,
+        "no_hermes_dispatch_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+    return {
+        **base,
+        "determination_receipt_id": determination_id,
+        "proposal_admission": admission if action == ACTION_FIX else None,
+        "queue_candidate": candidate if action == ACTION_FIX else None,
+    }
+
+
+def _rebind_determination_admission(
+    determination: Mapping[str, Any],
+    admission_updates: Mapping[str, Any],
+) -> dict[str, Any]:
+    rebound = json.loads(json.dumps(determination, sort_keys=True))
+    admission = dict(rebound["proposal_admission"])
+    admission.update(admission_updates)
+    admission.pop("receipt_id", None)
+    admission["receipt_id"] = proposal_admission._digest(admission)
+    determination_seed = {
+        "cycle_id": rebound.get("cycle_id"),
+        "action": rebound.get("action"),
+        "next_slice_name": rebound.get("next_slice_name"),
+        "model_result_digest": rebound.get("model_result_digest"),
+        "model_selection_digest": rebound.get("model_selection_digest"),
+        "provider_call_id": rebound.get("provider_call_id"),
+        "provider_call_receipt_id": rebound.get("provider_call_receipt_id"),
+        "provider_call_evidence_digest": rebound.get(
+            "provider_call_evidence_digest"
+        ),
+        "proposal_admission_receipt_id": admission["receipt_id"],
+    }
+    determination_id = proposal_admission._digest(determination_seed)
+    candidate = dict(rebound["queue_candidate"])
+    candidate["source_determination_receipt_id"] = determination_id
+    candidate["proposal_admission_receipt_id"] = admission["receipt_id"]
+    candidate["proposal_admission_digest"] = promotion._digest(admission)
+    candidate["queue_candidate_id"] = proposal_admission._digest(
+        {
+            "source_determination_receipt_id": determination_id,
+            "slice_id": candidate["slice_id"],
+            "snapshot_receipt_id": rebound["snapshot_receipt_id"],
+            "report_bundle_id": rebound["report_bundle_id"],
+            "wsp15_allocation_receipt_id": rebound[
+                "wsp15_allocation_receipt_id"
+            ],
+            "proposal_admission_receipt_id": admission["receipt_id"],
+        }
+    )
+    rebound["proposal_admission"] = admission
+    rebound["determination_receipt_id"] = determination_id
+    rebound["queue_candidate"] = candidate
+    return rebound
 
 
 def _authority_profile(**overrides: Any) -> dict[str, Any]:
@@ -366,9 +551,21 @@ def _promote(**overrides: Any):
         "memex_supply_receipt": _memex_supply(),
         "worker_id": "reddog-worker-1",
         "now_iso": NOW,
+        "current_repo_head_sha": REPO_HEAD,
+        "current_holoindex_receipt": _holo_receipt(),
+        "authority_profile_precommit_writer": lambda profile: None,
     }
     args.update(overrides)
-    return promotion.promote_reddog_architect_fix_to_signed_wsp15_work_order(**args), store
+    with patch(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_architect_proposal_admission_contract."
+        "current_architect_proposal_admission_policy",
+        return_value=ready_proposal_policy(),
+    ):
+        result = promotion.promote_reddog_architect_fix_to_signed_wsp15_work_order(
+            **args
+        )
+    return result, store
 
 
 def test_promotes_fix_determination_to_queue_item_and_authority_profile() -> None:
@@ -552,6 +749,161 @@ def test_rejects_conflicting_wsp15_allocation_before_store_mutation() -> None:
 
     assert result.accepted is False
     assert promotion.ArchitectFixPromotionReason.WSP15_ALLOCATION_MISMATCH in result.rejection_reasons
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_valid_but_execution_blocked_candidate_before_store_mutation() -> None:
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=_determination(proposal_ready=False),
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.PROPOSAL_ADMISSION_INVALID
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_tampered_proposal_admission_before_store_mutation() -> None:
+    determination = _determination()
+    determination["proposal_admission"]["allowed_paths"] = ["modules/other/**"]
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=determination,
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.PROPOSAL_ADMISSION_INVALID
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_rehashed_underdeclared_effect_capabilities() -> None:
+    determination = _rebind_determination_admission(
+        _determination(),
+        {"required_capabilities": []},
+    )
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=determination,
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.PROPOSAL_ADMISSION_INVALID
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_noncanonical_queue_candidate_id() -> None:
+    determination = _determination()
+    determination["queue_candidate"]["queue_candidate_id"] = "sha256:forged"
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=determination,
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.QUEUE_CANDIDATE_MALFORMED
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_changed_holoindex_generation_before_store_mutation() -> None:
+    current = _holo_receipt().to_dict()
+    current["generation_id"] = "sha256:different-generation"
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        current_holoindex_receipt=current,
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.HOLOINDEX_BINDING_MISMATCH
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_precommit_profile_failure_leaves_authoritative_queue_empty() -> None:
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    def fail_profile_write(_profile: Mapping[str, Any]) -> None:
+        raise OSError("simulated profile write failure")
+
+    result, _ = _promote(
+        store=store,
+        authority_profile_precommit_writer=fail_profile_write,
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.AUTHORITY_PROFILE_PRECOMMIT_WRITE_FAILED
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+    assert store.load()["worker_claims"] == []
+
+
+def test_exact_authorized_base_sha_is_bound_across_promotion_outputs() -> None:
+    result, store = _promote()
+
+    assert result.accepted is True
+    assert result.authority_profile is not None
+    assert result.authority_profile["base_ref"] == REPO_HEAD
+    assert result.authority_profile["authorized_base_sha"] == REPO_HEAD
+    binding = result.authority_profile["operational_context_binding"]
+    assert binding["authorized_base_sha"] == REPO_HEAD
+    snapshot = store.load()
+    assert snapshot["worker_claims"][0]["authorized_base_sha"] == REPO_HEAD
+    assert snapshot["wre_queue_items"][0]["authorized_base_sha"] == REPO_HEAD
+
+
+def test_rejects_changed_repository_head_before_store_mutation() -> None:
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+
+    result, _ = _promote(
+        store=store,
+        current_repo_head_sha="sha256:different-head",
+    )
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.REPO_HEAD_MISMATCH
+        in result.rejection_reasons
+    )
+    assert store.load()["wre_queue_items"] == []
+
+
+def test_rejects_changed_work_state_revision_before_store_mutation() -> None:
+    changed = _work_state()
+    changed["revision"] = "sha256:different-work-state"
+    store = InMemoryAuthoritativeWorkStateStore(changed)
+
+    result, _ = _promote(store=store)
+
+    assert result.accepted is False
+    assert (
+        promotion.ArchitectFixPromotionReason.PROPOSAL_ADMISSION_INVALID
+        in result.rejection_reasons
+    )
     assert store.load()["wre_queue_items"] == []
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_executability_admission.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_executability_admission.py
@@ -1,0 +1,469 @@
+"""Tests for architect proposal validity and execution-readiness admission."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_architect_proposal_admission_contract as proposal_admission,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_executability_admission import (
+    ArchitectProposalAdmissionPolicy,
+    EFFECT_LIVE_WORKTREE_CANARY,
+    EFFECT_REPOSITORY_CODE_CHANGE,
+    EXTEND_EXISTING,
+    LIVE_EXECUTION_CAPABILITIES,
+    READINESS_EVIDENCE_BLOCKED,
+    READINESS_IMPLEMENTATION_BLOCKED,
+    READINESS_PLATFORM_BLOCKED,
+    READINESS_READY,
+    VALIDITY_NEEDS_RESEARCH,
+    VALIDITY_VALID,
+    evaluate_architect_proposal_executability,
+    reevaluate_architect_proposal_execution_readiness,
+    validate_architect_proposal_executability_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
+    ArchitectDeterminationReason,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_backend_architect_determination_runtime import (
+    NOW,
+    FakeArchitectRunner,
+    InMemoryArchitectDeterminationStore,
+    _build_inputs,
+    _model_output,
+    _runtime_kwargs,
+    run_reddog_backend_architect_determination_runtime,
+)
+
+
+def _policy(
+    *,
+    platform: str = "linux",
+    available: tuple[str, ...] = LIVE_EXECUTION_CAPABILITIES,
+    missing: dict[str, str] | None = None,
+) -> ArchitectProposalAdmissionPolicy:
+    return ArchitectProposalAdmissionPolicy(
+        platform=platform,
+        available_capabilities=available,
+        missing_capability_reasons=missing or {},
+    )
+
+
+def _evaluate(
+    *,
+    output_updates: dict | None = None,
+    policy: ArchitectProposalAdmissionPolicy | None = None,
+    index_gap: bool = False,
+):
+    inputs = _build_inputs()
+    output = _model_output(
+        inputs["allocation"],
+        inputs["reports"][0]["evidence_refs"][0],
+    )
+    output.update(output_updates or {})
+    snapshot = inputs["snapshot"]
+    if index_gap:
+        snapshot = replace(
+            snapshot,
+            holoindex_state={
+                **snapshot.holoindex_state,
+                "freshness_ok": False,
+                "rejection_reasons": ("INDEX_GAP",),
+            },
+        )
+    receipt = evaluate_architect_proposal_executability(
+        model_output=output,
+        snapshot=snapshot,
+        reports=inputs["reports"],
+        report_bundle_id=inputs["report_collection"].validation.bundle.bundle_id,
+        wsp15_allocation_receipt=inputs["allocation"],
+        policy=policy,
+    )
+    return receipt, inputs, output
+
+
+def test_production_policy_keeps_sha_only_proposal_receipts_blocked() -> None:
+    policy = proposal_admission.current_architect_proposal_admission_policy()
+
+    assert (
+        proposal_admission.CAP_PROPOSAL_AUTHENTICITY
+        not in policy.available_capabilities
+    )
+    assert policy.missing_capability_reasons[
+        proposal_admission.CAP_PROPOSAL_AUTHENTICITY
+    ] == proposal_admission.PROPOSAL_AUTHENTICITY_VERIFIER_MISSING
+
+
+def test_missing_trust_anchor_keeps_proposal_valid_but_blocks_promotion() -> None:
+    missing_capability = LIVE_EXECUTION_CAPABILITIES[0]
+    receipt, _, _ = _evaluate(
+        policy=_policy(
+            available=tuple(
+                item
+                for item in LIVE_EXECUTION_CAPABILITIES
+                if item != missing_capability
+            ),
+            missing={missing_capability: "canonical_trust_anchor_missing"},
+        )
+    )
+
+    assert receipt.accepted is True
+    assert receipt.proposal_validity == VALIDITY_VALID
+    assert receipt.execution_readiness == READINESS_IMPLEMENTATION_BLOCKED
+    assert receipt.admissible_to_authoritative_queue is False
+    assert "canonical_trust_anchor_missing" in receipt.missing_preconditions
+
+
+def test_slice_producing_missing_capability_does_not_self_authorize() -> None:
+    missing_capability = LIVE_EXECUTION_CAPABILITIES[0]
+    receipt, _, _ = _evaluate(
+        output_updates={"produced_capabilities": [missing_capability]},
+        policy=_policy(
+            available=tuple(
+                item
+                for item in LIVE_EXECUTION_CAPABILITIES
+                if item != missing_capability
+            ),
+            missing={missing_capability: "canonical_trust_anchor_missing"},
+        ),
+    )
+
+    assert receipt.execution_readiness == READINESS_IMPLEMENTATION_BLOCKED
+    assert receipt.admissible_to_authoritative_queue is False
+    assert any(
+        reason.startswith("produced_capability_is_output_not_current_authority:")
+        for reason in receipt.decision_reasons
+    )
+
+
+def test_model_supplied_readiness_boolean_has_no_authority() -> None:
+    missing_capability = LIVE_EXECUTION_CAPABILITIES[0]
+    receipt, _, _ = _evaluate(
+        output_updates={"execution_ready": True, "queue_admissible": True},
+        policy=_policy(
+            available=tuple(
+                item
+                for item in LIVE_EXECUTION_CAPABILITIES
+                if item != missing_capability
+            ),
+            missing={missing_capability: "canonical_trust_anchor_missing"},
+        ),
+    )
+
+    assert receipt.execution_readiness == READINESS_IMPLEMENTATION_BLOCKED
+    assert receipt.admissible_to_authoritative_queue is False
+
+
+def test_all_current_capabilities_admit_repository_change() -> None:
+    receipt, _, _ = _evaluate(policy=_policy())
+
+    assert receipt.proposal_validity == VALIDITY_VALID
+    assert receipt.execution_readiness == READINESS_READY
+    assert receipt.admissible_to_authoritative_queue is True
+    assert validate_architect_proposal_executability_receipt(
+        receipt.to_dict()
+    ) == receipt
+
+
+def test_index_gap_blocks_arbitrary_repository_change() -> None:
+    receipt, _, _ = _evaluate(policy=_policy(), index_gap=True)
+
+    assert receipt.accepted is True
+    assert receipt.execution_readiness == READINESS_EVIDENCE_BLOCKED
+    assert receipt.admissible_to_authoritative_queue is False
+    assert "holoindex_index_gap" in receipt.missing_preconditions
+
+
+def test_index_gap_allows_only_direct_read_grounded_holo_maintenance() -> None:
+    inputs = _build_inputs()
+    reports = [dict(report) for report in inputs["reports"]]
+    reports[0] = {
+        **reports[0],
+        "evidence_refs": ["file:holo_index/query_owner.py:sha256:test:lines:1"],
+        "findings": [
+            {
+                **reports[0]["findings"][0],
+                "next_slice_name": "HOLOINDEX_OWNER_REPAIR_PHASE1",
+                "evidence_refs": [
+                    "file:holo_index/query_owner.py:sha256:test:lines:1"
+                ],
+            }
+        ],
+    }
+    output = _model_output(
+        inputs["allocation"],
+        reports[0]["evidence_refs"][0],
+    )
+    output.update(
+        {
+            "next_slice_name": "HOLOINDEX_OWNER_REPAIR_PHASE1",
+            "requested_operation": "holoindex_maintenance",
+            "allowed_paths": ["holo_index/query_owner.py"],
+        }
+    )
+    snapshot = replace(
+        inputs["snapshot"],
+        holoindex_state={
+            **inputs["snapshot"].holoindex_state,
+            "freshness_ok": False,
+        },
+    )
+
+    receipt = evaluate_architect_proposal_executability(
+        model_output=output,
+        snapshot=snapshot,
+        reports=reports,
+        report_bundle_id=inputs["report_collection"].validation.bundle.bundle_id,
+        wsp15_allocation_receipt=inputs["allocation"],
+        policy=_policy(),
+    )
+
+    assert receipt.proposal_validity == VALIDITY_VALID
+    assert receipt.execution_readiness == READINESS_READY
+    assert receipt.admissible_to_authoritative_queue is True
+    assert receipt.direct_read_grounded is True
+    assert receipt.holoindex_maintenance_exception_applied is True
+    rehydrated = validate_architect_proposal_executability_receipt(
+        receipt.to_dict()
+    )
+    assert (
+        reevaluate_architect_proposal_execution_readiness(
+            rehydrated,
+            policy=_policy(),
+        )
+        == ()
+    )
+
+
+def test_unrelated_holo_reference_does_not_unlock_maintenance_exception() -> None:
+    inputs = _build_inputs()
+    reports = [dict(report) for report in inputs["reports"]]
+    reports[0] = {
+        **reports[0],
+        "evidence_refs": [
+            *reports[0]["evidence_refs"],
+            "file:holo_index/unrelated.py:sha256:test:lines:1",
+        ],
+        "findings": [
+            {
+                **reports[0]["findings"][0],
+                "next_slice_name": "HOLOINDEX_OWNER_REPAIR_PHASE1",
+            }
+        ],
+    }
+    output = _model_output(
+        inputs["allocation"],
+        reports[0]["findings"][0]["evidence_refs"][0],
+    )
+    output.update(
+        {
+            "next_slice_name": "HOLOINDEX_OWNER_REPAIR_PHASE1",
+            "requested_operation": "holoindex_maintenance",
+            "allowed_paths": ["holo_index/query_owner.py"],
+        }
+    )
+    snapshot = replace(
+        inputs["snapshot"],
+        holoindex_state={
+            **inputs["snapshot"].holoindex_state,
+            "freshness_ok": False,
+        },
+    )
+
+    receipt = evaluate_architect_proposal_executability(
+        model_output=output,
+        snapshot=snapshot,
+        reports=reports,
+        report_bundle_id=inputs["report_collection"].validation.bundle.bundle_id,
+        wsp15_allocation_receipt=inputs["allocation"],
+        policy=_policy(),
+    )
+
+    assert receipt.proposal_validity == VALIDITY_VALID
+    assert receipt.execution_readiness == READINESS_EVIDENCE_BLOCKED
+    assert receipt.direct_read_grounded is False
+    assert receipt.holoindex_maintenance_exception_applied is False
+
+
+def test_holo_maintenance_direct_read_cannot_widen_to_directory_wildcard() -> None:
+    inputs = _build_inputs()
+    reports = [dict(report) for report in inputs["reports"]]
+    reports[0] = {
+        **reports[0],
+        "evidence_refs": ["file:holo_index/query_owner.py:sha256:test:lines:1"],
+        "findings": [
+            {
+                **reports[0]["findings"][0],
+                "next_slice_name": "HOLOINDEX_OWNER_REPAIR_PHASE1",
+                "evidence_refs": [
+                    "file:holo_index/query_owner.py:sha256:test:lines:1"
+                ],
+            }
+        ],
+    }
+    output = _model_output(
+        inputs["allocation"],
+        reports[0]["evidence_refs"][0],
+    )
+    output.update(
+        {
+            "next_slice_name": "HOLOINDEX_OWNER_REPAIR_PHASE1",
+            "requested_operation": "holoindex_maintenance",
+            "allowed_paths": ["holo_index/**"],
+        }
+    )
+    snapshot = replace(
+        inputs["snapshot"],
+        holoindex_state={
+            **inputs["snapshot"].holoindex_state,
+            "freshness_ok": False,
+        },
+    )
+
+    receipt = evaluate_architect_proposal_executability(
+        model_output=output,
+        snapshot=snapshot,
+        reports=reports,
+        report_bundle_id=inputs["report_collection"].validation.bundle.bundle_id,
+        wsp15_allocation_receipt=inputs["allocation"],
+        policy=_policy(),
+    )
+
+    assert receipt.proposal_validity == VALIDITY_VALID
+    assert receipt.execution_readiness == READINESS_EVIDENCE_BLOCKED
+    assert receipt.holoindex_maintenance_exception_applied is False
+
+
+def test_windows_blocks_live_canary_but_not_readonly_reasoning() -> None:
+    receipt, _, _ = _evaluate(
+        output_updates={
+            "target_effect_plane": EFFECT_LIVE_WORKTREE_CANARY,
+            "requested_operation": "live_worktree_canary",
+        },
+        policy=_policy(platform="windows"),
+    )
+
+    assert receipt.proposal_validity == VALIDITY_VALID
+    assert receipt.execution_readiness == READINESS_PLATFORM_BLOCKED
+    assert receipt.admissible_to_authoritative_queue is False
+
+
+def test_unsupported_fix_becomes_research_not_a_queue_authority() -> None:
+    receipt, _, _ = _evaluate(
+        output_updates={"next_slice_name": "UNOBSERVED_SLICE_PHASE1"},
+        policy=_policy(),
+    )
+
+    assert receipt.accepted is False
+    assert receipt.proposal_validity == VALIDITY_NEEDS_RESEARCH
+    assert receipt.admissible_to_authoritative_queue is False
+
+
+def test_mixed_valid_and_traversal_paths_fail_instead_of_silently_narrowing() -> None:
+    receipt, _, _ = _evaluate(
+        output_updates={
+            "allowed_paths": [
+                "modules/communication/moltbot_bridge/src/valid.py",
+                "../outside.py",
+            ]
+        },
+        policy=_policy(),
+    )
+
+    assert receipt.accepted is False
+    assert "repository_path_token_invalid" in receipt.rejection_reasons
+
+
+def test_tampered_serialized_receipt_fails_closed() -> None:
+    receipt, _, _ = _evaluate(policy=_policy())
+    tampered = receipt.to_dict()
+    tampered["allowed_paths"] = ["modules/other/**"]
+
+    with pytest.raises(ValueError, match="proposal_admission_receipt_invalid"):
+        validate_architect_proposal_executability_receipt(tampered)
+
+
+def test_holo_maintenance_exception_cannot_be_forged_by_receipt_rehash() -> None:
+    receipt, _, _ = _evaluate(policy=_policy())
+    forged = receipt.to_dict()
+    forged["index_gap_detected"] = True
+    forged["direct_read_grounded"] = False
+    forged["holoindex_maintenance_exception_applied"] = True
+    body = dict(forged)
+    body.pop("receipt_id")
+    forged["receipt_id"] = proposal_admission._digest(body)
+
+    with pytest.raises(ValueError, match="proposal_admission_receipt_invalid"):
+        validate_architect_proposal_executability_receipt(forged)
+
+
+def test_backend_persists_valid_blocked_candidate_without_authoritative_admission() -> None:
+    inputs = _build_inputs()
+    evidence_ref = inputs["reports"][0]["evidence_refs"][0]
+    missing_capability = LIVE_EXECUTION_CAPABILITIES[0]
+    policy = _policy(
+        available=tuple(
+            item
+            for item in LIVE_EXECUTION_CAPABILITIES
+            if item != missing_capability
+        ),
+        missing={missing_capability: "canonical_trust_anchor_missing"},
+    )
+    kwargs = _runtime_kwargs(inputs)
+    kwargs["proposal_admission_policy"] = policy
+
+    result = run_reddog_backend_architect_determination_runtime(
+        **kwargs,
+        wsp15_allocation_receipt=inputs["allocation"],
+        store=InMemoryArchitectDeterminationStore(),
+        model_runner=FakeArchitectRunner(
+            _model_output(inputs["allocation"], evidence_ref)
+        ),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is True
+    assert result.receipt.proposal_admission is not None
+    assert result.receipt.proposal_admission.accepted is True
+    assert (
+        result.receipt.proposal_admission.admissible_to_authoritative_queue
+        is False
+    )
+    assert result.receipt.queue_candidate is not None
+    assert result.receipt.queue_candidate.status == "BLOCKED_CANDIDATE"
+    assert (
+        ArchitectDeterminationReason.PROPOSAL_EXECUTABILITY_ADMISSION
+        not in result.rejection_reasons
+    )
+
+
+def test_admission_modules_have_no_execution_network_or_index_mutation_imports() -> None:
+    src = Path(__file__).resolve().parents[1] / "src"
+    banned_imports = {
+        "subprocess", "requests", "urllib", "http", "socket", "git", "gh"
+    }
+    banned_calls = {"eval", "exec", "compile", "__import__"}
+    for name in (
+        "reddog_architect_proposal_admission_contract.py",
+        "reddog_architect_proposal_executability_admission.py",
+        "reddog_architect_proposal_prompt.py",
+        "reddog_architect_fix_candidate_gate.py",
+        "reddog_architect_fix_promotion_profile.py",
+        "reddog_architect_fix_promotion_records.py",
+    ):
+        tree = ast.parse((src / name).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                assert all(
+                    alias.name.split(".")[0] not in banned_imports
+                    for alias in node.names
+                )
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert node.module.split(".")[0] not in banned_imports
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_seed_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_seed_supply.py
@@ -7,12 +7,6 @@ import json
 from dataclasses import asdict
 from pathlib import Path
 
-from modules.communication.moltbot_bridge.src import (
-    reddog_architect_fix_signed_wsp15_work_order_promotion as promotion,
-)
-from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
-    InMemoryAuthoritativeWorkStateStore,
-)
 from modules.communication.moltbot_bridge.src.reddog_authority_profile_seed_supply import (
     AUTHORITY_PROFILE_SEED_SUPPLY_ACCEPT,
     AUTHORITY_PROFILE_SEED_SUPPLY_REJECT,
@@ -26,7 +20,7 @@ from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed
     _determination,
     _memex_supply,
     _model_selection,
-    _work_state,
+    _promote,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_authority_profile_source_artifact_supply import (
     _principal,
@@ -92,15 +86,7 @@ def test_seed_supply_writes_seed_consumable_by_source_supplier_and_promotion(tmp
     assert source.accepted is True
 
     profile = json.loads(source_path.read_text(encoding="utf-8"))
-    promoted = promotion.promote_reddog_architect_fix_to_signed_wsp15_work_order(
-        architect_determination=_determination(),
-        work_state_store=InMemoryAuthoritativeWorkStateStore(_work_state()),
-        authority_profile=profile,
-        model_selection_receipt=_model_selection(),
-        memex_supply_receipt=_memex_supply(),
-        worker_id="reddog-seed-test",
-        now_iso="2026-07-16T00:00:00+00:00",
-    )
+    promoted, _ = _promote(authority_profile=profile)
     assert promoted.accepted is True
     assert promoted.authority_profile is not None
     assert promoted.authority_profile["seed_supply_receipt_id"] == seed["seed_supply_receipt_id"]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_source_artifact_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_source_artifact_supply.py
@@ -6,17 +6,11 @@ import ast
 import json
 from pathlib import Path
 
-from modules.communication.moltbot_bridge.src import (
-    reddog_architect_fix_signed_wsp15_work_order_promotion as promotion,
-)
 from modules.communication.moltbot_bridge.src.reddog_authority_profile_source_artifact_supply import (
     AUTHORITY_PROFILE_SOURCE_SUPPLY_ACCEPT,
     AUTHORITY_PROFILE_SOURCE_SUPPLY_REJECT,
     AuthorityProfileSourceSupplyReason,
     run_reddog_authority_profile_source_artifact_supply,
-)
-from modules.communication.moltbot_bridge.src.reddog_authoritative_work_state_refresh_runtime import (
-    InMemoryAuthoritativeWorkStateStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     PrincipalAuthorityRecord,
@@ -28,10 +22,7 @@ from modules.communication.moltbot_bridge.src.reddog_wre_execution_valve import 
     VALVE_OPEN_WORKTREE_CREATE,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
-    _determination,
-    _memex_supply,
-    _model_selection,
-    _work_state,
+    _promote,
 )
 
 
@@ -133,15 +124,7 @@ def test_supplier_writes_profile_source_consumable_by_fix_promotion(tmp_path: Pa
     assert profile["no_holoindex_reindex_performed"] is True
     assert profile["source_authority_basis"]["permission_snapshot_can_write"] is True
 
-    promoted = promotion.promote_reddog_architect_fix_to_signed_wsp15_work_order(
-        architect_determination=_determination(),
-        work_state_store=InMemoryAuthoritativeWorkStateStore(_work_state()),
-        authority_profile=profile,
-        model_selection_receipt=_model_selection(),
-        memex_supply_receipt=_memex_supply(),
-        worker_id="reddog-worker-1",
-        now_iso="2026-07-16T00:00:00+00:00",
-    )
+    promoted, _ = _promote(authority_profile=profile)
     assert promoted.accepted is True
     assert promoted.authority_profile is not None
     assert promoted.authority_profile["authority_profile_source_receipt_id"] == profile[

--- a/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_backend_architect_determination_runtime.py
@@ -59,6 +59,10 @@ from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_te
 from modules.communication.moltbot_bridge.tests.holoindex_freshness_receipt_test_helpers import (
     build_fresh_holoindex_receipt,
 )
+from modules.communication.moltbot_bridge.tests.architect_proposal_test_helpers import (
+    architect_model_output as _model_output,
+    runtime_kwargs as _runtime_kwargs,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -266,31 +270,6 @@ def _reports(plan) -> tuple[dict[str, Any], ...]:
             }
         )
     return tuple(reports)
-
-
-def _model_output(allocation: Mapping[str, Any], evidence_ref: str, *, action: str = ACTION_FIX) -> dict[str, Any]:
-    return {
-        "action": action,
-        "next_slice_name": "REDDOG_NEXT_RUNTIME_SLICE_PHASE1" if action != "STOP" else None,
-        "summary": "Verified reports support one next backend runtime slice.",
-        "decision_reasons": ["selected verified P0 runtime gap"],
-        "evidence_refs": [evidence_ref],
-        "wsp15_allocation_receipt_id": allocation["receipt_id"],
-    }
-
-
-def _runtime_kwargs(inputs: Mapping[str, Any]) -> dict[str, Any]:
-    kwargs = {
-        "snapshot": inputs["snapshot"],
-        "context_view": inputs["context_view"],
-        "evidence_bundle": inputs["evidence_bundle"],
-        "fusion_gate": inputs["fusion_gate"],
-        "report_collection": inputs["report_collection"],
-        "reports": inputs["reports"],
-    }
-    if inputs["architect_runtime_binding"] is not None:
-        kwargs["model_runtime_binding_receipt"] = inputs["architect_runtime_binding"]
-    return kwargs
 
 
 def _provider_call_evidence_from_binding(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap import (
     REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED,
     REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_NOT_READY,
@@ -15,10 +17,14 @@ from modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotio
 from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
     _authority_profile,
     _determination,
+    _holo_receipt,
     _memex_supply,
     _model_selection,
     _runtime_binding,
     _work_state,
+)
+from modules.communication.moltbot_bridge.tests.architect_proposal_test_helpers import (
+    ready_proposal_policy,
 )
 
 
@@ -34,9 +40,21 @@ MODULE_PATH = (
 NOW = "2026-07-16T00:00:00+00:00"
 
 
+@pytest.fixture(autouse=True)
+def _current_holo_owner_binding(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_architect_fix_promotion_bootstrap."
+        "verify_reddog_holoindex_owner_binding",
+        lambda **_kwargs: True,
+    )
+
+
 def _repo(tmp_path: Path) -> Path:
     path = tmp_path / "repo"
     path.mkdir()
+    (path / ".git").mkdir()
+    (path / ".git" / "HEAD").write_text("sha256:repo-head\n", encoding="utf-8")
     return path
 
 
@@ -65,24 +83,51 @@ def _runtime_files(tmp_path: Path) -> dict[str, Path]:
             _authority_profile(),
         ),
         "authority_profile_output": tmp_path / "runtime" / "authority_profile.json",
+        "holoindex_receipt": _write_json(
+            tmp_path,
+            "holoindex_freshness_receipt.json",
+            _holo_receipt().to_dict(),
+        ),
     }
+
+
+def _holo_receipt_file(tmp_path: Path) -> Path:
+    return _write_json(
+        tmp_path,
+        "holoindex_freshness_receipt.json",
+        _holo_receipt().to_dict(),
+    )
 
 
 def test_bootstrap_promotes_fix_and_writes_authority_profile(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     files = _runtime_files(tmp_path)
 
-    result = run_reddog_main_architect_fix_promotion_bootstrap(
-        repo_root=repo,
-        work_state_path=files["work_state"],
-        architect_determination_path=files["determination"],
-        model_selection_receipt_path=files["model_selection"],
-        memex_supply_receipt_path=files["memex_supply"],
-        authority_profile_source_path=files["authority_profile_source"],
-        authority_profile_output_path=files["authority_profile_output"],
-        worker_id="reddog-main-test",
-        now_iso=NOW,
-    )
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap.read_git_head_sha",
+            return_value="sha256:repo-head",
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_architect_proposal_admission_contract."
+            "current_architect_proposal_admission_policy",
+            return_value=ready_proposal_policy(),
+        ),
+    ):
+        result = run_reddog_main_architect_fix_promotion_bootstrap(
+            repo_root=repo,
+            work_state_path=files["work_state"],
+            architect_determination_path=files["determination"],
+            model_selection_receipt_path=files["model_selection"],
+            memex_supply_receipt_path=files["memex_supply"],
+            authority_profile_source_path=files["authority_profile_source"],
+            authority_profile_output_path=files["authority_profile_output"],
+            holoindex_receipt_path=files["holoindex_receipt"],
+            worker_id="reddog-main-test",
+            now_iso=NOW,
+        )
 
     assert result.accepted is True
     assert result.status == REDDOG_ARCHITECT_FIX_PROMOTION_BOOTSTRAP_APPLIED
@@ -108,18 +153,32 @@ def test_bootstrap_forwards_runtime_binding_receipt_into_promotion(tmp_path: Pat
     repo = _repo(tmp_path)
     files = _runtime_files(tmp_path)
 
-    result = run_reddog_main_architect_fix_promotion_bootstrap(
-        repo_root=repo,
-        work_state_path=files["work_state"],
-        architect_determination_path=files["determination"],
-        model_selection_receipt_path=files["model_selection"],
-        model_runtime_binding_receipt_path=files["model_runtime_binding"],
-        memex_supply_receipt_path=files["memex_supply"],
-        authority_profile_source_path=files["authority_profile_source"],
-        authority_profile_output_path=files["authority_profile_output"],
-        worker_id="reddog-main-test",
-        now_iso=NOW,
-    )
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap.read_git_head_sha",
+            return_value="sha256:repo-head",
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_architect_proposal_admission_contract."
+            "current_architect_proposal_admission_policy",
+            return_value=ready_proposal_policy(),
+        ),
+    ):
+        result = run_reddog_main_architect_fix_promotion_bootstrap(
+            repo_root=repo,
+            work_state_path=files["work_state"],
+            architect_determination_path=files["determination"],
+            model_selection_receipt_path=files["model_selection"],
+            model_runtime_binding_receipt_path=files["model_runtime_binding"],
+            memex_supply_receipt_path=files["memex_supply"],
+            authority_profile_source_path=files["authority_profile_source"],
+            authority_profile_output_path=files["authority_profile_output"],
+            holoindex_receipt_path=files["holoindex_receipt"],
+            worker_id="reddog-main-test",
+            now_iso=NOW,
+        )
 
     assert result.accepted is True
     promoted_profile = json.loads(files["authority_profile_output"].read_text(encoding="utf-8"))
@@ -142,6 +201,7 @@ def test_bootstrap_rejects_authority_profile_output_inside_repo(tmp_path: Path) 
         memex_supply_receipt_path=files["memex_supply"],
         authority_profile_source_path=files["authority_profile_source"],
         authority_profile_output_path=repo / "authority_profile.json",
+        holoindex_receipt_path=files["holoindex_receipt"],
         worker_id="reddog-main-test",
         now_iso=NOW,
     )
@@ -151,6 +211,161 @@ def test_bootstrap_rejects_authority_profile_output_inside_repo(tmp_path: Path) 
     assert "authority_profile_output_path_inside_repo" in result.rejection_reasons
 
 
+def test_bootstrap_rejects_when_active_holo_owner_serves_another_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+    monkeypatch.setattr(
+        "modules.communication.moltbot_bridge.src."
+        "reddog_main_architect_fix_promotion_bootstrap."
+        "verify_reddog_holoindex_owner_binding",
+        lambda **_kwargs: False,
+    )
+
+    result = run_reddog_main_architect_fix_promotion_bootstrap(
+        repo_root=repo,
+        work_state_path=files["work_state"],
+        architect_determination_path=files["determination"],
+        model_selection_receipt_path=files["model_selection"],
+        memex_supply_receipt_path=files["memex_supply"],
+        authority_profile_source_path=files["authority_profile_source"],
+        authority_profile_output_path=files["authority_profile_output"],
+        holoindex_receipt_path=files["holoindex_receipt"],
+        worker_id="reddog-main-test",
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "holoindex_owner_binding_not_current" in result.rejection_reasons
+    assert not files["authority_profile_output"].exists()
+
+
+def test_bootstrap_restores_previous_profile_when_promotion_rejects_after_prewrite(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+    previous = {"receipt_id": "sha256:previous-profile"}
+    files["authority_profile_output"].write_text(
+        json.dumps(previous, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    def reject_after_prewrite(**kwargs):
+        kwargs["authority_profile_precommit_writer"](
+            {"receipt_id": "sha256:uncommitted-profile"}
+        )
+        return type(
+            "PromotionResult",
+            (),
+            {
+                "accepted": False,
+                "status": "ARCHITECT_FIX_WSP15_PROMOTION_REJECT",
+                "authority_profile": None,
+                "receipt": None,
+                "rejection_reasons": ("authoritative_work_state_commit_rejected",),
+            },
+        )()
+
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap.read_git_head_sha",
+            return_value="sha256:repo-head",
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap."
+            "promote_reddog_architect_fix_to_signed_wsp15_work_order",
+            side_effect=reject_after_prewrite,
+        ),
+    ):
+        result = run_reddog_main_architect_fix_promotion_bootstrap(
+            repo_root=repo,
+            work_state_path=files["work_state"],
+            architect_determination_path=files["determination"],
+            model_selection_receipt_path=files["model_selection"],
+            memex_supply_receipt_path=files["memex_supply"],
+            authority_profile_source_path=files["authority_profile_source"],
+            authority_profile_output_path=files["authority_profile_output"],
+            holoindex_receipt_path=files["holoindex_receipt"],
+            worker_id="reddog-main-test",
+            now_iso=NOW,
+        )
+
+    assert result.accepted is False
+    assert json.loads(
+        files["authority_profile_output"].read_text(encoding="utf-8")
+    ) == previous
+
+
+def test_bootstrap_does_not_overwrite_newer_profile_when_rollback_cas_fails(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    files = _runtime_files(tmp_path)
+    previous = {"receipt_id": "sha256:previous-profile"}
+    newer = {"receipt_id": "sha256:newer-profile"}
+    files["authority_profile_output"].write_text(
+        json.dumps(previous, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    def reject_after_external_replacement(**kwargs):
+        kwargs["authority_profile_precommit_writer"](
+            {"receipt_id": "sha256:uncommitted-profile"}
+        )
+        files["authority_profile_output"].write_text(
+            json.dumps(newer, sort_keys=True),
+            encoding="utf-8",
+        )
+        return type(
+            "PromotionResult",
+            (),
+            {
+                "accepted": False,
+                "status": "ARCHITECT_FIX_WSP15_PROMOTION_REJECT",
+                "authority_profile": None,
+                "receipt": None,
+                "rejection_reasons": ("authoritative_work_state_commit_rejected",),
+            },
+        )()
+
+    with (
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap.read_git_head_sha",
+            return_value="sha256:repo-head",
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap."
+            "promote_reddog_architect_fix_to_signed_wsp15_work_order",
+            side_effect=reject_after_external_replacement,
+        ),
+    ):
+        result = run_reddog_main_architect_fix_promotion_bootstrap(
+            repo_root=repo,
+            work_state_path=files["work_state"],
+            architect_determination_path=files["determination"],
+            model_selection_receipt_path=files["model_selection"],
+            memex_supply_receipt_path=files["memex_supply"],
+            authority_profile_source_path=files["authority_profile_source"],
+            authority_profile_output_path=files["authority_profile_output"],
+            holoindex_receipt_path=files["holoindex_receipt"],
+            worker_id="reddog-main-test",
+            now_iso=NOW,
+        )
+
+    assert result.accepted is False
+    assert "authority_profile_rollback_failed" in result.rejection_reasons
+    assert json.loads(
+        files["authority_profile_output"].read_text(encoding="utf-8")
+    ) == newer
+
+
 def test_main_preflight_auto_runs_when_all_artifacts_are_present(tmp_path: Path) -> None:
     import main
 
@@ -158,22 +373,36 @@ def test_main_preflight_auto_runs_when_all_artifacts_are_present(tmp_path: Path)
     files = _runtime_files(tmp_path)
     runtime_root = tmp_path / "runtime"
 
-    with patch.dict(
-        "os.environ",
-        {
+    with (
+        patch.dict(
+            "os.environ",
+            {
             "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(files["work_state"]),
             "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(files["determination"]),
             "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(files["model_selection"]),
             "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(files["memex_supply"]),
             "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(files["authority_profile_source"]),
+            "HOLOINDEX_FRESHNESS_RECEIPT": str(files["holoindex_receipt"]),
             "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
             "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
             "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "0",
             "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "0",
             "REDDOG_GITHUB_PRINCIPAL_PERMISSION_SNAPSHOT_SUPPLY": "0",
             "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "0",
-        },
-        clear=True,
+            },
+            clear=True,
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_architect_proposal_admission_contract."
+            "current_architect_proposal_admission_policy",
+            return_value=ready_proposal_policy(),
+        ),
+        patch(
+            "modules.communication.moltbot_bridge.src."
+            "reddog_main_architect_fix_promotion_bootstrap.read_git_head_sha",
+            return_value="sha256:repo-head",
+        ),
     ):
         assert main.run_reddog_architect_fix_promotion_preflight(repo) is True
         assert main.os.environ["REDDOG_RESIDENT_QUEUE_AUTHORITY_PROFILE_PATH"] == str(
@@ -233,6 +462,7 @@ def test_main_preflight_handoff_materializes_resident_cycle_artifacts_before_pro
                     "REDDOG_RESIDENT_FIX_PROMOTION_HANDOFF": "1",
                     "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "sha256:intent-handoff",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(model_selection),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -311,6 +541,7 @@ def test_main_preflight_model_selection_supply_runs_before_promotion(tmp_path: P
                     "REDDOG_MODEL_SELECTION_ARTIFACT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -409,6 +640,7 @@ def test_main_preflight_model_runtime_binding_supply_runs_after_model_selection(
                         "REDDOG_MODEL_RUNTIME_BINDING_ARTIFACT_SUPPLY": "1",
                         "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                         "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                        "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                         "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                         "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                         "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -506,6 +738,7 @@ def test_main_preflight_model_autoresearch_plan_supply_runs_before_promotion(
                     "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -596,6 +829,7 @@ def test_main_preflight_defaults_autoresearch_feedback_to_existing_cycle_feedbac
                     "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -678,6 +912,7 @@ def test_main_preflight_explicit_autoresearch_feedback_path_overrides_cycle_feed
                     "REDDOG_MODEL_AUTORESEARCH_PLAN_ARTIFACT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -798,6 +1033,7 @@ def test_main_preflight_model_autoresearch_campaign_execution_supply_runs_before
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_EXECUTION_ARTIFACT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -946,6 +1182,7 @@ def test_main_preflight_model_autoresearch_campaign_gate_supply_runs_before_prom
                     "REDDOG_MODEL_AUTORESEARCH_CAMPAIGN_PROMOTION_GATE_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -1041,6 +1278,7 @@ def test_main_preflight_model_autoresearch_cycle_feedback_chain_runs_before_prom
                     "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION": "0",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -1222,6 +1460,7 @@ def test_main_preflight_model_autoresearch_cycle_receipt_supply_runs_before_prom
                     "REDDOG_MODEL_AUTORESEARCH_CYCLE_RECEIPT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -1349,6 +1588,7 @@ def test_main_preflight_model_autoresearch_cycle_feedback_admission_runs_before_
                     "REDDOG_MODEL_AUTORESEARCH_CYCLE_FEEDBACK_LEDGER_ADMISSION": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_PATH": str(authority_source),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -1525,6 +1765,7 @@ def test_main_preflight_authority_source_supply_runs_before_promotion(tmp_path: 
                     "REDDOG_AUTHORITY_PROFILE_SOURCE_ARTIFACT_SUPPLY": "1",
                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
                     "REDDOG_ARCHITECT_FIX_DETERMINATION_PATH": str(determination),
+                    "HOLOINDEX_FRESHNESS_RECEIPT": str(_holo_receipt_file(tmp_path)),
                     "REDDOG_MODEL_SELECTION_RECEIPT_PATH": str(model_selection),
                     "REDDOG_MEMEX_SUPPLY_RECEIPT_PATH": str(memex),
                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
@@ -1664,6 +1905,9 @@ def test_main_preflight_profile_runs_artifact_supply_chain_before_promotion(tmp_
                                     "REDDOG_RESIDENT_QUEUE_BINDING_PROFILE": "signed_0102_bounded_code",
                                     "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
                                     "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state),
+                                    "HOLOINDEX_FRESHNESS_RECEIPT": str(
+                                        _holo_receipt_file(tmp_path)
+                                    ),
                                     "REDDOG_RESIDENT_ARCHITECT_INTENT_ID": "intent-profile",
                                     "REDDOG_MODEL_CATALOG_SNAPSHOT_PATH": str(tmp_path / "catalog.json"),
                                     "REDDOG_MODEL_PRODUCTION_EVIDENCE_BUNDLE_PATH": str(tmp_path / "evidence.json"),
@@ -1860,7 +2104,6 @@ def test_module_has_no_execution_network_or_reindex_imports() -> None:
         "http",
         "socket",
         "sqlite3",
-        "holo_index",
         "git",
     }
     banned_calls = {"eval", "exec", "compile", "__import__"}

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_readonly_operational_bootstrap.py
@@ -58,6 +58,9 @@ from modules.communication.moltbot_bridge.tests.model_runtime_binding_receipt_te
 from modules.communication.moltbot_bridge.tests.provider_call_evidence_test_helpers import (
     architect_provider_call_evidence,
 )
+from modules.communication.moltbot_bridge.tests.architect_proposal_test_helpers import (
+    architect_model_output,
+)
 from modules.infrastructure.foundups_mcp_bridge.src import (
     reddog_holoindex_owner_bootstrap as owner_bootstrap,
 )
@@ -201,14 +204,11 @@ class _FakeArchitectRunner:
         )
         prompt_payload = json.loads(prompt)
         evidence_ref = prompt_payload["reports"][0]["evidence_refs"][0]
-        content = {
-            "action": ACTION_FIX,
-            "next_slice_name": "REDDOG_RUNTIME_RECONCILER_PHASE1",
-            "summary": "Collected read-only reports support one backend runtime fix.",
-            "decision_reasons": ["selected verified runtime reconciler gap"],
-            "evidence_refs": [evidence_ref],
-            "wsp15_allocation_receipt_id": prompt_payload["wsp15_allocation_receipt_id"],
-        }
+        content = architect_model_output(
+            {"receipt_id": prompt_payload["wsp15_allocation_receipt_id"]},
+            evidence_ref,
+            slice_name="REDDOG_RUNTIME_RECONCILER_PHASE1",
+        )
         return ArchitectModelResult(
             ok=True,
             status="MODEL_OK",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_readonly_audit_research_decision_e2e_runtime.py
@@ -50,6 +50,9 @@ from modules.communication.moltbot_bridge.tests.provider_call_evidence_test_help
     architect_provider_call_evidence,
     audit_provider_call_evidence,
 )
+from modules.communication.moltbot_bridge.tests.architect_proposal_test_helpers import (
+    architect_model_output,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -230,14 +233,11 @@ class _ArchitectRunner:
         self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
         parsed = json.loads(prompt)
         evidence_ref = parsed["reports"][0]["evidence_refs"][0]
-        content = {
-            "action": "FIX",
-            "next_slice_name": "REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
-            "summary": "All read-only audit reports support one next resident runtime slice.",
-            "decision_reasons": ["selected highest priority verified read-only audit finding"],
-            "evidence_refs": [evidence_ref],
-            "wsp15_allocation_receipt_id": parsed["wsp15_allocation_receipt_id"],
-        }
+        content = architect_model_output(
+            {"receipt_id": parsed["wsp15_allocation_receipt_id"]},
+            evidence_ref,
+            slice_name="REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
+        )
         return ArchitectModelResult(
             ok=True,
             status="MODEL_OK",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_architect_durable_agentdb_cycle.py
@@ -21,6 +21,9 @@ from modules.communication.moltbot_bridge.tests.provider_call_evidence_test_help
     architect_provider_call_evidence,
     audit_provider_call_evidence,
 )
+from modules.communication.moltbot_bridge.tests.architect_proposal_test_helpers import (
+    architect_model_output,
+)
 from modules.communication.moltbot_bridge.src.reddog_openclaw_readonly_audit_swarm_enqueue import (
     READONLY_AUDIT_TASK_SOURCE,
 )
@@ -298,14 +301,11 @@ class _ArchitectRunner:
         self.calls.append({"prompt": prompt, "context": context, "binding": dict(binding)})
         parsed = json.loads(prompt)
         evidence_ref = parsed["reports"][0]["evidence_refs"][0]
-        content = {
-            "action": "FIX",
-            "next_slice_name": "REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
-            "summary": "Read-only OpenClaw audit reports support one next resident runtime slice.",
-            "decision_reasons": ["selected highest-priority verified report"],
-            "evidence_refs": [evidence_ref],
-            "wsp15_allocation_receipt_id": parsed["wsp15_allocation_receipt_id"],
-        }
+        content = architect_model_output(
+            {"receipt_id": parsed["wsp15_allocation_receipt_id"]},
+            evidence_ref,
+            slice_name="REDDOG_RESIDENT_RUNTIME_NEXT_PHASE1",
+        )
         return ArchitectModelResult(
             ok=True,
             status="MODEL_OK",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py
@@ -63,13 +63,14 @@ class _CycleStore:
 
 
 def _cycle(**overrides: Any) -> dict[str, Any]:
+    determination_id = _determination()["determination_receipt_id"]
     record = {
         "schema_version": "reddog_resident_architect_cycle.v1",
         "intent_id": INTENT_ID,
         "cycle_id": CYCLE_ID,
         "status": STATUS_DETERMINED,
         "architect_action": "FIX",
-        "architect_determination_id": "sha256:architect-determination-1",
+        "architect_determination_id": determination_id,
         "initial_bootstrap": {
             "memex_snapshot_supply_receipt": _memex_supply(),
         },
@@ -108,7 +109,9 @@ def test_handoff_writes_determination_and_memex_artifacts_outside_repo(tmp_path:
     assert result.memex_supply_receipt_path == str((runtime / "memex_supply_receipt.json").resolve())
     determination = json.loads(Path(result.architect_determination_path).read_text(encoding="utf-8"))
     memex = json.loads(Path(result.memex_supply_receipt_path).read_text(encoding="utf-8"))
-    assert determination["determination_receipt_id"] == "sha256:architect-determination-1"
+    assert determination["determination_receipt_id"] == _determination()[
+        "determination_receipt_id"
+    ]
     assert memex["schema_version"] == "reddog_operational_memex_snapshot_supply_receipt.v1"
     assert memex["receipt_id"] == "sha256:memex-supply"
     assert result.no_signing_performed is True

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -25,7 +25,7 @@ exemptions:
       contract records the required yield, separate author/verifier claims,
       revocation, and bounded renewal semantics; splitting the historical
       registry remains separate documentation-maintenance work.
-    threshold_override: 1175
+    threshold_override: 1240
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -70,10 +70,10 @@ exemptions:
   - <<: *reddog_security_repair
     file: "src/reddog_main_resident_queue_serial_loop_bootstrap.py"
     reason: "Inherited serial startup boundary retained while assurance reservation injection and persisted yield telemetry cross the existing bootstrap API."
-    threshold_override: 1787
-    function_threshold_override: 465
+    threshold_override: 1791
+    function_threshold_override: 467
     functions: ["run_reddog_main_resident_queue_serial_loop_bootstrap", "_materialize_work_orders_from_authority_profile"]
-    no_growth_ceiling: {file_lines: 1787, functions: {run_reddog_main_resident_queue_serial_loop_bootstrap: 465, _materialize_work_orders_from_authority_profile: 159}}
+    no_growth_ceiling: {file_lines: 1791, functions: {run_reddog_main_resident_queue_serial_loop_bootstrap: 467, _materialize_work_orders_from_authority_profile: 159}}
 
   - <<: *reddog_security_repair
     file: "src/reddog_openclaw_live_enqueue.py"
@@ -94,10 +94,10 @@ exemptions:
   - <<: *reddog_security_repair
     file: "src/reddog_signed_worker_queue_serial_loop_runner.py"
     reason: "The inherited multi-capability runner remains oversized, but request validation, bootstrap invocation, rejection, and result projection are now bounded functions."
-    threshold_override: 523
+    threshold_override: 532
     function_threshold_override: 0
     functions: []
-    no_growth_ceiling: {file_lines: 523, functions: {}}
+    no_growth_ceiling: {file_lines: 532, functions: {}}
 
   - <<: *reddog_security_repair
     file: "src/reddog_signer_delegated_authority_runtime.py"
@@ -148,10 +148,10 @@ exemptions:
   - <<: *reddog_security_repair
     file: "tests/test_reddog_main_openclaw_signed_worker_claim_loop_preflight.py"
     reason: "Inherited startup integration matrix retained while the independent runtime root is threaded."
-    threshold_override: 1683
-    function_threshold_override: 222
+    threshold_override: 1736
+    function_threshold_override: 257
     functions: ["test_main_resident_control_loop_enforced_fails_closed_when_profile_signer_socket_missing", "test_main_openclaw_signed_worker_claim_loop_runs_real_agentdb_queue_stage", "test_main_openclaw_signed_0102_bounded_code_uses_fusion_artifact_generation", "test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain"]
-    no_growth_ceiling: {file_lines: 1683, functions: {test_main_resident_control_loop_enforced_fails_closed_when_profile_signer_socket_missing: 99, test_main_openclaw_signed_worker_claim_loop_runs_real_agentdb_queue_stage: 139, test_main_openclaw_signed_0102_bounded_code_uses_fusion_artifact_generation: 153, test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain: 222}}
+    no_growth_ceiling: {file_lines: 1736, functions: {test_main_resident_control_loop_enforced_fails_closed_when_profile_signer_socket_missing: 99, test_main_openclaw_signed_worker_claim_loop_runs_real_agentdb_queue_stage: 139, test_main_openclaw_signed_0102_bounded_code_uses_fusion_artifact_generation: 173, test_main_openclaw_signed_worker_claim_loop_completes_env_bound_chain: 238}}
 
   - <<: *reddog_security_repair
     file: "tests/test_reddog_main_resident_queue_serial_loop_bootstrap.py"
@@ -162,10 +162,10 @@ exemptions:
   - <<: *reddog_security_repair
     file: "tests/test_reddog_signed_worker_dispatch_task_executor.py"
     reason: "Inherited worker-dispatch integration matrix retained while the runtime root is threaded."
-    threshold_override: 2959
+    threshold_override: 3016
     function_threshold_override: 199
     functions: ["test_openclaw_claim_env_bound_queue_loop_runner_materializes_bounded_artifact", "test_openclaw_claim_env_bound_queue_loop_runner_reaches_slice_verifier", "test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_draft_pr_publish", "test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_outcome_ratchet", "test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues", "test_openclaw_claim_uses_profile_paths_for_bounded_code_readiness"]
-    no_growth_ceiling: {file_lines: 2959, functions: {test_openclaw_queue_stage_does_not_materialize_bounded_artifact: 102, test_openclaw_claim_env_bound_queue_loop_runner_reaches_slice_verifier: 185, test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_draft_pr_publish: 149, test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_outcome_ratchet: 184, test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues: 199, test_openclaw_claim_uses_profile_paths_for_bounded_code_readiness: 174}}
+    no_growth_ceiling: {file_lines: 3016, functions: {test_openclaw_queue_stage_does_not_materialize_bounded_artifact: 102, test_openclaw_claim_env_bound_queue_loop_runner_reaches_slice_verifier: 189, test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_draft_pr_publish: 149, test_openclaw_claim_env_bound_queue_loop_runner_reaches_verified_outcome_ratchet: 184, test_openclaw_claim_loop_drains_env_bound_queue_chain_with_requeues: 199, test_openclaw_claim_uses_profile_paths_for_bounded_code_readiness: 178}}
 
   - file: "scripts/run_task.py"
     reason: >-
@@ -223,18 +223,18 @@ exemptions:
       and queue-candidate projection. This repair only binds provider evidence
       into the accepted receipt identity; transaction extraction is tracked
       separately to avoid mixing lifecycle refactoring into the safety fix.
-    threshold_override: 1672
-    function_threshold_override: 332
+    threshold_override: 1666
+    function_threshold_override: 330
     functions:
       - "run_reddog_backend_architect_determination_runtime"
       - "FoundupsFusionArchitectModelRunner.run_architect_determination"
       - "_receipt"
     remediation: "modules/communication/moltbot_bridge/ROADMAP.md#reddog-provider-call-evidence-follow-ups"
     no_growth_ceiling:
-      file_lines: 1672
+      file_lines: 1666
       functions:
-        run_reddog_backend_architect_determination_runtime: 332
-        _receipt: 103
+        run_reddog_backend_architect_determination_runtime: 330
+        _receipt: 98
         run_architect_determination: 146
 
   - <<: *reddog_security_repair
@@ -293,11 +293,11 @@ exemptions:
   - <<: *reddog_security_repair
     file: "tests/test_reddog_backend_architect_determination_runtime.py"
     reason: "Legacy architect-input fixture and suite awaiting fixture extraction."
-    threshold_override: 924
+    threshold_override: 903
     function_threshold_override: 77
     functions: ["_build_inputs"]
     remediation: "modules/communication/moltbot_bridge/ROADMAP.md#2026-07-18-reddog--holoindex-truth-boundary-follow-ups"
-    no_growth_ceiling: {file_lines: 924, functions: {_build_inputs: 77}}
+    no_growth_ceiling: {file_lines: 903, functions: {_build_inputs: 77}}
 
   - <<: *reddog_security_repair
     file: "tests/test_reddog_main_readonly_operational_bootstrap.py"
@@ -383,7 +383,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 8874
+    threshold_override: 8938
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -395,7 +395,7 @@ exemptions:
     reason: >-
       Legacy WSP_22 test journal. Current entries record focused validation;
       historical test evidence is not split during a runtime-security slice.
-    threshold_override: 1662
+    threshold_override: 1678
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/infrastructure/foundups_mcp_bridge/INTERFACE.md
+++ b/modules/infrastructure/foundups_mcp_bridge/INTERFACE.md
@@ -2,6 +2,13 @@
 
 ## Public API
 
+### `verify_reddog_holoindex_owner_binding(...) -> bool`
+
+Read-only promotion-time proof that the already-running private query owner
+serves the exact repository root, repository HEAD, HoloIndex generation, and
+on-disk freshness-receipt digest supplied by the caller. It never starts an
+owner or re-indexes; absent or mismatched owner state returns `False`.
+
 ### FoundUpsMCPBridge
 
 Main bridge class for MCP tool access.

--- a/modules/infrastructure/foundups_mcp_bridge/ModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/ModLog.md
@@ -1,5 +1,13 @@
 # foundups_mcp_bridge - ModLog
 
+## 2026-07-27 - Promotion-time HoloIndex owner binding
+
+- Added a read-only exact-binding verifier for RedDog promotion gates.
+- The verifier accepts only an already-running owned or configured query owner
+  that proves the expected repository root, HEAD, generation, and on-disk
+  freshness-receipt digest.
+- No owner startup, HoloIndex mutation, re-index, or query authority was added.
+
 ## 2026-07-26 - HoloIndex authority update transaction
 
 - Added a distinct cross-process authority-update lease around exact-SHA,

--- a/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_owner_bootstrap.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/reddog_holoindex_owner_bootstrap.py
@@ -196,6 +196,44 @@ def resolve_reddog_holoindex_owner_handoff() -> tuple[str, str] | None:
     return restart_reddog_holoindex_owner(failed_handoff=failed_handoff)
 
 
+def verify_reddog_holoindex_owner_binding(
+    *,
+    repo_root: Path | str,
+    expected_repo_head_sha: str,
+    expected_generation_id: str,
+    expected_receipt_digest: str,
+) -> bool:
+    """Verify that the active query owner serves one exact generation."""
+
+    expected_binding = _requested_binding(
+        repo_root,
+        expected_repo_head_sha,
+        expected_generation_id,
+        expected_receipt_digest,
+    )
+    with _OWNER_LOCK:
+        supervisor = _OWNER_SUPERVISOR
+        if (
+            supervisor is not None
+            and _OWNER_HANDOFF is not None
+            and supervisor.is_ready
+        ):
+            return supervisor.verified_binding == expected_binding
+
+        service_url = os.environ.get(SERVICE_URL_ENV, "").strip()
+        token = os.environ.get(SERVICE_TOKEN_ENV, "").strip()
+        if not service_url or not token:
+            return False
+        return _configured_owner_health_ready(
+            service_url=service_url,
+            token=token,
+            expected_repo_head_sha=expected_binding[0],
+            expected_repo_root_digest=expected_binding[1],
+            expected_generation_id=expected_binding[2],
+            expected_receipt_digest=expected_binding[3],
+        )
+
+
 def restart_reddog_holoindex_owner(
     *,
     failed_handoff: tuple[str, str],
@@ -400,4 +438,5 @@ __all__ = [
     "ensure_reddog_holoindex_owner",
     "restart_reddog_holoindex_owner",
     "resolve_reddog_holoindex_owner_handoff",
+    "verify_reddog_holoindex_owner_binding",
 ]

--- a/modules/infrastructure/foundups_mcp_bridge/tests/TestModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/TestModLog.md
@@ -1,5 +1,10 @@
 # foundups_mcp_bridge TestModLog
 
+## [2026-07-27] Promotion-time owner binding
+
+- Proved configured-owner exact binding without process startup.
+- Proved an owned query owner serving another generation is rejected.
+
 ## [2026-07-25] HoloIndex parent-process watchdog
 
 - Replaced pipe-EOF tests with injected and real parent-process termination coverage.

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_reddog_holoindex_owner_bootstrap.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_reddog_holoindex_owner_bootstrap.py
@@ -149,6 +149,54 @@ def test_explicit_loopback_service_bypasses_auto_start(
     constructor.assert_not_called()
 
 
+def test_verify_binding_uses_configured_owner_health_without_starting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(SERVICE_URL_ENV, SAFE_URL)
+    monkeypatch.setenv(SERVICE_TOKEN_ENV, SAFE_TOKEN)
+    health = Mock(return_value=True)
+    monkeypatch.setattr(bootstrap, "_configured_owner_health_ready", health)
+
+    assert bootstrap.verify_reddog_holoindex_owner_binding(
+        repo_root=tmp_path,
+        expected_repo_head_sha="a" * 40,
+        expected_generation_id="sha256:" + ("b" * 64),
+        expected_receipt_digest="sha256:" + ("c" * 64),
+    )
+
+    health.assert_called_once_with(
+        service_url=SAFE_URL,
+        token=SAFE_TOKEN,
+        expected_repo_head_sha="a" * 40,
+        expected_repo_root_digest=bootstrap.repository_root_digest(tmp_path),
+        expected_generation_id="sha256:" + ("b" * 64),
+        expected_receipt_digest="sha256:" + ("c" * 64),
+    )
+
+
+def test_verify_binding_rejects_owned_owner_serving_another_generation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(bootstrap, "HoloQueryServiceSupervisor", _FakeSupervisor)
+    started = bootstrap.ensure_reddog_holoindex_owner(
+        repo_root=tmp_path,
+        requested=True,
+        expected_repo_head_sha="a" * 40,
+        expected_generation_id="sha256:" + ("b" * 64),
+        expected_receipt_digest="sha256:" + ("c" * 64),
+    )
+    assert started.ready is True
+
+    assert not bootstrap.verify_reddog_holoindex_owner_binding(
+        repo_root=tmp_path,
+        expected_repo_head_sha="a" * 40,
+        expected_generation_id="sha256:" + ("d" * 64),
+        expected_receipt_digest="sha256:" + ("c" * 64),
+    )
+
+
 def test_configured_health_wrapper_uses_authenticated_loopback_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- separate architect proposal validity from current execution readiness
- bind proposal admission to canonical determination/candidate IDs, exact repository SHA, WSP 15 allocation, HoloIndex generation, and active query-owner proof
- persist valid blocked candidates while admitting only execution-ready proposals
- make authority-profile prewrite and authoritative queue commit one rollback-safe promotion transaction

## WSP 97 truth boundary
- OBSERVED: proposal structure, code-derived capability requirements, exact-SHA lineage, current Holo owner binding, and promotion transaction are implemented and tested
- OBSERVED: independent assurance replayed rollback-race and stale-valid-Holo attacks and returned GO
- SPECIFIED_NOT_IMPLEMENTED: per-receipt proposal authenticity verifier; production policy remains permanently fail-closed until that verifier exists

## Validation
- 146 focused admission/promotion/Holo/WSP62 tests passed
- 134 startup/durable-cycle tests passed, 1 skipped; 1 pre-existing Memex fixture failure independently reproduced on current main
- 302 simulator CI-parity tests passed
- 42 red-team tests passed
- compileall and git diff --check passed
- WSP 15: P0 / ULTRA, independent verifier required

## Boundaries
- no worker spawn
- no shell/worktree execution
- no OpenClaw/Hermes dispatch
- no PR/merge authority expansion
- no HoloIndex re-index