### PR TITLE
fix(reddog): confine authority runtime stores

### DIFF
--- a/main.py
+++ b/main.py
@@ -3350,6 +3350,7 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             resident_queue_pattern_memory_admission_db_path,
             resident_queue_runtime_file_path,
             resident_queue_runtime_root_path,
+            resident_queue_signer_runtime_root_path,
             resident_queue_worktree_runner_mode,
         )
         from modules.communication.moltbot_bridge.src.reddog_verified_pattern_memory_sink import (
@@ -3488,6 +3489,8 @@ def run_reddog_resident_queue_serial_loop_preflight(repo_root: Path) -> bool:
             )
             signer_config = run_reddog_signer_socket_service_config_supply(
                 repo_root=repo_root,
+                runtime_root=resident_queue_runtime_root_path(os.environ, repo_root),
+                signer_runtime_root=resident_queue_signer_runtime_root_path(os.environ, repo_root),
                 authority_profile=(
                     authority_profile_payload
                     if isinstance(authority_profile_payload, Mapping)
@@ -3962,6 +3965,7 @@ def _reddog_record_queue_control_result(repo_root: Path, result: Mapping[str, An
         from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_profile import (
             resident_queue_runtime_file_path,
             resident_queue_runtime_flag_enabled,
+            resident_queue_runtime_root_path,
         )
 
         if resident_queue_runtime_flag_enabled(
@@ -3975,7 +3979,11 @@ def _reddog_record_queue_control_result(repo_root: Path, result: Mapping[str, An
             )
             if receipt_path:
                 _reddog_persist_queue_control_receipt(
-                    repo_root, recorded, receipt_path, resident_queue_runtime_file_path
+                    repo_root,
+                    recorded,
+                    receipt_path,
+                    resident_queue_runtime_file_path,
+                    resident_queue_runtime_root_path,
                 )
     except Exception as exc:
         recorded["accepted"] = False
@@ -4013,6 +4021,7 @@ def _reddog_persist_queue_control_receipt(
     recorded: Dict[str, Any],
     receipt_path: Path,
     runtime_file_path: Any,
+    runtime_root_path: Any,
 ) -> None:
     from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_receipt_store import (
         append_resident_control_loop_receipt,
@@ -4046,6 +4055,7 @@ def _reddog_persist_queue_control_receipt(
         created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         signing_context=signing_context,
         require_authentication=True,
+        runtime_root=runtime_root_path(os.environ, repo_root),
         head_state_path=runtime_file_path(
             os.environ, repo_root, "REDDOG_AUTHORITY_RUNTIME_STATE_PATH"
         ),

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,43 @@
 # ModLog - moltbot_bridge
+## 2026-07-27: REDDOG_AUTHORITY_RUNTIME_STORE_CONFINEMENT_PHASE1
+- Required every atomic authority runtime store to bind an explicit repository
+  root and runtime root, then revalidate the target before reads, writes, and
+  atomic replacement.
+- Rejected missing out-of-root targets, hard links, repository-contained or
+  repository-containing roots, Windows namespaces, and linked path components;
+  atomic replacement now pins the verified parent against swap races.
+- Split the platform replacement adapters, scrubbed rejected temporary payloads,
+  restored the previous authority snapshot after post-replace verification
+  failure, and rejected POSIX parent relocation before accepting a write.
+- Bound authority commits to a platform-level revision witness, recovered
+  interrupted authority artifacts only when the caller supplies the exact
+  expected revision, and made snapshot revisions independent of a prior
+  embedded revision.
+- Moved Linux payload staging to an `O_TMPFILE` unnamed inode with mode-zero
+  rename, descriptor-backed rollback, and inode/directory fsync. Unsupported
+  filesystems fail closed rather than falling back to pathname temp files.
+- Kept the security boundary explicit: descriptor and compare-and-swap checks
+  protect cooperative runtime access, while hostile same-principal filesystem
+  writers remain excluded by the signer service's distinct OS-principal
+  isolation contract.
+- Preserved the exact authenticated runtime root through control-receipt reads
+  and appends, required schema-v2 signer anchor and authority-policy bindings,
+  confined socket/anchor paths at supply, bootstrap, and public runtime wiring,
+  and aligned readiness around the same direct-child root contract.
+- Required run-packet supply to pass the same canonical schema-v2 config
+  rehydration as the signer bootstrap, so an accepted launch artifact cannot
+  omit runtime roots, signer roots, the control anchor, or a fully validated
+  authority policy, peer policy, and signer profile set. Canonical profile
+  validation is shared by config supply, run-packet admission, and provider
+  admission; malformed public keys, bounded service limits, and
+  policy-to-profile identity are rejected before config write or launch
+  acceptance, with strict finite JSON numbers and string-only policy bindings
+  for both mapping and typed runtime inputs.
+- Threaded independent repository/runtime roots through queue dependencies,
+  signer config, control-loop heads, signer anchors, and live-canary verification
+  without enabling proposal authority, queue promotion, worker execution, or repository
+  mutation (WSP 00, 15, 22, 50, 62, 97).
+
 ## 2026-07-27: REDDOG_ARCHITECT_PROPOSAL_AUTHENTICITY_ATTESTATION_PHASE1
 - Added a domain-separated architect-proposal Ed25519 attestation that binds
   the complete proposal, determination, queue candidate, snapshot, exact SHA,

--- a/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store.py
@@ -5,22 +5,43 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import tempfile
 import threading
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Dict, Mapping, Optional, Protocol, Tuple
+from typing import Any, Dict, Iterator, Mapping, Optional, Protocol, Tuple
 
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store_posix import (
+    posix_atomic_replace,
+    recover_posix_interrupted_files,
+)
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store_windows import (
+    close_windows_handle,
+    open_windows_directory_without_delete_share,
+    recover_windows_interrupted_files,
+    windows_atomic_replace,
+)
 from modules.communication.moltbot_bridge.src.reddog_runtime_json_read import (
     read_reddog_runtime_json_mapping,
 )
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
     runtime_operation_lock,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
 )
+
+_NO_REVISION_CHECK = object()
 
 
 def _canonical_digest(payload: Mapping[str, Any]) -> str:
-    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    unsigned = dict(payload)
+    unsigned.pop("revision", None)
+    raw = json.dumps(
+        unsigned,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
@@ -105,20 +126,46 @@ class InMemoryAuthorityRuntimeStore:
 class AtomicJsonAuthorityRuntimeStore:
     """Single-file authority store using durable atomic replace."""
 
-    def __init__(self, path: str | Path, *, allowed_root: str | Path) -> None:
-        self.path = Path(os.path.abspath(Path(path).expanduser()))
-        self.allowed_root = Path(os.path.abspath(Path(allowed_root).expanduser()))
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        allowed_root: str | Path,
+        repo_root: str | Path,
+    ) -> None:
+        repo_candidate = Path(repo_root).expanduser()
+        root_candidate = Path(allowed_root).expanduser()
+        if not repo_candidate.is_absolute():
+            raise ValueError("authority_runtime_store_repo_root_not_absolute")
+        if not root_candidate.is_absolute():
+            raise ValueError("authority_runtime_store_root_not_absolute")
+        self.repo_root = repo_candidate.resolve()
+        self.allowed_root = validate_runtime_root_path(
+            root_candidate,
+            repo_root=self.repo_root,
+        )
+        self.path = self._validated_path(path)
 
     def load(self) -> Dict[str, Any]:
         with runtime_operation_lock(str(self.path) + ".operation"):
             return self._load_unlocked()
 
-    def _load_unlocked(self) -> Dict[str, Any]:
-        if not self.path.exists():
+    def _load_unlocked(
+        self,
+        *,
+        expected_recovery_revision: object = _NO_REVISION_CHECK,
+    ) -> Dict[str, Any]:
+        target = self._validated_path(self.path)
+        self._recover_interrupted_write(
+            target,
+            expected_revision=expected_recovery_revision,
+        )
+        target = self._validated_path(self.path)
+        if not target.exists():
             return {}
         return dict(
             read_reddog_runtime_json_mapping(
-                self.path,
+                target,
                 allowed_root=self.allowed_root,
             )
         )
@@ -127,10 +174,15 @@ class AtomicJsonAuthorityRuntimeStore:
         self, snapshot: Mapping[str, Any], *, expected_revision: Optional[str]
     ) -> str:
         with runtime_operation_lock(str(self.path) + ".operation"):
-            current = self._load_unlocked()
+            current = self._load_unlocked(
+                expected_recovery_revision=expected_revision,
+            )
             if current.get("revision") != expected_revision:
                 raise RuntimeError("revision_conflict")
-            return self._write_snapshot(snapshot)
+            return self._write_snapshot(
+                snapshot,
+                expected_revision=expected_revision,
+            )
 
     def consume_verified_work_authority_nonce(self, nonce: str) -> bool:
         with runtime_operation_lock(str(self.path) + ".operation"):
@@ -140,32 +192,161 @@ class AtomicJsonAuthorityRuntimeStore:
                 return False
             updated = dict(current)
             updated["verified_work_authority_nonces"] = [*seen, nonce]
-            self._write_snapshot(updated)
+            self._write_snapshot(
+                updated,
+                expected_revision=current.get("revision"),
+            )
             return True
 
-    def _write_snapshot(self, snapshot: Mapping[str, Any]) -> str:
+    def _write_snapshot(
+        self,
+        snapshot: Mapping[str, Any],
+        *,
+        expected_revision: Optional[str],
+    ) -> str:
         committed = json.loads(json.dumps(snapshot, sort_keys=True))
         revision = _canonical_digest(committed)
         committed["revision"] = revision
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self._atomic_write(committed)
+        target = self._validated_path(self.path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target = self._validated_path(target)
+        self._atomic_write(
+            target,
+            committed,
+            expected_revision=expected_revision,
+        )
         return revision
 
-    def _atomic_write(self, committed: Mapping[str, Any]) -> None:
-        fd, tmp_name = tempfile.mkstemp(
-            prefix=f".{self.path.name}.", suffix=".tmp", dir=str(self.path.parent)
+    def _atomic_write(
+        self,
+        target: Path,
+        committed: Mapping[str, Any],
+        *,
+        expected_revision: Optional[str],
+    ) -> None:
+        atomic_replace_confined_mapping(
+            target,
+            committed,
+            allowed_root=self.allowed_root,
+            repo_root=self.repo_root,
+            expected_revision=expected_revision,
         )
+
+    def _recover_interrupted_write(
+        self,
+        target: Path,
+        *,
+        expected_revision: object,
+    ) -> None:
+        if not target.parent.exists():
+            return
+        recovery_revision = (
+            expected_revision
+            if isinstance(expected_revision, str) and expected_revision
+            else None
+        )
+        with _stable_parent_directory(target.parent) as parent_handle:
+            if os.name == "nt":
+                recover_windows_interrupted_files(
+                    target,
+                    expected_revision=recovery_revision,
+                )
+            else:
+                recover_posix_interrupted_files(
+                    parent_handle,
+                    target.name,
+                    expected_revision=recovery_revision,
+                )
+
+    def _validated_path(self, path: str | Path) -> Path:
+        target = validate_runtime_artifact_path(
+            path,
+            repo_root=self.repo_root,
+            allowed_root=self.allowed_root,
+        )
+        expected = getattr(self, "path", target)
+        if os.path.normcase(str(target)) != os.path.normcase(str(expected)):
+            raise ValueError("authority_runtime_store_path_changed")
+        return target
+
+
+def atomic_replace_confined_mapping(
+    path: Path | str,
+    payload: Mapping[str, Any],
+    *,
+    allowed_root: Path | str,
+    repo_root: Path | str,
+    expected_revision: object = _NO_REVISION_CHECK,
+) -> Path:
+    """Atomically replace one JSON mapping under an explicit runtime root."""
+
+    root = validate_runtime_root_path(allowed_root, repo_root=repo_root)
+    target = validate_runtime_artifact_path(
+        path,
+        repo_root=repo_root,
+        allowed_root=root,
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target = validate_runtime_artifact_path(
+        target,
+        repo_root=repo_root,
+        allowed_root=root,
+    )
+    encoded = (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8")
+    check_revision = expected_revision is not _NO_REVISION_CHECK
+    with _stable_parent_directory(target.parent) as parent_handle:
+        if os.name == "nt":
+            windows_atomic_replace(
+                parent_handle,
+                target,
+                encoded,
+                check_revision=check_revision,
+                expected_revision=(
+                    None if expected_revision is _NO_REVISION_CHECK
+                    else expected_revision
+                ),
+            )
+        else:
+            posix_atomic_replace(
+                parent_handle,
+                target.parent,
+                target.name,
+                encoded,
+                check_revision=check_revision,
+                expected_revision=(
+                    None if expected_revision is _NO_REVISION_CHECK
+                    else expected_revision
+                ),
+            )
+        if os.name == "nt":
+            validate_runtime_artifact_path(
+                target,
+                repo_root=repo_root,
+                allowed_root=root,
+            )
+            _fsync_parent_directory(target.parent)
+    return target
+
+
+@contextmanager
+def _stable_parent_directory(path: Path) -> Iterator[int]:
+    if os.name == "nt":
+        handle = open_windows_directory_without_delete_share(path)
         try:
-            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
-                json.dump(committed, handle, sort_keys=True, indent=2)
-                handle.write("\n")
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(tmp_name, self.path)
-            _fsync_parent_directory(self.path.parent)
+            yield handle
         finally:
-            if os.path.exists(tmp_name):
-                os.unlink(tmp_name)
+            close_windows_handle(handle)
+        return
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        opened = os.fstat(descriptor)
+        expected = os.stat(path, follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != (expected.st_dev, expected.st_ino):
+            raise ValueError("authority_runtime_store_parent_changed")
+        yield descriptor
+    finally:
+        os.close(descriptor)
 
 
 def _fsync_parent_directory(path: Path) -> None:
@@ -188,4 +369,5 @@ __all__ = [
     "InMemoryAuthorityRuntimeStore",
     "PrincipalAuthorityRecord",
     "PrincipalAuthorityResolver",
+    "atomic_replace_confined_mapping",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store_posix.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store_posix.py
@@ -1,0 +1,550 @@
+"""Linux descriptor operations for confined authority runtime replacement.
+
+The durable replacement path requires ``O_TMPFILE`` and fails closed when the
+host filesystem cannot provide an unnamed inode. No pathname temp fallback is
+used for authority state.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import json
+import os
+import secrets
+import stat
+from pathlib import Path
+
+
+_AT_EMPTY_PATH = 0x1000
+
+
+def posix_atomic_replace(
+    parent_fd: int,
+    parent_path: Path,
+    target_name: str,
+    payload: bytes,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    """Replace one target from an unnamed inode with descriptor rollback."""
+
+    _recover_interrupted_files(
+        parent_fd,
+        target_name,
+        restore_missing=False,
+        expected_revision=None,
+    )
+    old_fd, old_mode = _open_target_witness(
+        parent_fd,
+        target_name,
+        check_revision=check_revision,
+        expected_revision=expected_revision,
+    )
+    descriptor = _open_unnamed_temp(parent_fd)
+    temp_name = f".{target_name}.{secrets.token_hex(16)}.tmp"
+    backup_name = f".{target_name}.{secrets.token_hex(16)}.bak"
+    linked = False
+    backup_created = False
+    renamed = False
+    verified = False
+    try:
+        _write_descriptor(descriptor, payload)
+        _require_unnamed_private_regular(os.fstat(descriptor))
+        os.fchmod(descriptor, 0)
+        _require_parent_identity(parent_fd, parent_path)
+        _link_descriptor(descriptor, parent_fd, temp_name)
+        linked = True
+        expected_temp = os.fstat(descriptor)
+        _require_entry_identity(parent_fd, temp_name, expected_temp, mode=0)
+        _require_target_witness(
+            parent_fd,
+            target_name,
+            old_fd,
+            check_revision=check_revision,
+            expected_revision=expected_revision,
+        )
+        if old_fd is not None:
+            _link_descriptor(old_fd, parent_fd, backup_name)
+            backup_created = True
+            os.fchmod(old_fd, 0)
+            _require_backup_identity(
+                parent_fd,
+                target_name,
+                backup_name,
+                old_fd,
+                check_revision=check_revision,
+                expected_revision=expected_revision,
+            )
+        _require_parent_identity(parent_fd, parent_path)
+        _replace_entry(
+            parent_fd,
+            temp_name,
+            target_name,
+            old_fd=old_fd,
+            backup_name=backup_name if backup_created else None,
+            check_revision=check_revision,
+            expected_revision=expected_revision,
+        )
+        linked = False
+        renamed = True
+        _require_entry_identity(parent_fd, target_name, expected_temp, mode=0)
+        _require_parent_identity(parent_fd, parent_path)
+        os.fsync(parent_fd)
+        _require_parent_identity(parent_fd, parent_path)
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+        _require_entry_identity(parent_fd, target_name, os.fstat(descriptor), mode=0o600)
+        _require_parent_identity(parent_fd, parent_path)
+        verified = True
+    finally:
+        if renamed and not verified:
+            _restore_previous(
+                parent_fd,
+                target_name,
+                old_fd=old_fd,
+                old_mode=old_mode,
+                backup_name=backup_name,
+                backup_created=backup_created,
+            )
+        else:
+            if linked:
+                _unlink(parent_fd, temp_name)
+            if backup_created:
+                if old_fd is not None:
+                    os.fchmod(old_fd, old_mode)
+                _unlink(parent_fd, backup_name)
+        os.close(descriptor)
+        if old_fd is not None:
+            os.close(old_fd)
+
+
+def _open_unnamed_temp(parent_fd: int) -> int:
+    flags = os.O_RDWR | getattr(os, "O_TMPFILE", 0)
+    if not getattr(os, "O_TMPFILE", 0):
+        raise OSError("authority_runtime_store_unnamed_temp_unavailable")
+    try:
+        return os.open(".", flags, 0o600, dir_fd=parent_fd)
+    except OSError as exc:
+        raise OSError("authority_runtime_store_unnamed_temp_unavailable") from exc
+
+
+def _open_target_witness(
+    parent_fd: int,
+    target_name: str,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> tuple[int | None, int]:
+    try:
+        descriptor = os.open(
+            target_name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_fd,
+        )
+    except FileNotFoundError:
+        if check_revision and expected_revision is not None:
+            raise RuntimeError("revision_conflict")
+        return None, 0o600
+    try:
+        metadata = os.fstat(descriptor)
+        _require_private_regular(metadata)
+        if check_revision and _read_revision(descriptor) != expected_revision:
+            raise RuntimeError("revision_conflict")
+        return descriptor, stat.S_IMODE(metadata.st_mode)
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _require_target_witness(
+    parent_fd: int,
+    target_name: str,
+    old_fd: int | None,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    try:
+        observed = os.stat(target_name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        if old_fd is not None or (check_revision and expected_revision is not None):
+            raise RuntimeError("revision_conflict")
+        return
+    if old_fd is None:
+        raise RuntimeError("revision_conflict")
+    opened = os.fstat(old_fd)
+    if (observed.st_dev, observed.st_ino) != (opened.st_dev, opened.st_ino):
+        raise RuntimeError("revision_conflict")
+    _require_private_regular(observed)
+    if check_revision and _read_revision(old_fd) != expected_revision:
+        raise RuntimeError("revision_conflict")
+
+
+def _restore_previous(
+    parent_fd: int,
+    target_name: str,
+    *,
+    old_fd: int | None,
+    old_mode: int,
+    backup_name: str,
+    backup_created: bool,
+) -> None:
+    _unlink(parent_fd, target_name)
+    if old_fd is not None and backup_created:
+        os.fchmod(old_fd, old_mode)
+        os.fsync(old_fd)
+        os.replace(
+            backup_name,
+            target_name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+    os.fsync(parent_fd)
+
+
+def _recover_interrupted_files(
+    parent_fd: int,
+    target_name: str,
+    *,
+    restore_missing: bool,
+    expected_revision: str | None,
+) -> None:
+    prefix = f".{target_name}."
+    backups: list[str] = []
+    for name in os.listdir(parent_fd):
+        if not name.startswith(prefix):
+            continue
+        suffix = name[len(prefix) :]
+        token, separator, kind = suffix.partition(".")
+        if (
+            separator != "."
+            or len(token) != 32
+            or any(char not in "0123456789abcdef" for char in token)
+            or kind not in {"tmp", "bak"}
+        ):
+            continue
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("authority_runtime_store_recovery_artifact_invalid")
+        if kind == "tmp":
+            if metadata.st_nlink != 1:
+                raise ValueError("authority_runtime_store_recovery_artifact_invalid")
+            _unlink(parent_fd, name)
+        else:
+            backups.append(name)
+    if len(backups) > 1:
+        raise ValueError("authority_runtime_store_recovery_ambiguous")
+    if not backups:
+        return
+    backup = backups[0]
+    try:
+        target_metadata = os.stat(
+            target_name,
+            dir_fd=parent_fd,
+            follow_symlinks=False,
+        )
+    except FileNotFoundError:
+        if not restore_missing:
+            _unlink(parent_fd, backup)
+            return
+        if expected_revision is None:
+            raise ValueError("authority_runtime_store_recovery_revision_required")
+        os.chmod(backup, 0o600, dir_fd=parent_fd, follow_symlinks=False)
+        _fsync_named_file(parent_fd, backup)
+        if not _authority_snapshot_valid(parent_fd, backup):
+            raise ValueError("authority_runtime_store_recovery_snapshot_invalid")
+        if _read_named_revision(parent_fd, backup) != expected_revision:
+            raise RuntimeError("revision_conflict")
+        os.replace(
+            backup,
+            target_name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        os.fsync(parent_fd)
+        return
+    backup_metadata = os.stat(backup, dir_fd=parent_fd, follow_symlinks=False)
+    if backup_metadata.st_nlink not in {1, 2}:
+        raise ValueError("authority_runtime_store_recovery_artifact_invalid")
+    if not stat.S_ISREG(target_metadata.st_mode):
+        raise ValueError("authority_runtime_store_target_not_regular")
+    os.chmod(target_name, 0o600, dir_fd=parent_fd, follow_symlinks=False)
+    _fsync_named_file(parent_fd, target_name)
+    _unlink(parent_fd, backup)
+    os.fsync(parent_fd)
+
+
+def recover_posix_interrupted_files(
+    parent_fd: int,
+    target_name: str,
+    *,
+    expected_revision: object,
+) -> None:
+    """Recover only exact internal artifacts before an authority-store read."""
+
+    _recover_interrupted_files(
+        parent_fd,
+        target_name,
+        restore_missing=True,
+        expected_revision=(
+            expected_revision
+            if isinstance(expected_revision, str) and expected_revision
+            else None
+        ),
+    )
+
+
+def _authority_snapshot_valid(parent_fd: int, name: str) -> bool:
+    descriptor = os.open(
+        name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size > 8 * 1024 * 1024
+        ):
+            return False
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        raw = bytearray()
+        while len(raw) < metadata.st_size:
+            chunk = os.read(descriptor, metadata.st_size - len(raw))
+            if not chunk:
+                break
+            raw.extend(chunk)
+    finally:
+        os.close(descriptor)
+    if len(raw) != metadata.st_size:
+        return False
+    try:
+        payload = json.loads(bytes(raw).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    revision = payload.pop("revision", None)
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return (
+        isinstance(revision, str)
+        and revision
+        == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    )
+
+
+def _read_named_revision(parent_fd: int, name: str) -> object:
+    descriptor = os.open(
+        name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        return _read_revision(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _fsync_named_file(parent_fd: int, name: str) -> None:
+    descriptor = os.open(
+        name,
+        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        dir_fd=parent_fd,
+    )
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _require_backup_identity(
+    parent_fd: int,
+    target_name: str,
+    backup_name: str,
+    old_fd: int,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    opened = os.fstat(old_fd)
+    target = os.stat(target_name, dir_fd=parent_fd, follow_symlinks=False)
+    backup = os.stat(backup_name, dir_fd=parent_fd, follow_symlinks=False)
+    expected_identity = (opened.st_dev, opened.st_ino)
+    if (
+        (target.st_dev, target.st_ino) != expected_identity
+        or (backup.st_dev, backup.st_ino) != expected_identity
+        or opened.st_nlink != 2
+        or stat.S_IMODE(opened.st_mode) != 0
+    ):
+        raise RuntimeError("revision_conflict")
+    if check_revision and _read_revision(old_fd) != expected_revision:
+        raise RuntimeError("revision_conflict")
+
+
+def _link_descriptor(descriptor: int, parent_fd: int, name: str) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    linkat = libc.linkat
+    linkat.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+    ]
+    linkat.restype = ctypes.c_int
+    if linkat(
+        descriptor,
+        ctypes.c_char_p(b""),
+        parent_fd,
+        os.fsencode(name),
+        _AT_EMPTY_PATH,
+    ) != 0:
+        proc_path = f"/proc/self/fd/{descriptor}".encode("ascii")
+        if linkat(
+            -100,
+            proc_path,
+            parent_fd,
+            os.fsencode(name),
+            0x400,
+        ) != 0:
+            error = ctypes.get_errno()
+            raise OSError(
+                error,
+                "authority_runtime_store_unnamed_temp_link_failed",
+            )
+
+
+def _replace_entry(
+    parent_fd: int,
+    source_name: str,
+    target_name: str,
+    *,
+    old_fd: int | None,
+    backup_name: str | None,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    if old_fd is None:
+        try:
+            os.stat(target_name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            raise RuntimeError("revision_conflict")
+    else:
+        if backup_name is None:
+            raise RuntimeError("revision_conflict")
+        _require_backup_identity(
+            parent_fd,
+            target_name,
+            backup_name,
+            old_fd,
+            check_revision=check_revision,
+            expected_revision=expected_revision,
+        )
+    libc = ctypes.CDLL(None, use_errno=True)
+    renameat = libc.renameat
+    renameat.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+    ]
+    renameat.restype = ctypes.c_int
+    if renameat(
+        parent_fd,
+        os.fsencode(source_name),
+        parent_fd,
+        os.fsencode(target_name),
+    ) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, "authority_runtime_store_atomic_replace_failed")
+
+
+def _write_descriptor(descriptor: int, payload: bytes) -> None:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    remaining = memoryview(payload)
+    while remaining:
+        written = os.write(descriptor, remaining)
+        if written <= 0:
+            raise OSError("authority_runtime_store_write_incomplete")
+        remaining = remaining[written:]
+    os.ftruncate(descriptor, len(payload))
+    os.fsync(descriptor)
+
+
+def _read_revision(descriptor: int) -> object:
+    metadata = os.fstat(descriptor)
+    if metadata.st_size > 8 * 1024 * 1024:
+        raise ValueError("authority_runtime_store_target_too_large")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    raw = bytearray()
+    while len(raw) < metadata.st_size:
+        chunk = os.read(descriptor, metadata.st_size - len(raw))
+        if not chunk:
+            break
+        raw.extend(chunk)
+    if len(raw) != metadata.st_size:
+        raise ValueError("authority_runtime_store_target_read_incomplete")
+    try:
+        payload = json.loads(bytes(raw).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("authority_runtime_store_target_invalid") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("authority_runtime_store_target_invalid")
+    return payload.get("revision")
+
+
+def _require_unnamed_private_regular(metadata: os.stat_result) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("authority_runtime_store_temp_not_regular")
+    if metadata.st_nlink != 0:
+        raise ValueError("authority_runtime_store_temp_link_count")
+
+
+def _require_private_regular(metadata: os.stat_result) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("authority_runtime_store_target_not_regular")
+    if metadata.st_nlink != 1:
+        raise ValueError("authority_runtime_store_target_link_count")
+
+
+def _require_entry_identity(
+    parent_fd: int,
+    name: str,
+    expected: os.stat_result,
+    *,
+    mode: int,
+) -> None:
+    observed = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    if (observed.st_dev, observed.st_ino) != (expected.st_dev, expected.st_ino):
+        raise ValueError("authority_runtime_store_temp_identity_changed")
+    if not stat.S_ISREG(observed.st_mode) or observed.st_nlink != 1:
+        raise ValueError("authority_runtime_store_temp_link_count")
+    if stat.S_IMODE(observed.st_mode) != mode:
+        raise ValueError("authority_runtime_store_temp_mode_changed")
+
+
+def _require_parent_identity(parent_fd: int, parent_path: Path) -> None:
+    opened = os.fstat(parent_fd)
+    expected = os.stat(parent_path, follow_symlinks=False)
+    if (opened.st_dev, opened.st_ino) != (expected.st_dev, expected.st_ino):
+        raise ValueError("authority_runtime_store_parent_changed")
+
+
+def _unlink(parent_fd: int, name: str) -> None:
+    try:
+        os.unlink(name, dir_fd=parent_fd)
+    except FileNotFoundError:
+        pass
+
+
+__all__ = ["posix_atomic_replace", "recover_posix_interrupted_files"]

--- a/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store_windows.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_runtime_store_windows.py
@@ -1,0 +1,464 @@
+"""Windows handle operations for confined authority runtime replacement."""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import json
+import os
+import re
+import stat
+from ctypes import wintypes
+from pathlib import Path
+
+
+def windows_atomic_replace(
+    parent_handle: int,
+    target: Path,
+    payload: bytes,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    """Replace one target while the verified parent and temp handles stay open."""
+
+    import secrets
+
+    _recover_interrupted_files(
+        target,
+        check_revision=check_revision,
+        expected_revision=expected_revision,
+        restore_missing=False,
+    )
+    _require_target_revision(
+        target,
+        check_revision=check_revision,
+        expected_revision=expected_revision,
+    )
+    temp_path = target.parent / f".{target.name}.{secrets.token_hex(16)}.tmp"
+    backup_path = target.parent / f".{target.name}.{secrets.token_hex(16)}.bak"
+    backup_created = False
+    handle = _create_temp(temp_path)
+    renamed = False
+    verified = False
+    try:
+        _require_private_regular(handle)
+        _write_handle(handle, payload)
+        _verify_or_scrub(handle, len(payload))
+        _require_target_revision(
+            target,
+            check_revision=check_revision,
+            expected_revision=expected_revision,
+        )
+        if target.exists():
+            os.link(target, backup_path)
+            backup_created = True
+            _require_backup_identity(
+                target,
+                backup_path,
+                check_revision=check_revision,
+                expected_revision=expected_revision,
+            )
+        _rename_handle(
+            handle,
+            parent_handle,
+            target.name,
+            target=target,
+            backup=backup_path if backup_created else None,
+            check_revision=check_revision,
+            expected_revision=expected_revision,
+        )
+        renamed = True
+        if not _same_path(_handle_path(handle), target.resolve(strict=True)):
+            raise ValueError("authority_runtime_store_temp_identity_changed")
+        _verify_or_scrub(handle, len(payload))
+        verified = True
+    finally:
+        close_windows_handle(handle)
+        if renamed and not verified:
+            if backup_created:
+                os.replace(backup_path, target)
+            else:
+                target.unlink(missing_ok=True)
+        else:
+            temp_path.unlink(missing_ok=True)
+            backup_path.unlink(missing_ok=True)
+
+
+def _recover_interrupted_files(
+    target: Path,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+    restore_missing: bool,
+) -> None:
+    pattern = re.compile(
+        rf"^\.{re.escape(target.name)}\.[0-9a-f]{{32}}\.(tmp|bak)$"
+    )
+    backups: list[Path] = []
+    for candidate in target.parent.iterdir():
+        match = pattern.fullmatch(candidate.name)
+        if match is None:
+            continue
+        metadata = os.stat(candidate, follow_symlinks=False)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("authority_runtime_store_recovery_artifact_invalid")
+        if match.group(1) == "tmp":
+            if int(getattr(metadata, "st_nlink", 1)) != 1:
+                raise ValueError("authority_runtime_store_recovery_artifact_linked")
+            candidate.unlink()
+        else:
+            backups.append(candidate)
+    if len(backups) > 1:
+        raise ValueError("authority_runtime_store_recovery_ambiguous")
+    if not backups:
+        return
+    backup = backups[0]
+    if target.exists():
+        target_metadata = os.stat(target, follow_symlinks=False)
+        backup_metadata = os.stat(backup, follow_symlinks=False)
+        if (
+            target_metadata.st_dev,
+            target_metadata.st_ino,
+        ) == (
+            backup_metadata.st_dev,
+            backup_metadata.st_ino,
+        ):
+            backup.unlink()
+            return
+        _require_private_regular_path(backup_metadata)
+        backup.unlink()
+        return
+    if not restore_missing:
+        backup.unlink()
+        return
+    if not check_revision or not isinstance(expected_revision, str):
+        raise ValueError("authority_runtime_store_recovery_revision_required")
+    _require_private_regular_path(os.stat(backup, follow_symlinks=False))
+    if not _authority_snapshot_valid(backup):
+        raise ValueError("authority_runtime_store_recovery_snapshot_invalid")
+    if _read_revision(backup) != expected_revision:
+        raise RuntimeError("revision_conflict")
+    os.replace(backup, target)
+
+
+def recover_windows_interrupted_files(
+    target: Path,
+    *,
+    expected_revision: object,
+) -> None:
+    """Recover only exact internal artifacts before an authority-store read."""
+
+    _recover_interrupted_files(
+        target,
+        check_revision=isinstance(expected_revision, str) and bool(expected_revision),
+        expected_revision=expected_revision,
+        restore_missing=True,
+    )
+
+
+def _require_target_revision(
+    target: Path,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    if not target.exists():
+        if check_revision and expected_revision is not None:
+            raise RuntimeError("revision_conflict")
+        return
+    metadata = os.stat(target, follow_symlinks=False)
+    _require_private_regular_path(metadata)
+    if check_revision and _read_revision(target) != expected_revision:
+        raise RuntimeError("revision_conflict")
+
+
+def _require_backup_identity(
+    target: Path,
+    backup: Path,
+    *,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    target_metadata = os.stat(target, follow_symlinks=False)
+    backup_metadata = os.stat(backup, follow_symlinks=False)
+    if not stat.S_ISREG(target_metadata.st_mode):
+        raise ValueError("authority_runtime_store_target_not_regular")
+    if (
+        target_metadata.st_dev,
+        target_metadata.st_ino,
+    ) != (
+        backup_metadata.st_dev,
+        backup_metadata.st_ino,
+    ):
+        raise RuntimeError("revision_conflict")
+    if int(getattr(target_metadata, "st_nlink", 1)) != 2:
+        raise ValueError("authority_runtime_store_target_link_count")
+    if check_revision and _read_revision(backup) != expected_revision:
+        raise RuntimeError("revision_conflict")
+
+
+def _read_revision(path: Path) -> object:
+    metadata = os.stat(path, follow_symlinks=False)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("authority_runtime_store_target_not_regular")
+    if metadata.st_size > 8 * 1024 * 1024:
+        raise ValueError("authority_runtime_store_target_too_large")
+    raw = path.read_bytes()
+    if len(raw) != metadata.st_size:
+        raise ValueError("authority_runtime_store_target_read_incomplete")
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("authority_runtime_store_target_invalid") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("authority_runtime_store_target_invalid")
+    return payload.get("revision")
+
+
+def _authority_snapshot_valid(path: Path) -> bool:
+    metadata = os.stat(path, follow_symlinks=False)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or int(getattr(metadata, "st_nlink", 1)) != 1
+        or metadata.st_size > 8 * 1024 * 1024
+    ):
+        return False
+    raw = path.read_bytes()
+    if len(raw) != metadata.st_size:
+        return False
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    revision = payload.pop("revision", None)
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return (
+        isinstance(revision, str)
+        and revision
+        == hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    )
+
+
+def _require_private_regular_path(metadata: os.stat_result) -> None:
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("authority_runtime_store_target_not_regular")
+    if int(getattr(metadata, "st_nlink", 1)) != 1:
+        raise ValueError("authority_runtime_store_target_link_count")
+
+
+def _create_temp(path: Path) -> int:
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path),
+        0x40000000 | 0x00010000 | 0x00100000,
+        0,
+        None,
+        1,
+        0x00000100 | 0x80000000 | 0x00200000,
+        None,
+    )
+    if handle in (0, -1, ctypes.c_void_p(-1).value):
+        raise OSError("authority_runtime_store_temp_create_failed")
+    return int(handle)
+
+
+def _require_private_regular(handle: int) -> None:
+    metadata = os.stat(_handle_path(handle), follow_symlinks=False)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("authority_runtime_store_temp_not_regular")
+    if int(getattr(metadata, "st_nlink", 1)) != 1:
+        raise ValueError("authority_runtime_store_temp_link_count")
+
+
+def _verify_or_scrub(handle: int, size: int) -> None:
+    try:
+        _require_private_regular(handle)
+    except Exception:
+        _scrub_handle(handle, size)
+        raise
+
+
+def _scrub_handle(handle: int, size: int) -> None:
+    distance = ctypes.c_longlong(0)
+    set_pointer = ctypes.windll.kernel32.SetFilePointerEx
+    set_pointer.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_longlong,
+        ctypes.POINTER(ctypes.c_longlong),
+        wintypes.DWORD,
+    ]
+    set_pointer.restype = wintypes.BOOL
+    if not set_pointer(handle, distance, None, 0):
+        return
+    try:
+        _write_handle(handle, b"\x00" * max(size, 0))
+    except OSError:
+        pass
+
+
+def _write_handle(handle: int, payload: bytes) -> None:
+    write_file = ctypes.windll.kernel32.WriteFile
+    write_file.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPCVOID,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPVOID,
+    ]
+    write_file.restype = wintypes.BOOL
+    written = wintypes.DWORD()
+    buffer = ctypes.create_string_buffer(payload)
+    if not write_file(handle, buffer, len(payload), ctypes.byref(written), None):
+        raise OSError("authority_runtime_store_write_failed")
+    if int(written.value) != len(payload):
+        raise OSError("authority_runtime_store_write_incomplete")
+    if not ctypes.windll.kernel32.FlushFileBuffers(handle):
+        raise OSError("authority_runtime_store_flush_failed")
+
+
+def _rename_handle(
+    handle: int,
+    parent_handle: int,
+    target_name: str,
+    *,
+    target: Path,
+    backup: Path | None,
+    check_revision: bool,
+    expected_revision: object,
+) -> None:
+    if backup is None:
+        if target.exists():
+            raise RuntimeError("revision_conflict")
+    else:
+        _require_backup_identity(
+            target,
+            backup,
+            check_revision=check_revision,
+            expected_revision=expected_revision,
+        )
+
+    class _FileRenameInfo(ctypes.Structure):
+        _fields_ = [
+            ("ReplaceIfExists", wintypes.BOOL),
+            ("RootDirectory", wintypes.HANDLE),
+            ("FileNameLength", wintypes.DWORD),
+            ("FileName", wintypes.WCHAR * 1),
+        ]
+
+    target = _handle_path(parent_handle) / target_name
+    encoded = str(target).encode("utf-16-le")
+    size = ctypes.sizeof(_FileRenameInfo) + len(encoded)
+    storage = ctypes.create_string_buffer(size)
+    info = ctypes.cast(storage, ctypes.POINTER(_FileRenameInfo)).contents
+    info.ReplaceIfExists = True
+    info.RootDirectory = None
+    info.FileNameLength = len(encoded)
+    ctypes.memmove(
+        ctypes.addressof(storage) + _FileRenameInfo.FileName.offset,
+        encoded,
+        len(encoded),
+    )
+    set_info = ctypes.windll.kernel32.SetFileInformationByHandle
+    set_info.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+    ]
+    set_info.restype = wintypes.BOOL
+    if not set_info(handle, 3, storage, size):
+        error = ctypes.windll.kernel32.GetLastError()
+        raise OSError(int(error), "authority_runtime_store_atomic_replace_failed")
+
+
+def open_windows_directory_without_delete_share(path: Path) -> int:
+    """Open and verify a parent handle that prevents path replacement."""
+
+    create_file = ctypes.windll.kernel32.CreateFileW
+    create_file.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create_file.restype = wintypes.HANDLE
+    handle = create_file(
+        str(path),
+        0x80000000,
+        0x00000001 | 0x00000002,
+        None,
+        3,
+        0x02000000 | 0x00200000,
+        None,
+    )
+    if handle in (0, -1, ctypes.c_void_p(-1).value):
+        raise OSError("authority_runtime_store_parent_open_failed")
+    try:
+        if _same_path(_handle_path(handle), path.resolve(strict=True)):
+            return int(handle)
+    except Exception:
+        close_windows_handle(handle)
+        raise
+    close_windows_handle(handle)
+    raise ValueError("authority_runtime_store_parent_changed")
+
+
+def _handle_path(handle: int) -> Path:
+    buffer = ctypes.create_unicode_buffer(32768)
+    get_path = ctypes.windll.kernel32.GetFinalPathNameByHandleW
+    get_path.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+    ]
+    get_path.restype = wintypes.DWORD
+    length = get_path(handle, buffer, len(buffer), 0)
+    if length <= 0 or length >= len(buffer):
+        raise OSError("authority_runtime_store_parent_path_unavailable")
+    raw = buffer.value.replace("\\", "/")
+    if raw.startswith("//?/UNC/"):
+        raw = "//" + raw[8:]
+    elif raw.startswith("//?/"):
+        raw = raw[4:]
+    return Path(raw)
+
+
+def close_windows_handle(handle: int) -> None:
+    close_handle = ctypes.windll.kernel32.CloseHandle
+    close_handle.argtypes = [wintypes.HANDLE]
+    close_handle.restype = wintypes.BOOL
+    close_handle(handle)
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    return os.path.normcase(str(left)) == os.path.normcase(str(right))
+
+
+__all__ = [
+    "close_windows_handle",
+    "open_windows_directory_without_delete_share",
+    "recover_windows_interrupted_files",
+    "windows_atomic_replace",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_resident_service.py
+++ b/modules/communication/moltbot_bridge/src/reddog_isolated_signer_socket_resident_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import socket
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -102,11 +103,14 @@ def serve_reddog_isolated_signer_socket_bounded(
     if reasons:
         return _reject(*reasons)
     assert resolved is not None
-    limit_reasons = _validate_limits(timeout_s, max_request_bytes, max_response_bytes)
+    limit_reasons = validate_resident_signer_socket_limits(
+        max_requests=max_requests,
+        timeout_s=timeout_s,
+        max_request_bytes=max_request_bytes,
+        max_response_bytes=max_response_bytes,
+    )
     if limit_reasons:
         return _reject(*limit_reasons, socket_path=str(resolved))
-    if not isinstance(max_requests, int) or max_requests < 1 or max_requests > 128:
-        return _reject(FAIL_SIGNER_RESIDENT_SERVICE_MAX_REQUESTS_INVALID, socket_path=str(resolved))
     if not hasattr(socket, "AF_UNIX"):
         return _reject(FAIL_SIGNER_SERVICE_SOCKET_UNAVAILABLE, socket_path=str(resolved))
 
@@ -204,6 +208,37 @@ def _validate_limits(
     return tuple(reasons)
 
 
+def validate_resident_signer_socket_limits(
+    *,
+    max_requests: object,
+    timeout_s: object,
+    max_request_bytes: object,
+    max_response_bytes: object,
+) -> tuple[str, ...]:
+    """Validate the exact bounded-service limits without opening a socket."""
+
+    reasons: list[str] = []
+    if type(max_requests) is not int or not 1 <= max_requests <= 128:
+        reasons.append(FAIL_SIGNER_RESIDENT_SERVICE_MAX_REQUESTS_INVALID)
+    if (
+        isinstance(timeout_s, bool)
+        or not isinstance(timeout_s, (int, float))
+        or not math.isfinite(float(timeout_s))
+    ):
+        reasons.append(FAIL_SIGNER_SERVICE_TIMEOUT_INVALID)
+    if type(max_request_bytes) is not int:
+        reasons.append(FAIL_SIGNER_SERVICE_REQUEST_LIMIT_INVALID)
+    if type(max_response_bytes) is not int:
+        reasons.append(FAIL_SIGNER_SERVICE_RESPONSE_LIMIT_INVALID)
+    if reasons:
+        return tuple(dict.fromkeys(reasons))
+    return _validate_limits(
+        float(timeout_s),
+        max_request_bytes,
+        max_response_bytes,
+    )
+
+
 def _read_bounded(connection: socket.socket, max_request_bytes: int) -> bytes:
     chunks: list[bytes] = []
     total = 0
@@ -271,4 +306,5 @@ __all__ = [
     "SIGNER_SOCKET_RESIDENT_SERVICE_REJECT",
     "SIGNER_SOCKET_RESIDENT_SERVICE_SERVED",
     "serve_reddog_isolated_signer_socket_bounded",
+    "validate_resident_signer_socket_limits",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -235,7 +235,7 @@ def load_reddog_main_resident_queue_runtime_dependency_bundle(
         return _reject(*principal_reasons)
 
     authority_store = AtomicJsonAuthorityRuntimeStore(
-        authority_path, allowed_root=runtime_root
+        authority_path, allowed_root=runtime_root, repo_root=root
     )
     signer = FailClosedSignerClient()
     signer_mode = "fail_closed"

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_head_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_head_store.py
@@ -17,9 +17,15 @@ CONTROL_RECEIPT_HEAD_SCHEMA_VERSION = "reddog_control_receipt_head.v1"
 
 def load_control_receipt_head(
     path: Path | str,
+    *,
+    runtime_root: Path | str,
+    repo_root: Path | str,
 ) -> tuple[AtomicJsonAuthorityRuntimeStore, dict[str, Any], dict[str, Any] | None]:
-    resolved = Path(path).resolve()
-    store = AtomicJsonAuthorityRuntimeStore(resolved, allowed_root=resolved.parent)
+    store = AtomicJsonAuthorityRuntimeStore(
+        path,
+        allowed_root=runtime_root,
+        repo_root=repo_root,
+    )
     state = store.load()
     if not isinstance(state, dict):
         raise ValueError("resident_control_loop_head_state_invalid")

--- a/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_control_loop_receipt_store.py
@@ -55,6 +55,7 @@ from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
     secure_append_runtime_text,
     secure_read_confined_bytes,
     validate_runtime_artifact_path,
+    validate_runtime_root_path,
 )
 
 
@@ -316,46 +317,69 @@ def append_resident_control_loop_receipt(
     nonce: str | None = None,
     signing_context: ControlLoopReceiptSigningContext | None = None,
     require_authentication: bool = False,
+    runtime_root: Path | str | None = None,
     head_state_path: Path | str | None = None,
 ) -> ResidentControlLoopReceipt:
     """CAS-append one chain-linked control-loop receipt."""
 
     if require_authentication and signing_context is None:
         raise ValueError("resident_control_loop_receipt_signer_required")
-    target = validate_runtime_artifact_path(path, repo_root=repo_root)
-    resolved_head_path = (
-        head_state_path
-        if head_state_path is not None
-        else target.parent / "authority_runtime_state.json"
-        if require_authentication
-        else None
-    )
-    head_target = (
-        validate_runtime_artifact_path(resolved_head_path, repo_root=repo_root)
-        if resolved_head_path
-        else None
+    target, confined_root, head_target = _control_runtime_paths(
+        path=path, repo_root=repo_root, runtime_root=runtime_root,
+        head_state_path=head_state_path, require_authentication=require_authentication,
     )
     resolved_cycle_id = _bounded_text(cycle_id, 160) or _new_cycle_id()
     resolved_nonce = _bounded_text(nonce, 192) or _new_nonce()
     operation_identity = str(target) + ".control-chain-operation"
     with runtime_operation_lock(operation_identity):
         chain, head_store, head_state = _load_control_chain_for_append(
-            target, head_target, repo_root, signing_context, require_authentication
+            target, head_target, confined_root, repo_root,
+            signing_context, require_authentication
         )
         return _build_commit_append_receipt(
             target=target, chain=chain, result=result, repo_root=repo_root,
             created_at=created_at, cycle_id=resolved_cycle_id,
             nonce=resolved_nonce, signing_context=signing_context,
             require_authentication=require_authentication,
-            head_store=head_store, head_state=head_state,
+            runtime_root=confined_root, head_store=head_store, head_state=head_state,
         )
+
+
+def _control_runtime_paths(
+    *,
+    path: Path | str,
+    repo_root: Path | str,
+    runtime_root: Path | str | None,
+    head_state_path: Path | str | None,
+    require_authentication: bool,
+) -> tuple[Path, Path | None, Path | None]:
+    if require_authentication and runtime_root is None:
+        raise ValueError("resident_control_loop_runtime_root_required")
+    confined_root = (
+        validate_runtime_root_path(runtime_root, repo_root=repo_root)
+        if runtime_root is not None else None
+    )
+    target = validate_runtime_artifact_path(
+        path, repo_root=repo_root, allowed_root=confined_root
+    )
+    head_path = head_state_path
+    if head_path is None and require_authentication:
+        head_path = target.parent / "authority_runtime_state.json"
+    head_target = (
+        validate_runtime_artifact_path(
+            head_path, repo_root=repo_root, allowed_root=confined_root
+        )
+        if head_path is not None else None
+    )
+    return target, confined_root, head_target
 
 
 def _build_commit_append_receipt(
     *, target: Path, chain: Mapping[str, Any], result: Mapping[str, Any],
     repo_root: Path | str, created_at: str, cycle_id: str, nonce: str,
     signing_context: ControlLoopReceiptSigningContext | None,
-    require_authentication: bool, head_store: Any, head_state: Any,
+    require_authentication: bool, runtime_root: Path | None,
+    head_store: Any, head_state: Any,
 ) -> ResidentControlLoopReceipt:
     receipt = build_resident_control_loop_receipt(
         result=result, repo_root=repo_root, created_at=created_at,
@@ -372,7 +396,7 @@ def _build_commit_append_receipt(
         )
     _append_receipt_once(
         target, receipt, repo_root, signing_context=signing_context,
-        require_authentication=require_authentication,
+        require_authentication=require_authentication, runtime_root=runtime_root,
     )
     return receipt
 
@@ -380,25 +404,34 @@ def _build_commit_append_receipt(
 def _load_control_chain_for_append(
     target: Path,
     head_target: Path | None,
+    runtime_root: Path | None,
     repo_root: Path | str,
     signing_context: ControlLoopReceiptSigningContext | None,
     require_authentication: bool,
 ) -> tuple[dict[str, Any], Any, Any]:
     chain = _validate_existing_receipts(
-        _read_existing_chain(target),
+        _read_existing_chain(target, runtime_root),
         signing_context=signing_context,
         require_authenticated_current=require_authentication,
     )
     if not require_authentication or head_target is None:
         return chain, None, None
-    store, state, head = load_control_receipt_head(head_target)
+    if runtime_root is None:
+        raise ValueError("resident_control_loop_runtime_root_required")
+    store, state, head = load_control_receipt_head(
+        head_target,
+        runtime_root=runtime_root,
+        repo_root=repo_root,
+    )
     chain = reconcile_control_receipt_head(
         target=target, chain=chain, head=head, repo_root=repo_root,
         signing_context=signing_context,
         verify_receipt=verify_resident_control_loop_receipt,
-        append_receipt=_append_receipt_once,
+        append_receipt=lambda *args, **kwargs: _append_receipt_once(
+            *args, **kwargs, runtime_root=runtime_root
+        ),
         validate_chain=_validate_existing_receipts,
-        read_chain=_read_existing_chain,
+        read_chain=lambda path: _read_existing_chain(path, runtime_root),
     )
     return chain, store, state
 
@@ -410,6 +443,7 @@ def _append_receipt_once(
     *,
     signing_context: ControlLoopReceiptSigningContext | None,
     require_authentication: bool,
+    runtime_root: Path | None,
 ) -> None:
     line = json.dumps(receipt.to_dict(), sort_keys=True, separators=(",", ":")) + "\n"
     if len(line.encode("utf-8")) > 64 * 1024:
@@ -444,19 +478,20 @@ def _append_receipt_once(
         target,
         line,
         repo_root=repo_root,
+        allowed_root=runtime_root,
         validate_existing=validate_before_append,
         max_existing_bytes=MAX_CONTROL_RECEIPT_CHAIN_BYTES,
     )
 
 
-def _read_existing_chain(path: Path) -> str:
+def _read_existing_chain(path: Path, runtime_root: Path | None) -> str:
     if not path.exists():
         return ""
     if path.stat().st_size > MAX_CONTROL_RECEIPT_CHAIN_BYTES:
         raise ValueError("runtime_artifact_retention_limit_exceeded")
     raw, offset = secure_read_confined_bytes(
         path,
-        allowed_root=path.parent,
+        allowed_root=runtime_root or path.parent,
         max_bytes=MAX_CONTROL_RECEIPT_CHAIN_BYTES,
     )
     if offset != path.stat().st_size:

--- a/modules/communication/moltbot_bridge/src/reddog_resident_live_canary.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_live_canary.py
@@ -1,7 +1,6 @@
 """Operator harness for one guarded resident RedDog live canary.
 
 Slice: REDDOG_RESIDENT_LIVE_CANARY_PHASE1
-
 This module does not implement queue orchestration.  It validates the operator
 boundary for the existing highest guarded resident profile and, only after an
 explicit confirmation, delegates once to ``main.py``'s bounded resident control
@@ -325,7 +324,7 @@ def _verified_post_control_receipts(
             allowed_root=context.runtime_root,
         )
         verify_live_canary_control_prestate(
-            runtime_root=context.runtime_root,
+            repo_root=context.repo_root, runtime_root=context.runtime_root,
             receipts=post_receipts,
             authority_profile=profile,
             authority_profile_source=source,
@@ -333,7 +332,7 @@ def _verified_post_control_receipts(
                 context.environ.get("REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID")
                 or ""
             ),
-            signer_anchor_path=_signer_anchor_path(context),
+            **_signer_anchor_binding(context),
         )
     except (KeyError, TypeError, ValueError):
         blockers.append("control_receipt_stream_auth_or_integrity_invalid")
@@ -358,29 +357,30 @@ def _verify_control_receipts(
             context.environ.get("REDDOG_AUTHORITY_PROFILE_SOURCE_RECEIPT_ID") or ""
         )
         verify_live_canary_control_prestate(
-            runtime_root=context.runtime_root,
+            repo_root=context.repo_root, runtime_root=context.runtime_root,
             receipts=receipts,
             authority_profile=profile,
             authority_profile_source=source,
             expected_source_receipt_id=expected_source,
-            signer_anchor_path=_signer_anchor_path(context),
+            **_signer_anchor_binding(context),
         )
     except (KeyError, TypeError, ValueError):
         blockers.append("control_receipt_prestate_auth_or_integrity_invalid")
 
 
-def _signer_anchor_path(context: _CanaryContext) -> Path:
+def _signer_anchor_binding(context: _CanaryContext) -> dict[str, Path]:
     config = _read_json_mapping(
         context.runtime_root / "signer_service_config.json",
         allowed_root=context.runtime_root,
     )
     value = str(config.get("control_loop_anchor_path") or "").strip()
-    if not value:
+    root_value = str(config.get("signer_runtime_root") or "").strip()
+    if not value or not root_value:
         raise ValueError("signer_control_loop_anchor_path_missing")
-    path = Path(value)
-    if not path.is_absolute():
+    path, root = Path(value), Path(root_value)
+    if not path.is_absolute() or not root.is_absolute():
         raise ValueError("signer_control_loop_anchor_path_invalid")
-    return path.resolve()
+    return {"signer_anchor_path": path, "signer_anchor_root": root}
 
 
 def _read_control_receipt_stream(

--- a/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_control_preflight.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_live_canary_control_preflight.py
@@ -23,12 +23,14 @@ from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor 
 
 def verify_live_canary_control_prestate(
     *,
+    repo_root: Path,
     runtime_root: Path,
     receipts: Sequence[Mapping[str, Any]],
     authority_profile: Mapping[str, Any],
     authority_profile_source: Mapping[str, Any],
     expected_source_receipt_id: str,
     signer_anchor_path: Path,
+    signer_anchor_root: Path,
 ) -> None:
     validate_authority_profile_source(
         authority_profile_source, expected_source_receipt_id
@@ -38,7 +40,9 @@ def verify_live_canary_control_prestate(
     )
     verify_control_receipt_chain_against_profile(receipts, authority_profile)
     _, _, head = load_control_receipt_head(
-        runtime_root / "authority_runtime_state.json"
+        runtime_root / "authority_runtime_state.json",
+        runtime_root=runtime_root,
+        repo_root=repo_root,
     )
     current_ids, child_receipts, child_evidence = _chain_evidence(receipts)
     if head is None:
@@ -55,6 +59,8 @@ def verify_live_canary_control_prestate(
     )
     _verify_signer_anchor(
         signer_anchor_path,
+        runtime_root=signer_anchor_root,
+        repo_root=repo_root,
         receipts=receipts,
         current_ids=current_ids,
         child_receipts=child_receipts,
@@ -90,12 +96,18 @@ def _chain_evidence(
 def _verify_signer_anchor(
     path: Path,
     *,
+    runtime_root: Path,
+    repo_root: Path,
     receipts: Sequence[Mapping[str, Any]],
     current_ids: tuple[str, ...],
     child_receipts: tuple[str, ...],
     child_evidence: tuple[str, ...],
 ) -> None:
-    state = AtomicSignerControlLoopAnchorStore(path).load()
+    state = AtomicSignerControlLoopAnchorStore(
+        path,
+        runtime_root=runtime_root,
+        repo_root=repo_root,
+    ).load()
     if not state:
         raise ValueError("signer_control_loop_anchor_missing")
     if (

--- a/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py
@@ -199,6 +199,27 @@ def resident_queue_runtime_root_path(env: Mapping[str, str], repo_root: Path | s
     return str(validate_runtime_root_path(runtime_root, repo_root=root))
 
 
+def resident_queue_signer_runtime_root_path(
+    env: Mapping[str, str],
+    repo_root: Path | str,
+) -> str:
+    """Return the signer-owned root kept separate from resident runtime state."""
+
+    root = Path(repo_root).resolve()
+    raw = str(env.get("REDDOG_SIGNER_RUNTIME_ROOT") or "").strip()
+    if raw:
+        path = Path(raw)
+        if not path.is_absolute():
+            path = root.parent / path
+        return str(validate_runtime_root_path(path, repo_root=root))
+    resident = resident_queue_runtime_root_path(env, root)
+    if not resident:
+        return ""
+    resident_path = Path(resident)
+    signer_root = resident_path.parent / f"{resident_path.name}-signer-state"
+    return str(validate_runtime_root_path(signer_root, repo_root=root))
+
+
 def resident_queue_runtime_file_path(
     env: Mapping[str, str],
     repo_root: Path | str,
@@ -365,5 +386,6 @@ __all__ = [
     "resident_queue_runtime_file_path",
     "resident_queue_runtime_flag_enabled",
     "resident_queue_runtime_root_path",
+    "resident_queue_signer_runtime_root_path",
     "resident_queue_worktree_runner_mode",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_runtime_artifact_readiness.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_runtime_artifact_readiness.py
@@ -34,6 +34,13 @@ from modules.communication.moltbot_bridge.src.reddog_execution_valve_use_time_au
 from modules.communication.moltbot_bridge.src.reddog_runtime_json_read import (
     read_reddog_runtime_json_mapping,
 )
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
+)
 
 
 REQUIRED_RUNTIME_ARTIFACTS = (
@@ -42,7 +49,9 @@ REQUIRED_RUNTIME_ARTIFACTS = (
     "signer_service_config.json", "signer_service_run_packet.json",
 )
 _SIGNER_CONFIG_FIELDS = {
-    "schema_version", "socket_path", "provider_mode", "allow_test_only_key_material",
+    "schema_version", "runtime_root", "signer_runtime_root", "socket_path",
+    "control_loop_anchor_path", "control_loop_authority_policy",
+    "provider_mode", "allow_test_only_key_material",
     "permission_snapshot_fresh", "max_requests", "timeout_s", "max_request_bytes",
     "max_response_bytes", "key_provider_profiles", "peer_policy",
 }
@@ -223,15 +232,14 @@ def _signer_config_reasons(
         reasons.append("signer_config_field_set_invalid")
     if _forbidden_serialized_keys(config):
         reasons.append("signer_config_forbidden_key_present")
-    if config.get("schema_version") != "reddog_signer_service_config.v1":
+    if config.get("schema_version") != SIGNER_SERVICE_CONFIG_SCHEMA_VERSION:
         reasons.append("signer_config_schema_invalid")
     if config.get("provider_mode") != "WSP71_PERMISSIONED":
         reasons.append("signer_provider_mode_invalid")
     if config.get("allow_test_only_key_material") is not False:
         reasons.append("signer_test_key_material_forbidden")
-    socket_path = Path(str(config.get("socket_path") or "")).resolve()
-    if _inside(socket_path, repo) or socket_path != (runtime / "reddog_signer.sock").resolve():
-        reasons.append("signer_socket_path_invalid")
+    reasons.extend(_signer_runtime_path_reasons(repo, runtime, config))
+    reasons.extend(_signer_control_policy_reasons(profile, config))
     expected = (
         ("principal-identity", profile.get("principal_public_key")),
         ("reddog-work-authority", profile.get("reddog_public_key")),
@@ -273,6 +281,71 @@ def _signer_config_reasons(
     # challenge currently authenticates the signer peer.
     reasons.append("signer_client_peer_handshake_verifier_missing")
     return reasons
+
+
+def _signer_runtime_path_reasons(
+    repo: Path,
+    runtime: Path,
+    config: Mapping[str, Any],
+) -> list[str]:
+    reasons: list[str] = []
+    try:
+        configured_runtime = validate_runtime_root_path(
+            config.get("runtime_root"),
+            repo_root=repo,
+        )
+        signer_runtime = validate_runtime_root_path(
+            config.get("signer_runtime_root"),
+            repo_root=repo,
+        )
+        socket_path = validate_runtime_artifact_path(
+            config.get("socket_path"),
+            repo_root=repo,
+            allowed_root=configured_runtime,
+        )
+        anchor_path = validate_runtime_artifact_path(
+            config.get("control_loop_anchor_path"),
+            repo_root=repo,
+            allowed_root=signer_runtime,
+        )
+    except (TypeError, ValueError):
+        return ["signer_runtime_path_invalid"]
+    roots_overlap = (
+        signer_runtime == configured_runtime
+        or configured_runtime in signer_runtime.parents
+        or signer_runtime in configured_runtime.parents
+    )
+    if configured_runtime != runtime or roots_overlap:
+        reasons.append("signer_runtime_root_binding_invalid")
+    if socket_path != runtime / "reddog_signer.sock":
+        reasons.append("signer_socket_path_invalid")
+    if anchor_path.parent != signer_runtime:
+        reasons.append("signer_control_loop_anchor_path_invalid")
+    return reasons
+
+
+def _signer_control_policy_reasons(
+    profile: Mapping[str, Any],
+    config: Mapping[str, Any],
+) -> list[str]:
+    policy = config.get("control_loop_authority_policy")
+    if not isinstance(policy, Mapping):
+        return ["signer_control_loop_authority_policy_invalid"]
+    expected = {
+        "issuer_principal_id": profile.get("principal_id"),
+        "signer_public_key": profile.get("reddog_public_key"),
+        "key_epoch": profile.get("key_epoch"),
+        "consensus_receipt_digest": profile.get("consensus_receipt_digest"),
+        "authority_profile_digest": _digest(profile),
+        "authority_profile_source_receipt_id": profile.get(
+            "authority_profile_source_receipt_id"
+        ),
+    }
+    if set(policy) != set(expected):
+        return ["signer_control_loop_authority_policy_field_set_invalid"]
+    if any(policy.get(key) != value for key, value in expected.items()):
+        return ["signer_control_loop_authority_policy_binding_mismatch"]
+    return []
 
 
 def _signer_packet_reasons(

--- a/modules/communication/moltbot_bridge/src/reddog_signer_control_loop_anchor.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_control_loop_anchor.py
@@ -39,11 +39,18 @@ class ControlLoopAnchorStore(Protocol):
 class AtomicSignerControlLoopAnchorStore:
     """Persist the signer high-water witness outside resident runtime state."""
 
-    def __init__(self, path: Path | str) -> None:
-        self.path = Path(path).resolve()
+    def __init__(
+        self,
+        path: Path | str,
+        *,
+        runtime_root: Path | str,
+        repo_root: Path | str,
+    ) -> None:
+        self.path = Path(path)
         self._store = AtomicJsonAuthorityRuntimeStore(
             self.path,
-            allowed_root=self.path.parent,
+            allowed_root=runtime_root,
+            repo_root=repo_root,
         )
 
     def prepare(self, payload: Mapping[str, Any]) -> ControlLoopAnchorPreparation:

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -20,6 +20,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Optional, Protocol
 
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    decode_ed25519_public_key,
     encode_ed25519_public_key,
 )
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
@@ -167,16 +168,11 @@ def build_test_only_signer_backend_from_provider(
         resolver=resolver,
     ):
         return _reject(FAIL_PROVIDER_MOCK_IN_PRODUCTION, profile=profile)
-    if not _profile_ascii_and_complete(profile):
-        return _reject(FAIL_PROVIDER_PROFILE_INVALID, profile=profile)
+    profile_rejection = validate_signer_key_provider_profile(profile)
+    if profile_rejection is not None:
+        return _reject(profile_rejection, profile=profile)
     if not permission_snapshot_fresh:
         return _reject(FAIL_PROVIDER_PERMISSION_DENIED, profile=profile)
-    if profile.signing_key_ref == profile.audit_mac_key_ref:
-        return _reject(FAIL_PROVIDER_REFERENCE_FORBIDDEN, profile=profile)
-    if not parse_op_reference(profile.signing_key_ref) or not parse_op_reference(profile.audit_mac_key_ref):
-        return _reject(FAIL_PROVIDER_REFERENCE_INVALID, profile=profile)
-    if profile.ttl_seconds <= 0:
-        return _reject(FAIL_PROVIDER_TTL_EXPIRED, profile=profile)
 
     signing_result = _resolve(profile.signing_key_ref, profile.signer_agent_id, resolver)
     if not signing_result.success:
@@ -402,6 +398,28 @@ def _profile_ascii_and_complete(profile: SignerKeyProviderProfile) -> bool:
     return _assert_ascii_deep(payload)
 
 
+def validate_signer_key_provider_profile(
+    profile: object,
+) -> str | None:
+    """Return the provider rejection code for invalid static profile data."""
+
+    if not isinstance(profile, SignerKeyProviderProfile):
+        return FAIL_PROVIDER_PROFILE_INVALID
+    if not _profile_ascii_and_complete(profile):
+        return FAIL_PROVIDER_PROFILE_INVALID
+    if profile.signing_key_ref == profile.audit_mac_key_ref:
+        return FAIL_PROVIDER_REFERENCE_FORBIDDEN
+    if not parse_op_reference(profile.signing_key_ref) or not parse_op_reference(
+        profile.audit_mac_key_ref
+    ):
+        return FAIL_PROVIDER_REFERENCE_INVALID
+    if profile.ttl_seconds <= 0:
+        return FAIL_PROVIDER_TTL_EXPIRED
+    if decode_ed25519_public_key(profile.expected_public_key) is None:
+        return FAIL_PROVIDER_PROFILE_INVALID
+    return None
+
+
 def _assert_ascii_deep(value: object) -> bool:
     if isinstance(value, str):
         return all(ord(char) < 128 for char in value)
@@ -437,4 +455,5 @@ __all__ = [
     "SignerKeyProviderProfile",
     "build_signer_backend_from_provider",
     "build_test_only_signer_backend_from_provider",
+    "validate_signer_key_provider_profile",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
@@ -14,24 +14,37 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
+    atomic_replace_confined_mapping,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
+    validate_resident_signer_socket_limits,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     public_key_fingerprint,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     PROVIDER_MODE_WSP71_PERMISSIONED,
 )
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
+    SignerSocketServiceRuntimeWiringConfig,
+    validate_signer_socket_service_runtime_config,
+)
 from modules.infrastructure.secrets_mcp.src.vault_resolver import parse_op_reference
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    runtime_operation_lock,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
+)
 
 
 SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT = "SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT"
 SIGNER_SERVICE_CONFIG_SUPPLY_REJECT = "SIGNER_SERVICE_CONFIG_SUPPLY_REJECT"
-SIGNER_SERVICE_CONFIG_SCHEMA_VERSION = "reddog_signer_service_config.v1"
+SIGNER_SERVICE_CONFIG_SCHEMA_VERSION = "reddog_signer_service_config.v2"
 
 FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID = "signer_config_authority_profile_invalid"
 FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID = "signer_config_output_path_invalid"
@@ -91,6 +104,8 @@ class SignerServiceConfigSupplyResult:
 def run_reddog_signer_socket_service_config_supply(
     *,
     repo_root: Path | str,
+    runtime_root: Path | str,
+    signer_runtime_root: Path | str,
     authority_profile: Mapping[str, Any] | None,
     output_path: Path | str | None,
     socket_path: Path | str | None,
@@ -114,21 +129,15 @@ def run_reddog_signer_socket_service_config_supply(
     profile = _mapping(authority_profile)
     reasons: list[str] = []
     reasons.extend(_authority_profile_reasons(profile))
-    out, output_reasons = _resolve_output_path(root, output_path)
-    reasons.extend(output_reasons)
-    sock, socket_reasons = _resolve_socket_path(root, socket_path)
-    reasons.extend(socket_reasons)
-    anchor_value = control_loop_anchor_path
-    if anchor_value is None and out is not None:
-        anchor_value = (
-            out.parent.parent
-            / f"{out.parent.name}-signer-state"
-            / "signer_control_loop_anchor.json"
-        )
-    anchor, anchor_reasons = _resolve_outside_repo(
-        root, anchor_value, FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID
+    runtime, signer_runtime, out, sock, anchor, path_reasons = _runtime_artifact_paths(
+        root,
+        runtime_root,
+        signer_runtime_root,
+        output_path,
+        socket_path,
+        control_loop_anchor_path,
     )
-    reasons.extend(anchor_reasons)
+    reasons.extend(path_reasons)
     op_refs = (
         principal_signing_key_ref,
         principal_audit_mac_key_ref,
@@ -147,9 +156,13 @@ def run_reddog_signer_socket_service_config_supply(
     assert out is not None
     assert sock is not None
     assert anchor is not None
+    assert runtime is not None
+    assert signer_runtime is not None
     assert peer_policy is not None
     config = _config(
         authority_profile=profile,
+        runtime_root=runtime,
+        signer_runtime_root=signer_runtime,
         socket_path=sock,
         principal_signing_key_ref=principal_signing_key_ref,
         principal_audit_mac_key_ref=principal_audit_mac_key_ref,
@@ -164,6 +177,27 @@ def run_reddog_signer_socket_service_config_supply(
         reddog_signer_agent_id=reddog_signer_agent_id,
         control_loop_anchor_path=anchor,
     )
+    runtime_config_reasons = validate_signer_socket_service_runtime_config(
+        SignerSocketServiceRuntimeWiringConfig(
+            repo_root=root,
+            runtime_root=runtime,
+            signer_runtime_root=signer_runtime,
+            socket_path=sock,
+            peer_policy=config["peer_policy"],
+            provider_mode=str(config["provider_mode"]),
+            allow_test_only_key_material=False,
+            permission_snapshot_fresh=True,
+            max_requests=config["max_requests"],
+            timeout_s=config["timeout_s"],
+            max_request_bytes=config["max_request_bytes"],
+            max_response_bytes=config["max_response_bytes"],
+            key_provider_profiles=tuple(config["key_provider_profiles"]),
+            control_loop_anchor_path=anchor,
+            control_loop_authority_policy=config["control_loop_authority_policy"],
+        )
+    )
+    if runtime_config_reasons:
+        return _reject((FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":runtime_config",))
     config_digest = _digest(config)
     receipt = {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
@@ -181,7 +215,10 @@ def run_reddog_signer_socket_service_config_supply(
     }
     receipt["config_supply_receipt_id"] = _digest(receipt)
     try:
-        _write_json_atomic(out, config)
+        with runtime_operation_lock(str(out) + ".operation"):
+            atomic_replace_confined_mapping(
+                out, config, repo_root=root, allowed_root=runtime
+            )
     except Exception:
         return _reject((FAIL_SIGNER_CONFIG_WRITE_FAILED,))
     return SignerServiceConfigSupplyResult(
@@ -198,9 +235,89 @@ def run_reddog_signer_socket_service_config_supply(
     )
 
 
+def _runtime_artifact_paths(
+    repo_root: Path,
+    runtime_root: Path | str,
+    signer_runtime_root: Path | str,
+    output_path: Path | str | None,
+    socket_path: Path | str | None,
+    anchor_path: Path | str | None,
+) -> tuple[Path | None, Path | None, Path | None, Path | None, Path | None, list[str]]:
+    reasons: list[str] = []
+
+    def resolve(
+        value: Path | str | None,
+        root: Path | None,
+        reason: str,
+    ) -> Path | None:
+        if not value or root is None:
+            reasons.append(reason)
+            return None
+        try:
+            return validate_runtime_artifact_path(
+                value,
+                repo_root=repo_root,
+                allowed_root=root,
+            )
+        except ValueError:
+            reasons.append(reason)
+            return None
+
+    try:
+        runtime = validate_runtime_root_path(runtime_root, repo_root=repo_root)
+    except ValueError:
+        runtime = None
+        reasons.append(FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID)
+    try:
+        signer_runtime = validate_runtime_root_path(
+            signer_runtime_root,
+            repo_root=repo_root,
+        )
+    except ValueError:
+        signer_runtime = None
+        reasons.append(FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID)
+    if (
+        runtime is not None
+        and signer_runtime is not None
+        and (
+            signer_runtime == runtime
+            or runtime in signer_runtime.parents
+            or signer_runtime in runtime.parents
+        )
+    ):
+        reasons.append(FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID)
+    out = resolve(output_path, runtime, FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID)
+    sock = resolve(socket_path, runtime, FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID)
+    if out is not None and (
+        out.parent != runtime
+        or (out.exists() and not out.is_file())
+    ):
+        reasons.append(FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID)
+        out = None
+    if sock is not None and (
+        sock.parent != runtime
+        or sock.exists()
+    ):
+        reasons.append(FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID)
+        sock = None
+    if anchor_path is None and signer_runtime is not None:
+        anchor_path = signer_runtime / "signer_control_loop_anchor.json"
+    anchor = resolve(
+        anchor_path,
+        signer_runtime,
+        FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID,
+    )
+    if anchor is not None and anchor.parent != signer_runtime:
+        reasons.append(FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID)
+        anchor = None
+    return runtime, signer_runtime, out, sock, anchor, reasons
+
+
 def _config(
     *,
     authority_profile: Mapping[str, Any],
+    runtime_root: Path,
+    signer_runtime_root: Path,
     socket_path: Path,
     principal_signing_key_ref: str,
     principal_audit_mac_key_ref: str,
@@ -221,6 +338,8 @@ def _config(
     key_epoch = str(authority_profile["key_epoch"])
     return {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "runtime_root": str(runtime_root),
+        "signer_runtime_root": str(signer_runtime_root),
         "socket_path": str(socket_path),
         "control_loop_anchor_path": str(control_loop_anchor_path),
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
@@ -295,45 +414,6 @@ def _is_sha256_digest(value: object) -> bool:
     )
 
 
-def _resolve_output_path(repo_root: Path, value: Path | str | None) -> tuple[Path | None, list[str]]:
-    path, reasons = _resolve_outside_repo(repo_root, value, FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID)
-    if reasons:
-        return None, reasons
-    assert path is not None
-    if path.exists() and not path.is_file():
-        return None, [FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID]
-    return path, []
-
-
-def _resolve_socket_path(repo_root: Path, value: Path | str | None) -> tuple[Path | None, list[str]]:
-    path, reasons = _resolve_outside_repo(repo_root, value, FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID)
-    if reasons:
-        return None, reasons
-    assert path is not None
-    if path.exists():
-        return None, [FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID]
-    return path, []
-
-
-def _resolve_outside_repo(
-    repo_root: Path,
-    value: Path | str | None,
-    reason: str,
-) -> tuple[Path | None, list[str]]:
-    if not value:
-        return None, [reason]
-    text = str(value)
-    if "\x00" in text or text.startswith("\\\\?\\") or text.startswith("//?/"):
-        return None, [reason]
-    path = Path(value)
-    if not path.is_absolute():
-        return None, [reason]
-    resolved = path.resolve()
-    if _is_inside(resolved, repo_root):
-        return None, [reason]
-    return resolved, []
-
-
 def _op_ref_reasons(values: Sequence[str]) -> list[str]:
     refs = tuple(str(value or "").strip() for value in values)
     reasons: list[str] = []
@@ -374,36 +454,18 @@ def _limit_reasons(
     max_request_bytes: int,
     max_response_bytes: int,
 ) -> list[str]:
-    if (
-        not isinstance(max_requests, int)
-        or max_requests < 2
-        or max_requests > 128
-        or timeout_s <= 0
-        or timeout_s > 30
-        or max_request_bytes < 1024
-        or max_request_bytes > 262144
-        or max_response_bytes < 1024
-        or max_response_bytes > 262144
-    ):
+    if validate_resident_signer_socket_limits(
+        max_requests=max_requests,
+        timeout_s=timeout_s,
+        max_request_bytes=max_request_bytes,
+        max_response_bytes=max_response_bytes,
+    ) or type(max_requests) is not int or max_requests < 2:
         return [FAIL_SIGNER_CONFIG_LIMITS_INVALID]
     return []
 
 
 def _mapping(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
-
-
-def _write_json_atomic(path: Path, payload: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
-            json.dump(payload, handle, sort_keys=True, indent=2)
-            handle.write("\n")
-        os.replace(tmp_name, path)
-    finally:
-        if os.path.exists(tmp_name):
-            os.unlink(tmp_name)
 
 
 def _reject(reasons: Sequence[str]) -> SignerServiceConfigSupplyResult:
@@ -428,12 +490,6 @@ def _digest(payload: Mapping[str, Any]) -> str:
 
 def _dedupe(values: Sequence[str]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(str(value) for value in values if str(value)))
-
-
-def _is_inside(child: Path, parent: Path) -> bool:
-    child_r = child.resolve()
-    parent_r = parent.resolve()
-    return child_r == parent_r or parent_r in child_r.parents
 
 
 def _ascii_string(value: object) -> bool:

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
@@ -27,6 +27,13 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
     SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
 )
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_bootstrap import (
+    rehydrate_signer_socket_service_runtime_config,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    secure_read_confined_text,
+    validate_runtime_root_path,
+)
 
 SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT = "SIGNER_SERVICE_RUN_PACKET_SUPPLY_ACCEPT"
 SIGNER_SERVICE_RUN_PACKET_SUPPLY_REJECT = "SIGNER_SERVICE_RUN_PACKET_SUPPLY_REJECT"
@@ -180,17 +187,33 @@ def _read_config(
         return None, None, None, reasons
     assert path is not None
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
+        runtime_root = validate_runtime_root_path(path.parent, repo_root=repo_root)
+        payload = json.loads(
+            secure_read_confined_text(
+                path,
+                allowed_root=runtime_root,
+                max_bytes=256 * 1024,
+            ),
+            parse_constant=_reject_json_constant,
+        )
     except Exception:
         return None, None, None, (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
-    if not isinstance(payload, dict) or _config_reasons(repo_root, payload):
+    if not isinstance(payload, dict) or _config_reasons(
+        repo_root,
+        path.parent,
+        payload,
+    ):
         return None, None, None, (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     digest = "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return payload, digest, path, ()
 
 
-def _config_reasons(repo_root: Path, payload: Mapping[str, Any]) -> tuple[str, ...]:
+def _config_reasons(
+    repo_root: Path,
+    expected_runtime_root: Path,
+    payload: Mapping[str, Any],
+) -> tuple[str, ...]:
     if payload.get("schema_version") != SIGNER_SERVICE_CONFIG_SCHEMA_VERSION:
         return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
     if payload.get("provider_mode") != PROVIDER_MODE_WSP71_PERMISSIONED:
@@ -198,6 +221,12 @@ def _config_reasons(repo_root: Path, payload: Mapping[str, Any]) -> tuple[str, .
     if payload.get("allow_test_only_key_material") is not False:
         return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
     if payload.get("permission_snapshot_fresh") is not True:
+        return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
+    if rehydrate_signer_socket_service_runtime_config(
+        repo_root,
+        expected_runtime_root,
+        dict(payload),
+    ) is None:
         return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
     socket_path = str(payload.get("socket_path") or "")
     if "\x00" in socket_path or socket_path.startswith("\\\\?\\") or socket_path.startswith("//?/"):
@@ -213,6 +242,10 @@ def _config_reasons(repo_root: Path, payload: Mapping[str, Any]) -> tuple[str, .
     if not _ascii_deep(payload):
         return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
     return ()
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non_finite_json_constant:{value}")
 
 
 def _resolve_existing_file(

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
@@ -20,10 +20,19 @@ from typing import Any, Callable, Optional
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     SignerKeyResolver,
 )
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     ServeSignerSocketBounded,
     SignerSocketServiceRuntimeWiringConfig,
     run_reddog_signer_socket_service_runtime_wiring,
+    validate_signer_socket_service_runtime_config,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    secure_read_confined_text,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
 )
 
 
@@ -79,13 +88,17 @@ def run_reddog_signer_socket_service_runtime_bootstrap(
         return _reject(*path_reasons)
     assert path is not None
 
-    payload, digest, read_reasons = _read_config(path)
+    payload, digest, read_reasons = _read_config(path, path.parent)
     if read_reasons:
         return _reject(*read_reasons, config_path=str(path))
     assert payload is not None
     assert digest is not None
 
-    config = _runtime_config(root, payload)
+    config = rehydrate_signer_socket_service_runtime_config(
+        root,
+        path.parent,
+        payload,
+    )
     if config is None:
         return _reject(
             FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED,
@@ -128,18 +141,33 @@ def _resolve_config_path(
     path = Path(value)
     if not path.is_absolute():
         return None, (FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_RELATIVE,)
-    resolved = path.resolve()
-    if _is_inside(resolved, repo_root):
+    if _is_inside(path, repo_root):
         return None, (FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_INSIDE_REPO,)
+    try:
+        runtime_root = validate_runtime_root_path(path.parent, repo_root=repo_root)
+        resolved = validate_runtime_artifact_path(
+            path,
+            repo_root=repo_root,
+            allowed_root=runtime_root,
+        )
+    except (OSError, ValueError):
+        return None, (FAIL_SIGNER_BOOTSTRAP_CONFIG_UNREADABLE,)
     if not resolved.exists() or not resolved.is_file():
         return None, (FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_MISSING,)
     return resolved, ()
 
 
-def _read_config(path: Path) -> tuple[Optional[dict[str, Any]], Optional[str], tuple[str, ...]]:
+def _read_config(
+    path: Path,
+    runtime_root: Path,
+) -> tuple[Optional[dict[str, Any]], Optional[str], tuple[str, ...]]:
     try:
-        text = path.read_text(encoding="utf-8")
-        payload = json.loads(text)
+        text = secure_read_confined_text(
+            path,
+            allowed_root=runtime_root,
+            max_bytes=256 * 1024,
+        )
+        payload = json.loads(text, parse_constant=_reject_json_constant)
     except Exception:
         return None, None, (FAIL_SIGNER_BOOTSTRAP_CONFIG_UNREADABLE,)
     if not isinstance(payload, dict):
@@ -149,11 +177,49 @@ def _read_config(path: Path) -> tuple[Optional[dict[str, Any]], Optional[str], t
     return payload, digest, ()
 
 
-def _runtime_config(
+def rehydrate_signer_socket_service_runtime_config(
     repo_root: Path,
+    expected_runtime_root: Path,
     payload: dict[str, Any],
 ) -> Optional[SignerSocketServiceRuntimeWiringConfig]:
+    """Validate and rehydrate the canonical schema-v2 signer config."""
+
     try:
+        if payload.get("schema_version") != SIGNER_SERVICE_CONFIG_SCHEMA_VERSION:
+            return None
+        if not payload.get("control_loop_anchor_path") or not isinstance(
+            payload.get("control_loop_authority_policy"),
+            dict,
+        ):
+            return None
+        runtime_root = validate_runtime_root_path(
+            payload["runtime_root"],
+            repo_root=repo_root,
+        )
+        if runtime_root != expected_runtime_root.resolve():
+            return None
+        signer_runtime_root = validate_runtime_root_path(
+            payload["signer_runtime_root"],
+            repo_root=repo_root,
+        )
+        if (
+            signer_runtime_root == runtime_root
+            or runtime_root in signer_runtime_root.parents
+            or signer_runtime_root in runtime_root.parents
+        ):
+            return None
+        socket_path = validate_runtime_artifact_path(
+            payload["socket_path"],
+            repo_root=repo_root,
+            allowed_root=runtime_root,
+        )
+        anchor_path = validate_runtime_artifact_path(
+            payload["control_loop_anchor_path"],
+            repo_root=repo_root,
+            allowed_root=signer_runtime_root,
+        )
+        if socket_path.parent != runtime_root or anchor_path.parent != signer_runtime_root:
+            return None
         peer_policy = payload["peer_policy"]
         key_profile = payload.get("key_provider_profile")
         key_profiles = payload.get("key_provider_profiles") or ()
@@ -171,26 +237,33 @@ def _runtime_config(
             key_profiles = tuple(key_profiles)
         if key_profile is None and not key_profiles:
             return None
-        return SignerSocketServiceRuntimeWiringConfig(
+        config = SignerSocketServiceRuntimeWiringConfig(
             repo_root=repo_root,
-            socket_path=payload.get("socket_path"),
+            runtime_root=runtime_root,
+            signer_runtime_root=signer_runtime_root,
+            socket_path=socket_path,
             peer_policy=peer_policy,
             key_provider_profile=key_profile,
             provider_mode=str(payload.get("provider_mode") or ""),
             allow_test_only_key_material=payload.get("allow_test_only_key_material") is True,
             permission_snapshot_fresh=payload.get("permission_snapshot_fresh") is True,
-            max_requests=int(payload.get("max_requests") or 0),
-            timeout_s=float(payload.get("timeout_s") or 0),
-            max_request_bytes=int(payload.get("max_request_bytes") or 0),
-            max_response_bytes=int(payload.get("max_response_bytes") or 0),
+            max_requests=payload.get("max_requests"),
+            timeout_s=payload.get("timeout_s"),
+            max_request_bytes=payload.get("max_request_bytes"),
+            max_response_bytes=payload.get("max_response_bytes"),
             key_provider_profiles=key_profiles,
-            control_loop_anchor_path=payload.get("control_loop_anchor_path"),
-            control_loop_authority_policy=payload.get(
-                "control_loop_authority_policy"
-            ),
+            control_loop_anchor_path=anchor_path,
+            control_loop_authority_policy=payload["control_loop_authority_policy"],
         )
     except Exception:
         return None
+    if validate_signer_socket_service_runtime_config(config):
+        return None
+    return config
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non_finite_json_constant:{value}")
 
 
 def _reject(
@@ -225,5 +298,6 @@ __all__ = [
     "SIGNER_SOCKET_RUNTIME_BOOTSTRAP_REJECT",
     "SIGNER_SOCKET_RUNTIME_BOOTSTRAP_SERVED",
     "SignerSocketServiceRuntimeBootstrapResult",
+    "rehydrate_signer_socket_service_runtime_config",
     "run_reddog_signer_socket_service_runtime_bootstrap",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -24,6 +24,7 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resi
     SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
     IsolatedSignerSocketResidentServiceResult,
     serve_reddog_isolated_signer_socket_bounded,
+    validate_resident_signer_socket_limits,
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
     DEFAULT_SIGNER_SOCKET_MAX_REQUEST_BYTES,
@@ -34,14 +35,17 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_serv
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
     SignerKeyProviderProfile,
     SignerKeyResolver,
     build_signer_backend_from_provider,
+    validate_signer_key_provider_profile,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     RuntimeRejectCode,
     SigningRequest,
     SigningResponse,
+    public_key_fingerprint,
 )
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
     ControlLoopAuthorityPolicy,
@@ -53,6 +57,10 @@ from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor 
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     KernelPeerCredentialAttestor,
     PeerCredentialPolicy,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
 )
 
 
@@ -80,6 +88,8 @@ class SignerSocketServiceRuntimeWiringConfig:
     """Signer-owned runtime service wiring configuration."""
 
     repo_root: Path | str
+    runtime_root: Path | str
+    signer_runtime_root: Path | str
     socket_path: Path | str | None
     peer_policy: PeerCredentialPolicy | Mapping[str, Any]
     key_provider_profile: SignerKeyProviderProfile | Mapping[str, Any] | None = None
@@ -129,13 +139,14 @@ def run_reddog_signer_socket_service_runtime_wiring(
 ) -> SignerSocketServiceRuntimeWiringResult:
     """Build a signer backend and serve a bounded signer socket service."""
 
-    if not isinstance(config, SignerSocketServiceRuntimeWiringConfig):
-        return _reject(FAIL_SIGNER_RUNTIME_CONFIG_INVALID)
+    config_reasons = validate_signer_socket_service_runtime_config(config)
+    if config_reasons:
+        return _reject(*config_reasons)
     profiles, profile_reasons = _profiles(config)
     if profile_reasons:
         return _reject(*profile_reasons)
     policy = _peer_policy(config.peer_policy)
-    if policy is None or not _peer_policy_valid(policy):
+    if policy is None:
         return _reject(FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID)
     anchor_store, anchor_reasons = _control_loop_anchor_store(config)
     if anchor_reasons:
@@ -143,8 +154,6 @@ def run_reddog_signer_socket_service_runtime_wiring(
     control_authority_policy = _control_loop_authority_policy(
         config.control_loop_authority_policy
     )
-    if config.control_loop_anchor_path is not None and control_authority_policy is None:
-        return _reject(FAIL_SIGNER_RUNTIME_CONFIG_INVALID)
 
     backend, key_receipt, key_reasons = _build_backend(
         profiles,
@@ -201,6 +210,72 @@ def run_reddog_signer_socket_service_runtime_wiring(
     )
 
 
+def validate_signer_socket_service_runtime_config(
+    config: object,
+) -> tuple[str, ...]:
+    """Validate all non-secret signer runtime config before launch."""
+
+    if not isinstance(config, SignerSocketServiceRuntimeWiringConfig):
+        return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    if not _socket_path_valid(config):
+        return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    _, profile_reasons = _profiles(config)
+    if profile_reasons:
+        return profile_reasons
+    profiles, _ = _profiles(config)
+    profile_public_keys = [profile.expected_public_key for profile in profiles]
+    if len(profile_public_keys) != len(set(profile_public_keys)):
+        return (FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE,)
+    policy = _peer_policy(config.peer_policy)
+    if policy is None or not _peer_policy_valid(policy):
+        return (FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID,)
+    anchor_store, anchor_reasons = _control_loop_anchor_store(config)
+    if anchor_reasons:
+        return anchor_reasons
+    control_authority_policy = _control_loop_authority_policy(
+        config.control_loop_authority_policy
+    )
+    if config.control_loop_anchor_path is not None and control_authority_policy is None:
+        return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    if (
+        config.provider_mode == PROVIDER_MODE_WSP71_PERMISSIONED
+        and (anchor_store is None or control_authority_policy is None)
+    ):
+        return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    if (
+        control_authority_policy is not None
+        and control_authority_policy.signer_public_key
+        not in set(profile_public_keys)
+    ):
+        return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    limit_reasons = validate_resident_signer_socket_limits(
+        max_requests=config.max_requests,
+        timeout_s=config.timeout_s,
+        max_request_bytes=config.max_request_bytes,
+        max_response_bytes=config.max_response_bytes,
+    )
+    if limit_reasons:
+        return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    return ()
+
+
+def _socket_path_valid(config: SignerSocketServiceRuntimeWiringConfig) -> bool:
+    try:
+        repo_root = Path(config.repo_root).resolve()
+        runtime_root = validate_runtime_root_path(
+            config.runtime_root,
+            repo_root=repo_root,
+        )
+        socket_path = validate_runtime_artifact_path(
+            config.socket_path,
+            repo_root=repo_root,
+            allowed_root=runtime_root,
+        )
+    except (OSError, TypeError, ValueError):
+        return False
+    return socket_path.parent == runtime_root
+
+
 @dataclass(frozen=True)
 class _RoutingSignerBackend(IsolatedSignerBackend):
     backends: Mapping[str, IsolatedSignerBackend]
@@ -234,7 +309,12 @@ def _profiles(
     profiles: list[SignerKeyProviderProfile] = []
     for raw in raw_profiles:
         profile = _profile(raw)
-        if profile is None:
+        if (
+            profile is None
+            or validate_signer_key_provider_profile(profile) is not None
+            or public_key_fingerprint(profile.expected_public_key)
+            != profile.expected_key_fingerprint
+        ):
             return [], (FAIL_SIGNER_RUNTIME_PROFILE_INVALID,)
         profiles.append(profile)
     return profiles, ()
@@ -295,13 +375,35 @@ def _control_loop_anchor_store(
         return None, ()
     try:
         repo_root = Path(config.repo_root).resolve()
+        runtime_root = validate_runtime_root_path(
+            config.runtime_root,
+            repo_root=repo_root,
+        )
+        signer_runtime_root = validate_runtime_root_path(
+            config.signer_runtime_root,
+            repo_root=repo_root,
+        )
+        if (
+            signer_runtime_root == runtime_root
+            or runtime_root in signer_runtime_root.parents
+            or signer_runtime_root in runtime_root.parents
+        ):
+            return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
         path = Path(config.control_loop_anchor_path)
         if not path.is_absolute():
             return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
-        resolved = path.resolve()
+        resolved = validate_runtime_artifact_path(
+            path,
+            repo_root=repo_root,
+            allowed_root=signer_runtime_root,
+        )
         if resolved == repo_root or repo_root in resolved.parents:
             return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
-        return AtomicSignerControlLoopAnchorStore(resolved), ()
+        return AtomicSignerControlLoopAnchorStore(
+            path,
+            runtime_root=signer_runtime_root,
+            repo_root=repo_root,
+        ), ()
     except Exception:
         return None, (FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,)
 
@@ -310,12 +412,13 @@ def _control_loop_authority_policy(
     value: ControlLoopAuthorityPolicy | Mapping[str, Any] | None,
 ) -> ControlLoopAuthorityPolicy | None:
     if isinstance(value, ControlLoopAuthorityPolicy):
-        return value
-    if not isinstance(value, Mapping):
-        return None
-    try:
-        policy = ControlLoopAuthorityPolicy(**dict(value))
-    except Exception:
+        policy = value
+    elif isinstance(value, Mapping):
+        try:
+            policy = ControlLoopAuthorityPolicy(**dict(value))
+        except Exception:
+            return None
+    else:
         return None
     values = (
         policy.issuer_principal_id,
@@ -405,8 +508,8 @@ def _peer_policy_valid(policy: PeerCredentialPolicy) -> bool:
     return all(isinstance(gid, int) and gid >= 0 for gid in policy.allowed_gids)
 
 
-def _ascii(value: str) -> bool:
-    return all(ord(char) < 128 for char in value)
+def _ascii(value: object) -> bool:
+    return isinstance(value, str) and all(ord(char) < 128 for char in value)
 
 
 def _reject(
@@ -440,4 +543,5 @@ __all__ = [
     "SignerSocketServiceRuntimeWiringConfig",
     "SignerSocketServiceRuntimeWiringResult",
     "run_reddog_signer_socket_service_runtime_wiring",
+    "validate_signer_socket_service_runtime_config",
 ]

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,27 @@
+## 2026-07-27: REDDOG_AUTHORITY_RUNTIME_STORE_CONFINEMENT_PHASE1
+- Added missing/outside-root, repository ancestry, mixed namespace, symlink,
+  hard-link, parent-swap, concurrent compare-and-swap, nonce-consumption,
+  signer-config/anchor, and live-canary regressions for explicit root binding.
+- Added rejected-alias payload scrubbing, post-replace rollback, exact receipt
+  runtime-root propagation, schema-v2 control-authority, root-separation, and
+  direct-child config regressions. The affected bridge suite passed 157 tests
+  with seven platform skips; shared safety, startup, and WSP 62 gates passed
+  38 more tests with one platform skip.
+- Added intervening-revision rejection, interrupted-write recovery, escaped
+  socket, and nested-anchor regressions; the expanded bridge gate passed 168
+  tests with seven platform skips before final independent review.
+- Added exact-expected-revision recovery, self-consistent forged-backup
+  rejection, linked/oversized backup rejection, and post-nonce revision
+  recovery regressions. Required run-packet fixtures now carry the canonical
+  runtime, signer, anchor, and authority-policy bindings and reject every
+  missing or malformed nested binding or provider profile. Config supply now
+  proves that malformed Ed25519 public keys fail before write and that every
+  accepted config passes canonical run-packet admission. Final local gates:
+  210 bridge tests passed with eight platform skips, 14 shared-safety tests
+  passed with one platform skip, 21 startup tests passed, three WSP 62 checks
+  passed, 42 red-team tests passed, and 200 Windows authority commits left no
+  temporary or backup artifacts.
+
 ## 2026-07-27: Architect proposal executability admission
 - Added adversarial coverage for valid-but-blocked prerequisite slices,
   produced-capability self-authorization, model readiness forgery, INDEX_GAP

--- a/modules/communication/moltbot_bridge/tests/reddog_live_canary_artifact_test_support.py
+++ b/modules/communication/moltbot_bridge/tests/reddog_live_canary_artifact_test_support.py
@@ -13,6 +13,9 @@ from modules.communication.moltbot_bridge.src.reddog_authority_runtime_resolver_
 from modules.communication.moltbot_bridge.src.reddog_execution_valve_environment_supply import (
     run_reddog_execution_valve_environment_supply,
 )
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
     run_reddog_signer_socket_service_config_supply,
 )
@@ -33,6 +36,8 @@ from modules.communication.moltbot_bridge.tests.test_reddog_resident_queue_seria
 PERMISSION_DIGEST = "sha256:" + "a" * 64
 CONSENSUS_DIGEST = "sha256:" + "b" * 64
 SOVEREIGN_DIGEST = "sha256:" + "c" * 64
+PRINCIPAL_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32)))
+REDDOG_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32, 64)))
 
 
 def write_live_canary_artifacts(
@@ -114,8 +119,8 @@ def _profile(
 ) -> dict:
     return {
         "principal_id": "github:mjtrout", "principal_provider": "github",
-        "principal_public_key": "ed25519-pub-v1:principal",
-        "reddog_id": "reddog:canary", "reddog_public_key": "ed25519-pub-v1:reddog",
+        "principal_public_key": PRINCIPAL_PUBLIC_KEY,
+        "reddog_id": "reddog:canary", "reddog_public_key": REDDOG_PUBLIC_KEY,
         "repo_full_name": "FOUNDUPS/Foundups-Agent", "foundup_id": "paccess_001",
         "allowed_paths": ["modules/foundups/paccess_001/**"], "denied_paths": ["modules/foundups/paccess_001/secrets/**"],
         "requested_operation": "feature_slice", "permission_snapshot_digest": PERMISSION_DIGEST,
@@ -148,7 +153,7 @@ def _resolver_inputs(now: int) -> tuple[dict, dict]:
         "can_write": True, "can_admin": False, "repo_full_name": "FOUNDUPS/Foundups-Agent",
     }, {
         "principal_id": "github:mjtrout", "principal_provider": "github",
-        "principal_public_key": "ed25519-pub-v1:principal",
+        "principal_public_key": PRINCIPAL_PUBLIC_KEY,
         "repo_scope": ["FOUNDUPS/Foundups-Agent"], "foundup_scope": ["paccess_001"],
         "verified_subject_digest": "sha256:verified",
     })
@@ -167,7 +172,11 @@ def _write_valve(repo: Path, runtime: Path, work: dict, profile: dict, queue_id:
 
 def _write_signer(repo: Path, runtime: Path, profile: dict) -> None:
     config = run_reddog_signer_socket_service_config_supply(
-        repo_root=repo, authority_profile=profile, output_path=runtime / "signer_service_config.json",
+        repo_root=repo,
+        runtime_root=runtime,
+        signer_runtime_root=runtime.parent / f"{runtime.name}-signer-state",
+        authority_profile=profile,
+        output_path=runtime / "signer_service_config.json",
         socket_path=runtime / "reddog_signer.sock",
         principal_signing_key_ref="op://vault/principal/private",
         principal_audit_mac_key_ref="op://vault/principal/audit",

--- a/modules/communication/moltbot_bridge/tests/reddog_resident_live_canary_test_support.py
+++ b/modules/communication/moltbot_bridge/tests/reddog_resident_live_canary_test_support.py
@@ -258,13 +258,16 @@ def _roots(
         if filename == "authority_profile.json":
             payload = dict(_AUTHORITY_PROFILE)
         (runtime / filename).write_text(json.dumps(payload), encoding="utf-8")
-    anchor_path = (
-        runtime.parent
-        / f"{runtime.name}-signer-state"
-        / "signer_control_loop_anchor.json"
-    )
+    signer_runtime = runtime.parent / f"{runtime.name}-signer-state"
+    anchor_path = signer_runtime / "signer_control_loop_anchor.json"
     (runtime / "signer_service_config.json").write_text(
-        json.dumps({"control_loop_anchor_path": str(anchor_path)}),
+        json.dumps(
+            {
+                "control_loop_anchor_path": str(anchor_path),
+                "runtime_root": str(runtime),
+                "signer_runtime_root": str(signer_runtime),
+            }
+        ),
         encoding="utf-8",
     )
     (runtime / "authority_profile_source.json").write_text(
@@ -442,13 +445,17 @@ def _control_receipt(repo: Path, **changes: object) -> dict[str, object]:
 
 
 def _write_control_receipt_and_head(
-    runtime: Path, control: dict[str, object]
+    repo: Path,
+    runtime: Path,
+    control: dict[str, object],
 ) -> None:
     (runtime / "resident_queue_control_loop_receipts.jsonl").write_text(
         json.dumps(control) + "\n", encoding="utf-8"
     )
     store, state, _ = load_control_receipt_head(
-        runtime / "authority_runtime_state.json"
+        runtime / "authority_runtime_state.json",
+        runtime_root=runtime,
+        repo_root=repo,
     )
     head = build_control_receipt_head(
         receipt=control,
@@ -464,7 +471,11 @@ def _write_control_receipt_and_head(
     config = json.loads(
         (runtime / "signer_service_config.json").read_text(encoding="utf-8")
     )
-    anchor = AtomicSignerControlLoopAnchorStore(config["control_loop_anchor_path"])
+    anchor = AtomicSignerControlLoopAnchorStore(
+        config["control_loop_anchor_path"],
+        runtime_root=config["signer_runtime_root"],
+        repo_root=repo,
+    )
     unsigned = {
         key: value
         for key, value in control.items()
@@ -554,7 +565,7 @@ def _runner(
                     chain["receipts"][-1]["store_revision"] = revision
         (runtime / "resident_queue_chain_results.json").write_text(json.dumps(chain), encoding="utf-8")
         control = _control_receipt(repo, **(receipt_changes or {}))
-        _write_control_receipt_and_head(runtime, control)
+        _write_control_receipt_and_head(repo, runtime, control)
         return {"accepted": True, "status": "PASS", "receipt_id": result_receipt_id or control["receipt_id"]}
 
     return run

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_resident_queue_runtime_dependency_bundle.py
@@ -45,10 +45,15 @@ FID = "paccess_001"
 def test_atomic_runtime_nonce_consume_allows_exactly_one_concurrent_winner(
     tmp_path: Path,
 ) -> None:
+    repo = _repo(tmp_path)
     path = tmp_path / "runtime" / "authority_state.json"
     stores = [
         AuthorityRuntimeWorkAuthorityNonceStore(
-            AtomicJsonAuthorityRuntimeStore(path, allowed_root=path.parent)
+            AtomicJsonAuthorityRuntimeStore(
+                path,
+                allowed_root=path.parent,
+                repo_root=repo,
+            )
         )
         for _ in range(8)
     ]
@@ -62,7 +67,11 @@ def test_atomic_runtime_nonce_consume_allows_exactly_one_concurrent_winner(
 
     assert results.count(True) == 1
     assert results.count(False) == 7
-    state = AtomicJsonAuthorityRuntimeStore(path, allowed_root=path.parent).load()
+    state = AtomicJsonAuthorityRuntimeStore(
+        path,
+        allowed_root=path.parent,
+        repo_root=repo,
+    ).load()
     assert state["verified_work_authority_nonces"] == ["authoritative-use-nonce"]
 
 

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_signer_service_config_supply_preflight.py
@@ -9,6 +9,12 @@ from unittest.mock import patch
 
 import pytest
 
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     PROVIDER_MODE_WSP71_PERMISSIONED,
 )
@@ -19,6 +25,9 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_binding_prof
     PROFILE_SIGNED_0102_BOUNDED_CODE,
     resident_queue_runtime_file_path,
 )
+
+_PRINCIPAL_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32)))
+_REDDOG_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32, 64)))
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -60,9 +69,9 @@ def clean_signer_supply_env(monkeypatch) -> None:
 def _authority_profile(**overrides: object) -> dict[str, object]:
     profile: dict[str, object] = {
         "principal_id": "github:mjtrout",
-        "principal_public_key": "ed25519-pub-v1:principal",
+        "principal_public_key": _PRINCIPAL_PUBLIC_KEY,
         "reddog_id": "reddog:foundups-agent",
-        "reddog_public_key": "ed25519-pub-v1:reddog",
+        "reddog_public_key": _REDDOG_PUBLIC_KEY,
         "permission_snapshot_digest": "sha256:" + "1" * 64,
         "key_epoch": "epoch-1",
         "consensus_receipt_digest": "sha256:" + "c" * 64,
@@ -81,12 +90,27 @@ def _write_json(path: Path, payload: object) -> Path:
 
 
 def _signer_config(socket_path: Path) -> dict[str, object]:
+    runtime_root = socket_path.parent.resolve()
+    signer_runtime_root = (
+        runtime_root.parent / f"{runtime_root.name}-signer-state"
+    ).resolve()
     return {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
-        "socket_path": str(socket_path),
+        "runtime_root": str(runtime_root),
+        "signer_runtime_root": str(signer_runtime_root),
+        "socket_path": str(socket_path.resolve()),
+        "control_loop_anchor_path": str(signer_runtime_root / "anchor.json"),
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
         "allow_test_only_key_material": False,
         "permission_snapshot_fresh": True,
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "github:mjtrout",
+            "signer_public_key": _REDDOG_PUBLIC_KEY,
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:" + "c" * 64,
+            "authority_profile_digest": "sha256:" + "b" * 64,
+            "authority_profile_source_receipt_id": "sha256:" + "a" * 64,
+        },
         "max_requests": 3,
         "timeout_s": 2.5,
         "max_request_bytes": 4096,
@@ -97,8 +121,10 @@ def _signer_config(socket_path: Path) -> dict[str, object]:
                 "signer_agent_id": "signer:principal",
                 "signing_key_ref": "op://prod-vault/principal/private",
                 "audit_mac_key_ref": "op://prod-vault/principal/audit",
-                "expected_public_key": "ed25519-pub-v1:principal",
-                "expected_key_fingerprint": "sha256:principal",
+                "expected_public_key": _PRINCIPAL_PUBLIC_KEY,
+                "expected_key_fingerprint": public_key_fingerprint(
+                    _PRINCIPAL_PUBLIC_KEY
+                ),
                 "expected_key_epoch": "epoch-1",
                 "permission_snapshot_digest": "sha256:permission",
                 "ttl_seconds": 60,
@@ -108,8 +134,10 @@ def _signer_config(socket_path: Path) -> dict[str, object]:
                 "signer_agent_id": "signer:reddog",
                 "signing_key_ref": "op://prod-vault/reddog/private",
                 "audit_mac_key_ref": "op://prod-vault/reddog/audit",
-                "expected_public_key": "ed25519-pub-v1:reddog",
-                "expected_key_fingerprint": "sha256:reddog",
+                "expected_public_key": _REDDOG_PUBLIC_KEY,
+                "expected_key_fingerprint": public_key_fingerprint(
+                    _REDDOG_PUBLIC_KEY
+                ),
                 "expected_key_epoch": "epoch-1",
                 "permission_snapshot_digest": "sha256:permission",
                 "ttl_seconds": 60,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_receipt_auth.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_receipt_auth.py
@@ -273,6 +273,59 @@ def test_authority_profile_source_receipt_is_signature_bound(tmp_path: Path) -> 
         verify_resident_control_loop_receipt(receipt, require_authenticated=True)
 
 
+def test_authenticated_receipt_io_preserves_exact_runtime_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "nested" / "control.jsonl"
+    target.parent.mkdir()
+    target.write_text("", encoding="utf-8")
+    observed: list[tuple[str, Path | None]] = []
+
+    def read_bytes(path, *, allowed_root, max_bytes):
+        observed.append(("read", allowed_root))
+        return b"", 0
+
+    def append_text(
+        path,
+        text,
+        *,
+        repo_root,
+        allowed_root,
+        validate_existing,
+        max_existing_bytes,
+    ):
+        observed.append(("append", allowed_root))
+        validate_existing("")
+
+    monkeypatch.setattr(receipt_store, "secure_read_confined_bytes", read_bytes)
+    monkeypatch.setattr(receipt_store, "secure_append_runtime_text", append_text)
+
+    assert receipt_store._read_existing_chain(target, runtime) == ""
+    receipt = build_resident_control_loop_receipt(
+        result=_result(),
+        repo_root=repo,
+        created_at="2026-07-18T00:00:00Z",
+        cycle_id="cycle-root",
+        nonce="nonce-root",
+        signing_context=_SIGNING_CONTEXT,
+    )
+    receipt_store._append_receipt_once(
+        target,
+        receipt,
+        repo,
+        signing_context=_SIGNING_CONTEXT,
+        require_authentication=True,
+        runtime_root=runtime,
+    )
+
+    assert observed == [("read", runtime), ("append", runtime)]
+
+
 def test_chain_links_receipts_and_rejects_cycle_or_nonce_replay(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -285,7 +338,7 @@ def test_chain_links_receipts_and_rejects_cycle_or_nonce_replay(tmp_path: Path) 
         cycle_id="cycle-1",
         nonce="nonce-1",
         signing_context=_SIGNING_CONTEXT,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
     )
     second = append_resident_control_loop_receipt(
         path=path,
@@ -295,7 +348,7 @@ def test_chain_links_receipts_and_rejects_cycle_or_nonce_replay(tmp_path: Path) 
         cycle_id="cycle-2",
         nonce="nonce-2",
         signing_context=_SIGNING_CONTEXT,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
     )
 
     assert second.previous_receipt_id == first.receipt_id
@@ -308,7 +361,7 @@ def test_chain_links_receipts_and_rejects_cycle_or_nonce_replay(tmp_path: Path) 
             cycle_id="cycle-1",
             nonce="nonce-3",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
 
 
@@ -320,7 +373,7 @@ def test_child_receipt_and_evidence_reuse_is_rejected_across_cycles(tmp_path: Pa
         path=path, result=_result(), repo_root=repo,
         created_at="2026-07-18T00:00:00Z", cycle_id="cycle-1",
         nonce="nonce-1", signing_context=_SIGNING_CONTEXT,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
     )
 
     with pytest.raises(ValueError, match="child_(receipt|evidence)_replay"):
@@ -328,7 +381,7 @@ def test_child_receipt_and_evidence_reuse_is_rejected_across_cycles(tmp_path: Pa
             path=path, result=_result(), repo_root=repo,
             created_at="2026-07-18T00:00:01Z", cycle_id="cycle-2",
             nonce="nonce-2", signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
 
 
@@ -354,14 +407,14 @@ def test_head_recovers_exact_signed_receipt_after_append_interruption(
             path=path, result=_result(), repo_root=repo,
             created_at="2026-07-18T00:00:00Z", cycle_id="cycle-1",
             nonce="nonce-1", signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
 
     second = append_resident_control_loop_receipt(
         path=path, result=_result(receipt_ids=("child-receipt-2",)),
         repo_root=repo, created_at="2026-07-18T00:00:01Z",
         cycle_id="cycle-2", nonce="nonce-2", signing_context=_SIGNING_CONTEXT,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
     )
     payloads = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
     assert len(payloads) == 2
@@ -385,7 +438,7 @@ def test_retention_limit_rejects_before_advancing_high_water_head(
         cycle_id="cycle-capacity-1",
         nonce="nonce-capacity-1",
         signing_context=_SIGNING_CONTEXT,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
         head_state_path=state_path,
     )
     before = json.loads(state_path.read_text(encoding="utf-8"))
@@ -404,7 +457,7 @@ def test_retention_limit_rejects_before_advancing_high_water_head(
             cycle_id="cycle-capacity-2",
             nonce="nonce-capacity-2",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
             head_state_path=state_path,
         )
 
@@ -428,7 +481,7 @@ def test_concurrent_same_cycle_allows_exactly_one_signed_append(tmp_path: Path) 
             cycle_id="same-cycle",
             nonce="same-nonce",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
         return receipt.receipt_id
 
@@ -459,7 +512,7 @@ def test_concurrent_distinct_signed_appends_are_serialized_without_loss(
             cycle_id=f"distinct-cycle-{index}",
             nonce=f"distinct-nonce-{index}",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         ).receipt_id
 
     with ThreadPoolExecutor(max_workers=2) as executor:
@@ -780,7 +833,7 @@ def test_authenticated_append_rejects_unsigned_v2_predecessor(tmp_path: Path) ->
             cycle_id="signed-cycle",
             nonce="signed-nonce",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
 
 
@@ -827,7 +880,7 @@ def test_authenticated_append_rejects_foreign_signed_v2_predecessor(
         cycle_id="foreign-cycle",
         nonce="foreign-nonce",
         signing_context=foreign_context,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
     )
 
     with pytest.raises(ValueError, match="signer_invalid"):
@@ -839,7 +892,7 @@ def test_authenticated_append_rejects_foreign_signed_v2_predecessor(
             cycle_id="local-cycle",
             nonce="local-nonce",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
 
 
@@ -858,7 +911,7 @@ def test_complete_chain_verifier_rejects_tamper_and_reorder(tmp_path: Path) -> N
             cycle_id=f"chain-cycle-{index}",
             nonce=f"chain-nonce-{index}",
             signing_context=_SIGNING_CONTEXT,
-            require_authentication=True,
+            require_authentication=True, runtime_root=path.parent,
         )
     payloads = tuple(
         json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
@@ -921,7 +974,7 @@ def test_first_v2_receipt_binds_validated_legacy_prefix(tmp_path: Path) -> None:
         cycle_id="cycle-current",
         nonce="nonce-current",
         signing_context=_SIGNING_CONTEXT,
-        require_authentication=True,
+        require_authentication=True, runtime_root=path.parent,
     )
 
     assert current.previous_receipt_id == legacy["receipt_id"]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_live_canary.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_live_canary.py
@@ -178,7 +178,7 @@ def test_valid_json_signature_tamper_blocks_before_runner(tmp_path: Path) -> Non
     repo, runtime = _roots(tmp_path)
     _write_pre_state(repo, runtime)
     control = _control_receipt(repo)
-    _write_control_receipt_and_head(runtime, control)
+    _write_control_receipt_and_head(repo, runtime, control)
     control["status"] = "TAMPERED"
     (runtime / "resident_queue_control_loop_receipts.jsonl").write_text(
         json.dumps(control) + "\n", encoding="utf-8"
@@ -207,7 +207,7 @@ def test_canary_blocks_when_signer_anchor_is_ahead_of_resident_chain(
 
     repo, runtime = _roots(tmp_path)
     first = _control_receipt(repo)
-    _write_control_receipt_and_head(runtime, first)
+    _write_control_receipt_and_head(repo, runtime, first)
     second = build_resident_control_loop_receipt(
         result={
             "accepted": True,
@@ -230,7 +230,11 @@ def test_canary_blocks_when_signer_anchor_is_ahead_of_resident_chain(
     config = json.loads(
         (runtime / "signer_service_config.json").read_text(encoding="utf-8")
     )
-    store = AtomicSignerControlLoopAnchorStore(config["control_loop_anchor_path"])
+    store = AtomicSignerControlLoopAnchorStore(
+        config["control_loop_anchor_path"],
+        runtime_root=config["signer_runtime_root"],
+        repo_root=repo,
+    )
     state = store.load()
     unsigned = {
         key: value
@@ -280,7 +284,7 @@ def test_signed_chain_suffix_truncation_blocks_before_runner(tmp_path: Path) -> 
             path=path, result=base_result, repo_root=repo,
             created_at=f"2026-07-14T00:00:0{index}Z",
             cycle_id=f"truncate-cycle-{index}", nonce=f"truncate-nonce-{index}",
-            signing_context=_SIGNING_CONTEXT, require_authentication=True,
+            signing_context=_SIGNING_CONTEXT, require_authentication=True, runtime_root=path.parent,
             head_state_path=runtime / "authority_runtime_state.json",
         )
     first_line = path.read_text(encoding="utf-8").splitlines()[0]
@@ -305,7 +309,7 @@ def test_head_consumed_evidence_tamper_blocks_before_runner(tmp_path: Path) -> N
     repo, runtime = _roots(tmp_path)
     _write_pre_state(repo, runtime)
     control = _control_receipt(repo)
-    _write_control_receipt_and_head(runtime, control)
+    _write_control_receipt_and_head(repo, runtime, control)
     state_path = runtime / "authority_runtime_state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))
     state["control_receipt_head"]["consumed_child_evidence_digests"] = [
@@ -379,7 +383,7 @@ def test_canary_rejects_control_receipt_stream_replacement(tmp_path: Path) -> No
     original = control("canary-prefix-cycle", "canary-prefix-nonce")
     replacement = control("canary-replacement-cycle", "canary-replacement-nonce")
     path = runtime / "resident_queue_control_loop_receipts.jsonl"
-    _write_control_receipt_and_head(runtime, original)
+    _write_control_receipt_and_head(repo, runtime, original)
 
     def runner(_: Path) -> dict[str, object]:
         path.write_text(json.dumps(replacement) + "\n", encoding="utf-8")

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_runtime_artifact_readiness.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_runtime_artifact_readiness.py
@@ -59,8 +59,29 @@ def test_unsigned_seven_artifact_pack_is_not_execution_authority(tmp_path: Path)
     signer = next(item for item in result.checks if item.filename == "signer_service_config.json")
     assert SIGNED_RUNTIME_ARTIFACT_MANIFEST_PRODUCER_MISSING in valve.rejection_reasons
     assert "signer_client_peer_handshake_verifier_missing" in signer.rejection_reasons
+    assert "signer_config_schema_invalid" not in signer.rejection_reasons
     assert result.authorization_mode == "signed_work_authority_consensus"
     assert result.authorization_binding_digest and result.authorization_binding_digest.startswith("sha256:")
+
+
+def test_readiness_rejects_overlapping_signer_runtime_root(
+    tmp_path: Path,
+) -> None:
+    repo, runtime = _roots(tmp_path, canonical_artifacts=True)
+    config_path = runtime / "signer_service_config.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    signer_root = runtime / "signer"
+    config["signer_runtime_root"] = str(signer_root)
+    config["control_loop_anchor_path"] = str(signer_root / "anchor.json")
+    config_path.write_text(json.dumps(config, sort_keys=True), encoding="utf-8")
+
+    result = _validate(repo, runtime)
+
+    signer = next(
+        item for item in result.checks
+        if item.filename == "signer_service_config.json"
+    )
+    assert "signer_runtime_root_binding_invalid" in signer.rejection_reasons
 
 
 def test_linked_runtime_root_cannot_supply_artifacts(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_control_loop_anchor.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_control_loop_anchor.py
@@ -40,10 +40,41 @@ def _commit(store: AtomicSignerControlLoopAnchorStore, payload: dict[str, object
     )
 
 
+def _store(tmp_path: Path) -> AtomicSignerControlLoopAnchorStore:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    return AtomicSignerControlLoopAnchorStore(
+        tmp_path / "signer" / "anchor.json",
+        runtime_root=tmp_path / "signer",
+        repo_root=repo,
+    )
+
+
+def test_anchor_store_rejects_linked_runtime_path(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    real = runtime / "real"
+    real.mkdir()
+    linked = runtime / "linked"
+    try:
+        linked.symlink_to(real, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="path_link_rejected"):
+        AtomicSignerControlLoopAnchorStore(
+            linked / "anchor.json",
+            runtime_root=runtime,
+            repo_root=repo,
+        )
+
+
 def test_anchor_rejects_resident_rollback_but_allows_exact_recovery(
     tmp_path: Path,
 ) -> None:
-    store = AtomicSignerControlLoopAnchorStore(tmp_path / "signer" / "anchor.json")
+    store = _store(tmp_path)
     first = _payload(1)
     second = _payload(2, "receipt-1")
     _commit(store, first)
@@ -64,7 +95,7 @@ def test_anchor_rejects_resident_rollback_but_allows_exact_recovery(
 
 
 def test_anchor_rejects_reused_child_evidence(tmp_path: Path) -> None:
-    store = AtomicSignerControlLoopAnchorStore(tmp_path / "signer" / "anchor.json")
+    store = _store(tmp_path)
     first = _payload(1)
     _commit(store, first)
     second = _payload(2, "receipt-1")
@@ -77,7 +108,7 @@ def test_anchor_rejects_reused_child_evidence(tmp_path: Path) -> None:
 
 def test_anchor_state_tamper_fails_closed(tmp_path: Path) -> None:
     path = tmp_path / "signer" / "anchor.json"
-    store = AtomicSignerControlLoopAnchorStore(path)
+    store = _store(tmp_path)
     _commit(store, _payload(1))
     path.write_text('{"schema_version":"forged"}\n', encoding="utf-8")
     with pytest.raises(ValueError, match="state_invalid"):

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_delegated_authority_runtime.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import ast
 import hashlib
 import hmac
+import json
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -489,10 +491,17 @@ def test_signer_boundary_attestation_is_required() -> None:
 
 def test_json_store_commits_authority_receipt(tmp_path) -> None:
     request = _request()
-    path = tmp_path / "authority-state.json"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    path = runtime / "authority-state.json"
     result = issue_delegated_authority_runtime(
         request=request,
-        store=AtomicJsonAuthorityRuntimeStore(path, allowed_root=tmp_path),
+        store=AtomicJsonAuthorityRuntimeStore(
+            path,
+            allowed_root=runtime,
+            repo_root=repo,
+        ),
         signer=_MockSigner(),
         principal_resolver=_PrincipalResolver(_principal()),
         snapshot_resolver=_SnapshotResolver({request.permission_snapshot_digest: _snapshot()}),
@@ -508,13 +517,20 @@ def test_json_store_commits_authority_receipt(tmp_path) -> None:
 def test_json_store_compare_and_swap_is_serialized_across_store_instances(
     tmp_path,
 ) -> None:
-    path = tmp_path / "authority-state.json"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    path = runtime / "authority-state.json"
     barrier = threading.Barrier(2)
 
     def commit(index: int) -> str:
         barrier.wait(timeout=5)
         try:
-            AtomicJsonAuthorityRuntimeStore(path, allowed_root=tmp_path).commit(
+            AtomicJsonAuthorityRuntimeStore(
+                path,
+                allowed_root=runtime,
+                repo_root=repo,
+            ).commit(
                 {"writer": index}, expected_revision=None
             )
         except RuntimeError as exc:
@@ -525,9 +541,11 @@ def test_json_store_compare_and_swap_is_serialized_across_store_instances(
         outcomes = list(executor.map(commit, (1, 2)))
 
     assert sorted(outcomes) == ["committed", "revision_conflict"]
-    assert AtomicJsonAuthorityRuntimeStore(path, allowed_root=tmp_path).load()[
-        "writer"
-    ] in {1, 2}
+    assert AtomicJsonAuthorityRuntimeStore(
+        path,
+        allowed_root=runtime,
+        repo_root=repo,
+    ).load()["writer"] in {1, 2}
 
 
 def test_json_store_fsyncs_parent_directory_after_atomic_replace(
@@ -543,33 +561,132 @@ def test_json_store_fsyncs_parent_directory_after_atomic_replace(
         "_fsync_parent_directory",
         lambda path: observed.append(path),
     )
-    target = tmp_path / "authority-state.json"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority-state.json"
 
-    AtomicJsonAuthorityRuntimeStore(target, allowed_root=tmp_path).commit(
+    AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    ).commit(
         {"writer": 1}, expected_revision=None
     )
 
-    assert observed == [tmp_path]
+    assert observed == [runtime]
+
+
+def test_json_store_parent_swap_cannot_redirect_atomic_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = runtime / "authority-state.json"
+    displaced = tmp_path / "runtime-displaced"
+    swap_attempted = False
+    swap_succeeded = False
+
+    def attempt_swap() -> None:
+        nonlocal swap_attempted, swap_succeeded
+        if not swap_attempted:
+            swap_attempted = True
+            try:
+                runtime.rename(displaced)
+                runtime.symlink_to(outside, target_is_directory=True)
+                swap_succeeded = True
+            except OSError:
+                pass
+
+    if os.name == "nt":
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_windows as windows_store,
+        )
+
+        real_windows_rename = windows_store._rename_handle
+
+        def adversarial_windows_rename(*args, **kwargs):
+            attempt_swap()
+            return real_windows_rename(*args, **kwargs)
+
+        monkeypatch.setattr(
+            windows_store,
+            "_rename_handle",
+            adversarial_windows_rename,
+        )
+    else:
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_posix as posix_store,
+        )
+
+        real_replace = posix_store._replace_entry
+
+        def adversarial_replace(*args, **kwargs):
+            attempt_swap()
+            return real_replace(*args, **kwargs)
+
+        monkeypatch.setattr(posix_store, "_replace_entry", adversarial_replace)
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    rejection: ValueError | None = None
+    try:
+        try:
+            store.commit({"writer": 1}, expected_revision=None)
+        except ValueError as exc:
+            rejection = exc
+    finally:
+        if swap_succeeded:
+            runtime.unlink()
+            displaced.rename(runtime)
+
+    assert swap_attempted is True
+    if swap_succeeded:
+        assert rejection is not None
+        assert "parent_changed" in str(rejection)
+        assert not target.exists()
+    else:
+        assert rejection is None
+        assert json.loads(target.read_text(encoding="utf-8"))["writer"] == 1
+    assert not (outside / target.name).exists()
 
 
 def test_json_store_load_rejects_symlink_state_file(tmp_path: Path) -> None:
-    target = tmp_path / "target.json"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "target.json"
     target.write_text("{}", encoding="utf-8")
-    link = tmp_path / "authority-state.json"
+    link = runtime / "authority-state.json"
     try:
         link.symlink_to(target)
     except OSError as exc:
         pytest.skip(f"symlink creation unavailable: {exc}")
 
     with pytest.raises(ValueError, match="symlink_forbidden|path_link_rejected"):
-        AtomicJsonAuthorityRuntimeStore(link, allowed_root=tmp_path).load()
+        AtomicJsonAuthorityRuntimeStore(
+            link,
+            allowed_root=runtime,
+            repo_root=repo,
+        ).load()
 
 
 def test_json_store_load_rejects_linked_parent_state_file(tmp_path: Path) -> None:
-    target = tmp_path / "target"
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "target"
     target.mkdir()
     (target / "authority.json").write_text("{}", encoding="utf-8")
-    linked = tmp_path / "linked"
+    linked = runtime / "linked"
     try:
         linked.symlink_to(target, target_is_directory=True)
     except OSError as exc:
@@ -577,8 +694,545 @@ def test_json_store_load_rejects_linked_parent_state_file(tmp_path: Path) -> Non
 
     with pytest.raises((OSError, ValueError)):
         AtomicJsonAuthorityRuntimeStore(
-            linked / "authority.json", allowed_root=tmp_path
+            linked / "authority.json",
+            allowed_root=runtime,
+            repo_root=repo,
         ).load()
+
+
+def test_json_store_load_rejects_hard_linked_state_file(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text("{}", encoding="utf-8")
+    linked = runtime / "authority.json"
+    try:
+        os.link(outside, linked)
+    except OSError as exc:
+        pytest.skip(f"hard-link creation unavailable: {exc}")
+
+    with pytest.raises(ValueError, match="target_link_count"):
+        AtomicJsonAuthorityRuntimeStore(
+            linked,
+            allowed_root=runtime,
+            repo_root=repo,
+        ).load()
+
+
+def test_json_store_windows_rejects_hard_linked_temporary_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    if os.name != "nt":
+        pytest.skip("Windows handle replacement only")
+    from modules.communication.moltbot_bridge.src import (
+        reddog_authority_runtime_store_windows as windows_store,
+    )
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    captured = tmp_path / "captured.json"
+    real_write = windows_store._write_handle
+
+    def write_and_link(handle: int, payload: bytes) -> None:
+        real_write(handle, payload)
+        os.link(windows_store._handle_path(handle), captured)
+
+    monkeypatch.setattr(windows_store, "_write_handle", write_and_link)
+
+    with pytest.raises(ValueError, match="temp_link_count"):
+        AtomicJsonAuthorityRuntimeStore(
+            target,
+            allowed_root=runtime,
+            repo_root=repo,
+        ).commit({"writer": 1}, expected_revision=None)
+
+    assert not target.exists()
+    assert captured.exists()
+    assert captured.read_bytes() == b"\x00" * captured.stat().st_size
+
+
+def test_json_store_atomic_failure_preserves_previous_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+
+    def reject_replace(*args, **kwargs) -> None:
+        raise OSError("injected")
+
+    if os.name == "nt":
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_windows as windows_store,
+        )
+
+        monkeypatch.setattr(
+            windows_store,
+            "_rename_handle",
+            reject_replace,
+        )
+    else:
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_posix as posix_store,
+        )
+
+        monkeypatch.setattr(
+            posix_store,
+            "_write_descriptor",
+            reject_replace,
+        )
+
+    with pytest.raises(OSError, match="injected"):
+        store.commit({"writer": 2}, expected_revision=revision)
+
+    assert store.load()["writer"] == 1
+
+
+def test_json_store_rejects_intervening_revision_before_replace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+
+    if os.name == "nt":
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_windows as platform_store,
+        )
+    else:
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_posix as platform_store,
+        )
+
+    original = platform_store._require_target_revision if os.name == "nt" else (
+        platform_store._require_target_witness
+    )
+    calls = 0
+
+    def mutate_before_second_check(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            external = {"writer": "external"}
+            external["revision"] = hashlib.sha256(
+                json.dumps(
+                    external,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=True,
+                ).encode("utf-8")
+            ).hexdigest()
+            target.write_text(
+                json.dumps(external, sort_keys=True),
+                encoding="utf-8",
+            )
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        platform_store,
+        "_require_target_revision" if os.name == "nt" else "_require_target_witness",
+        mutate_before_second_check,
+    )
+
+    with pytest.raises(RuntimeError, match="revision_conflict"):
+        store.commit({"writer": 2}, expected_revision=revision)
+
+    assert store.load()["writer"] == "external"
+
+
+def test_json_store_rejects_target_alias_created_at_replace_seam(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    captured = tmp_path / "captured-authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+
+    if os.name == "nt":
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_windows as platform_store,
+        )
+    else:
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_posix as platform_store,
+        )
+    original = platform_store._require_backup_identity
+    injected = False
+
+    def alias_before_identity_check(*args, **kwargs):
+        nonlocal injected
+        if not injected:
+            injected = True
+            os.link(target, captured)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        platform_store,
+        "_require_backup_identity",
+        alias_before_identity_check,
+    )
+
+    with pytest.raises((RuntimeError, ValueError)):
+        store.commit({"writer": 2}, expected_revision=revision)
+
+    assert injected is True
+    assert json.loads(captured.read_text(encoding="utf-8"))["writer"] == 1
+    captured.unlink()
+    assert store.load()["writer"] == 1
+
+
+def test_json_store_recovers_interrupted_backup_and_temp(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+    backup = runtime / f".{target.name}.{'a' * 32}.bak"
+    temp = runtime / f".{target.name}.{'b' * 32}.tmp"
+    os.link(target, backup)
+    temp.write_text("interrupted", encoding="utf-8")
+
+    next_revision = store.commit({"writer": 2}, expected_revision=revision)
+
+    assert store.load() == {"writer": 2, "revision": next_revision}
+    assert not backup.exists()
+    assert not temp.exists()
+
+
+def test_json_store_recovers_only_revision_valid_lone_backup(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+    backup = runtime / f".{target.name}.{'c' * 32}.bak"
+    os.replace(target, backup)
+    if os.name != "nt":
+        os.chmod(backup, 0)
+
+    with pytest.raises(
+        ValueError,
+        match="recovery_revision_required",
+    ):
+        store.load()
+
+    assert backup.exists()
+    next_revision = store.commit({"writer": 2}, expected_revision=revision)
+
+    assert store.load() == {"writer": 2, "revision": next_revision}
+    assert target.exists()
+    assert not backup.exists()
+
+
+def test_json_store_rejects_self_consistent_but_unauthorized_lone_backup(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "authority.json"
+    backup = runtime / f".{target.name}.{'d' * 32}.bak"
+    forged = {"writer": "forged"}
+    forged["revision"] = hashlib.sha256(
+        json.dumps(
+            forged,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    backup.write_text(
+        json.dumps(forged),
+        encoding="utf-8",
+    )
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+
+    with pytest.raises(RuntimeError, match="revision_conflict"):
+        store.commit({"writer": 2}, expected_revision="e" * 64)
+
+    assert not target.exists()
+    assert backup.exists()
+
+
+def test_json_store_rejects_linked_lone_recovery_backup(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+    backup = runtime / f".{target.name}.{'f' * 32}.bak"
+    os.replace(target, backup)
+    alias = tmp_path / "backup-alias.json"
+    os.link(backup, alias)
+
+    with pytest.raises(
+        (ValueError, RuntimeError),
+        match="(link_count|snapshot_invalid|revision_conflict)",
+    ):
+        store.commit({"writer": 2}, expected_revision=revision)
+
+    assert not target.exists()
+    assert backup.exists()
+    assert alias.exists()
+
+
+def test_json_store_rejects_oversized_lone_recovery_backup_before_json_read(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    target = runtime / "authority.json"
+    backup = runtime / f".{target.name}.{'1' * 32}.bak"
+    with backup.open("wb") as handle:
+        handle.truncate((8 * 1024 * 1024) + 1)
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+
+    with pytest.raises(
+        (ValueError, RuntimeError),
+        match="(snapshot_invalid|target_too_large|revision_conflict)",
+    ):
+        store.commit({"writer": 2}, expected_revision="2" * 64)
+
+    assert not target.exists()
+    assert backup.exists()
+
+
+def test_json_store_nonce_revision_remains_recoverable_with_exact_commitment(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    store.commit({"writer": 1}, expected_revision=None)
+    assert store.consume_verified_work_authority_nonce("nonce-001") is True
+    committed = store.load()
+    nonce_revision = committed["revision"]
+    backup = runtime / f".{target.name}.{'e' * 32}.bak"
+    os.replace(target, backup)
+    if os.name != "nt":
+        os.chmod(backup, 0)
+
+    next_revision = store.commit(
+        {
+            "writer": 2,
+            "verified_work_authority_nonces": ["nonce-001"],
+        },
+        expected_revision=nonce_revision,
+    )
+
+    assert store.load() == {
+        "writer": 2,
+        "verified_work_authority_nonces": ["nonce-001"],
+        "revision": next_revision,
+    }
+
+
+def test_json_store_post_replace_verification_failure_restores_previous_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    target = runtime / "authority.json"
+    store = AtomicJsonAuthorityRuntimeStore(
+        target,
+        allowed_root=runtime,
+        repo_root=repo,
+    )
+    revision = store.commit({"writer": 1}, expected_revision=None)
+
+    if os.name == "nt":
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_windows as platform_store,
+        )
+
+        original = platform_store._verify_or_scrub
+        calls = 0
+
+        def reject_after_replace(handle: int, size: int) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise ValueError("injected_post_replace_failure")
+            original(handle, size)
+
+        monkeypatch.setattr(platform_store, "_verify_or_scrub", reject_after_replace)
+    else:
+        from modules.communication.moltbot_bridge.src import (
+            reddog_authority_runtime_store_posix as platform_store,
+        )
+
+        original = platform_store._require_entry_identity
+        calls = 0
+
+        def reject_after_replace(*args, **kwargs) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise ValueError("injected_post_replace_failure")
+            original(*args, **kwargs)
+
+        monkeypatch.setattr(
+            platform_store,
+            "_require_entry_identity",
+            reject_after_replace,
+        )
+
+    with pytest.raises(ValueError, match="injected_post_replace_failure"):
+        store.commit({"writer": 2}, expected_revision=revision)
+
+    assert store.load()["writer"] == 1
+
+
+def test_json_store_rejects_nonexistent_target_outside_allowed_root(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    outside = tmp_path / "outside" / "authority.json"
+
+    with pytest.raises(ValueError, match="outside_runtime_root"):
+        AtomicJsonAuthorityRuntimeStore(
+            outside,
+            allowed_root=runtime,
+            repo_root=repo,
+        )
+
+    assert not outside.exists()
+
+
+def test_json_store_rejects_relative_security_roots(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+
+    with pytest.raises(ValueError, match="repo_root_not_absolute"):
+        AtomicJsonAuthorityRuntimeStore(
+            runtime / "authority.json",
+            allowed_root=runtime,
+            repo_root=Path("relative-repo"),
+        )
+    with pytest.raises(ValueError, match="store_root_not_absolute"):
+        AtomicJsonAuthorityRuntimeStore(
+            runtime / "authority.json",
+            allowed_root=Path("relative-runtime"),
+            repo_root=repo,
+        )
+
+
+def test_json_store_rejects_runtime_root_inside_or_around_repo(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    with pytest.raises(ValueError, match="(?:path|root)_inside_repo"):
+        AtomicJsonAuthorityRuntimeStore(
+            repo / "runtime" / "authority.json",
+            allowed_root=repo / "runtime",
+            repo_root=repo,
+        )
+    with pytest.raises(ValueError, match="root_contains_repo"):
+        AtomicJsonAuthorityRuntimeStore(
+            tmp_path / "authority.json",
+            allowed_root=tmp_path,
+            repo_root=repo,
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        r"\\?\C:\runtime\authority.json",
+        r"\\.\C:\runtime\authority.json",
+        r"//?\\C:\\runtime\\authority.json",
+        r"//server/share/runtime/authority.json",
+        r"\??\C:\runtime\authority.json",
+    ],
+)
+def test_json_store_rejects_windows_device_paths(
+    tmp_path: Path,
+    path: str,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+
+    with pytest.raises(ValueError, match="path_invalid"):
+        AtomicJsonAuthorityRuntimeStore(
+            path,
+            allowed_root=runtime,
+            repo_root=repo,
+        )
 
 
 def test_result_contains_no_secret_or_signing_material_labels() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
@@ -5,19 +5,27 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import os
 from pathlib import Path
 
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     public_key_fingerprint,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
     FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID,
+    FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID,
     FAIL_SIGNER_CONFIG_LIMITS_INVALID,
     FAIL_SIGNER_CONFIG_OP_REF_INVALID,
     FAIL_SIGNER_CONFIG_OP_REF_REUSED,
     FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID,
     FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID,
     FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID,
+    FAIL_SIGNER_CONFIG_WRITE_FAILED,
     SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
     SIGNER_SERVICE_CONFIG_SUPPLY_ACCEPT,
     run_reddog_signer_socket_service_config_supply,
@@ -33,6 +41,8 @@ MODULE_PATH = (
     / "src"
     / "reddog_signer_socket_service_config_supply.py"
 )
+_PRINCIPAL_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32)))
+_REDDOG_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32, 64)))
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -44,9 +54,9 @@ def _repo(tmp_path: Path) -> Path:
 def _authority_profile(**overrides: object) -> dict[str, object]:
     profile: dict[str, object] = {
         "principal_id": "github:mjtrout",
-        "principal_public_key": "ed25519-pub-v1:principal",
+        "principal_public_key": _PRINCIPAL_PUBLIC_KEY,
         "reddog_id": "reddog:foundups-agent",
-        "reddog_public_key": "ed25519-pub-v1:reddog",
+        "reddog_public_key": _REDDOG_PUBLIC_KEY,
         "permission_snapshot_digest": "sha256:" + "1" * 64,
         "key_epoch": "epoch-1",
         "consensus_receipt_digest": "sha256:" + "2" * 64,
@@ -59,8 +69,11 @@ def _authority_profile(**overrides: object) -> dict[str, object]:
 
 
 def _kwargs(repo: Path, runtime: Path, **overrides: object) -> dict[str, object]:
+    signer_runtime = runtime.parent / f"{runtime.name}-signer-state"
     values: dict[str, object] = {
         "repo_root": repo,
+        "runtime_root": runtime,
+        "signer_runtime_root": signer_runtime,
         "authority_profile": _authority_profile(),
         "output_path": runtime / "signer-service.json",
         "socket_path": runtime / "reddog-signer.sock",
@@ -94,6 +107,10 @@ def test_config_supply_writes_multi_profile_signer_cli_config(tmp_path: Path) ->
 
     payload = json.loads((runtime / "signer-service.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == SIGNER_SERVICE_CONFIG_SCHEMA_VERSION
+    assert payload["runtime_root"] == str(runtime.resolve())
+    assert payload["signer_runtime_root"] == str(
+        (runtime.parent / f"{runtime.name}-signer-state").resolve()
+    )
     assert payload["provider_mode"] == "WSP71_PERMISSIONED"
     assert payload["allow_test_only_key_material"] is False
     assert payload["permission_snapshot_fresh"] is True
@@ -101,7 +118,7 @@ def test_config_supply_writes_multi_profile_signer_cli_config(tmp_path: Path) ->
     control_policy = payload["control_loop_authority_policy"]
     assert control_policy == {
         "issuer_principal_id": "github:mjtrout",
-        "signer_public_key": "ed25519-pub-v1:reddog",
+        "signer_public_key": _REDDOG_PUBLIC_KEY,
         "key_epoch": "epoch-1",
         "consensus_receipt_digest": "sha256:" + "2" * 64,
         "authority_profile_digest": control_policy["authority_profile_digest"],
@@ -127,13 +144,13 @@ def test_config_supply_writes_multi_profile_signer_cli_config(tmp_path: Path) ->
         "principal-identity",
         "reddog-work-authority",
     ]
-    assert profiles[0]["expected_public_key"] == "ed25519-pub-v1:principal"
+    assert profiles[0]["expected_public_key"] == _PRINCIPAL_PUBLIC_KEY
     assert profiles[0]["expected_key_fingerprint"] == public_key_fingerprint(
-        "ed25519-pub-v1:principal"
+        _PRINCIPAL_PUBLIC_KEY
     )
-    assert profiles[1]["expected_public_key"] == "ed25519-pub-v1:reddog"
+    assert profiles[1]["expected_public_key"] == _REDDOG_PUBLIC_KEY
     assert profiles[1]["expected_key_fingerprint"] == public_key_fingerprint(
-        "ed25519-pub-v1:reddog"
+        _REDDOG_PUBLIC_KEY
     )
     serialized = json.dumps(payload, sort_keys=True)
     assert "ed25519-private-raw-b64-v1" not in serialized
@@ -151,7 +168,9 @@ def test_config_supply_rejects_invalid_authority_profile_and_key_reuse(tmp_path:
         **_kwargs(
             repo,
             runtime,
-            authority_profile=_authority_profile(reddog_public_key="ed25519-pub-v1:principal"),
+            authority_profile=_authority_profile(
+                reddog_public_key=_PRINCIPAL_PUBLIC_KEY
+            ),
         )
     )
 
@@ -162,6 +181,28 @@ def test_config_supply_rejects_invalid_authority_profile_and_key_reuse(tmp_path:
     )
     assert reused.accepted is False
     assert FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":key_reuse" in reused.rejection_reasons
+
+
+def test_config_supply_rejects_malformed_public_key_before_write(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+
+    result = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            authority_profile=_authority_profile(
+                reddog_public_key="ed25519-pub-v1:not-a-key"
+            ),
+        )
+    )
+
+    assert result.accepted is False
+    assert (
+        FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":runtime_config"
+        in result.rejection_reasons
+    )
+    assert not (runtime / "signer-service.json").exists()
 
 
 def test_config_supply_rejects_inside_repo_or_existing_socket_paths(tmp_path: Path) -> None:
@@ -184,6 +225,112 @@ def test_config_supply_rejects_inside_repo_or_existing_socket_paths(tmp_path: Pa
     assert FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID in inside_output.rejection_reasons
     assert FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID in inside_socket.rejection_reasons
     assert FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID in existing.rejection_reasons
+
+
+def test_config_supply_rejects_paths_outside_bound_runtime_root(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    outside = tmp_path / "outside"
+
+    output = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, output_path=outside / "signer-service.json")
+    )
+    anchor = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            control_loop_anchor_path=outside / "anchor.json",
+        )
+    )
+
+    assert FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID in output.rejection_reasons
+    assert FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID in anchor.rejection_reasons
+
+
+def test_config_supply_rejects_nested_config_output_path(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+
+    result = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            output_path=runtime / "nested" / "signer-service.json",
+        )
+    )
+
+    assert not result.accepted
+    assert FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID in result.rejection_reasons
+
+
+def test_config_supply_rejects_nested_socket_or_anchor_path(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "runtime-signer-state"
+
+    socket = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            socket_path=runtime / "nested" / "reddog-signer.sock",
+        )
+    )
+    anchor = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(
+            repo,
+            runtime,
+            control_loop_anchor_path=signer_runtime / "nested" / "anchor.json",
+        )
+    )
+
+    assert FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID in socket.rejection_reasons
+    assert (
+        FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID
+        in anchor.rejection_reasons
+    )
+
+
+def test_config_supply_rejects_shared_resident_and_signer_runtime_root(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    state = tmp_path / "state"
+    runtime = state / "resident"
+
+    for signer_root in (runtime, runtime / "signer", state):
+        result = run_reddog_signer_socket_service_config_supply(
+            **_kwargs(repo, runtime, signer_runtime_root=signer_root)
+        )
+        assert not result.accepted
+        assert (
+            FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID
+            in result.rejection_reasons
+        )
+
+
+def test_config_supply_rejects_hard_linked_output_without_mutating_source(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"sentinel":true}\n', encoding="utf-8")
+    output = runtime / "signer-service.json"
+    try:
+        os.link(outside, output)
+    except OSError as exc:
+        pytest.skip(f"hard-link creation unavailable: {exc}")
+
+    result = run_reddog_signer_socket_service_config_supply(
+        **_kwargs(repo, runtime, output_path=output)
+    )
+
+    assert not result.accepted
+    assert result.rejection_reasons == (FAIL_SIGNER_CONFIG_WRITE_FAILED,)
+    assert outside.read_text(encoding="utf-8") == '{"sentinel":true}\n'
 
 
 def test_config_supply_rejects_bad_or_reused_op_refs(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_run_packet_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_run_packet_supply.py
@@ -6,6 +6,12 @@ import ast
 import json
 from pathlib import Path
 
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     PROVIDER_MODE_WSP71_PERMISSIONED,
 )
@@ -33,6 +39,8 @@ MODULE_PATH = (
     / "src"
     / "reddog_signer_socket_service_run_packet_supply.py"
 )
+_PRINCIPAL_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32)))
+_REDDOG_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32, 64)))
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -48,9 +56,23 @@ def _write_json(path: Path, payload: object) -> Path:
 
 
 def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
+    signer_runtime = (
+        socket_path.parent.parent / f"{socket_path.parent.name}-signer-state"
+    )
     payload: dict[str, object] = {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "runtime_root": str(socket_path.parent),
+        "signer_runtime_root": str(signer_runtime),
         "socket_path": str(socket_path),
+        "control_loop_anchor_path": str(signer_runtime / "anchor.json"),
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "github:012",
+            "signer_public_key": _REDDOG_PUBLIC_KEY,
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:" + ("1" * 64),
+            "authority_profile_digest": "sha256:" + ("2" * 64),
+            "authority_profile_source_receipt_id": "sha256:" + ("3" * 64),
+        },
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
         "allow_test_only_key_material": False,
         "permission_snapshot_fresh": True,
@@ -64,8 +86,10 @@ def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
                 "signer_agent_id": "signer:principal",
                 "signing_key_ref": "op://prod-vault/principal/private",
                 "audit_mac_key_ref": "op://prod-vault/principal/audit",
-                "expected_public_key": "ed25519-pub-v1:principal",
-                "expected_key_fingerprint": "sha256:principal",
+                "expected_public_key": _PRINCIPAL_PUBLIC_KEY,
+                "expected_key_fingerprint": public_key_fingerprint(
+                    _PRINCIPAL_PUBLIC_KEY
+                ),
                 "expected_key_epoch": "epoch-1",
                 "permission_snapshot_digest": "sha256:permission",
                 "ttl_seconds": 60,
@@ -75,8 +99,10 @@ def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
                 "signer_agent_id": "signer:reddog",
                 "signing_key_ref": "op://prod-vault/reddog/private",
                 "audit_mac_key_ref": "op://prod-vault/reddog/audit",
-                "expected_public_key": "ed25519-pub-v1:reddog",
-                "expected_key_fingerprint": "sha256:reddog",
+                "expected_public_key": _REDDOG_PUBLIC_KEY,
+                "expected_key_fingerprint": public_key_fingerprint(
+                    _REDDOG_PUBLIC_KEY
+                ),
                 "expected_key_epoch": "epoch-1",
                 "permission_snapshot_digest": "sha256:permission",
                 "ttl_seconds": 60,
@@ -174,6 +200,222 @@ def test_run_packet_supply_rejects_config_inside_repo_missing_or_malformed(tmp_p
     assert FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID in missing.rejection_reasons
     assert FAIL_SIGNER_RUN_PACKET_CONFIG_PATH_INVALID in inside.rejection_reasons
     assert FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED in malformed.rejection_reasons
+
+
+def test_run_packet_supply_rejects_unbootable_schema_v2_config(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+
+    for field in (
+        "runtime_root",
+        "signer_runtime_root",
+        "control_loop_anchor_path",
+        "control_loop_authority_policy",
+    ):
+        payload = _config(runtime / "socket.sock")
+        payload.pop(field)
+        result = run_reddog_signer_socket_service_run_packet_supply(
+            repo_root=repo,
+            config_path=_write_json(runtime / f"missing-{field}.json", payload),
+            output_path=output,
+        )
+
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED
+            in result.rejection_reasons
+        )
+        assert not output.exists()
+
+
+def test_run_packet_supply_rejects_malformed_nested_runtime_config(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+    mutations = (
+        {"control_loop_authority_policy": {}},
+        {
+            "control_loop_authority_policy": {
+                "issuer_principal_id": "github:012",
+                "signer_public_key": "ed25519-pub-v1:reddog",
+                "key_epoch": "epoch-1",
+                "consensus_receipt_digest": "not-a-digest",
+                "authority_profile_digest": "sha256:" + ("2" * 64),
+                "authority_profile_source_receipt_id": "sha256:" + ("3" * 64),
+            }
+        },
+        {"peer_policy": {}},
+        {"key_provider_profiles": [{}]},
+    )
+
+    for index, overrides in enumerate(mutations):
+        payload = _config(runtime / "socket.sock", **overrides)
+        result = run_reddog_signer_socket_service_run_packet_supply(
+            repo_root=repo,
+            config_path=_write_json(runtime / f"malformed-{index}.json", payload),
+            output_path=output,
+        )
+
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED
+            in result.rejection_reasons
+        )
+        assert not output.exists()
+
+
+def test_run_packet_supply_rejects_non_string_control_policy_fields(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+    fields = (
+        "issuer_principal_id",
+        "signer_public_key",
+        "key_epoch",
+        "consensus_receipt_digest",
+        "authority_profile_digest",
+        "authority_profile_source_receipt_id",
+    )
+
+    for field in fields:
+        payload = _config(runtime / "socket.sock")
+        policy = dict(payload["control_loop_authority_policy"])
+        policy[field] = 1
+        payload["control_loop_authority_policy"] = policy
+        result = run_reddog_signer_socket_service_run_packet_supply(
+            repo_root=repo,
+            config_path=_write_json(runtime / f"bad-policy-{field}.json", payload),
+            output_path=output,
+        )
+
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED
+            in result.rejection_reasons
+        )
+        assert not output.exists()
+
+
+def test_run_packet_supply_rejects_invalid_profile_values(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+    profile_mutations = (
+        {"signer_agent_id": ""},
+        {"signer_agent_id": "signer:" + chr(0x2603)},
+        {
+            "audit_mac_key_ref": "op://prod-vault/principal/private",
+        },
+        {"signing_key_ref": "not-an-op-reference"},
+        {"ttl_seconds": 0},
+        {"expected_public_key": "ed25519-pub-v1:invalid"},
+        {"expected_key_fingerprint": "sha256:" + ("0" * 64)},
+    )
+
+    for index, profile_overrides in enumerate(profile_mutations):
+        payload = _config(runtime / "socket.sock")
+        profiles = list(payload["key_provider_profiles"])
+        profiles[0] = {**profiles[0], **profile_overrides}
+        payload["key_provider_profiles"] = profiles
+        result = run_reddog_signer_socket_service_run_packet_supply(
+            repo_root=repo,
+            config_path=_write_json(runtime / f"bad-profile-{index}.json", payload),
+            output_path=output,
+        )
+
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED
+            in result.rejection_reasons
+        )
+        assert not output.exists()
+
+
+def test_run_packet_supply_rejects_duplicate_or_policy_mismatched_profiles(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+    duplicate = _config(runtime / "socket.sock")
+    profiles = list(duplicate["key_provider_profiles"])
+    profiles[1] = {
+        **profiles[1],
+        "expected_public_key": _PRINCIPAL_PUBLIC_KEY,
+        "expected_key_fingerprint": public_key_fingerprint(
+            _PRINCIPAL_PUBLIC_KEY
+        ),
+    }
+    duplicate["key_provider_profiles"] = profiles
+    mismatched_policy = _config(runtime / "socket.sock")
+    policy = dict(mismatched_policy["control_loop_authority_policy"])
+    policy["signer_public_key"] = encode_ed25519_public_key(b"x" * 32)
+    mismatched_policy["control_loop_authority_policy"] = policy
+
+    for index, payload in enumerate((duplicate, mismatched_policy)):
+        result = run_reddog_signer_socket_service_run_packet_supply(
+            repo_root=repo,
+            config_path=_write_json(runtime / f"profile-set-{index}.json", payload),
+            output_path=output,
+        )
+
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED
+            in result.rejection_reasons
+        )
+        assert not output.exists()
+
+
+def test_run_packet_supply_rejects_invalid_embedded_service_limits(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    output = runtime / "run-packet.json"
+    mutations = (
+        {"max_requests": 0},
+        {"max_requests": 129},
+        {"max_requests": "3"},
+        {"timeout_s": 0},
+        {"timeout_s": 31},
+        {"timeout_s": True},
+        {"timeout_s": float("nan")},
+        {"timeout_s": float("inf")},
+        {"timeout_s": float("-inf")},
+        {"max_request_bytes": 1023},
+        {"max_request_bytes": 262145},
+        {"max_request_bytes": "4096"},
+        {"max_response_bytes": 1023},
+        {"max_response_bytes": 262145},
+        {"max_response_bytes": "8192"},
+    )
+
+    for index, overrides in enumerate(mutations):
+        result = run_reddog_signer_socket_service_run_packet_supply(
+            repo_root=repo,
+            config_path=_write_json(
+                runtime / f"bad-limit-{index}.json",
+                _config(runtime / "socket.sock", **overrides),
+            ),
+            output_path=output,
+        )
+
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED
+            in result.rejection_reasons
+        )
+        assert not output.exists()
 
 
 def test_run_packet_supply_rejects_bad_output_op_and_limits(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_bootstrap.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import base64
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,9 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runti
     SIGNER_SOCKET_RUNTIME_BOOTSTRAP_REJECT,
     SIGNER_SOCKET_RUNTIME_BOOTSTRAP_SERVED,
     run_reddog_signer_socket_service_runtime_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
 )
 from modules.infrastructure.secrets_mcp.src.vault_resolver import ResolveResult, hash_reference
 
@@ -134,8 +138,23 @@ def _resolver(private_key) -> FakeResolver:
 
 
 def _config(public_key: str, *, socket_path: Path, **overrides: object) -> dict[str, object]:
+    signer_runtime = (
+        socket_path.parent.parent / f"{socket_path.parent.name}-signer-state"
+    )
     values: dict[str, object] = {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "runtime_root": str(socket_path.parent),
+        "signer_runtime_root": str(signer_runtime),
         "socket_path": str(socket_path),
+        "control_loop_anchor_path": str(signer_runtime / "anchor.json"),
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "github:012",
+            "signer_public_key": public_key,
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:" + ("1" * 64),
+            "authority_profile_digest": "sha256:" + ("2" * 64),
+            "authority_profile_source_receipt_id": "sha256:" + ("3" * 64),
+        },
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
         "allow_test_only_key_material": False,
         "permission_snapshot_fresh": True,
@@ -311,12 +330,182 @@ def test_bootstrap_rejects_missing_relative_inside_and_unreadable_config(tmp_pat
     assert FAIL_SIGNER_BOOTSTRAP_CONFIG_UNREADABLE in unreadable.rejection_reasons
 
 
+def test_bootstrap_rejects_hard_linked_config_before_runtime_call(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    source = _write_json(
+        tmp_path / "outside.json",
+        _config(public_key, socket_path=runtime / "signer.sock"),
+    )
+    linked = runtime / "signer-service.json"
+    linked.parent.mkdir(parents=True)
+    try:
+        os.link(source, linked)
+    except OSError as exc:
+        pytest.skip(f"hard-link creation unavailable: {exc}")
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=linked,
+        resolver=_resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_UNREADABLE in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_bootstrap_rejects_config_runtime_root_mismatch(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    config = _config(public_key, socket_path=runtime / "signer.sock")
+    config["runtime_root"] = str(tmp_path / "other-runtime")
+    path = _write_json(runtime / "signer-service.json", config)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=path,
+        resolver=_resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in result.rejection_reasons
+    assert service.calls == []
+
+
+@pytest.mark.parametrize("escaped_field", ("socket_path", "control_loop_anchor_path"))
+def test_bootstrap_rejects_runtime_artifact_outside_declared_root(
+    tmp_path: Path,
+    escaped_field: str,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    config = _config(
+        _public_text(private_key),
+        socket_path=runtime / "signer.sock",
+    )
+    config[escaped_field] = str(tmp_path / "outside" / "escaped")
+    path = _write_json(runtime / "signer-service.json", config)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=path,
+        resolver=_resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_bootstrap_rejects_nested_control_anchor(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    config = _config(
+        _public_text(private_key),
+        socket_path=runtime / "signer.sock",
+    )
+    signer_runtime = Path(str(config["signer_runtime_root"]))
+    config["control_loop_anchor_path"] = str(
+        signer_runtime / "nested" / "anchor.json"
+    )
+    path = _write_json(runtime / "signer-service.json", config)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=path,
+        resolver=_resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in result.rejection_reasons
+    assert service.calls == []
+
+
+@pytest.mark.parametrize(
+    "missing_key",
+    ("control_loop_anchor_path", "control_loop_authority_policy"),
+)
+def test_bootstrap_rejects_v2_config_without_control_authority_binding(
+    tmp_path: Path,
+    missing_key: str,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    config = _config(
+        _public_text(private_key),
+        socket_path=runtime / "signer.sock",
+    )
+    config.pop(missing_key)
+    path = _write_json(runtime / "signer-service.json", config)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=path,
+        resolver=_resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_bootstrap_rejects_overlapping_resident_and_signer_roots(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    runtime = tmp_path / "runtime"
+    private_key = _private_key()
+    config = _config(
+        _public_text(private_key),
+        socket_path=runtime / "signer.sock",
+    )
+    config["signer_runtime_root"] = str(runtime)
+    config["control_loop_anchor_path"] = str(runtime / "anchor.json")
+    path = _write_json(runtime / "signer-service.json", config)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=path,
+        resolver=_resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in result.rejection_reasons
+    assert service.calls == []
+
+
 def test_bootstrap_rejects_malformed_runtime_shape_and_preserves_runtime_reject(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
     runtime = tmp_path / "runtime"
     private_key = _private_key()
     public_key = _public_text(private_key)
     malformed = _write_json(runtime / "malformed.json", {"key_provider_profile": []})
+    wrong_schema = _write_json(
+        runtime / "wrong-schema.json",
+        _config(
+            public_key,
+            socket_path=runtime / "wrong-schema.sock",
+            schema_version="reddog_signer_service_config.v1",
+        ),
+    )
     rejected = _write_json(
         runtime / "rejected.json",
         _config(
@@ -332,6 +521,12 @@ def test_bootstrap_rejects_malformed_runtime_shape_and_preserves_runtime_reject(
         resolver=_resolver(private_key),
         serve_bounded=CapturingBoundedService(),
     )
+    wrong_schema_result = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=wrong_schema,
+        resolver=_resolver(private_key),
+        serve_bounded=CapturingBoundedService(),
+    )
     rejected_result = run_reddog_signer_socket_service_runtime_bootstrap(
         repo_root=repo,
         config_path=rejected,
@@ -340,6 +535,7 @@ def test_bootstrap_rejects_malformed_runtime_shape_and_preserves_runtime_reject(
     )
 
     assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in malformed_result.rejection_reasons
+    assert FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED in wrong_schema_result.rejection_reasons
     assert FAIL_SIGNER_BOOTSTRAP_RUNTIME_REJECTED in rejected_result.rejection_reasons
     assert rejected_result.runtime_result is not None
     assert rejected_result.runtime_result["accepted"] is False

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_cli.py
@@ -24,6 +24,9 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     PROVIDER_MODE_WSP71_PERMISSIONED,
     SIGNING_KEY_PREFIX,
 )
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_cli import (
     SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT,
     SIGNER_SOCKET_SERVICE_RUNTIME_CLI_REJECT,
@@ -130,8 +133,23 @@ def _repo(tmp_path: Path) -> Path:
 
 
 def _config(public_key: str, *, socket_path: Path) -> dict[str, object]:
+    signer_runtime = (
+        socket_path.parent.parent / f"{socket_path.parent.name}-signer-state"
+    )
     return {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "runtime_root": str(socket_path.parent),
+        "signer_runtime_root": str(signer_runtime),
         "socket_path": str(socket_path),
+        "control_loop_anchor_path": str(signer_runtime / "anchor.json"),
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "github:012",
+            "signer_public_key": public_key,
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:" + ("1" * 64),
+            "authority_profile_digest": "sha256:" + ("2" * 64),
+            "authority_profile_source_receipt_id": "sha256:" + ("3" * 64),
+        },
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
         "allow_test_only_key_material": False,
         "permission_snapshot_fresh": True,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
@@ -21,6 +21,9 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resi
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
     SignerPeerAttestation,
 )
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    ControlLoopAuthorityPolicy,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     SigningRequest,
     public_key_fingerprint,
@@ -37,6 +40,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credenti
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     FAIL_SIGNER_RUNTIME_CONFIG_INVALID,
+    FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID,
     FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE,
     FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
     FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID,
@@ -179,6 +183,8 @@ def _policy(**overrides: object) -> PeerCredentialPolicy:
 def _config(public_key: str, **overrides: object) -> SignerSocketServiceRuntimeWiringConfig:
     values = {
         "repo_root": "O:/Foundups-Agent",
+        "runtime_root": "O:/tmp",
+        "signer_runtime_root": "O:/tmp-signer-state",
         "socket_path": "O:/tmp/reddog-signer.sock",
         "key_provider_profile": _profile(public_key),
         "peer_policy": _policy(),
@@ -189,6 +195,15 @@ def _config(public_key: str, **overrides: object) -> SignerSocketServiceRuntimeW
         "timeout_s": 2.5,
         "max_request_bytes": 4096,
         "max_response_bytes": 8192,
+        "control_loop_anchor_path": "O:/tmp-signer-state/anchor.json",
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "github:012",
+            "signer_public_key": public_key,
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:" + ("1" * 64),
+            "authority_profile_digest": "sha256:" + ("2" * 64),
+            "authority_profile_source_receipt_id": "sha256:" + ("3" * 64),
+        },
     }
     values.update(overrides)
     return SignerSocketServiceRuntimeWiringConfig(**values)
@@ -393,6 +408,159 @@ def test_default_provider_mode_rejects_before_service_call() -> None:
     assert result.accepted is False
     assert result.status == SIGNER_SOCKET_RUNTIME_WIRING_REJECT
     assert FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_runtime_wiring_rejects_linked_control_anchor_path(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    signer_runtime = tmp_path / "signer-runtime"
+    signer_runtime.mkdir()
+    real = signer_runtime / "real"
+    real.mkdir()
+    linked = signer_runtime / "linked"
+    try:
+        linked.symlink_to(real, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            repo_root=repo,
+            runtime_root=runtime,
+            signer_runtime_root=signer_runtime,
+            control_loop_anchor_path=linked / "anchor.json",
+        ),
+        _resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert result.accepted is False
+    assert FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_runtime_wiring_rejects_socket_outside_declared_runtime_root(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    runtime = tmp_path / "resident"
+    signer_runtime = tmp_path / "signer"
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            repo_root=repo,
+            runtime_root=runtime,
+            signer_runtime_root=signer_runtime,
+            socket_path=tmp_path / "outside" / "escaped.sock",
+            control_loop_anchor_path=signer_runtime / "anchor.json",
+        ),
+        _resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert not result.accepted
+    assert FAIL_SIGNER_RUNTIME_CONFIG_INVALID in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_wsp71_runtime_wiring_requires_control_anchor_and_policy() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+            allow_test_only_key_material=False,
+            control_loop_anchor_path=None,
+            control_loop_authority_policy=None,
+        ),
+        _resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert not result.accepted
+    assert FAIL_SIGNER_RUNTIME_CONFIG_INVALID in result.rejection_reasons
+    assert service.calls == []
+
+
+def test_runtime_wiring_rejects_malformed_typed_control_policy() -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    service = CapturingBoundedService()
+    malformed = ControlLoopAuthorityPolicy(
+        issuer_principal_id=1,  # type: ignore[arg-type]
+        signer_public_key=public_key,
+        key_epoch="epoch-1",
+        consensus_receipt_digest="sha256:" + ("1" * 64),
+        authority_profile_digest="sha256:" + ("2" * 64),
+        authority_profile_source_receipt_id="sha256:" + ("3" * 64),
+    )
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+            allow_test_only_key_material=False,
+            control_loop_authority_policy=malformed,
+        ),
+        _resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert not result.accepted
+    assert FAIL_SIGNER_RUNTIME_CONFIG_INVALID in result.rejection_reasons
+    assert service.calls == []
+
+
+@pytest.mark.parametrize("relation", ["same", "nested", "ancestor"])
+def test_runtime_wiring_rejects_overlapping_runtime_roots(
+    tmp_path: Path,
+    relation: str,
+) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state = tmp_path / "state"
+    runtime = state / "resident"
+    signer_runtime = {
+        "same": runtime,
+        "nested": runtime / "signer",
+        "ancestor": state,
+    }[relation]
+    service = CapturingBoundedService()
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            repo_root=repo,
+            runtime_root=runtime,
+            signer_runtime_root=signer_runtime,
+            socket_path=runtime / "reddog-signer.sock",
+            control_loop_anchor_path=signer_runtime / "anchor.json",
+        ),
+        _resolver(private_key),
+        serve_bounded=service,
+    )
+
+    assert not result.accepted
+    assert FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID in result.rejection_reasons
     assert service.calls == []
 
 

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -25,7 +25,7 @@ exemptions:
       contract records the required yield, separate author/verifier claims,
       revocation, and bounded renewal semantics; splitting the historical
       registry remains separate documentation-maintenance work.
-    threshold_override: 1240
+    threshold_override: 1246
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -383,7 +383,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 8938
+    threshold_override: 8993
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -395,7 +395,7 @@ exemptions:
     reason: >-
       Legacy WSP_22 test journal. Current entries record focused validation;
       historical test evidence is not split during a runtime-security slice.
-    threshold_override: 1678
+    threshold_override: 1702
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Mapping
 
 
-_DEVICE_PATH_PREFIXES = ("\\\\", "//?/", "//./")
 _WINDOWS_RESERVED_NAMES = {
     "CON",
     "PRN",
@@ -23,6 +22,7 @@ _WINDOWS_RESERVED_NAMES = {
     *(f"COM{index}" for index in range(1, 10)),
     *(f"LPT{index}" for index in range(1, 10)),
 }
+_UNSAFE_RUNTIME_NAMESPACE = re.compile(r"^(?://|/\?\?/|GLOBALROOT/)", re.IGNORECASE)
 _PRIVATE_KEY_BLOCK = re.compile(
     r"-----BEGIN [^-\r\n]*PRIVATE KEY-----.*?"
     r"(?:-----END [^-\r\n]*PRIVATE KEY-----|\Z)",
@@ -76,7 +76,7 @@ def validate_runtime_artifact_path(
     """Resolve a writable artifact path outside source and within its runtime root."""
 
     raw = str(path or "").strip()
-    if not raw or "\x00" in raw or raw.startswith(_DEVICE_PATH_PREFIXES):
+    if not raw or "\x00" in raw or _UNSAFE_RUNTIME_NAMESPACE.match(raw.replace("\\", "/")):
         raise ValueError("runtime_artifact_path_invalid")
     _validate_path_components(raw)
 
@@ -305,7 +305,7 @@ def secure_read_confined_bytes(
     """Read a source file only after its descriptor proves root confinement."""
 
     raw = str(path or "").strip()
-    if not raw or "\x00" in raw or raw.startswith(_DEVICE_PATH_PREFIXES):
+    if not raw or "\x00" in raw or _UNSAFE_RUNTIME_NAMESPACE.match(raw.replace("\\", "/")):
         raise ValueError("confined_read_path_invalid")
     root_candidate = Path(os.path.abspath(Path(allowed_root).expanduser()))
     expected_candidate = Path(raw).expanduser()
@@ -330,8 +330,7 @@ def secure_read_confined_bytes(
     descriptor = os.open(expected, flags)
     try:
         metadata = os.fstat(descriptor)
-        if not stat.S_ISREG(metadata.st_mode):
-            raise ValueError("confined_read_target_not_regular")
+        _require_private_regular_file(metadata)
         final_path = _descriptor_final_path(descriptor)
         final_resolved = _without_windows_extended_prefix(final_path.resolve(strict=True))
         if not _is_relative_to(final_resolved, root):
@@ -359,7 +358,7 @@ def secure_read_confined_text(
     if (
         not raw
         or "\x00" in raw
-        or raw.startswith(_DEVICE_PATH_PREFIXES)
+        or _UNSAFE_RUNTIME_NAMESPACE.match(raw.replace("\\", "/"))
         or limit < 0
     ):
         raise ValueError("confined_read_path_invalid")

--- a/wsp_62_exemptions.yaml
+++ b/wsp_62_exemptions.yaml
@@ -62,7 +62,7 @@ exemptions:
       functions:
         run_reddog_wre_queue_consumer_preflight: 60
         run_reddog_resident_queue_next_stage_dispatch_preflight: 84
-        run_reddog_resident_queue_serial_loop_preflight: 614
+        run_reddog_resident_queue_serial_loop_preflight: 617
 
   - file: "ModLog.md"
     reason: >-


### PR DESCRIPTION
## Summary

Confines RedDog authority, signer, control-loop, and canary artifacts to explicit outside-repository runtime roots and hardens atomic store recovery on Windows and POSIX.

## What changed

- Added platform-specific confined atomic replacement adapters with hard-link, symlink, namespace, ancestry, parent-swap, size, revision, and recovery validation.
- Bound signer socket config, run packets, control-loop anchors, readiness, live canaries, and queue dependencies to explicit resident and signer runtime roots.
- Required signer config supply to pass the same canonical schema-v2 runtime validator used by run-packet admission before any config write.
- Rejected malformed Ed25519 keys, duplicate/reused profiles, non-finite or malformed limits, mismatched authority policies, stale revisions, and unsafe recovery artifacts.
- Preserved fail-closed boundaries: no proposal authority, queue promotion, worker execution, repository mutation, secret resolution, or HoloIndex re-index is added.

## Root cause

Authority runtime artifacts were accepted through several partially overlapping path, schema, and profile-validation paths. That allowed producer/consumer drift and left filesystem recovery dependent on assumptions that were not consistently revalidated at each boundary.

## Validation

- 210 affected bridge tests passed, 8 platform skips.
- 59 focused signer/config/startup tests passed, 1 platform skip.
- 14 shared runtime-artifact safety tests passed, 1 platform skip.
- 21 product startup tests passed.
- 3 WSP 62 no-growth checks passed.
- 42 WRE red-team tests passed.
- Ruff passed across changed modules/tests; `git diff --check` and `py_compile` passed.
- Two independent exact-SHA reviews returned GO with zero blocker, major, or minor findings.
- HoloIndex query correctly failed closed with `REPO_HEAD_MISMATCH` for the isolated pre-merge worktree and performed no re-index.

## Truth boundary

This PR strengthens integrity and confinement for authority runtime state. It does not grant RedDog new repository, shell, merge, queue-promotion, or signing authority.