### PR TITLE
feat(reddog): enforce architect proposal signing integrity

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -27,12 +27,18 @@ name. INDEX_GAP blocks ordinary code work; the only phase-one exception is a
 HoloIndex maintenance slice whose exact non-wildcard paths equal the supporting
 direct-read paths.
 
-The receipt's SHA is integrity evidence, not authentication. Production policy
-therefore keeps `architect_proposal_admission_authenticity` unavailable until a
-trusted verifier is implemented. Promotion also remains blocked by the
-code-owned incomplete trust anchors documented in the execution-valve roadmap.
-Tests may inject a complete policy to validate the queue mechanics; callers
-cannot inject that policy into the production promotion seam.
+The receipt's SHA is integrity evidence, not authentication.
+`reddog_architect_proposal_authenticity.py` defines a domain-separated Ed25519
+attestation, an exact signer-owned proposal policy, transactional signer-side
+nonce reservation, and strict serialized-attestation integrity validation.
+The validated attestation is still evidence, not authority. It is not accepted
+by proposal admission, the candidate gate, or promotion.
+
+Production policy still keeps `architect_proposal_admission_authenticity`
+unavailable because startup does not provision an independent pre-promotion
+signer policy, authoritative key and revocation resolver, durable proposal
+nonce store, trusted verification context, opaque authority proof, attestation
+artifact, or transactional queue binding.
 
 ### Resident queue exact-SHA commit stage
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,20 @@
 # ModLog - moltbot_bridge
+## 2026-07-27: REDDOG_ARCHITECT_PROPOSAL_AUTHENTICITY_ATTESTATION_PHASE1
+- Added a domain-separated architect-proposal Ed25519 attestation that binds
+  the complete proposal, determination, queue candidate, snapshot, exact SHA,
+  work state, HoloIndex, WSP 15, policy, path/test/gate, principal, RedDog,
+  signer-key, consensus, nonce, and expiry context.
+- Required an exact immutable signer-owned proposal policy and transactional
+  nonce reservation; malformed, partial, expired, replayed, cross-domain, or
+  policy-mismatched requests fail before signing.
+- Added strict serialized-attestation integrity validation for exact fields,
+  signatures, TTL, and key-epoch revocation. The returned typed attestation is
+  evidence only and cannot satisfy proposal admission or promotion.
+- Kept independent trust-root resolution, startup signer provisioning, durable
+  replay state, opaque authority proof, attestation artifact supply, and
+  production promotion wiring explicitly unimplemented. This slice creates no
+  queue item and performs no repository effect (WSP 00, 15, 22, 50, 64, 97).
+
 ## 2026-07-27: REDDOG_ARCHITECT_PROPOSAL_EXECUTABILITY_ADMISSION_PHASE1
 - Added a deterministic post-Fusion proposal admission receipt that binds the
   audit finding, operational snapshot, repository HEAD, work-state revision,

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
@@ -1,0 +1,633 @@
+"""Signed integrity boundary for backend architect proposal admissions.
+
+The signer enforces an exact, domain-separated proposal policy before signing.
+The verifier rehydrates and validates the serialized attestation against an
+exact expected payload.  The result is integrity evidence only: this module
+does not authenticate the verification context or grant runtime authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Protocol
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    IsolatedSignerClient,
+    SigningRequest,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    SignatureVerifier,
+)
+
+
+PROPOSAL_AUTHENTICITY_SCHEMA_VERSION = (
+    "reddog_architect_proposal_authenticity_attestation.v1"
+)
+PROPOSAL_AUTHENTICITY_SIGNING_OPERATION = "attest_architect_proposal"
+PROPOSAL_AUTHENTICITY_SIGNING_PREFIX = "reddog-architect-proposal.v1."
+PROPOSAL_AUTHENTICITY_SIGNER_ROLE = "reddog_architect"
+DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class ArchitectProposalAuthenticityPayload:
+    schema_version: str
+    attestation_id: str
+    proposal_admission_receipt_id: str
+    proposal_admission_digest: str
+    determination_receipt_id: str
+    determination_digest: str
+    queue_candidate_id: str
+    queue_candidate_digest: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    repo_head_sha: str
+    work_state_revision: str
+    report_bundle_id: str
+    wsp15_allocation_receipt_id: str
+    wsp15_allocation_digest: str
+    holoindex_generation_id: str
+    holoindex_freshness_receipt_digest: str
+    policy_digest: str
+    allowed_paths_digest: str
+    denied_paths_digest: str
+    required_tests_digest: str
+    required_policy_gates_digest: str
+    target_effect_plane: str
+    requester_principal_id: str
+    reddog_id: str
+    signer_public_key: str
+    signer_key_fingerprint: str
+    key_epoch: str
+    consensus_receipt_digest: str
+    authority_profile_source_receipt_id: str
+    nonce: str
+    issued_at: int
+    expires_at: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ArchitectProposalAuthenticityAttestation:
+    payload: ArchitectProposalAuthenticityPayload
+    signature: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self.payload.to_dict(),
+            "signature": self.signature,
+        }
+
+
+@dataclass(frozen=True)
+class ArchitectProposalSignerPolicy:
+    """Signer-owned exact authorization for one proposal attestation."""
+
+    expected_payload: ArchitectProposalAuthenticityPayload
+    max_ttl_seconds: int = DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+
+
+@dataclass(frozen=True)
+class ArchitectProposalIntegrityContext:
+    """Complete comparison input for cryptographic integrity verification.
+
+    This context does not authenticate its own origin and therefore cannot
+    grant queue or execution authority.
+    """
+
+    expected_payload: ArchitectProposalAuthenticityPayload
+    now_epoch: int
+    revoked_key_epochs: frozenset[str] = frozenset()
+    max_ttl_seconds: int = DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+
+
+@dataclass(frozen=True)
+class ArchitectProposalSigningContext:
+    signer: IsolatedSignerClient
+    signature_verifier: SignatureVerifier
+    requester_principal_id: str
+    signer_public_key: str
+    key_epoch: str
+    authority_tier: str
+    consensus_receipt_digest: str
+
+
+class ProposalAuthenticityNonceStore(Protocol):
+    def reserve(self, nonce: str, *, expires_at: int, subject: str) -> str | None: ...
+
+    def commit(self, reservation: str) -> None: ...
+
+    def rollback(self, reservation: str) -> None: ...
+
+
+class InMemoryProposalAuthenticityNonceStore:
+    """Process-local nonce store for tests; production must inject durability."""
+
+    def __init__(self) -> None:
+        self._seen: set[tuple[str, str]] = set()
+        self._reserved: dict[str, tuple[str, str]] = {}
+        self._lock = threading.Lock()
+
+    def reserve(self, nonce: str, *, expires_at: int, subject: str) -> str | None:
+        if not nonce or not subject or expires_at <= 0:
+            return None
+        key = (subject, nonce)
+        with self._lock:
+            if key in self._seen or key in self._reserved.values():
+                return None
+            reservation = _digest(
+                {"expires_at": expires_at, "nonce": nonce, "subject": subject}
+            )
+            self._reserved[reservation] = key
+            return reservation
+
+    def commit(self, reservation: str) -> None:
+        with self._lock:
+            key = self._reserved.pop(reservation, None)
+            if key is None or key in self._seen:
+                raise ValueError("proposal_authenticity_nonce_reservation_invalid")
+            self._seen.add(key)
+
+    def rollback(self, reservation: str) -> None:
+        with self._lock:
+            self._reserved.pop(reservation, None)
+
+
+def build_architect_proposal_authenticity_payload(
+    *,
+    proposal_admission: Mapping[str, Any],
+    determination: Mapping[str, Any],
+    queue_candidate: Mapping[str, Any],
+    requester_principal_id: str,
+    reddog_id: str,
+    signer_public_key: str,
+    key_epoch: str,
+    consensus_receipt_digest: str,
+    authority_profile_source_receipt_id: str,
+    nonce: str,
+    issued_at: int,
+    expires_at: int,
+) -> ArchitectProposalAuthenticityPayload:
+    """Build the complete canonical proposal payload from existing receipts."""
+
+    proposal = _mapping(proposal_admission)
+    candidate = _mapping(queue_candidate)
+    values = {
+        "schema_version": PROPOSAL_AUTHENTICITY_SCHEMA_VERSION,
+        **_proposal_binding_values(proposal, determination, candidate),
+        **_proposal_identity_values(
+            requester_principal_id=requester_principal_id,
+            reddog_id=reddog_id,
+            signer_public_key=signer_public_key,
+            key_epoch=key_epoch,
+            consensus_receipt_digest=consensus_receipt_digest,
+            authority_profile_source_receipt_id=(
+                authority_profile_source_receipt_id
+            ),
+            nonce=nonce,
+            issued_at=issued_at,
+            expires_at=expires_at,
+        ),
+    }
+    attestation_id = "reddog_architect_proposal_attestation_" + _digest(values)[
+        7:39
+    ]
+    payload = ArchitectProposalAuthenticityPayload(
+        attestation_id=attestation_id, **values
+    )
+    _validate_payload_shape(payload.to_dict())
+    return payload
+
+
+def _proposal_binding_values(
+    proposal: Mapping[str, Any],
+    determination: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+) -> dict[str, Any]:
+    determination_body = {
+        key: value
+        for key, value in _mapping(determination).items()
+        if key != "proposal_authenticity_attestation"
+    }
+    return {
+        "proposal_admission_receipt_id": _text(proposal.get("receipt_id")),
+        "proposal_admission_digest": _digest(proposal),
+        "determination_receipt_id": _text(
+            determination_body.get("determination_receipt_id")
+        ),
+        "determination_digest": _digest(determination_body),
+        "queue_candidate_id": _text(candidate.get("queue_candidate_id")),
+        "queue_candidate_digest": _digest(candidate),
+        "snapshot_receipt_id": _text(proposal.get("snapshot_receipt_id")),
+        "snapshot_content_digest": _text(proposal.get("snapshot_content_digest")),
+        "repo_head_sha": _text(proposal.get("repo_head_sha")),
+        "work_state_revision": _text(proposal.get("work_state_revision")),
+        "report_bundle_id": _text(proposal.get("report_bundle_id")),
+        "wsp15_allocation_receipt_id": _text(
+            proposal.get("wsp15_allocation_receipt_id")
+        ),
+        "wsp15_allocation_digest": _text(
+            proposal.get("wsp15_allocation_digest")
+        ),
+        "holoindex_generation_id": _text(
+            proposal.get("holoindex_generation_id")
+        ),
+        "holoindex_freshness_receipt_digest": _text(
+            proposal.get("holoindex_freshness_receipt_digest")
+        ),
+        "policy_digest": _text(proposal.get("policy_digest")),
+        "allowed_paths_digest": _digest(proposal.get("allowed_paths")),
+        "denied_paths_digest": _digest(proposal.get("denied_paths")),
+        "required_tests_digest": _digest(proposal.get("required_tests")),
+        "required_policy_gates_digest": _digest(
+            proposal.get("required_policy_gates")
+        ),
+        "target_effect_plane": _text(proposal.get("target_effect_plane")),
+    }
+
+
+def _proposal_identity_values(
+    *,
+    requester_principal_id: str,
+    reddog_id: str,
+    signer_public_key: str,
+    key_epoch: str,
+    consensus_receipt_digest: str,
+    authority_profile_source_receipt_id: str,
+    nonce: str,
+    issued_at: int,
+    expires_at: int,
+) -> dict[str, Any]:
+    return {
+        "requester_principal_id": _text(requester_principal_id),
+        "reddog_id": _text(reddog_id),
+        "signer_public_key": _text(signer_public_key),
+        "signer_key_fingerprint": public_key_fingerprint(signer_public_key),
+        "key_epoch": _text(key_epoch),
+        "consensus_receipt_digest": _text(consensus_receipt_digest),
+        "authority_profile_source_receipt_id": _text(
+            authority_profile_source_receipt_id
+        ),
+        "nonce": _text(nonce),
+        "issued_at": int(issued_at),
+        "expires_at": int(expires_at),
+    }
+
+
+def canonical_architect_proposal_signing_input(
+    payload: ArchitectProposalAuthenticityPayload | Mapping[str, Any],
+) -> str:
+    raw = payload.to_dict() if hasattr(payload, "to_dict") else dict(payload)
+    return PROPOSAL_AUTHENTICITY_SIGNING_PREFIX + _canonical_json(raw)
+
+
+def attest_architect_proposal(
+    payload: ArchitectProposalAuthenticityPayload,
+    context: ArchitectProposalSigningContext,
+) -> ArchitectProposalAuthenticityAttestation:
+    """Request signing and independently verify the signer response."""
+
+    _validate_payload_shape(payload.to_dict())
+    if (
+        payload.requester_principal_id != context.requester_principal_id
+        or payload.signer_public_key != context.signer_public_key
+        or payload.key_epoch != context.key_epoch
+        or payload.consensus_receipt_digest != context.consensus_receipt_digest
+    ):
+        raise ValueError("architect_proposal_signing_context_mismatch")
+    signing_input = canonical_architect_proposal_signing_input(payload)
+    response = context.signer.sign(_proposal_signing_request(
+        payload, context, signing_input
+    ))
+    if not _proposal_signing_response_valid(response, context, signing_input):
+        raise ValueError("architect_proposal_signing_rejected")
+    return ArchitectProposalAuthenticityAttestation(
+        payload=payload,
+        signature=response.signature,
+    )
+
+
+def _proposal_signing_request(
+    payload: ArchitectProposalAuthenticityPayload,
+    context: ArchitectProposalSigningContext,
+    signing_input: str,
+) -> SigningRequest:
+    return SigningRequest(
+        signing_input=signing_input,
+        payload_digest=_digest({"signing_input": signing_input}),
+        signer_role=PROPOSAL_AUTHENTICITY_SIGNER_ROLE,
+        signer_public_key=context.signer_public_key,
+        requester_principal_id=context.requester_principal_id,
+        nonce=payload.nonce,
+        key_epoch=context.key_epoch,
+        requested_operation=PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+        authority_tier=context.authority_tier,
+        consensus_receipt_digest=context.consensus_receipt_digest,
+    )
+
+
+def _proposal_signing_response_valid(
+    response: Any,
+    context: ArchitectProposalSigningContext,
+    signing_input: str,
+) -> bool:
+    return bool(
+        response.accepted
+        and response.signer_public_key == context.signer_public_key
+        and response.key_fingerprint
+        == public_key_fingerprint(context.signer_public_key)
+        and response.key_epoch == context.key_epoch
+        and response.signature
+        and response.audit_mac
+        and response.boundary_attested
+        and response.requester_identity_attested
+        and response.signer_loads_no_untrusted_code
+        and response.no_secret_material_returned
+        and context.signature_verifier.verify(
+            context.signer_public_key, signing_input, response.signature
+        )
+    )
+
+
+def verify_architect_proposal_attestation_integrity(
+    value: Mapping[str, Any],
+    *,
+    context: ArchitectProposalIntegrityContext,
+) -> ArchitectProposalAuthenticityAttestation:
+    """Verify exact payload equality, freshness, revocation, and signature.
+
+    The returned typed attestation is integrity evidence only.  It is not an
+    opaque authority proof and is intentionally not accepted by proposal
+    admission or promotion.
+    """
+
+    if (
+        not isinstance(context, ArchitectProposalIntegrityContext)
+        or not isinstance(
+            context.expected_payload, ArchitectProposalAuthenticityPayload
+        )
+    ):
+        raise ValueError("architect_proposal_authenticity_trust_context_invalid")
+    attestation = _rehydrate_attestation(value)
+    payload = attestation.payload.to_dict()
+    _validate_payload_shape(payload)
+    if payload != context.expected_payload.to_dict():
+        raise ValueError("architect_proposal_authenticity_binding_mismatch")
+    now = int(context.now_epoch)
+    ttl = int(payload["expires_at"]) - int(payload["issued_at"])
+    if (
+        payload["issued_at"] > now
+        or payload["expires_at"] <= now
+        or ttl <= 0
+        or ttl > int(context.max_ttl_seconds)
+    ):
+        raise ValueError("architect_proposal_authenticity_expired")
+    if payload["key_epoch"] in context.revoked_key_epochs:
+        raise ValueError("architect_proposal_authenticity_key_revoked")
+    if not Ed25519SignatureVerifier().verify(
+        payload["signer_public_key"],
+        canonical_architect_proposal_signing_input(payload),
+        attestation.signature,
+    ):
+        raise ValueError("architect_proposal_authenticity_signature_invalid")
+    return attestation
+
+
+def validate_proposal_signing_request(
+    request: SigningRequest,
+    policy: ArchitectProposalSignerPolicy,
+    *,
+    now_epoch: int,
+) -> Mapping[str, Any] | None:
+    """Signer-side exact-domain and exact-policy validation."""
+
+    if not _proposal_policy_valid(policy):
+        return None
+    payload = _parse_proposal_signing_payload(request)
+    if payload is None:
+        return None
+    if not _proposal_request_bindings_match(request, payload):
+        return None
+    if payload != policy.expected_payload.to_dict():
+        return None
+    if not _proposal_time_window_valid(payload, now_epoch, policy.max_ttl_seconds):
+        return None
+    return payload
+
+
+def _proposal_policy_valid(policy: Any) -> bool:
+    return isinstance(policy, ArchitectProposalSignerPolicy) and isinstance(
+        policy.expected_payload, ArchitectProposalAuthenticityPayload
+    )
+
+
+def _parse_proposal_signing_payload(
+    request: SigningRequest,
+) -> Mapping[str, Any] | None:
+    if (
+        request.requested_operation != PROPOSAL_AUTHENTICITY_SIGNING_OPERATION
+        or request.signer_role != PROPOSAL_AUTHENTICITY_SIGNER_ROLE
+        or request.authority_tier not in {"HIGH", "ULTRA"}
+        or not request.signing_input.startswith(PROPOSAL_AUTHENTICITY_SIGNING_PREFIX)
+    ):
+        return None
+    raw = request.signing_input[len(PROPOSAL_AUTHENTICITY_SIGNING_PREFIX) :]
+    try:
+        payload = json.loads(raw)
+        if not isinstance(payload, Mapping) or raw != _canonical_json(payload):
+            return None
+        _validate_payload_shape(payload)
+    except (TypeError, json.JSONDecodeError, ValueError):
+        return None
+    return payload
+
+
+def _proposal_request_bindings_match(
+    request: SigningRequest,
+    payload: Mapping[str, Any],
+) -> bool:
+    return not (
+        request.payload_digest != _digest({"signing_input": request.signing_input})
+        or request.requester_principal_id != payload["requester_principal_id"]
+        or request.signer_public_key != payload["signer_public_key"]
+        or request.key_epoch != payload["key_epoch"]
+        or request.nonce != payload["nonce"]
+        or request.consensus_receipt_digest != payload["consensus_receipt_digest"]
+    )
+
+
+def _proposal_time_window_valid(
+    payload: Mapping[str, Any],
+    now_epoch: int,
+    max_ttl_seconds: int,
+) -> bool:
+    ttl = int(payload["expires_at"]) - int(payload["issued_at"])
+    return not (
+        int(payload["issued_at"]) > now_epoch
+        or int(payload["expires_at"]) <= now_epoch
+        or ttl <= 0
+        or ttl > int(max_ttl_seconds)
+    )
+
+
+def _rehydrate_attestation(
+    value: Mapping[str, Any],
+) -> ArchitectProposalAuthenticityAttestation:
+    expected = set(ArchitectProposalAuthenticityPayload.__dataclass_fields__) | {
+        "signature",
+    }
+    if not isinstance(value, Mapping) or set(value) != expected:
+        raise ValueError("architect_proposal_authenticity_field_set_invalid")
+    payload = ArchitectProposalAuthenticityPayload(
+        **{
+            key: value[key]
+            for key in ArchitectProposalAuthenticityPayload.__dataclass_fields__
+        }
+    )
+    return ArchitectProposalAuthenticityAttestation(
+        payload=payload,
+        signature=_text(value.get("signature")),
+    )
+
+
+def _validate_payload_shape(payload: Mapping[str, Any]) -> None:
+    expected = set(ArchitectProposalAuthenticityPayload.__dataclass_fields__)
+    if set(payload) != expected:
+        raise ValueError("architect_proposal_authenticity_payload_fields_invalid")
+    if payload.get("schema_version") != PROPOSAL_AUTHENTICITY_SCHEMA_VERSION:
+        raise ValueError("architect_proposal_authenticity_schema_invalid")
+    unsigned = {
+        key: value for key, value in payload.items() if key != "attestation_id"
+    }
+    expected_id = "reddog_architect_proposal_attestation_" + _digest(unsigned)[7:39]
+    if payload.get("attestation_id") != expected_id:
+        raise ValueError("architect_proposal_authenticity_id_invalid")
+    if not _ascii_deep(payload):
+        raise ValueError("architect_proposal_authenticity_non_ascii")
+    required_text = expected.difference({"issued_at", "expires_at"})
+    if any(
+        not isinstance(payload.get(key), str) or not payload.get(key)
+        for key in required_text
+    ):
+        raise ValueError("architect_proposal_authenticity_value_missing")
+    if not _proposal_digests_valid(payload):
+        raise ValueError("architect_proposal_authenticity_digest_invalid")
+    _validate_proposal_key_and_time(payload)
+
+
+def _proposal_digests_valid(payload: Mapping[str, Any]) -> bool:
+    return all(
+        _sha256(payload.get(key))
+        for key in (
+            "proposal_admission_digest",
+            "determination_digest",
+            "queue_candidate_digest",
+            "snapshot_content_digest",
+            "wsp15_allocation_digest",
+            "holoindex_freshness_receipt_digest",
+            "policy_digest",
+            "allowed_paths_digest",
+            "denied_paths_digest",
+            "required_tests_digest",
+            "required_policy_gates_digest",
+            "consensus_receipt_digest",
+            "authority_profile_source_receipt_id",
+        )
+    )
+
+
+def _validate_proposal_key_and_time(payload: Mapping[str, Any]) -> None:
+    if payload.get("signer_key_fingerprint") != public_key_fingerprint(
+        _text(payload.get("signer_public_key"))
+    ):
+        raise ValueError("architect_proposal_authenticity_fingerprint_invalid")
+    issued_at = payload.get("issued_at")
+    expires_at = payload.get("expires_at")
+    if (
+        isinstance(issued_at, bool)
+        or not isinstance(issued_at, int)
+        or isinstance(expires_at, bool)
+        or not isinstance(expires_at, int)
+    ):
+        raise ValueError("architect_proposal_authenticity_time_invalid")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _sha256(value: Any) -> bool:
+    text = _text(value)
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
+
+
+def _ascii_deep(value: Any) -> bool:
+    if isinstance(value, str):
+        return all(ord(char) < 128 for char in value)
+    if isinstance(value, Mapping):
+        return all(
+            isinstance(key, str)
+            and all(ord(char) < 128 for char in key)
+            and _ascii_deep(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return all(_ascii_deep(item) for item in value)
+    return value is None or isinstance(value, (bool, int, float))
+
+
+__all__ = [
+    "ArchitectProposalAuthenticityAttestation",
+    "ArchitectProposalAuthenticityPayload",
+    "ArchitectProposalSignerPolicy",
+    "ArchitectProposalSigningContext",
+    "ArchitectProposalIntegrityContext",
+    "DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS",
+    "InMemoryProposalAuthenticityNonceStore",
+    "PROPOSAL_AUTHENTICITY_SCHEMA_VERSION",
+    "PROPOSAL_AUTHENTICITY_SIGNER_ROLE",
+    "PROPOSAL_AUTHENTICITY_SIGNING_OPERATION",
+    "PROPOSAL_AUTHENTICITY_SIGNING_PREFIX",
+    "ProposalAuthenticityNonceStore",
+    "attest_architect_proposal",
+    "build_architect_proposal_authenticity_payload",
+    "canonical_architect_proposal_signing_input",
+    "validate_proposal_signing_request",
+    "verify_architect_proposal_attestation_integrity",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_ed25519_signer_backend.py
+++ b/modules/communication/moltbot_bridge/src/reddog_ed25519_signer_backend.py
@@ -16,8 +16,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
     ControlLoopAnchorStore,
@@ -35,6 +36,13 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
     SigningRequest,
     SigningResponse,
     public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalSignerPolicy,
+    PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+    PROPOSAL_AUTHENTICITY_SIGNING_PREFIX,
+    ProposalAuthenticityNonceStore,
+    validate_proposal_signing_request,
 )
 
 
@@ -56,6 +64,18 @@ REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISSING = (
 )
 REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH = (
     "REJECT_ED25519_SIGNER_CONTROL_AUTHORITY_POLICY_MISMATCH"
+)
+REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING = (
+    "REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING"
+)
+REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH = (
+    "REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH"
+)
+REJECT_ED25519_SIGNER_PROPOSAL_NONCE_STORE_MISSING = (
+    "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_STORE_MISSING"
+)
+REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY = (
+    "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY"
 )
 
 CONTROL_LOOP_SIGNING_OPERATION = "attest_control_loop_receipt"
@@ -120,6 +140,9 @@ class Ed25519SignerBackend(IsolatedSignerBackend):
     audit_mac_builder: SignerAuditMacBuilder
     control_loop_anchor_store: ControlLoopAnchorStore | None = None
     control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None
+    proposal_authority_policy: ArchitectProposalSignerPolicy | None = None
+    proposal_nonce_store: ProposalAuthenticityNonceStore | None = None
+    proposal_clock: Callable[[], float] = time.time
 
     def sign(self, request: SigningRequest, peer: SignerPeerAttestation) -> SigningResponse:
         reason = _signer_request_rejection(self, request, peer)
@@ -130,11 +153,22 @@ class Ed25519SignerBackend(IsolatedSignerBackend):
         )
         if reason:
             return _reject(reason)
+        proposal_reservation, reason = _prepare_proposal_signing(self, request)
+        if reason:
+            return _reject(reason)
         response, reason = _sign_response(
             self, request, peer, control_payload is not None
         )
         if reason:
+            _rollback_proposal_reservation(self, proposal_reservation)
             return _reject(reason)
+        if proposal_reservation is not None:
+            try:
+                assert self.proposal_nonce_store is not None
+                self.proposal_nonce_store.commit(proposal_reservation)
+            except Exception:
+                _rollback_proposal_reservation(self, proposal_reservation)
+                return _reject(REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY)
         if control_payload is not None and preparation is not None:
             try:
                 self.control_loop_anchor_store.commit(
@@ -163,8 +197,17 @@ def _signer_request_rejection(
         return REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH
     if not request.signing_input:
         return REJECT_ED25519_SIGNER_REQUEST_INVALID
-    is_control = request.requested_operation == CONTROL_LOOP_SIGNING_OPERATION
-    if is_control is not request.signing_input.startswith(CONTROL_LOOP_SIGNING_PREFIX):
+    domain_pairs = (
+        (
+            request.requested_operation == CONTROL_LOOP_SIGNING_OPERATION,
+            request.signing_input.startswith(CONTROL_LOOP_SIGNING_PREFIX),
+        ),
+        (
+            request.requested_operation == PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+            request.signing_input.startswith(PROPOSAL_AUTHENTICITY_SIGNING_PREFIX),
+        ),
+    )
+    if any(operation is not prefix for operation, prefix in domain_pairs):
         return REJECT_ED25519_SIGNER_DOMAIN_MISMATCH
     try:
         derived = encode_ed25519_public_key(_public_bytes_from_private_key(backend.private_key))
@@ -192,6 +235,48 @@ def _prepare_control_signing(
     except Exception:
         return None, None, REJECT_ED25519_SIGNER_CONTROL_ANCHOR_REJECTED
     return payload, preparation, ""
+
+
+def _prepare_proposal_signing(
+    backend: Ed25519SignerBackend,
+    request: SigningRequest,
+) -> tuple[str | None, str]:
+    if request.requested_operation != PROPOSAL_AUTHENTICITY_SIGNING_OPERATION:
+        return None, ""
+    if backend.proposal_authority_policy is None:
+        return None, REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING
+    payload = validate_proposal_signing_request(
+        request,
+        backend.proposal_authority_policy,
+        now_epoch=int(backend.proposal_clock()),
+    )
+    if payload is None:
+        return None, REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH
+    if backend.proposal_nonce_store is None:
+        return None, REJECT_ED25519_SIGNER_PROPOSAL_NONCE_STORE_MISSING
+    try:
+        reservation = backend.proposal_nonce_store.reserve(
+            str(payload["nonce"]),
+            expires_at=int(payload["expires_at"]),
+            subject=str(payload["requester_principal_id"]),
+        )
+    except Exception:
+        reservation = None
+    if not reservation:
+        return None, REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY
+    return reservation, ""
+
+
+def _rollback_proposal_reservation(
+    backend: Ed25519SignerBackend,
+    reservation: str | None,
+) -> None:
+    if reservation is None or backend.proposal_nonce_store is None:
+        return
+    try:
+        backend.proposal_nonce_store.rollback(reservation)
+    except Exception:
+        pass
 
 
 def _sign_response(
@@ -400,6 +485,10 @@ __all__ = [
     "REJECT_ED25519_SIGNER_KEY_EPOCH_MISMATCH",
     "REJECT_ED25519_SIGNER_KEY_INVALID",
     "REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH",
+    "REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH",
+    "REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING",
+    "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY",
+    "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_STORE_MISSING",
     "REJECT_ED25519_SIGNER_REQUEST_INVALID",
     "REJECT_ED25519_SIGNER_SIGN_FAILED",
     "SignerAuditMacBuilder",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_authenticity.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_authenticity.py
@@ -1,0 +1,533 @@
+"""Tests for REDDOG_ARCHITECT_PROPOSAL_AUTHENTICITY_ATTESTATION_PHASE1."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalAuthenticityPayload,
+    ArchitectProposalIntegrityContext,
+    ArchitectProposalSignerPolicy,
+    ArchitectProposalSigningContext,
+    InMemoryProposalAuthenticityNonceStore,
+    PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+    PROPOSAL_AUTHENTICITY_SIGNING_PREFIX,
+    attest_architect_proposal,
+    build_architect_proposal_authenticity_payload,
+    canonical_architect_proposal_signing_input,
+    verify_architect_proposal_attestation_integrity,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+    encode_ed25519_public_key,
+    encode_ed25519_signature,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    Ed25519SignerBackend,
+    REJECT_ED25519_SIGNER_DOMAIN_MISMATCH,
+    REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH,
+    REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING,
+    REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+)
+
+
+pytest.importorskip("cryptography")
+
+NOW = int(time.time())
+SHA = "sha256:" + "a" * 64
+
+
+class _AuditMac:
+    def build(
+        self,
+        request: SigningRequest,
+        signature: str,
+        peer: SignerPeerAttestation,
+    ) -> str:
+        return "audit:" + request.nonce + ":" + peer.peer_principal_id
+
+
+class _EmptyAuditMac:
+    def build(
+        self,
+        request: SigningRequest,
+        signature: str,
+        peer: SignerPeerAttestation,
+    ) -> str:
+        return ""
+
+
+class _DirectClient:
+    def __init__(self, backend: Ed25519SignerBackend) -> None:
+        self.backend = backend
+
+    def sign(self, request: SigningRequest):
+        return self.backend.sign(request, _peer())
+
+
+def _private_key():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return Ed25519PrivateKey.generate()
+
+
+def _public_text(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    return encode_ed25519_public_key(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+
+def _peer() -> SignerPeerAttestation:
+    return SignerPeerAttestation(
+        peer_principal_id="github:012",
+        transport="unix_socket",
+        credential_source="kernel_peer_credential",
+        boundary_attested=True,
+    )
+
+
+def _proposal() -> dict:
+    return {
+        "receipt_id": "sha256:" + "1" * 64,
+        "snapshot_receipt_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:" + "2" * 64,
+        "repo_head_sha": "a" * 40,
+        "work_state_revision": "revision-1",
+        "report_bundle_id": "report-bundle-1",
+        "wsp15_allocation_receipt_id": "wsp15-1",
+        "wsp15_allocation_digest": "sha256:" + "3" * 64,
+        "holoindex_generation_id": "generation-1",
+        "holoindex_freshness_receipt_digest": "sha256:" + "4" * 64,
+        "policy_digest": "sha256:" + "5" * 64,
+        "allowed_paths": ["modules/communication/moltbot_bridge/src/example.py"],
+        "denied_paths": [".github/workflows/**", ".env"],
+        "required_tests": ["pytest focused"],
+        "required_policy_gates": ["WSP_50", "WSP_97"],
+        "target_effect_plane": "REPOSITORY_CODE_CHANGE",
+    }
+
+
+def _candidate() -> dict:
+    return {
+        "queue_candidate_id": "sha256:" + "6" * 64,
+        "status": "BLOCKED_CANDIDATE",
+        "slice_id": "REDDOG_EXAMPLE_PHASE1",
+    }
+
+
+def _determination(candidate: dict | None = None) -> dict:
+    return {
+        "determination_receipt_id": "sha256:" + "7" * 64,
+        "action": "FIX",
+        "next_slice_name": "REDDOG_EXAMPLE_PHASE1",
+        "queue_candidate": candidate or _candidate(),
+    }
+
+
+def _payload(public_key: str, *, nonce: str = "proposal-nonce-1"):
+    candidate = _candidate()
+    determination = _determination(candidate)
+    payload = build_architect_proposal_authenticity_payload(
+        proposal_admission=_proposal(),
+        determination=determination,
+        queue_candidate=candidate,
+        requester_principal_id="github:012",
+        reddog_id="reddog-0102",
+        signer_public_key=public_key,
+        key_epoch="epoch-1",
+        consensus_receipt_digest="sha256:" + "8" * 64,
+        authority_profile_source_receipt_id="sha256:" + "9" * 64,
+        nonce=nonce,
+        issued_at=NOW - 5,
+        expires_at=NOW + 120,
+    )
+    return payload, determination, candidate
+
+
+def _backend(private_key, payload, **overrides):
+    values = {
+        "private_key": private_key,
+        "public_key": payload.signer_public_key,
+        "key_epoch": "epoch-1",
+        "audit_mac_builder": _AuditMac(),
+        "proposal_authority_policy": ArchitectProposalSignerPolicy(
+            expected_payload=payload,
+        ),
+        "proposal_nonce_store": InMemoryProposalAuthenticityNonceStore(),
+        "proposal_clock": lambda: NOW,
+    }
+    values.update(overrides)
+    return Ed25519SignerBackend(**values)
+
+
+def _attestation():
+    private_key = _private_key()
+    payload, determination, candidate = _payload(_public_text(private_key))
+    backend = _backend(private_key, payload)
+    context = ArchitectProposalSigningContext(
+        signer=_DirectClient(backend),
+        signature_verifier=Ed25519SignatureVerifier(),
+        requester_principal_id="github:012",
+        signer_public_key=payload.signer_public_key,
+        key_epoch="epoch-1",
+        authority_tier="ULTRA",
+        consensus_receipt_digest=payload.consensus_receipt_digest,
+    )
+    return (
+        attest_architect_proposal(payload, context),
+        determination,
+        candidate,
+    )
+
+
+def _integrity_verified(attestation, *, now_epoch: int = NOW, revoked=()):
+    return verify_architect_proposal_attestation_integrity(
+        attestation.to_dict(),
+        context=ArchitectProposalIntegrityContext(
+            expected_payload=attestation.payload,
+            now_epoch=now_epoch,
+            revoked_key_epochs=frozenset(revoked),
+        ),
+    )
+
+
+def test_exact_policy_signs_and_integrity_verifier_rehydrates() -> None:
+    attestation, _, _ = _attestation()
+
+    verified = _integrity_verified(attestation)
+
+    assert verified == attestation
+    assert not hasattr(verified, "accepted")
+    assert not hasattr(verified, "verified")
+
+
+def test_serialized_attestation_has_no_authority_marker() -> None:
+    attestation, _, _ = _attestation()
+
+    serialized = attestation.to_dict()
+
+    assert "accepted" not in serialized
+    assert "verified" not in serialized
+    assert "authority_granted" not in serialized
+
+
+@pytest.mark.parametrize("operation,prefix", [
+    ("create_foundup", PROPOSAL_AUTHENTICITY_SIGNING_PREFIX),
+    (PROPOSAL_AUTHENTICITY_SIGNING_OPERATION, "reddog-workauth.v1."),
+])
+def test_proposal_domain_confusion_is_rejected(operation: str, prefix: str) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    payload, _, _ = _payload(public_key)
+    backend = _backend(private_key, payload)
+    response = backend.sign(
+        SigningRequest(
+            signing_input=prefix + "{}",
+            payload_digest=SHA,
+            signer_role="reddog_architect",
+            signer_public_key=public_key,
+            requester_principal_id="github:012",
+            nonce="n",
+            key_epoch="epoch-1",
+            requested_operation=operation,
+            authority_tier="ULTRA",
+            consensus_receipt_digest=payload.consensus_receipt_digest,
+        ),
+        _peer(),
+    )
+
+    assert response.accepted is False
+    assert response.rejection_code == REJECT_ED25519_SIGNER_DOMAIN_MISMATCH
+
+
+def test_signer_requires_policy_and_exact_payload() -> None:
+    private_key = _private_key()
+    payload, _, _ = _payload(_public_text(private_key))
+    context = ArchitectProposalSigningContext(
+        signer=_DirectClient(
+            _backend(private_key, payload, proposal_authority_policy=None)
+        ),
+        signature_verifier=Ed25519SignatureVerifier(),
+        requester_principal_id="github:012",
+        signer_public_key=payload.signer_public_key,
+        key_epoch="epoch-1",
+        authority_tier="ULTRA",
+        consensus_receipt_digest=payload.consensus_receipt_digest,
+    )
+    with pytest.raises(ValueError):
+        attest_architect_proposal(payload, context)
+    request = SigningRequest(
+        signing_input=PROPOSAL_AUTHENTICITY_SIGNING_PREFIX + json.dumps(
+            {**payload.to_dict(), "repo_head_sha": "b" * 40},
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+        payload_digest=SHA,
+        signer_role="reddog_architect",
+        signer_public_key=payload.signer_public_key,
+        requester_principal_id="github:012",
+        nonce=payload.nonce,
+        key_epoch="epoch-1",
+        requested_operation=PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+        authority_tier="ULTRA",
+        consensus_receipt_digest=payload.consensus_receipt_digest,
+    )
+    response = _backend(private_key, payload).sign(request, _peer())
+    assert response.accepted is False
+    assert response.rejection_code in {
+        REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH,
+        REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING,
+    }
+    malformed_policy_backend = _backend(
+        private_key,
+        payload,
+        proposal_authority_policy=ArchitectProposalSignerPolicy(  # type: ignore[arg-type]
+            expected_payload={}
+        ),
+    )
+    malformed_response = malformed_policy_backend.sign(request, _peer())
+    assert malformed_response.accepted is False
+    assert (
+        malformed_response.rejection_code
+        == REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH
+    )
+
+
+def test_signer_consumes_nonce_once() -> None:
+    private_key = _private_key()
+    payload, _, _ = _payload(_public_text(private_key))
+    backend = _backend(private_key, payload)
+    context = ArchitectProposalSigningContext(
+        signer=_DirectClient(backend),
+        signature_verifier=Ed25519SignatureVerifier(),
+        requester_principal_id="github:012",
+        signer_public_key=payload.signer_public_key,
+        key_epoch="epoch-1",
+        authority_tier="ULTRA",
+        consensus_receipt_digest=payload.consensus_receipt_digest,
+    )
+
+    attest_architect_proposal(payload, context)
+    response = backend.sign(
+        SigningRequest(
+            signing_input=PROPOSAL_AUTHENTICITY_SIGNING_PREFIX
+            + json.dumps(payload.to_dict(), sort_keys=True, separators=(",", ":")),
+            payload_digest=_digest(
+                {
+                    "signing_input": PROPOSAL_AUTHENTICITY_SIGNING_PREFIX
+                    + json.dumps(
+                        payload.to_dict(),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                }
+            ),
+            signer_role="reddog_architect",
+            signer_public_key=payload.signer_public_key,
+            requester_principal_id="github:012",
+            nonce=payload.nonce,
+            key_epoch="epoch-1",
+            requested_operation=PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+            authority_tier="ULTRA",
+            consensus_receipt_digest=payload.consensus_receipt_digest,
+        ),
+        _peer(),
+    )
+    assert response.accepted is False
+    assert response.rejection_code == REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY
+
+
+def test_signer_rolls_back_nonce_reservation_when_audit_mac_fails() -> None:
+    private_key = _private_key()
+    payload, _, _ = _payload(_public_text(private_key))
+    nonce_store = InMemoryProposalAuthenticityNonceStore()
+    failing = _backend(
+        private_key,
+        payload,
+        audit_mac_builder=_EmptyAuditMac(),
+        proposal_nonce_store=nonce_store,
+    )
+    succeeding = _backend(
+        private_key,
+        payload,
+        audit_mac_builder=_AuditMac(),
+        proposal_nonce_store=nonce_store,
+    )
+    context_values = {
+        "signature_verifier": Ed25519SignatureVerifier(),
+        "requester_principal_id": "github:012",
+        "signer_public_key": payload.signer_public_key,
+        "key_epoch": "epoch-1",
+        "authority_tier": "ULTRA",
+        "consensus_receipt_digest": payload.consensus_receipt_digest,
+    }
+
+    with pytest.raises(ValueError):
+        attest_architect_proposal(
+            payload,
+            ArchitectProposalSigningContext(
+                signer=_DirectClient(failing),
+                **context_values,
+            ),
+        )
+    accepted = attest_architect_proposal(
+        payload,
+        ArchitectProposalSigningContext(
+            signer=_DirectClient(succeeding),
+            **context_values,
+        ),
+    )
+
+    assert accepted.signature
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("repo_head_sha", "b" * 40),
+        ("wsp15_allocation_digest", "sha256:" + "b" * 64),
+        ("holoindex_generation_id", "generation-2"),
+        ("key_epoch", "epoch-2"),
+        ("requester_principal_id", "github:attacker"),
+    ],
+)
+def test_tampered_signed_field_fails_verification(field: str, value: object) -> None:
+    attestation, _, _ = _attestation()
+    serialized = attestation.to_dict()
+    serialized[field] = value
+
+    with pytest.raises(ValueError):
+        verify_architect_proposal_attestation_integrity(
+            serialized,
+            context=ArchitectProposalIntegrityContext(
+                expected_payload=attestation.payload,
+                now_epoch=NOW,
+            ),
+        )
+
+
+def test_verifier_rejects_non_typed_integrity_context() -> None:
+    attestation, _, _ = _attestation()
+
+    with pytest.raises(ValueError, match="trust_context_invalid"):
+        verify_architect_proposal_attestation_integrity(
+            attestation.to_dict(),
+            context={},  # type: ignore[arg-type]
+        )
+
+
+def test_expiry_and_revocation_fail_closed() -> None:
+    attestation, _, _ = _attestation()
+    with pytest.raises(ValueError):
+        _integrity_verified(attestation, now_epoch=NOW + 121)
+    with pytest.raises(ValueError):
+        _integrity_verified(attestation, revoked=("epoch-1",))
+
+
+def test_verifier_rejects_ttl_above_policy_maximum() -> None:
+    private_key = _private_key()
+    payload, _, _ = _payload(_public_text(private_key))
+    extended = build_architect_proposal_authenticity_payload(
+        proposal_admission=_proposal(),
+        determination=_determination(),
+        queue_candidate=_candidate(),
+        requester_principal_id="github:012",
+        reddog_id="reddog-0102",
+        signer_public_key=payload.signer_public_key,
+        key_epoch="epoch-1",
+        consensus_receipt_digest="sha256:" + "8" * 64,
+        authority_profile_source_receipt_id="sha256:" + "9" * 64,
+        nonce="long-lived-proposal",
+        issued_at=NOW - 5,
+        expires_at=NOW + 601,
+    )
+    attestation = attest_architect_proposal(
+        extended,
+        ArchitectProposalSigningContext(
+            signer=_DirectClient(
+                _backend(
+                    private_key,
+                    extended,
+                    proposal_authority_policy=ArchitectProposalSignerPolicy(
+                        expected_payload=extended,
+                        max_ttl_seconds=700,
+                    ),
+                )
+            ),
+            signature_verifier=Ed25519SignatureVerifier(),
+            requester_principal_id="github:012",
+            signer_public_key=extended.signer_public_key,
+            key_epoch="epoch-1",
+            authority_tier="ULTRA",
+            consensus_receipt_digest=extended.consensus_receipt_digest,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        verify_architect_proposal_attestation_integrity(
+            attestation.to_dict(),
+            context=ArchitectProposalIntegrityContext(
+                expected_payload=extended,
+                now_epoch=NOW,
+                max_ttl_seconds=600,
+            ),
+        )
+
+
+def test_verifier_rejects_non_string_identity_scalar() -> None:
+    private_key = _private_key()
+    payload, _, _ = _payload(_public_text(private_key))
+    malformed = payload.to_dict()
+    malformed["reddog_id"] = 123
+    malformed["attestation_id"] = (
+        "reddog_architect_proposal_attestation_"
+        + _digest(
+            {
+                key: value
+                for key, value in malformed.items()
+                if key != "attestation_id"
+            }
+        )[7:39]
+    )
+    malformed_payload = ArchitectProposalAuthenticityPayload(**malformed)
+    serialized = {
+        **malformed,
+        "signature": encode_ed25519_signature(
+            private_key.sign(
+                canonical_architect_proposal_signing_input(
+                    malformed_payload
+                ).encode("utf-8")
+            )
+        ),
+    }
+
+    with pytest.raises(ValueError, match="value_missing"):
+        verify_architect_proposal_attestation_integrity(
+            serialized,
+            context=ArchitectProposalIntegrityContext(
+                expected_payload=malformed_payload,
+                now_epoch=NOW,
+            ),
+        )
+
+
+def _digest(value: object) -> str:
+    raw = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()


### PR DESCRIPTION
## What changed
- add a domain-separated architect-proposal Ed25519 attestation with complete proposal, queue, snapshot, WSP 15, HoloIndex, policy, principal, signer, consensus, nonce, and expiry bindings
- require the isolated signer to enforce an exact proposal policy and reserve/commit the proposal nonce transactionally
- add strict canonical rehydration and cryptographic integrity validation
- keep candidate admission and promotion unchanged; the attestation is evidence only and does not grant runtime authority

## Why
The production proposal-admission capability is correctly fail-closed, but the signer had no proposal-specific domain or exact-field policy. This establishes that lower integrity boundary without pretending caller-controlled verification context is authority.

## Truth boundary
- no proposal candidate is admitted
- no queue item is created
- no promotion path is changed
- no runtime trust root, durable nonce store, authoritative revocation resolver, or opaque authority proof is implemented
- `CAP_PROPOSAL_AUTHENTICITY` remains blocked

## Validation
- `129 passed` across proposal authenticity, signer, admission, promotion bootstrap, key-provider, and socket-runtime tests
- focused independent review: GO; candidate/admission/promotion files identical to `origin/main`
- WSP 62: production files below 675 lines; no production function exceeds 50 lines
- `compileall` and `git diff --check` clean
- added lines ASCII-clean