### PR TITLE
feat(reddog): provision architect proposal signer policy runtime

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -55,7 +55,9 @@ authority. One atomic state document, a canonical transaction lock beside that
 document under the signer-owned runtime root, compare-and-swap commits, and
 one-step crash roll-forward prevent split-file ambiguity. The transaction lock
 is descriptor-path verified and does not depend on process-local temporary
-directories. Nonce freshness is checked at reservation and again at durable
+directories. Descriptor verification supports Windows and Linux with procfs;
+other POSIX environments fail closed. Nonce freshness is checked at durable
+reservation and again at durable
 commit. The principal policy authorization is durably
 consumed before the backend is exposed; service failure never restores it.
 Runtime recomputes the signed security-context digest over paths, peer policy,
@@ -65,8 +67,10 @@ Unsigned, expired, altered, self-consistently re-digested,
 profile/key-substituted, replayed, rolled-back, deleted,
 high-water-mismatched, and out-of-root inputs fail closed. Runtime receipts
 stop claiming that no file I/O occurred once injected proposal trust, key, or
-replay dependencies have been invoked. Effects performed by injected
-dependencies remain outside this receipt's direct observation.
+replay dependencies have been invoked. Once any injected dependency is called,
+every negative side-effect attestation that the runtime cannot directly
+observe is false; the receipt does not infer purity from the dependency
+interface.
 
 The public generic key-provider API has no architect-proposal policy or nonce
 parameters. Proposal backend construction is an internal runtime-only path

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -43,26 +43,37 @@ and the socket exposes only that proposal-domain backend. The signer validates
 the exact payload and consumes a MAC-authenticated, bounded nonce store before
 returning an accepted signature. Replay rollback is checked against an
 independently injected monotonic high-water authority outside the nonce-state
-rollback domain. The signed replay binding includes that authority's immutable
-identifier, and runtime rejects a mismatched or missing authority. One atomic
-state document, a cross-session file lock, compare-and-swap commits, and
-one-step crash roll-forward prevent split-file ambiguity. The principal policy
-authorization is durably consumed before the backend is exposed; service
-failure never restores it. Runtime recomputes the signed security-context
-digest over paths, peer policy, limits, key profile, policy, and replay
-namespace. Startup also requires the exact serialized config digest from
-outside the config file. Unsigned, expired, altered, self-consistently
-re-digested, profile/key-substituted, replayed, rolled-back, deleted,
-high-water-mismatched, and out-of-root inputs fail closed.
+rollback domain. Production mode additionally requires that injected authority
+to be supplied by trusted signer-runtime composition, declare durable storage,
+and present the exact SHA-256 durability receipt bound into signer
+configuration and its normalized security-context digest; the in-memory test
+store is rejected. This slice validates capability and receipt agreement at
+that injection boundary; it does not issue or independently authenticate the
+durability receipt. The signed replay binding includes the authority's
+immutable identifier. Runtime rejects a mismatched, missing, or volatile
+authority. One atomic state document, the shared cross-session runtime
+operation lock, compare-and-swap commits, and one-step crash roll-forward
+prevent split-file ambiguity. Nonce freshness is checked at reservation and
+again at durable commit. The principal policy authorization is durably
+consumed before the backend is exposed; service failure never restores it.
+Runtime recomputes the signed security-context digest over paths, peer policy,
+limits, key profile, policy, durability receipt, and replay namespace. Startup
+also requires the exact serialized config digest from outside the config file.
+Unsigned, expired, altered, self-consistently re-digested,
+profile/key-substituted, replayed, rolled-back, deleted,
+high-water-mismatched, and out-of-root inputs fail closed. Runtime receipts
+report signer-state file I/O truthfully and separately attest that no repository
+file I/O occurred.
 
 Production policy still keeps `architect_proposal_admission_authenticity`
 unavailable because the resident proposal path does not yet derive the exact
 signer policy from authoritative work state, produce its principal-signed
 policy authorization, configure a production principal-key resolver, request
 proposal signing, supply the independently administered production high-water
-authority, resolve independent key/revocation/freshness trust, produce an
-opaque process-local authority proof, or consume the attestation
-transactionally during queue promotion.
+authority and an authenticated durability receipt issuer/verifier, resolve
+independent key/revocation/freshness trust, produce an opaque process-local
+authority proof, or consume the attestation transactionally during queue
+promotion.
 
 ### Resident queue exact-SHA commit stage
 

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -36,24 +36,33 @@ by proposal admission, the candidate gate, or promotion.
 
 The signer-service configuration and runtime wiring can provision one exact
 proposal policy only with a fresh, principal-signed, domain-separated policy
-authorization. WSP71 resolves both configured key profiles and proves their
-public-key bindings, but only the RedDog 0102 backend is placed in the socket
-routing table; the principal key is verification-only. The signer validates
-the exact payload and consumes a MAC-authenticated, bounded nonce store
-confined to the isolated signer runtime root before returning an accepted
-signature. Proposal-enabled keys accept only proposal and separately
-configured control-loop domains. Startup also requires an expected config
-digest delivered outside the config file. Unsigned, expired, altered,
-self-consistently re-digested, profile/key-substituted, replayed, and
-out-of-root inputs fail closed.
+authorization. An independently injected principal resolver supplies the
+trusted public verification key; proposal mode never resolves or loads the
+principal private key. WSP71 resolves only the RedDog 0102 proposal profile,
+and the socket exposes only that proposal-domain backend. The signer validates
+the exact payload and consumes a MAC-authenticated, bounded nonce store before
+returning an accepted signature. Replay rollback is checked against an
+independently injected monotonic high-water authority outside the nonce-state
+rollback domain. The signed replay binding includes that authority's immutable
+identifier, and runtime rejects a mismatched or missing authority. One atomic
+state document, a cross-session file lock, compare-and-swap commits, and
+one-step crash roll-forward prevent split-file ambiguity. The principal policy
+authorization is durably consumed before the backend is exposed; service
+failure never restores it. Runtime recomputes the signed security-context
+digest over paths, peer policy, limits, key profile, policy, and replay
+namespace. Startup also requires the exact serialized config digest from
+outside the config file. Unsigned, expired, altered, self-consistently
+re-digested, profile/key-substituted, replayed, rolled-back, deleted,
+high-water-mismatched, and out-of-root inputs fail closed.
 
 Production policy still keeps `architect_proposal_admission_authenticity`
 unavailable because the resident proposal path does not yet derive the exact
 signer policy from authoritative work state, produce its principal-signed
-policy authorization, request proposal signing, resolve
-independent key/revocation/freshness trust, produce an opaque process-local
-authority proof, or consume the attestation transactionally during queue
-promotion.
+policy authorization, configure a production principal-key resolver, request
+proposal signing, supply the independently administered production high-water
+authority, resolve independent key/revocation/freshness trust, produce an
+opaque process-local authority proof, or consume the attestation
+transactionally during queue promotion.
 
 ### Resident queue exact-SHA commit stage
 

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -51,10 +51,12 @@ store is rejected. This slice validates capability and receipt agreement at
 that injection boundary; it does not issue or independently authenticate the
 durability receipt. The signed replay binding includes the authority's
 immutable identifier. Runtime rejects a mismatched, missing, or volatile
-authority. One atomic state document, the shared cross-session runtime
-operation lock, compare-and-swap commits, and one-step crash roll-forward
-prevent split-file ambiguity. Nonce freshness is checked at reservation and
-again at durable commit. The principal policy authorization is durably
+authority. One atomic state document, a canonical transaction lock beside that
+document under the signer-owned runtime root, compare-and-swap commits, and
+one-step crash roll-forward prevent split-file ambiguity. The transaction lock
+is descriptor-path verified and does not depend on process-local temporary
+directories. Nonce freshness is checked at reservation and again at durable
+commit. The principal policy authorization is durably
 consumed before the backend is exposed; service failure never restores it.
 Runtime recomputes the signed security-context digest over paths, peer policy,
 limits, key profile, policy, durability receipt, and replay namespace. Startup

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -62,8 +62,19 @@ also requires the exact serialized config digest from outside the config file.
 Unsigned, expired, altered, self-consistently re-digested,
 profile/key-substituted, replayed, rolled-back, deleted,
 high-water-mismatched, and out-of-root inputs fail closed. Runtime receipts
-report signer-state file I/O truthfully and separately attest that no repository
-file I/O occurred.
+stop claiming that no file I/O occurred once injected proposal trust, key, or
+replay dependencies have been invoked. Effects performed by injected
+dependencies remain outside this receipt's direct observation.
+
+The public generic key-provider API has no architect-proposal policy or nonce
+parameters. Proposal backend construction is an internal runtime-only path
+reached after principal authorization, replay-authority, durability-receipt,
+and path validation. It always constructs the canonical atomic nonce store;
+callers cannot inject a volatile proposal nonce store through the public
+provider boundary. Proposal-enabled configuration is intentionally rejected by
+the signer run-packet supplier until production principal resolution and
+durable replay-authority composition exist in the CLI sidecar. Direct runtime
+and bootstrap injection remain the tested integration seams in this slice.
 
 Production policy still keeps `architect_proposal_admission_authenticity`
 unavailable because the resident proposal path does not yet derive the exact
@@ -72,8 +83,8 @@ policy authorization, configure a production principal-key resolver, request
 proposal signing, supply the independently administered production high-water
 authority and an authenticated durability receipt issuer/verifier, resolve
 independent key/revocation/freshness trust, produce an opaque process-local
-authority proof, or consume the attestation transactionally during queue
-promotion.
+authority proof, compose those adapters into the signer-owned CLI sidecar, or
+consume the attestation transactionally during queue promotion.
 
 ### Resident queue exact-SHA commit stage
 

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -34,11 +34,26 @@ nonce reservation, and strict serialized-attestation integrity validation.
 The validated attestation is still evidence, not authority. It is not accepted
 by proposal admission, the candidate gate, or promotion.
 
+The signer-service configuration and runtime wiring can provision one exact
+proposal policy only with a fresh, principal-signed, domain-separated policy
+authorization. WSP71 resolves both configured key profiles and proves their
+public-key bindings, but only the RedDog 0102 backend is placed in the socket
+routing table; the principal key is verification-only. The signer validates
+the exact payload and consumes a MAC-authenticated, bounded nonce store
+confined to the isolated signer runtime root before returning an accepted
+signature. Proposal-enabled keys accept only proposal and separately
+configured control-loop domains. Startup also requires an expected config
+digest delivered outside the config file. Unsigned, expired, altered,
+self-consistently re-digested, profile/key-substituted, replayed, and
+out-of-root inputs fail closed.
+
 Production policy still keeps `architect_proposal_admission_authenticity`
-unavailable because startup does not provision an independent pre-promotion
-signer policy, authoritative key and revocation resolver, durable proposal
-nonce store, trusted verification context, opaque authority proof, attestation
-artifact, or transactional queue binding.
+unavailable because the resident proposal path does not yet derive the exact
+signer policy from authoritative work state, produce its principal-signed
+policy authorization, request proposal signing, resolve
+independent key/revocation/freshness trust, produce an opaque process-local
+authority proof, or consume the attestation transactionally during queue
+promotion.
 
 ### Resident queue exact-SHA commit stage
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,36 @@
 # ModLog - moltbot_bridge
+## 2026-07-27: REDDOG_ARCHITECT_PROPOSAL_SIGNER_POLICY_RUNTIME_PHASE1
+- Extended the existing signer config, bootstrap, key-provider, and runtime
+  wiring so one exact architect-proposal signer policy can be provisioned only
+  against the configured RedDog signer profile.
+- Added a signer-owned atomic proposal nonce store under the isolated signer
+  runtime root. Every state is MAC-bound to the signer audit key and revision
+  checked; bounded retention recovers expired crash reservations without
+  allowing still-valid replay or unbounded state growth.
+- Required the proposal payload identity, signer key, key epoch, consensus
+  receipt, authority-profile source, and TTL to match the supplied authority
+  profile before a signer configuration can be written, with a fixed
+  protocol-level TTL ceiling and an exact RedDog signer profile.
+- Required a fresh principal-signed, domain-separated authorization over the
+  exact proposal policy. The signer resolves both WSP71 key profiles to prove
+  their configured public keys, but exposes only the RedDog 0102 proposal
+  backend; the principal key remains verification-only and cannot become a
+  generic socket signing oracle.
+- Rehydrated and revalidated the exact serialized proposal policy at bootstrap;
+  launch requires an expected digest supplied outside the config file, and
+  partial, unsigned, expired, tampered, self-consistently re-digested,
+  mismatched-key, profile-substituted, or out-of-root pairs never reach the
+  signer backend.
+- Restricted a proposal-enabled signer backend to the proposal domain plus its
+  separately configured control-loop domain. Unknown and generic signing
+  operations cannot reuse that private key during the proposal service run.
+- Preserved the authority boundary: this slice provisions signer policy and
+  durable replay state only. It does not derive proposal facts from
+  authoritative work state, produce an attestation in the resident loop,
+  produce the principal policy authorization in the resident loop,
+  satisfy the proposal-admission capability, promote a queue item, execute a
+  worker, or grant merge authority (WSP 00, 15, 22, 50, 62, 97).
+
 ## 2026-07-27: REDDOG_AUTHORITY_RUNTIME_STORE_CONFINEMENT_PHASE1
 - Required every atomic authority runtime store to bind an explicit repository
   root and runtime root, then revalidate the target before reads, writes, and

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -37,7 +37,9 @@
   Reservation and commit independently reject expired authorization. A service
   rejection or exception after signing cannot roll authorization back or reuse
   it on another launch. Runtime receipts stop claiming no file I/O once
-  injected proposal trust, key, or replay dependencies have been invoked.
+  injected proposal trust, key, or replay dependencies have been invoked, and
+  all other unobservable negative side-effect attestations become false after
+  any injected dependency call.
 - Rejected proposal-enabled signer run packets until production principal and
   replay adapters are composed into the CLI sidecar, rather than emitting an
   accepted packet that the shipped CLI must reject.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -7,10 +7,11 @@
   injected monotonic high-water authority outside the nonce-state rollback
   domain. Production requires a matching configuration-bound durability
   receipt and rejects the volatile in-memory implementation. The signed
-  authority identifier, MAC, sequence, revision, shared cross-session runtime
-  operation lock, and one-step crash roll-forward make rollback, deletion,
-  mismatched authority, lock-path substitution, and tampering fail closed while
-  bounded retention prevents unbounded growth.
+  authority identifier, MAC, sequence, revision, distinct proposal-transaction
+  lock, and one-step crash roll-forward make rollback, deletion, mismatched
+  authority, nested-lock deadlock, lock-path substitution, and tampering fail
+  closed while bounded retention prevents unbounded growth. Windows uses the
+  shared machine-global runtime mutex; POSIX keeps the confined lock primitive.
 - Required the proposal payload identity, signer key, key epoch, consensus
   receipt, authority-profile source, and TTL to match the supplied authority
   profile before a signer configuration can be written, with a fixed
@@ -27,12 +28,17 @@
   signer backend.
 - Restricted a proposal-enabled signer backend to the proposal domain only.
   Unknown, generic, and control-loop signing operations cannot reuse that
-  private key during the proposal service run.
+  private key during the proposal service run. Removed architect-proposal
+  parameters from the public key-provider API; only the verified internal
+  runtime constructor can attach the canonical proposal policy and nonce store.
 - Consumed principal policy authorization before exposing the signer backend.
   Reservation and commit independently reject expired authorization. A service
   rejection or exception after signing cannot roll authorization back or reuse
-  it on another launch. Runtime receipts distinguish signer-state file I/O from
-  the separately attested absence of repository file I/O.
+  it on another launch. Runtime receipts stop claiming no file I/O once
+  injected proposal trust, key, or replay dependencies have been invoked.
+- Rejected proposal-enabled signer run packets until production principal and
+  replay adapters are composed into the CLI sidecar, rather than emitting an
+  accepted packet that the shipped CLI must reject.
 - Preserved the authority boundary: this slice provisions signer policy and
   durable replay state only. It does not derive proposal facts from
   authoritative work state, produce an attestation in the resident loop,

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -10,8 +10,10 @@
   authority identifier, MAC, sequence, revision, distinct proposal-transaction
   lock, and one-step crash roll-forward make rollback, deletion, mismatched
   authority, nested-lock deadlock, lock-path substitution, and tampering fail
-  closed while bounded retention prevents unbounded growth. Windows uses the
-  shared machine-global runtime mutex; POSIX keeps the confined lock primitive.
+  closed while bounded retention prevents unbounded growth. The proposal
+  transaction lock is a descriptor-verified file beside the canonical nonce
+  state, so Windows sessions and POSIX processes with different temporary
+  namespaces serialize against the same signer-owned runtime artifact.
 - Required the proposal payload identity, signer key, key epoch, consensus
   receipt, authority-profile source, and TTL to match the supplied authority
   profile before a signer configuration can be written, with a fixed

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -3,31 +3,38 @@
 - Extended the existing signer config, bootstrap, key-provider, and runtime
   wiring so one exact architect-proposal signer policy can be provisioned only
   against the configured RedDog signer profile.
-- Added a signer-owned atomic proposal nonce store under the isolated signer
-  runtime root. Every state is MAC-bound to the signer audit key and revision
-  checked; bounded retention recovers expired crash reservations without
-  allowing still-valid replay or unbounded state growth.
+- Added a signer-owned atomic proposal nonce store bound to an independently
+  injected monotonic high-water authority outside the nonce-state rollback
+  domain. The signed authority identifier, MAC, sequence, revision,
+  cross-session file lock, and one-step crash roll-forward make rollback,
+  deletion, mismatched authority, and tampering fail closed while bounded
+  retention prevents unbounded growth.
 - Required the proposal payload identity, signer key, key epoch, consensus
   receipt, authority-profile source, and TTL to match the supplied authority
   profile before a signer configuration can be written, with a fixed
   protocol-level TTL ceiling and an exact RedDog signer profile.
 - Required a fresh principal-signed, domain-separated authorization over the
-  exact proposal policy. The signer resolves both WSP71 key profiles to prove
-  their configured public keys, but exposes only the RedDog 0102 proposal
-  backend; the principal key remains verification-only and cannot become a
-  generic socket signing oracle.
+  exact proposal policy, signer instance, replay namespace, and normalized
+  runtime security context. An independent principal resolver supplies only
+  the trusted public verification key; WSP71 resolves only the RedDog 0102
+  proposal profile, so no principal private key enters the proposal service.
 - Rehydrated and revalidated the exact serialized proposal policy at bootstrap;
   launch requires an expected digest supplied outside the config file, and
   partial, unsigned, expired, tampered, self-consistently re-digested,
   mismatched-key, profile-substituted, or out-of-root pairs never reach the
   signer backend.
-- Restricted a proposal-enabled signer backend to the proposal domain plus its
-  separately configured control-loop domain. Unknown and generic signing
-  operations cannot reuse that private key during the proposal service run.
+- Restricted a proposal-enabled signer backend to the proposal domain only.
+  Unknown, generic, and control-loop signing operations cannot reuse that
+  private key during the proposal service run.
+- Consumed principal policy authorization before exposing the signer backend.
+  A service rejection or exception after signing cannot roll authorization
+  back or reuse it on another launch.
 - Preserved the authority boundary: this slice provisions signer policy and
   durable replay state only. It does not derive proposal facts from
   authoritative work state, produce an attestation in the resident loop,
   produce the principal policy authorization in the resident loop,
+  configure the production principal-key resolver,
+  supply the independently administered production high-water authority,
   satisfy the proposal-admission capability, promote a queue item, execute a
   worker, or grant merge authority (WSP 00, 15, 22, 50, 62, 97).
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -5,10 +5,12 @@
   against the configured RedDog signer profile.
 - Added a signer-owned atomic proposal nonce store bound to an independently
   injected monotonic high-water authority outside the nonce-state rollback
-  domain. The signed authority identifier, MAC, sequence, revision,
-  cross-session file lock, and one-step crash roll-forward make rollback,
-  deletion, mismatched authority, and tampering fail closed while bounded
-  retention prevents unbounded growth.
+  domain. Production requires a matching configuration-bound durability
+  receipt and rejects the volatile in-memory implementation. The signed
+  authority identifier, MAC, sequence, revision, shared cross-session runtime
+  operation lock, and one-step crash roll-forward make rollback, deletion,
+  mismatched authority, lock-path substitution, and tampering fail closed while
+  bounded retention prevents unbounded growth.
 - Required the proposal payload identity, signer key, key epoch, consensus
   receipt, authority-profile source, and TTL to match the supplied authority
   profile before a signer configuration can be written, with a fixed
@@ -27,14 +29,17 @@
   Unknown, generic, and control-loop signing operations cannot reuse that
   private key during the proposal service run.
 - Consumed principal policy authorization before exposing the signer backend.
-  A service rejection or exception after signing cannot roll authorization
-  back or reuse it on another launch.
+  Reservation and commit independently reject expired authorization. A service
+  rejection or exception after signing cannot roll authorization back or reuse
+  it on another launch. Runtime receipts distinguish signer-state file I/O from
+  the separately attested absence of repository file I/O.
 - Preserved the authority boundary: this slice provisions signer policy and
   durable replay state only. It does not derive proposal facts from
   authoritative work state, produce an attestation in the resident loop,
   produce the principal policy authorization in the resident loop,
   configure the production principal-key resolver,
-  supply the independently administered production high-water authority,
+  supply the independently administered production high-water authority and
+  its durability receipt,
   satisfy the proposal-admission capability, promote a queue item, execute a
   worker, or grant merge authority (WSP 00, 15, 22, 50, 62, 97).
 

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
@@ -33,6 +33,12 @@ PROPOSAL_AUTHENTICITY_SCHEMA_VERSION = (
 PROPOSAL_AUTHENTICITY_SIGNING_OPERATION = "attest_architect_proposal"
 PROPOSAL_AUTHENTICITY_SIGNING_PREFIX = "reddog-architect-proposal.v1."
 PROPOSAL_AUTHENTICITY_SIGNER_ROLE = "reddog_architect"
+PROPOSAL_POLICY_AUTHORIZATION_SCHEMA_VERSION = (
+    "reddog_architect_proposal_policy_authorization.v1"
+)
+PROPOSAL_POLICY_AUTHORIZATION_PREFIX = (
+    "reddog-architect-proposal-policy-authorization.v1."
+)
 DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS = 300
 
 
@@ -94,6 +100,28 @@ class ArchitectProposalSignerPolicy:
 
     expected_payload: ArchitectProposalAuthenticityPayload
     max_ttl_seconds: int = DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+
+
+@dataclass(frozen=True)
+class ArchitectProposalPolicyAuthorization:
+    """Principal-signed authorization for one exact signer policy."""
+
+    schema_version: str
+    authorization_id: str
+    proposal_policy_digest: str
+    principal_id: str
+    principal_public_key: str
+    reddog_id: str
+    reddog_public_key: str
+    key_epoch: str
+    authority_profile_source_receipt_id: str
+    nonce: str
+    issued_at: int
+    expires_at: int
+    signature: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -288,6 +316,238 @@ def canonical_architect_proposal_signing_input(
 ) -> str:
     raw = payload.to_dict() if hasattr(payload, "to_dict") else dict(payload)
     return PROPOSAL_AUTHENTICITY_SIGNING_PREFIX + _canonical_json(raw)
+
+
+def architect_proposal_signer_policy_digest(
+    policy: ArchitectProposalSignerPolicy,
+) -> str:
+    """Return the canonical digest of one exact proposal signer policy."""
+
+    if not _proposal_policy_valid(policy):
+        raise ValueError("architect_proposal_signer_policy_invalid")
+    return _digest(
+        {
+            "expected_payload": policy.expected_payload.to_dict(),
+            "max_ttl_seconds": int(policy.max_ttl_seconds),
+        }
+    )
+
+
+def build_architect_proposal_policy_authorization_payload(
+    policy: ArchitectProposalSignerPolicy,
+    *,
+    principal_id: str,
+    principal_public_key: str,
+    reddog_id: str,
+    reddog_public_key: str,
+    key_epoch: str,
+    authority_profile_source_receipt_id: str,
+    nonce: str,
+    issued_at: int,
+    expires_at: int,
+) -> dict[str, Any]:
+    """Build the unsigned, principal-authorized policy payload."""
+
+    values = {
+        "schema_version": PROPOSAL_POLICY_AUTHORIZATION_SCHEMA_VERSION,
+        "proposal_policy_digest": architect_proposal_signer_policy_digest(
+            policy
+        ),
+        "principal_id": _text(principal_id),
+        "principal_public_key": _text(principal_public_key),
+        "reddog_id": _text(reddog_id),
+        "reddog_public_key": _text(reddog_public_key),
+        "key_epoch": _text(key_epoch),
+        "authority_profile_source_receipt_id": _text(
+            authority_profile_source_receipt_id
+        ),
+        "nonce": _text(nonce),
+        "issued_at": int(issued_at),
+        "expires_at": int(expires_at),
+    }
+    values["authorization_id"] = (
+        "reddog_architect_proposal_policy_authorization_"
+        + _digest(values)[7:39]
+    )
+    _validate_policy_authorization_payload(values)
+    return values
+
+
+def canonical_architect_proposal_policy_authorization_input(
+    value: Mapping[str, Any],
+) -> str:
+    """Return the domain-separated principal-signing input."""
+
+    payload = dict(value)
+    payload.pop("signature", None)
+    _validate_policy_authorization_payload(payload)
+    return PROPOSAL_POLICY_AUTHORIZATION_PREFIX + _canonical_json(payload)
+
+
+def verify_architect_proposal_policy_authorization(
+    value: Mapping[str, Any],
+    *,
+    policy: ArchitectProposalSignerPolicy,
+    authority_profile: Mapping[str, Any],
+    now_epoch: int,
+) -> ArchitectProposalPolicyAuthorization:
+    """Verify a principal signature over one exact signer policy."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError("architect_proposal_policy_authorization_invalid")
+    raw = dict(value)
+    expected_fields = {
+        "schema_version",
+        "authorization_id",
+        "proposal_policy_digest",
+        "principal_id",
+        "principal_public_key",
+        "reddog_id",
+        "reddog_public_key",
+        "key_epoch",
+        "authority_profile_source_receipt_id",
+        "nonce",
+        "issued_at",
+        "expires_at",
+        "signature",
+    }
+    if set(raw) != expected_fields:
+        raise ValueError(
+            "architect_proposal_policy_authorization_fields_invalid"
+        )
+    signature = _text(raw.pop("signature"))
+    _validate_policy_authorization_payload(raw)
+    expected_bindings = {
+        "proposal_policy_digest": architect_proposal_signer_policy_digest(
+            policy
+        ),
+        "principal_id": _text(authority_profile.get("principal_id")),
+        "principal_public_key": _text(
+            authority_profile.get("principal_public_key")
+        ),
+        "reddog_id": _text(authority_profile.get("reddog_id")),
+        "reddog_public_key": _text(
+            authority_profile.get("reddog_public_key")
+        ),
+        "key_epoch": _text(authority_profile.get("key_epoch")),
+        "authority_profile_source_receipt_id": _text(
+            authority_profile.get("authority_profile_source_receipt_id")
+        ),
+    }
+    if any(raw.get(key) != expected for key, expected in expected_bindings.items()):
+        raise ValueError(
+            "architect_proposal_policy_authorization_binding_mismatch"
+        )
+    ttl = int(raw["expires_at"]) - int(raw["issued_at"])
+    if (
+        int(raw["issued_at"]) > int(now_epoch)
+        or int(raw["expires_at"]) <= int(now_epoch)
+        or ttl <= 0
+        or ttl > DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+    ):
+        raise ValueError(
+            "architect_proposal_policy_authorization_expired"
+        )
+    signing_input = (
+        canonical_architect_proposal_policy_authorization_input(raw)
+    )
+    if not Ed25519SignatureVerifier().verify(
+        str(raw["principal_public_key"]),
+        signing_input,
+        signature,
+    ):
+        raise ValueError(
+            "architect_proposal_policy_authorization_signature_invalid"
+        )
+    return ArchitectProposalPolicyAuthorization(
+        **raw,
+        signature=signature,
+    )
+
+
+def rehydrate_architect_proposal_authenticity_payload(
+    value: Mapping[str, Any],
+) -> ArchitectProposalAuthenticityPayload:
+    """Rehydrate one exact proposal payload without accepting an attestation."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError("architect_proposal_authenticity_payload_invalid")
+    payload = dict(value)
+    _validate_payload_shape(payload)
+    return ArchitectProposalAuthenticityPayload(**payload)
+
+
+def _validate_policy_authorization_payload(
+    payload: Mapping[str, Any],
+) -> None:
+    fields = {
+        "schema_version",
+        "authorization_id",
+        "proposal_policy_digest",
+        "principal_id",
+        "principal_public_key",
+        "reddog_id",
+        "reddog_public_key",
+        "key_epoch",
+        "authority_profile_source_receipt_id",
+        "nonce",
+        "issued_at",
+        "expires_at",
+    }
+    if set(payload) != fields:
+        raise ValueError(
+            "architect_proposal_policy_authorization_fields_invalid"
+        )
+    if payload.get("schema_version") != (
+        PROPOSAL_POLICY_AUTHORIZATION_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "architect_proposal_policy_authorization_schema_invalid"
+        )
+    for field in (
+        "proposal_policy_digest",
+        "authority_profile_source_receipt_id",
+    ):
+        if not _sha256(payload.get(field)):
+            raise ValueError(
+                "architect_proposal_policy_authorization_digest_invalid"
+            )
+    for field in (
+        "authorization_id",
+        "principal_id",
+        "principal_public_key",
+        "reddog_id",
+        "reddog_public_key",
+        "key_epoch",
+        "nonce",
+    ):
+        if not isinstance(payload.get(field), str) or not _text(
+            payload.get(field)
+        ):
+            raise ValueError(
+                "architect_proposal_policy_authorization_value_missing"
+            )
+    if not _ascii_deep(payload):
+        raise ValueError(
+            "architect_proposal_policy_authorization_non_ascii"
+        )
+    unsigned = dict(payload)
+    supplied_id = str(unsigned.pop("authorization_id"))
+    expected_id = (
+        "reddog_architect_proposal_policy_authorization_"
+        + _digest(unsigned)[7:39]
+    )
+    if supplied_id != expected_id:
+        raise ValueError(
+            "architect_proposal_policy_authorization_id_invalid"
+        )
+    if (
+        type(payload.get("issued_at")) is not int
+        or type(payload.get("expires_at")) is not int
+    ):
+        raise ValueError(
+            "architect_proposal_policy_authorization_time_invalid"
+        )
 
 
 def attest_architect_proposal(
@@ -613,6 +873,7 @@ def _ascii_deep(value: Any) -> bool:
 
 
 __all__ = [
+    "ArchitectProposalPolicyAuthorization",
     "ArchitectProposalAuthenticityAttestation",
     "ArchitectProposalAuthenticityPayload",
     "ArchitectProposalSignerPolicy",
@@ -624,10 +885,17 @@ __all__ = [
     "PROPOSAL_AUTHENTICITY_SIGNER_ROLE",
     "PROPOSAL_AUTHENTICITY_SIGNING_OPERATION",
     "PROPOSAL_AUTHENTICITY_SIGNING_PREFIX",
+    "PROPOSAL_POLICY_AUTHORIZATION_PREFIX",
+    "PROPOSAL_POLICY_AUTHORIZATION_SCHEMA_VERSION",
     "ProposalAuthenticityNonceStore",
     "attest_architect_proposal",
+    "architect_proposal_signer_policy_digest",
+    "build_architect_proposal_policy_authorization_payload",
     "build_architect_proposal_authenticity_payload",
     "canonical_architect_proposal_signing_input",
+    "canonical_architect_proposal_policy_authorization_input",
+    "rehydrate_architect_proposal_authenticity_payload",
     "validate_proposal_signing_request",
+    "verify_architect_proposal_policy_authorization",
     "verify_architect_proposal_attestation_integrity",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import threading
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any, Mapping, Protocol
 
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
@@ -110,11 +111,15 @@ class ArchitectProposalPolicyAuthorization:
     authorization_id: str
     proposal_policy_digest: str
     principal_id: str
+    principal_provider: str
     principal_public_key: str
     reddog_id: str
     reddog_public_key: str
     key_epoch: str
     authority_profile_source_receipt_id: str
+    signer_instance_id: str
+    replay_store_binding_digest: str
+    security_context_digest: str
     nonce: str
     issued_at: int
     expires_at: int
@@ -333,15 +338,52 @@ def architect_proposal_signer_policy_digest(
     )
 
 
+def architect_proposal_signer_instance_id(
+    signer_runtime_root: Path | str,
+    reddog_public_key: str,
+    key_epoch: str,
+) -> str:
+    """Bind one proposal signer instance to its key and runtime root."""
+
+    root = Path(signer_runtime_root).resolve()
+    return "reddog-proposal-signer:" + _digest(
+        {
+            "key_epoch": _text(key_epoch),
+            "reddog_public_key": _text(reddog_public_key),
+            "signer_runtime_root": str(root),
+        }
+    )[7:39]
+
+
+def architect_proposal_replay_store_binding_digest(
+    signer_instance_id: str,
+    nonce_store_path: Path | str,
+    high_water_store_id: str,
+) -> str:
+    """Bind authorization replay to state plus an independent high-water authority."""
+
+    return _digest(
+        {
+            "high_water_store_id": _text(high_water_store_id),
+            "nonce_store_path": str(Path(nonce_store_path).resolve()),
+            "signer_instance_id": _text(signer_instance_id),
+        }
+    )
+
+
 def build_architect_proposal_policy_authorization_payload(
     policy: ArchitectProposalSignerPolicy,
     *,
     principal_id: str,
+    principal_provider: str,
     principal_public_key: str,
     reddog_id: str,
     reddog_public_key: str,
     key_epoch: str,
     authority_profile_source_receipt_id: str,
+    signer_instance_id: str,
+    replay_store_binding_digest: str,
+    security_context_digest: str,
     nonce: str,
     issued_at: int,
     expires_at: int,
@@ -354,6 +396,7 @@ def build_architect_proposal_policy_authorization_payload(
             policy
         ),
         "principal_id": _text(principal_id),
+        "principal_provider": _text(principal_provider),
         "principal_public_key": _text(principal_public_key),
         "reddog_id": _text(reddog_id),
         "reddog_public_key": _text(reddog_public_key),
@@ -361,6 +404,11 @@ def build_architect_proposal_policy_authorization_payload(
         "authority_profile_source_receipt_id": _text(
             authority_profile_source_receipt_id
         ),
+        "signer_instance_id": _text(signer_instance_id),
+        "replay_store_binding_digest": _text(
+            replay_store_binding_digest
+        ),
+        "security_context_digest": _text(security_context_digest),
         "nonce": _text(nonce),
         "issued_at": int(issued_at),
         "expires_at": int(expires_at),
@@ -389,6 +437,10 @@ def verify_architect_proposal_policy_authorization(
     *,
     policy: ArchitectProposalSignerPolicy,
     authority_profile: Mapping[str, Any],
+    trusted_principal_public_key: str,
+    expected_signer_instance_id: str,
+    expected_replay_store_binding_digest: str,
+    expected_security_context_digest: str,
     now_epoch: int,
 ) -> ArchitectProposalPolicyAuthorization:
     """Verify a principal signature over one exact signer policy."""
@@ -401,11 +453,15 @@ def verify_architect_proposal_policy_authorization(
         "authorization_id",
         "proposal_policy_digest",
         "principal_id",
+        "principal_provider",
         "principal_public_key",
         "reddog_id",
         "reddog_public_key",
         "key_epoch",
         "authority_profile_source_receipt_id",
+        "signer_instance_id",
+        "replay_store_binding_digest",
+        "security_context_digest",
         "nonce",
         "issued_at",
         "expires_at",
@@ -422,6 +478,9 @@ def verify_architect_proposal_policy_authorization(
             policy
         ),
         "principal_id": _text(authority_profile.get("principal_id")),
+        "principal_provider": _text(
+            authority_profile.get("principal_provider")
+        ),
         "principal_public_key": _text(
             authority_profile.get("principal_public_key")
         ),
@@ -433,10 +492,23 @@ def verify_architect_proposal_policy_authorization(
         "authority_profile_source_receipt_id": _text(
             authority_profile.get("authority_profile_source_receipt_id")
         ),
+        "signer_instance_id": _text(expected_signer_instance_id),
+        "replay_store_binding_digest": _text(
+            expected_replay_store_binding_digest
+        ),
+        "security_context_digest": _text(
+            expected_security_context_digest
+        ),
     }
     if any(raw.get(key) != expected for key, expected in expected_bindings.items()):
         raise ValueError(
             "architect_proposal_policy_authorization_binding_mismatch"
+        )
+    if raw["principal_public_key"] != _text(
+        trusted_principal_public_key
+    ):
+        raise ValueError(
+            "architect_proposal_policy_authorization_principal_untrusted"
         )
     ttl = int(raw["expires_at"]) - int(raw["issued_at"])
     if (
@@ -485,11 +557,15 @@ def _validate_policy_authorization_payload(
         "authorization_id",
         "proposal_policy_digest",
         "principal_id",
+        "principal_provider",
         "principal_public_key",
         "reddog_id",
         "reddog_public_key",
         "key_epoch",
         "authority_profile_source_receipt_id",
+        "signer_instance_id",
+        "replay_store_binding_digest",
+        "security_context_digest",
         "nonce",
         "issued_at",
         "expires_at",
@@ -507,6 +583,8 @@ def _validate_policy_authorization_payload(
     for field in (
         "proposal_policy_digest",
         "authority_profile_source_receipt_id",
+        "replay_store_binding_digest",
+        "security_context_digest",
     ):
         if not _sha256(payload.get(field)):
             raise ValueError(
@@ -515,10 +593,12 @@ def _validate_policy_authorization_payload(
     for field in (
         "authorization_id",
         "principal_id",
+        "principal_provider",
         "principal_public_key",
         "reddog_id",
         "reddog_public_key",
         "key_epoch",
+        "signer_instance_id",
         "nonce",
     ):
         if not isinstance(payload.get(field), str) or not _text(
@@ -890,6 +970,8 @@ __all__ = [
     "ProposalAuthenticityNonceStore",
     "attest_architect_proposal",
     "architect_proposal_signer_policy_digest",
+    "architect_proposal_signer_instance_id",
+    "architect_proposal_replay_store_binding_digest",
     "build_architect_proposal_policy_authorization_payload",
     "build_architect_proposal_authenticity_payload",
     "canonical_architect_proposal_signing_input",

--- a/modules/communication/moltbot_bridge/src/reddog_ed25519_signature_verifier_backend.py
+++ b/modules/communication/moltbot_bridge/src/reddog_ed25519_signature_verifier_backend.py
@@ -84,13 +84,20 @@ def decode_ed25519_signature(value: str) -> Optional[bytes]:
 
 
 def _decode_with_size(value: str, expected_size: int) -> Optional[bytes]:
-    if not value or not _is_ascii(value):
+    if not value or not _is_ascii(value) or "=" in value:
         return None
     try:
-        decoded = base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+        decoded = base64.b64decode(
+            value + "=" * (-len(value) % 4),
+            altchars=b"-_",
+            validate=True,
+        )
     except (binascii.Error, ValueError):
         return None
-    if len(decoded) != expected_size:
+    if (
+        len(decoded) != expected_size
+        or _b64url_no_padding(decoded) != value
+    ):
         return None
     return decoded
 

--- a/modules/communication/moltbot_bridge/src/reddog_ed25519_signer_backend.py
+++ b/modules/communication/moltbot_bridge/src/reddog_ed25519_signer_backend.py
@@ -77,6 +77,9 @@ REJECT_ED25519_SIGNER_PROPOSAL_NONCE_STORE_MISSING = (
 REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY = (
     "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY"
 )
+REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY = (
+    "REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY"
+)
 
 CONTROL_LOOP_SIGNING_OPERATION = "attest_control_loop_receipt"
 CONTROL_LOOP_SIGNING_PREFIX = "reddog-control-loop.v2."
@@ -209,6 +212,12 @@ def _signer_request_rejection(
     )
     if any(operation is not prefix for operation, prefix in domain_pairs):
         return REJECT_ED25519_SIGNER_DOMAIN_MISMATCH
+    if backend.proposal_authority_policy is not None:
+        allowed_operations = {PROPOSAL_AUTHENTICITY_SIGNING_OPERATION}
+        if backend.control_loop_authority_policy is not None:
+            allowed_operations.add(CONTROL_LOOP_SIGNING_OPERATION)
+        if request.requested_operation not in allowed_operations:
+            return REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY
     try:
         derived = encode_ed25519_public_key(_public_bytes_from_private_key(backend.private_key))
     except Exception:
@@ -487,6 +496,7 @@ __all__ = [
     "REJECT_ED25519_SIGNER_PUBLIC_KEY_MISMATCH",
     "REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISMATCH",
     "REJECT_ED25519_SIGNER_PROPOSAL_AUTHORITY_POLICY_MISSING",
+    "REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY",
     "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY",
     "REJECT_ED25519_SIGNER_PROPOSAL_NONCE_STORE_MISSING",
     "REJECT_ED25519_SIGNER_REQUEST_INVALID",

--- a/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
@@ -173,7 +173,11 @@ class AtomicProposalAuthenticityNonceStore:
                 "proposal_authenticity_high_water_store_invalid"
             )
         self._high_water_store = high_water_store
-        self._operation_lock_identity = str(self._store.path) + ".operation"
+        # This transaction lock must differ from AtomicJsonAuthorityRuntimeStore's
+        # own ".operation" lock because one mutation calls that store while held.
+        self._operation_lock_identity = (
+            str(self._store.path) + ".proposal-transaction"
+        )
         self._clock = clock
         self._clock_skew_seconds = clock_skew_seconds
         self._retention_seconds = retention_seconds

--- a/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
@@ -15,7 +15,7 @@ from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store imp
     AtomicJsonAuthorityRuntimeStore,
 )
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
-    runtime_operation_lock,
+    confined_runtime_operation_lock,
 )
 
 PROPOSAL_NONCE_STORE_SCHEMA_VERSION = (
@@ -157,6 +157,8 @@ class AtomicProposalAuthenticityNonceStore:
             allowed_root=allowed_root,
             repo_root=repo_root,
         )
+        self._repo_root = Path(repo_root).resolve()
+        self._allowed_root = Path(allowed_root).resolve()
         if not _sha256(replay_store_binding_digest):
             raise ValueError(
                 "proposal_authenticity_nonce_replay_binding_invalid"
@@ -175,8 +177,8 @@ class AtomicProposalAuthenticityNonceStore:
         self._high_water_store = high_water_store
         # This transaction lock must differ from AtomicJsonAuthorityRuntimeStore's
         # own ".operation" lock because one mutation calls that store while held.
-        self._operation_lock_identity = (
-            str(self._store.path) + ".proposal-transaction"
+        self._transaction_lock_path = Path(
+            str(self._store.path) + ".proposal-transaction.lock"
         )
         self._clock = clock
         self._clock_skew_seconds = clock_skew_seconds
@@ -310,7 +312,11 @@ class AtomicProposalAuthenticityNonceStore:
         ],
     ) -> Any:
         for _ in range(_MAX_COMMIT_RETRIES):
-            with runtime_operation_lock(self._operation_lock_identity):
+            with confined_runtime_operation_lock(
+                self._transaction_lock_path,
+                repo_root=self._repo_root,
+                allowed_root=self._allowed_root,
+            ):
                 state, high_water = self._load_state()
                 updated, result = mutation(state)
                 if updated is state:

--- a/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
@@ -5,18 +5,19 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-import os
-import stat
 import threading
 import time
-from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterator, Mapping, Protocol, runtime_checkable
+from typing import Any, Callable, Mapping, Protocol, runtime_checkable
 
 from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
     AtomicJsonAuthorityRuntimeStore,
 )
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    runtime_operation_lock,
+)
+
 PROPOSAL_NONCE_STORE_SCHEMA_VERSION = (
     "reddog_architect_proposal_nonce_store.v1"
 )
@@ -40,6 +41,12 @@ class ProposalReplayHighWaterStore(Protocol):
 
     @property
     def store_id(self) -> str: ...
+
+    @property
+    def durable(self) -> bool: ...
+
+    @property
+    def durability_receipt_id(self) -> str | None: ...
 
     def load(
         self,
@@ -68,6 +75,14 @@ class InMemoryProposalReplayHighWaterStore:
     @property
     def store_id(self) -> str:
         return self._store_id
+
+    @property
+    def durable(self) -> bool:
+        return False
+
+    @property
+    def durability_receipt_id(self) -> None:
+        return None
 
     def load(
         self,
@@ -158,7 +173,7 @@ class AtomicProposalAuthenticityNonceStore:
                 "proposal_authenticity_high_water_store_invalid"
             )
         self._high_water_store = high_water_store
-        self._operation_lock_path = Path(str(self._store.path) + ".lock")
+        self._operation_lock_identity = str(self._store.path) + ".operation"
         self._clock = clock
         self._clock_skew_seconds = clock_skew_seconds
         self._retention_seconds = retention_seconds
@@ -184,6 +199,8 @@ class AtomicProposalAuthenticityNonceStore:
 
         def mutate(state: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
             now_epoch = int(self._clock())
+            if expiry <= now_epoch:
+                return state, None
             consumed, reserved = _validated_entries(
                 state,
                 integrity_key=self._integrity_key,
@@ -236,6 +253,10 @@ class AtomicProposalAuthenticityNonceStore:
                 raise ValueError(
                     "proposal_authenticity_nonce_reservation_invalid"
                 )
+            if int(entry["expires_at"]) <= int(self._clock()):
+                raise ValueError(
+                    "proposal_authenticity_nonce_reservation_expired"
+                )
             key = _nonce_key(
                 _text(entry.get("subject")),
                 _text(entry.get("nonce")),
@@ -285,7 +306,7 @@ class AtomicProposalAuthenticityNonceStore:
         ],
     ) -> Any:
         for _ in range(_MAX_COMMIT_RETRIES):
-            with _cross_session_file_lock(self._operation_lock_path):
+            with runtime_operation_lock(self._operation_lock_identity):
                 state, high_water = self._load_state()
                 updated, result = mutation(state)
                 if updated is state:
@@ -496,42 +517,6 @@ def _state_mac(state: Mapping[str, Any], integrity_key: bytes) -> str:
         raw,
         hashlib.sha256,
     ).hexdigest()
-
-
-@contextmanager
-def _cross_session_file_lock(path: Path) -> Iterator[None]:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(path, flags, 0o600)
-    try:
-        file_stat = os.fstat(descriptor)
-        if not stat.S_ISREG(file_stat.st_mode):
-            raise ValueError(
-                "proposal_authenticity_nonce_lock_invalid"
-            )
-        if file_stat.st_size == 0:
-            os.write(descriptor, b"\0")
-            os.fsync(descriptor)
-        os.lseek(descriptor, 0, os.SEEK_SET)
-        if os.name == "nt":
-            import msvcrt
-
-            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
-            try:
-                yield
-            finally:
-                os.lseek(descriptor, 0, os.SEEK_SET)
-                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
-        else:
-            import fcntl
-
-            fcntl.flock(descriptor, fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
-    finally:
-        os.close(descriptor)
 
 
 def _digest(value: Any) -> str:

--- a/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
@@ -1,0 +1,373 @@
+"""Durable signer-owned replay store for architect proposal attestations."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
+    AtomicJsonAuthorityRuntimeStore,
+)
+
+
+PROPOSAL_NONCE_STORE_SCHEMA_VERSION = (
+    "reddog_architect_proposal_nonce_store.v1"
+)
+_MAX_COMMIT_RETRIES = 4
+DEFAULT_PROPOSAL_NONCE_CLOCK_SKEW_SECONDS = 60
+DEFAULT_PROPOSAL_NONCE_RETENTION_SECONDS = 300
+DEFAULT_PROPOSAL_NONCE_MAX_ENTRIES = 2048
+_MIN_INTEGRITY_KEY_BYTES = 16
+_STATE_MAC_PREFIX = "proposal-nonce-state-mac-v1:"
+
+
+class AtomicProposalAuthenticityNonceStore:
+    """Persist proposal nonce reservations under a confined signer runtime root."""
+
+    def __init__(
+        self,
+        path: Path | str,
+        *,
+        allowed_root: Path | str,
+        repo_root: Path | str,
+        integrity_key: bytes,
+        clock: Callable[[], float] = time.time,
+        clock_skew_seconds: int = (
+            DEFAULT_PROPOSAL_NONCE_CLOCK_SKEW_SECONDS
+        ),
+        retention_seconds: int = DEFAULT_PROPOSAL_NONCE_RETENTION_SECONDS,
+        max_entries: int = DEFAULT_PROPOSAL_NONCE_MAX_ENTRIES,
+    ) -> None:
+        if (
+            not isinstance(integrity_key, bytes)
+            or len(integrity_key) < _MIN_INTEGRITY_KEY_BYTES
+        ):
+            raise ValueError(
+                "proposal_authenticity_nonce_integrity_key_invalid"
+            )
+        if (
+            not callable(clock)
+            or type(clock_skew_seconds) is not int
+            or clock_skew_seconds < 0
+            or type(retention_seconds) is not int
+            or retention_seconds < clock_skew_seconds
+            or type(max_entries) is not int
+            or max_entries < 1
+            or max_entries > DEFAULT_PROPOSAL_NONCE_MAX_ENTRIES
+        ):
+            raise ValueError("proposal_authenticity_nonce_policy_invalid")
+        self._store = AtomicJsonAuthorityRuntimeStore(
+            path,
+            allowed_root=allowed_root,
+            repo_root=repo_root,
+        )
+        self._integrity_key = integrity_key
+        self._clock = clock
+        self._clock_skew_seconds = clock_skew_seconds
+        self._retention_seconds = retention_seconds
+        self._max_entries = max_entries
+
+    @property
+    def path(self) -> Path:
+        return self._store.path
+
+    def reserve(self, nonce: str, *, expires_at: int, subject: str) -> str | None:
+        clean_nonce = _text(nonce)
+        clean_subject = _text(subject)
+        expiry = int(expires_at)
+        if not clean_nonce or not clean_subject or expiry <= 0:
+            return None
+        reservation = _digest(
+            {
+                "expires_at": expiry,
+                "nonce": clean_nonce,
+                "subject": clean_subject,
+            }
+        )
+
+        def mutate(state: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+            now_epoch = int(self._clock())
+            consumed, reserved = _validated_entries(
+                state,
+                integrity_key=self._integrity_key,
+            )
+            consumed, reserved = _pruned_entries(
+                consumed,
+                reserved,
+                now_epoch=now_epoch,
+                clock_skew_seconds=self._clock_skew_seconds,
+                retention_seconds=self._retention_seconds,
+            )
+            key = _nonce_key(clean_subject, clean_nonce)
+            if key in consumed or any(
+                _nonce_key(
+                    _text(value.get("subject")),
+                    _text(value.get("nonce")),
+                )
+                == key
+                for value in reserved.values()
+            ):
+                return state, None
+            if len(consumed) + len(reserved) >= self._max_entries:
+                return state, None
+            updated = _base_state(state)
+            updated["consumed"] = consumed
+            updated["reservations"] = {
+                **reserved,
+                reservation: {
+                    "expires_at": expiry,
+                    "nonce": clean_nonce,
+                    "subject": clean_subject,
+                },
+            }
+            return updated, reservation
+
+        return self._mutate(mutate)
+
+    def commit(self, reservation: str) -> None:
+        token = _text(reservation)
+        if not token:
+            raise ValueError("proposal_authenticity_nonce_reservation_invalid")
+
+        def mutate(state: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+            consumed, reserved = _validated_entries(
+                state,
+                integrity_key=self._integrity_key,
+            )
+            entry = reserved.pop(token, None)
+            if entry is None:
+                raise ValueError(
+                    "proposal_authenticity_nonce_reservation_invalid"
+                )
+            key = _nonce_key(
+                _text(entry.get("subject")),
+                _text(entry.get("nonce")),
+            )
+            if key in consumed:
+                raise ValueError("proposal_authenticity_nonce_replay")
+            updated = _base_state(state)
+            updated["consumed"] = {
+                **consumed,
+                key: {
+                    "expires_at": int(entry["expires_at"]),
+                    "nonce_digest": _digest(_text(entry["nonce"])),
+                    "subject_digest": _digest(_text(entry["subject"])),
+                },
+            }
+            updated["reservations"] = reserved
+            return updated, True
+
+        if self._mutate(mutate) is not True:
+            raise ValueError("proposal_authenticity_nonce_commit_failed")
+
+    def rollback(self, reservation: str) -> None:
+        token = _text(reservation)
+        if not token:
+            return
+
+        def mutate(state: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+            consumed, reserved = _validated_entries(
+                state,
+                integrity_key=self._integrity_key,
+            )
+            if token not in reserved:
+                return state, True
+            reserved.pop(token)
+            updated = _base_state(state)
+            updated["consumed"] = consumed
+            updated["reservations"] = reserved
+            return updated, True
+
+        self._mutate(mutate)
+
+    def _mutate(
+        self,
+        mutation: Callable[
+            [dict[str, Any]],
+            tuple[dict[str, Any], Any],
+        ],
+    ) -> Any:
+        for _ in range(_MAX_COMMIT_RETRIES):
+            state = self._store.load()
+            updated, result = mutation(state)
+            if updated is state:
+                return result
+            try:
+                self._store.commit(
+                    _seal_state(updated, self._integrity_key),
+                    expected_revision=state.get("revision"),
+                )
+                return result
+            except RuntimeError as exc:
+                if str(exc) != "revision_conflict":
+                    raise
+        raise RuntimeError("proposal_authenticity_nonce_store_conflict")
+
+
+def _validated_entries(
+    state: Mapping[str, Any],
+    *,
+    integrity_key: bytes,
+) -> tuple[dict[str, Mapping[str, Any]], dict[str, Mapping[str, Any]]]:
+    if not state:
+        return {}, {}
+    _validate_state_integrity(state, integrity_key)
+    if state.get("schema_version") != PROPOSAL_NONCE_STORE_SCHEMA_VERSION:
+        raise ValueError("proposal_authenticity_nonce_store_schema_invalid")
+    raw_consumed = state.get("consumed")
+    raw_reserved = state.get("reservations")
+    if not isinstance(raw_consumed, Mapping) or not isinstance(
+        raw_reserved, Mapping
+    ):
+        raise ValueError("proposal_authenticity_nonce_store_state_invalid")
+    consumed = _entry_mapping(raw_consumed, consumed=True)
+    reserved = _entry_mapping(raw_reserved, consumed=False)
+    return consumed, reserved
+
+
+def _entry_mapping(
+    values: Mapping[str, Any],
+    *,
+    consumed: bool,
+) -> dict[str, Mapping[str, Any]]:
+    result: dict[str, Mapping[str, Any]] = {}
+    required = (
+        {"expires_at", "nonce_digest", "subject_digest"}
+        if consumed
+        else {"expires_at", "nonce", "subject"}
+    )
+    for key, value in values.items():
+        if (
+            not isinstance(key, str)
+            or not key
+            or not isinstance(value, Mapping)
+            or set(value) != required
+            or not isinstance(value.get("expires_at"), int)
+            or int(value["expires_at"]) <= 0
+            or any(not _text(value.get(field)) for field in required - {"expires_at"})
+        ):
+            raise ValueError("proposal_authenticity_nonce_store_state_invalid")
+        result[key] = dict(value)
+    return result
+
+
+def _base_state(state: Mapping[str, Any]) -> dict[str, Any]:
+    allowed = {
+        "schema_version",
+        "consumed",
+        "reservations",
+        "revision",
+        "state_mac",
+    }
+    if state and not set(state).issubset(allowed):
+        raise ValueError("proposal_authenticity_nonce_store_state_invalid")
+    return {"schema_version": PROPOSAL_NONCE_STORE_SCHEMA_VERSION}
+
+
+def _nonce_key(subject: str, nonce: str) -> str:
+    return _digest({"nonce": nonce, "subject": subject})
+
+
+def _pruned_entries(
+    consumed: Mapping[str, Mapping[str, Any]],
+    reserved: Mapping[str, Mapping[str, Any]],
+    *,
+    now_epoch: int,
+    clock_skew_seconds: int,
+    retention_seconds: int,
+) -> tuple[dict[str, Mapping[str, Any]], dict[str, Mapping[str, Any]]]:
+    live_consumed = {
+        key: dict(value)
+        for key, value in consumed.items()
+        if int(value["expires_at"]) + retention_seconds > now_epoch
+    }
+    live_reserved = {
+        key: dict(value)
+        for key, value in reserved.items()
+        if int(value["expires_at"]) + clock_skew_seconds > now_epoch
+    }
+    return live_consumed, live_reserved
+
+
+def _validate_state_integrity(
+    state: Mapping[str, Any],
+    integrity_key: bytes,
+) -> None:
+    supplied_mac = state.get("state_mac")
+    supplied_revision = state.get("revision")
+    if (
+        not isinstance(supplied_mac, str)
+        or not supplied_mac.startswith(_STATE_MAC_PREFIX)
+        or not isinstance(supplied_revision, str)
+        or not supplied_revision
+    ):
+        raise ValueError("proposal_authenticity_nonce_store_integrity_invalid")
+    expected_mac = _state_mac(state, integrity_key)
+    if not hmac.compare_digest(supplied_mac, expected_mac):
+        raise ValueError("proposal_authenticity_nonce_store_integrity_invalid")
+    unsigned = dict(state)
+    unsigned.pop("revision", None)
+    expected_revision = hashlib.sha256(
+        json.dumps(
+            unsigned,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    if not hmac.compare_digest(supplied_revision, expected_revision):
+        raise ValueError("proposal_authenticity_nonce_store_integrity_invalid")
+
+
+def _seal_state(state: Mapping[str, Any], integrity_key: bytes) -> dict[str, Any]:
+    sealed = dict(state)
+    sealed.pop("revision", None)
+    sealed.pop("state_mac", None)
+    sealed["state_mac"] = _state_mac(sealed, integrity_key)
+    return sealed
+
+
+def _state_mac(state: Mapping[str, Any], integrity_key: bytes) -> str:
+    unsigned = dict(state)
+    unsigned.pop("revision", None)
+    unsigned.pop("state_mac", None)
+    raw = json.dumps(
+        unsigned,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return _STATE_MAC_PREFIX + hmac.new(
+        integrity_key,
+        raw,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+__all__ = [
+    "AtomicProposalAuthenticityNonceStore",
+    "DEFAULT_PROPOSAL_NONCE_CLOCK_SKEW_SECONDS",
+    "DEFAULT_PROPOSAL_NONCE_MAX_ENTRIES",
+    "DEFAULT_PROPOSAL_NONCE_RETENTION_SECONDS",
+    "PROPOSAL_NONCE_STORE_SCHEMA_VERSION",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_proposal_authenticity_nonce_store.py
@@ -5,15 +5,18 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
+import stat
+import threading
 import time
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Iterator, Mapping, Protocol, runtime_checkable
 
 from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
     AtomicJsonAuthorityRuntimeStore,
 )
-
-
 PROPOSAL_NONCE_STORE_SCHEMA_VERSION = (
     "reddog_architect_proposal_nonce_store.v1"
 )
@@ -23,6 +26,78 @@ DEFAULT_PROPOSAL_NONCE_RETENTION_SECONDS = 300
 DEFAULT_PROPOSAL_NONCE_MAX_ENTRIES = 2048
 _MIN_INTEGRITY_KEY_BYTES = 16
 _STATE_MAC_PREFIX = "proposal-nonce-state-mac-v1:"
+
+
+@dataclass(frozen=True)
+class ProposalReplayHighWater:
+    sequence: int
+    state_revision: str
+
+
+@runtime_checkable
+class ProposalReplayHighWaterStore(Protocol):
+    """Independent monotonic authority outside the nonce-state rollback domain."""
+
+    @property
+    def store_id(self) -> str: ...
+
+    def load(
+        self,
+        replay_store_binding_digest: str,
+    ) -> ProposalReplayHighWater | None: ...
+
+    def advance(
+        self,
+        replay_store_binding_digest: str,
+        *,
+        expected: ProposalReplayHighWater | None,
+        next_value: ProposalReplayHighWater,
+    ) -> None: ...
+
+
+class InMemoryProposalReplayHighWaterStore:
+    """Thread-safe independent high-water authority for deterministic tests."""
+
+    def __init__(self, store_id: str = "in-memory:test-only") -> None:
+        if not _text(store_id) or not store_id.isascii():
+            raise ValueError("proposal_replay_high_water_store_id_invalid")
+        self._store_id = store_id
+        self._values: dict[str, ProposalReplayHighWater] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def store_id(self) -> str:
+        return self._store_id
+
+    def load(
+        self,
+        replay_store_binding_digest: str,
+    ) -> ProposalReplayHighWater | None:
+        with self._lock:
+            return self._values.get(replay_store_binding_digest)
+
+    def advance(
+        self,
+        replay_store_binding_digest: str,
+        *,
+        expected: ProposalReplayHighWater | None,
+        next_value: ProposalReplayHighWater,
+    ) -> None:
+        with self._lock:
+            current = self._values.get(replay_store_binding_digest)
+            if current != expected:
+                raise RuntimeError(
+                    "proposal_replay_high_water_conflict"
+                )
+            if (
+                next_value.sequence
+                != (current.sequence + 1 if current is not None else 1)
+                or not _text(next_value.state_revision)
+            ):
+                raise ValueError(
+                    "proposal_replay_high_water_invalid"
+                )
+            self._values[replay_store_binding_digest] = next_value
 
 
 class AtomicProposalAuthenticityNonceStore:
@@ -35,6 +110,8 @@ class AtomicProposalAuthenticityNonceStore:
         allowed_root: Path | str,
         repo_root: Path | str,
         integrity_key: bytes,
+        replay_store_binding_digest: str,
+        high_water_store: ProposalReplayHighWaterStore,
         clock: Callable[[], float] = time.time,
         clock_skew_seconds: int = (
             DEFAULT_PROPOSAL_NONCE_CLOCK_SKEW_SECONDS
@@ -65,7 +142,23 @@ class AtomicProposalAuthenticityNonceStore:
             allowed_root=allowed_root,
             repo_root=repo_root,
         )
+        if not _sha256(replay_store_binding_digest):
+            raise ValueError(
+                "proposal_authenticity_nonce_replay_binding_invalid"
+            )
         self._integrity_key = integrity_key
+        self._replay_store_binding_digest = (
+            replay_store_binding_digest
+        )
+        if not isinstance(
+            high_water_store,
+            ProposalReplayHighWaterStore,
+        ):
+            raise ValueError(
+                "proposal_authenticity_high_water_store_invalid"
+            )
+        self._high_water_store = high_water_store
+        self._operation_lock_path = Path(str(self._store.path) + ".lock")
         self._clock = clock
         self._clock_skew_seconds = clock_skew_seconds
         self._retention_seconds = retention_seconds
@@ -192,20 +285,69 @@ class AtomicProposalAuthenticityNonceStore:
         ],
     ) -> Any:
         for _ in range(_MAX_COMMIT_RETRIES):
-            state = self._store.load()
-            updated, result = mutation(state)
-            if updated is state:
-                return result
-            try:
-                self._store.commit(
-                    _seal_state(updated, self._integrity_key),
-                    expected_revision=state.get("revision"),
-                )
-                return result
-            except RuntimeError as exc:
-                if str(exc) != "revision_conflict":
-                    raise
+            with _cross_session_file_lock(self._operation_lock_path):
+                state, high_water = self._load_state()
+                updated, result = mutation(state)
+                if updated is state:
+                    return result
+                try:
+                    state_revision = self._store.commit(
+                        _seal_state(updated, self._integrity_key),
+                        expected_revision=state.get("revision"),
+                    )
+                    next_value = ProposalReplayHighWater(
+                        sequence=int(updated["sequence"]),
+                        state_revision=state_revision,
+                    )
+                    self._high_water_store.advance(
+                        self._replay_store_binding_digest,
+                        expected=high_water,
+                        next_value=next_value,
+                    )
+                    return result
+                except RuntimeError as exc:
+                    if str(exc) not in {
+                        "revision_conflict",
+                        "proposal_replay_high_water_conflict",
+                    }:
+                        raise
         raise RuntimeError("proposal_authenticity_nonce_store_conflict")
+
+    def _load_state(
+        self,
+    ) -> tuple[dict[str, Any], ProposalReplayHighWater | None]:
+        state = self._store.load()
+        high_water = self._high_water_store.load(
+            self._replay_store_binding_digest
+        )
+        if not state:
+            if high_water is None:
+                return {}, None
+            raise ValueError(
+                "proposal_authenticity_nonce_store_rollback_detected"
+            )
+        _validate_state_integrity(state, self._integrity_key)
+        state_value = ProposalReplayHighWater(
+            sequence=int(state.get("sequence") or 0),
+            state_revision=str(state.get("revision") or ""),
+        )
+        if high_water == state_value:
+            return state, high_water
+        expected_sequence = (
+            high_water.sequence + 1
+            if high_water is not None
+            else 1
+        )
+        if state_value.sequence != expected_sequence:
+            raise ValueError(
+                "proposal_authenticity_nonce_store_rollback_detected"
+            )
+        self._high_water_store.advance(
+            self._replay_store_binding_digest,
+            expected=high_water,
+            next_value=state_value,
+        )
+        return state, state_value
 
 
 def _validated_entries(
@@ -220,8 +362,11 @@ def _validated_entries(
         raise ValueError("proposal_authenticity_nonce_store_schema_invalid")
     raw_consumed = state.get("consumed")
     raw_reserved = state.get("reservations")
-    if not isinstance(raw_consumed, Mapping) or not isinstance(
-        raw_reserved, Mapping
+    if (
+        type(state.get("sequence")) is not int
+        or int(state["sequence"]) < 1
+        or not isinstance(raw_consumed, Mapping)
+        or not isinstance(raw_reserved, Mapping)
     ):
         raise ValueError("proposal_authenticity_nonce_store_state_invalid")
     consumed = _entry_mapping(raw_consumed, consumed=True)
@@ -258,6 +403,7 @@ def _entry_mapping(
 def _base_state(state: Mapping[str, Any]) -> dict[str, Any]:
     allowed = {
         "schema_version",
+        "sequence",
         "consumed",
         "reservations",
         "revision",
@@ -265,7 +411,10 @@ def _base_state(state: Mapping[str, Any]) -> dict[str, Any]:
     }
     if state and not set(state).issubset(allowed):
         raise ValueError("proposal_authenticity_nonce_store_state_invalid")
-    return {"schema_version": PROPOSAL_NONCE_STORE_SCHEMA_VERSION}
+    return {
+        "schema_version": PROPOSAL_NONCE_STORE_SCHEMA_VERSION,
+        "sequence": int(state.get("sequence") or 0) + 1,
+    }
 
 
 def _nonce_key(subject: str, nonce: str) -> str:
@@ -349,6 +498,42 @@ def _state_mac(state: Mapping[str, Any], integrity_key: bytes) -> str:
     ).hexdigest()
 
 
+@contextmanager
+def _cross_session_file_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError(
+                "proposal_authenticity_nonce_lock_invalid"
+            )
+        if file_stat.st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
 def _digest(value: Any) -> str:
     raw = json.dumps(
         value,
@@ -364,10 +549,20 @@ def _text(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+def _sha256(value: Any) -> bool:
+    text = _text(value)
+    return len(text) == 71 and text.startswith("sha256:") and all(
+        char in "0123456789abcdef" for char in text[7:]
+    )
+
+
 __all__ = [
     "AtomicProposalAuthenticityNonceStore",
     "DEFAULT_PROPOSAL_NONCE_CLOCK_SKEW_SECONDS",
     "DEFAULT_PROPOSAL_NONCE_MAX_ENTRIES",
     "DEFAULT_PROPOSAL_NONCE_RETENTION_SECONDS",
+    "InMemoryProposalReplayHighWaterStore",
+    "ProposalReplayHighWater",
+    "ProposalReplayHighWaterStore",
     "PROPOSAL_NONCE_STORE_SCHEMA_VERSION",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -32,9 +32,12 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend impo
 from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
     ArchitectProposalSignerPolicy,
     ProposalAuthenticityNonceStore,
+    architect_proposal_replay_store_binding_digest,
+    architect_proposal_signer_instance_id,
 )
 from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
     AtomicProposalAuthenticityNonceStore,
+    ProposalReplayHighWaterStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
     ControlLoopAnchorStore,
@@ -161,6 +164,8 @@ def build_test_only_signer_backend_from_provider(
     proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
     proposal_nonce_store: ProposalAuthenticityNonceStore | None = None,
     proposal_nonce_store_path: Path | str | None = None,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
+    proposal_replay_high_water_store_id: str | None = None,
     proposal_nonce_store_allowed_root: Path | str | None = None,
     proposal_nonce_store_repo_root: Path | str | None = None,
 ) -> SignerKeyProviderDryRunResult:
@@ -213,8 +218,20 @@ def build_test_only_signer_backend_from_provider(
         return _reject(FAIL_PROVIDER_FINGERPRINT_MISMATCH, profile=profile, signing=signing_result, audit=audit_result)
     effective_proposal_nonce_store = proposal_nonce_store
     if proposal_nonce_store_path is not None:
+        try:
+            high_water_store_matches = bool(
+                proposal_replay_high_water_store is not None
+                and proposal_replay_high_water_store_id
+                and hmac.compare_digest(
+                    proposal_replay_high_water_store.store_id,
+                    proposal_replay_high_water_store_id,
+                )
+            )
+        except Exception:
+            high_water_store_matches = False
         if (
             proposal_nonce_store is not None
+            or not high_water_store_matches
             or proposal_nonce_store_allowed_root is None
             or proposal_nonce_store_repo_root is None
         ):
@@ -231,6 +248,18 @@ def build_test_only_signer_backend_from_provider(
                     allowed_root=proposal_nonce_store_allowed_root,
                     repo_root=proposal_nonce_store_repo_root,
                     integrity_key=audit_key,
+                    high_water_store=proposal_replay_high_water_store,
+                    replay_store_binding_digest=(
+                        architect_proposal_replay_store_binding_digest(
+                            architect_proposal_signer_instance_id(
+                                proposal_nonce_store_allowed_root,
+                                profile.expected_public_key,
+                                profile.expected_key_epoch,
+                            ),
+                            proposal_nonce_store_path,
+                            proposal_replay_high_water_store_id,
+                        )
+                    ),
                 )
             )
         except (OSError, TypeError, ValueError):
@@ -277,6 +306,8 @@ def build_signer_backend_from_provider(
     proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
     proposal_nonce_store: ProposalAuthenticityNonceStore | None = None,
     proposal_nonce_store_path: Path | str | None = None,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
+    proposal_replay_high_water_store_id: str | None = None,
     proposal_nonce_store_allowed_root: Path | str | None = None,
     proposal_nonce_store_repo_root: Path | str | None = None,
 ) -> SignerKeyProviderDryRunResult:
@@ -293,6 +324,12 @@ def build_signer_backend_from_provider(
         proposal_authority_policy=proposal_authority_policy,
         proposal_nonce_store=proposal_nonce_store,
         proposal_nonce_store_path=proposal_nonce_store_path,
+        proposal_replay_high_water_store=(
+            proposal_replay_high_water_store
+        ),
+        proposal_replay_high_water_store_id=(
+            proposal_replay_high_water_store_id
+        ),
         proposal_nonce_store_allowed_root=(
             proposal_nonce_store_allowed_root
         ),

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -30,9 +30,10 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend impo
     SignerAuditMacBuilder,
 )
 from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalPolicyAuthorization,
     ArchitectProposalSignerPolicy,
-    ProposalAuthenticityNonceStore,
     architect_proposal_replay_store_binding_digest,
+    architect_proposal_signer_policy_digest,
     architect_proposal_signer_instance_id,
 )
 from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
@@ -152,7 +153,7 @@ class _HmacAuditMacBuilder(SignerAuditMacBuilder):
         return "audit-mac-v1:" + digest
 
 
-def build_test_only_signer_backend_from_provider(
+def _build_signer_backend_from_provider_core(
     profile: SignerKeyProviderProfile,
     resolver: SignerKeyResolver,
     *,
@@ -162,14 +163,15 @@ def build_test_only_signer_backend_from_provider(
     control_loop_anchor_store: ControlLoopAnchorStore | None = None,
     control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
     proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
-    proposal_nonce_store: ProposalAuthenticityNonceStore | None = None,
     proposal_nonce_store_path: Path | str | None = None,
     proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
     proposal_replay_high_water_store_id: str | None = None,
+    proposal_replay_high_water_durability_receipt_id: str | None = None,
     proposal_nonce_store_allowed_root: Path | str | None = None,
     proposal_nonce_store_repo_root: Path | str | None = None,
+    proposal_policy_authorization: ArchitectProposalPolicyAuthorization | None = None,
 ) -> SignerKeyProviderDryRunResult:
-    """Validate a signer profile and build an Ed25519 signer backend.
+    """Internal key-resolution core; public callers cannot enable proposal mode.
 
     The default path rejects. A caller must explicitly opt into
     ``TEST_ONLY_DRYRUN`` or ``WSP71_PERMISSIONED`` and provide a fresh
@@ -216,22 +218,55 @@ def build_test_only_signer_backend_from_provider(
     fingerprint = public_key_fingerprint(public_key)
     if fingerprint != profile.expected_key_fingerprint:
         return _reject(FAIL_PROVIDER_FINGERPRINT_MISMATCH, profile=profile, signing=signing_result, audit=audit_result)
-    effective_proposal_nonce_store = proposal_nonce_store
-    if proposal_nonce_store_path is not None:
+    effective_proposal_nonce_store = None
+    if proposal_authority_policy is not None:
         try:
             high_water_store_matches = bool(
-                proposal_replay_high_water_store is not None
+                isinstance(
+                    proposal_replay_high_water_store,
+                    ProposalReplayHighWaterStore,
+                )
                 and proposal_replay_high_water_store_id
                 and hmac.compare_digest(
                     proposal_replay_high_water_store.store_id,
                     proposal_replay_high_water_store_id,
                 )
+                and isinstance(
+                    proposal_policy_authorization,
+                    ArchitectProposalPolicyAuthorization,
+                )
+                and hmac.compare_digest(
+                    proposal_policy_authorization.proposal_policy_digest,
+                    architect_proposal_signer_policy_digest(
+                        proposal_authority_policy
+                    ),
+                )
+                and (
+                    provider_mode != PROVIDER_MODE_WSP71_PERMISSIONED
+                    or (
+                        proposal_replay_high_water_store.durable is True
+                        and isinstance(
+                            proposal_replay_high_water_durability_receipt_id,
+                            str,
+                        )
+                        and _is_sha256_digest(
+                            proposal_replay_high_water_durability_receipt_id
+                        )
+                        and hmac.compare_digest(
+                            str(
+                                proposal_replay_high_water_store
+                                .durability_receipt_id
+                            ),
+                            proposal_replay_high_water_durability_receipt_id,
+                        )
+                    )
+                )
             )
         except Exception:
             high_water_store_matches = False
         if (
-            proposal_nonce_store is not None
-            or not high_water_store_matches
+            not high_water_store_matches
+            or proposal_nonce_store_path is None
             or proposal_nonce_store_allowed_root is None
             or proposal_nonce_store_repo_root is None
         ):
@@ -269,6 +304,24 @@ def build_test_only_signer_backend_from_provider(
                 signing=signing_result,
                 audit=audit_result,
             )
+    elif any(
+        value is not None
+        for value in (
+            proposal_nonce_store_path,
+            proposal_replay_high_water_store,
+            proposal_replay_high_water_store_id,
+            proposal_replay_high_water_durability_receipt_id,
+            proposal_nonce_store_allowed_root,
+            proposal_nonce_store_repo_root,
+            proposal_policy_authorization,
+        )
+    ):
+        return _reject(
+            FAIL_PROVIDER_PROFILE_INVALID,
+            profile=profile,
+            signing=signing_result,
+            audit=audit_result,
+        )
 
     return SignerKeyProviderDryRunResult(
         ok=True,
@@ -294,6 +347,68 @@ def build_test_only_signer_backend_from_provider(
     )
 
 
+def build_test_only_signer_backend_from_provider(
+    profile: SignerKeyProviderProfile,
+    resolver: SignerKeyResolver,
+    *,
+    provider_mode: str = "",
+    allow_test_only_key_material: bool = False,
+    permission_snapshot_fresh: bool = False,
+    control_loop_anchor_store: ControlLoopAnchorStore | None = None,
+    control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
+) -> SignerKeyProviderDryRunResult:
+    """Build a generic signer backend without architect-proposal authority."""
+
+    return _build_signer_backend_from_provider_core(
+        profile,
+        resolver,
+        provider_mode=provider_mode,
+        allow_test_only_key_material=allow_test_only_key_material,
+        permission_snapshot_fresh=permission_snapshot_fresh,
+        control_loop_anchor_store=control_loop_anchor_store,
+        control_loop_authority_policy=control_loop_authority_policy,
+    )
+
+
+def _build_proposal_signer_backend_from_verified_runtime(
+    profile: SignerKeyProviderProfile,
+    resolver: SignerKeyResolver,
+    *,
+    provider_mode: str,
+    allow_test_only_key_material: bool,
+    permission_snapshot_fresh: bool,
+    proposal_authority_policy: ArchitectProposalSignerPolicy,
+    proposal_policy_authorization: ArchitectProposalPolicyAuthorization,
+    proposal_nonce_store_path: Path | str,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore,
+    proposal_replay_high_water_store_id: str,
+    proposal_replay_high_water_durability_receipt_id: str,
+    proposal_nonce_store_allowed_root: Path | str,
+    proposal_nonce_store_repo_root: Path | str,
+) -> SignerKeyProviderDryRunResult:
+    """Internal proposal constructor reached only after runtime authorization."""
+
+    return _build_signer_backend_from_provider_core(
+        profile,
+        resolver,
+        provider_mode=provider_mode,
+        allow_test_only_key_material=allow_test_only_key_material,
+        permission_snapshot_fresh=permission_snapshot_fresh,
+        proposal_authority_policy=proposal_authority_policy,
+        proposal_policy_authorization=proposal_policy_authorization,
+        proposal_nonce_store_path=proposal_nonce_store_path,
+        proposal_replay_high_water_store=proposal_replay_high_water_store,
+        proposal_replay_high_water_store_id=(
+            proposal_replay_high_water_store_id
+        ),
+        proposal_replay_high_water_durability_receipt_id=(
+            proposal_replay_high_water_durability_receipt_id
+        ),
+        proposal_nonce_store_allowed_root=proposal_nonce_store_allowed_root,
+        proposal_nonce_store_repo_root=proposal_nonce_store_repo_root,
+    )
+
+
 def build_signer_backend_from_provider(
     profile: SignerKeyProviderProfile,
     resolver: SignerKeyResolver,
@@ -303,17 +418,10 @@ def build_signer_backend_from_provider(
     permission_snapshot_fresh: bool = False,
     control_loop_anchor_store: ControlLoopAnchorStore | None = None,
     control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
-    proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
-    proposal_nonce_store: ProposalAuthenticityNonceStore | None = None,
-    proposal_nonce_store_path: Path | str | None = None,
-    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
-    proposal_replay_high_water_store_id: str | None = None,
-    proposal_nonce_store_allowed_root: Path | str | None = None,
-    proposal_nonce_store_repo_root: Path | str | None = None,
 ) -> SignerKeyProviderDryRunResult:
-    """Compatibility wrapper with the production-capable boundary name."""
+    """Production-capable generic signer boundary; proposal mode is internal."""
 
-    return build_test_only_signer_backend_from_provider(
+    return _build_signer_backend_from_provider_core(
         profile,
         resolver,
         provider_mode=provider_mode,
@@ -321,19 +429,6 @@ def build_signer_backend_from_provider(
         permission_snapshot_fresh=permission_snapshot_fresh,
         control_loop_anchor_store=control_loop_anchor_store,
         control_loop_authority_policy=control_loop_authority_policy,
-        proposal_authority_policy=proposal_authority_policy,
-        proposal_nonce_store=proposal_nonce_store,
-        proposal_nonce_store_path=proposal_nonce_store_path,
-        proposal_replay_high_water_store=(
-            proposal_replay_high_water_store
-        ),
-        proposal_replay_high_water_store_id=(
-            proposal_replay_high_water_store_id
-        ),
-        proposal_nonce_store_allowed_root=(
-            proposal_nonce_store_allowed_root
-        ),
-        proposal_nonce_store_repo_root=proposal_nonce_store_repo_root,
     )
 
 
@@ -350,6 +445,15 @@ def _provider_mode_authorized(
             return False
         return not _resolver_is_mock_vault(resolver)
     return False
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = value if isinstance(value, str) else ""
+    return (
+        len(text) == 71
+        and text.startswith("sha256:")
+        and all(char in "0123456789abcdef" for char in text[7:])
+    )
 
 
 def _resolver_is_mock_vault(resolver: object) -> bool:

--- a/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_key_provider_dryrun.py
@@ -17,6 +17,7 @@ import binascii
 import hashlib
 import hmac
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Optional, Protocol
 
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
@@ -27,6 +28,13 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend impo
     ControlLoopAuthorityPolicy,
     Ed25519SignerBackend,
     SignerAuditMacBuilder,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalSignerPolicy,
+    ProposalAuthenticityNonceStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
+    AtomicProposalAuthenticityNonceStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor import (
     ControlLoopAnchorStore,
@@ -150,6 +158,11 @@ def build_test_only_signer_backend_from_provider(
     permission_snapshot_fresh: bool = False,
     control_loop_anchor_store: ControlLoopAnchorStore | None = None,
     control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
+    proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
+    proposal_nonce_store: ProposalAuthenticityNonceStore | None = None,
+    proposal_nonce_store_path: Path | str | None = None,
+    proposal_nonce_store_allowed_root: Path | str | None = None,
+    proposal_nonce_store_repo_root: Path | str | None = None,
 ) -> SignerKeyProviderDryRunResult:
     """Validate a signer profile and build an Ed25519 signer backend.
 
@@ -198,6 +211,35 @@ def build_test_only_signer_backend_from_provider(
     fingerprint = public_key_fingerprint(public_key)
     if fingerprint != profile.expected_key_fingerprint:
         return _reject(FAIL_PROVIDER_FINGERPRINT_MISMATCH, profile=profile, signing=signing_result, audit=audit_result)
+    effective_proposal_nonce_store = proposal_nonce_store
+    if proposal_nonce_store_path is not None:
+        if (
+            proposal_nonce_store is not None
+            or proposal_nonce_store_allowed_root is None
+            or proposal_nonce_store_repo_root is None
+        ):
+            return _reject(
+                FAIL_PROVIDER_PROFILE_INVALID,
+                profile=profile,
+                signing=signing_result,
+                audit=audit_result,
+            )
+        try:
+            effective_proposal_nonce_store = (
+                AtomicProposalAuthenticityNonceStore(
+                    proposal_nonce_store_path,
+                    allowed_root=proposal_nonce_store_allowed_root,
+                    repo_root=proposal_nonce_store_repo_root,
+                    integrity_key=audit_key,
+                )
+            )
+        except (OSError, TypeError, ValueError):
+            return _reject(
+                FAIL_PROVIDER_PROFILE_INVALID,
+                profile=profile,
+                signing=signing_result,
+                audit=audit_result,
+            )
 
     return SignerKeyProviderDryRunResult(
         ok=True,
@@ -217,6 +259,8 @@ def build_test_only_signer_backend_from_provider(
             audit_mac_builder=_HmacAuditMacBuilder(audit_key),
             control_loop_anchor_store=control_loop_anchor_store,
             control_loop_authority_policy=control_loop_authority_policy,
+            proposal_authority_policy=proposal_authority_policy,
+            proposal_nonce_store=effective_proposal_nonce_store,
         ),
     )
 
@@ -230,6 +274,11 @@ def build_signer_backend_from_provider(
     permission_snapshot_fresh: bool = False,
     control_loop_anchor_store: ControlLoopAnchorStore | None = None,
     control_loop_authority_policy: ControlLoopAuthorityPolicy | None = None,
+    proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
+    proposal_nonce_store: ProposalAuthenticityNonceStore | None = None,
+    proposal_nonce_store_path: Path | str | None = None,
+    proposal_nonce_store_allowed_root: Path | str | None = None,
+    proposal_nonce_store_repo_root: Path | str | None = None,
 ) -> SignerKeyProviderDryRunResult:
     """Compatibility wrapper with the production-capable boundary name."""
 
@@ -241,6 +290,13 @@ def build_signer_backend_from_provider(
         permission_snapshot_fresh=permission_snapshot_fresh,
         control_loop_anchor_store=control_loop_anchor_store,
         control_loop_authority_policy=control_loop_authority_policy,
+        proposal_authority_policy=proposal_authority_policy,
+        proposal_nonce_store=proposal_nonce_store,
+        proposal_nonce_store_path=proposal_nonce_store_path,
+        proposal_nonce_store_allowed_root=(
+            proposal_nonce_store_allowed_root
+        ),
+        proposal_nonce_store_repo_root=proposal_nonce_store_repo_root,
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
@@ -156,6 +156,7 @@ def run_reddog_signer_socket_service_config_supply(
     ) = None,
     proposal_nonce_store_path: Path | str | None = None,
     proposal_replay_high_water_store_id: str | None = None,
+    proposal_replay_high_water_durability_receipt_id: str | None = None,
     now_epoch: int | None = None,
     principal_key_resolver: PrincipalKeyResolver | None = None,
 ) -> SignerServiceConfigSupplyResult:
@@ -206,6 +207,7 @@ def run_reddog_signer_socket_service_config_supply(
         proposal_authority_policy,
         proposal_nonce_store_path,
         proposal_replay_high_water_store_id,
+        proposal_replay_high_water_durability_receipt_id,
         reddog_signer_agent_id,
     )
     reasons.extend(proposal_reasons)
@@ -243,6 +245,9 @@ def run_reddog_signer_socket_service_config_supply(
         proposal_replay_high_water_store_id=(
             proposal_replay_high_water_store_id
         ),
+        proposal_replay_high_water_durability_receipt_id=(
+            proposal_replay_high_water_durability_receipt_id
+        ),
     )
     provisional_runtime_config = SignerSocketServiceRuntimeWiringConfig(
         repo_root=root,
@@ -270,6 +275,9 @@ def run_reddog_signer_socket_service_config_supply(
         proposal_nonce_store_path=proposal_nonce_path,
         proposal_replay_high_water_store_id=(
             proposal_replay_high_water_store_id
+        ),
+        proposal_replay_high_water_durability_receipt_id=(
+            proposal_replay_high_water_durability_receipt_id
         ),
     )
     try:
@@ -486,6 +494,7 @@ def _proposal_runtime_inputs(
     policy: ArchitectProposalSignerPolicy | None,
     nonce_store_path: Path | str | None,
     high_water_store_id: str | None,
+    high_water_durability_receipt_id: str | None,
     reddog_signer_agent_id: str,
 ) -> tuple[Path | None, str | None, list[str]]:
     if policy is None:
@@ -494,7 +503,11 @@ def _proposal_runtime_inputs(
             None,
             (
                 []
-                if nonce_store_path is None and high_water_store_id is None
+                if (
+                    nonce_store_path is None
+                    and high_water_store_id is None
+                    and high_water_durability_receipt_id is None
+                )
                 else [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
             ),
         )
@@ -502,6 +515,7 @@ def _proposal_runtime_inputs(
         not isinstance(policy, ArchitectProposalSignerPolicy)
         or signer_runtime_root is None
         or not _ascii_string(high_water_store_id)
+        or not _is_sha256_digest(high_water_durability_receipt_id)
         or reddog_signer_agent_id
         != REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID
     ):
@@ -628,6 +642,7 @@ def _config(
     proposal_policy_authorization: ArchitectProposalPolicyAuthorization | None,
     proposal_nonce_store_path: Path | None,
     proposal_replay_high_water_store_id: str | None,
+    proposal_replay_high_water_durability_receipt_id: str | None,
 ) -> dict[str, Any]:
     principal_public = str(authority_profile["principal_public_key"])
     reddog_public = str(authority_profile["reddog_public_key"])
@@ -687,6 +702,9 @@ def _config(
     if proposal_authority_policy is not None:
         assert proposal_nonce_store_path is not None
         assert proposal_replay_high_water_store_id is not None
+        assert (
+            proposal_replay_high_water_durability_receipt_id is not None
+        )
         config["key_provider_profiles"] = [
             config["key_provider_profiles"][1]
         ]
@@ -705,6 +723,9 @@ def _config(
         config["proposal_replay_high_water_store_id"] = (
             proposal_replay_high_water_store_id
         )
+        config[
+            "proposal_replay_high_water_durability_receipt_id"
+        ] = proposal_replay_high_water_durability_receipt_id
         if proposal_policy_authorization is not None:
             config["proposal_policy_authorization"] = (
                 proposal_policy_authorization.to_dict()

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
@@ -14,12 +14,19 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
     atomic_replace_confined_mapping,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalPolicyAuthorization,
+    ArchitectProposalSignerPolicy,
+    DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS,
+    verify_architect_proposal_policy_authorization,
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
     validate_resident_signer_socket_limits,
@@ -31,6 +38,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     PROVIDER_MODE_WSP71_PERMISSIONED,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
+    REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID,
     SignerSocketServiceRuntimeWiringConfig,
     validate_signer_socket_service_runtime_config,
 )
@@ -56,6 +64,15 @@ FAIL_SIGNER_CONFIG_OP_REF_INVALID = "signer_config_op_ref_invalid"
 FAIL_SIGNER_CONFIG_OP_REF_REUSED = "signer_config_op_ref_reused"
 FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID = "signer_config_peer_policy_invalid"
 FAIL_SIGNER_CONFIG_LIMITS_INVALID = "signer_config_limits_invalid"
+FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID = (
+    "signer_config_proposal_policy_invalid"
+)
+FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID = (
+    "signer_config_proposal_policy_authorization_invalid"
+)
+FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID = (
+    "signer_config_proposal_nonce_path_invalid"
+)
 FAIL_SIGNER_CONFIG_WRITE_FAILED = "signer_config_write_failed"
 
 _REQUIRED_AUTHORITY_FIELDS = (
@@ -84,6 +101,9 @@ class SignerServiceConfigSupplyResult:
     reddog_id: str | None
     profile_count: int
     rejection_reasons: tuple[str, ...]
+    proposal_policy_configured: bool = False
+    proposal_attestation_id: str | None = None
+    proposal_nonce_store_path: str | None = None
     no_secret_values_written: bool = True
     no_secret_values_resolved: bool = True
     no_signer_started: bool = True
@@ -122,6 +142,12 @@ def run_reddog_signer_socket_service_config_supply(
     principal_signer_agent_id: str = "signer:principal",
     reddog_signer_agent_id: str = "signer:reddog",
     control_loop_anchor_path: Path | str | None = None,
+    proposal_authority_policy: ArchitectProposalSignerPolicy | None = None,
+    proposal_policy_authorization: (
+        ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None
+    ) = None,
+    proposal_nonce_store_path: Path | str | None = None,
+    now_epoch: int | None = None,
 ) -> SignerServiceConfigSupplyResult:
     """Write one signer CLI config from existing authority artifacts."""
 
@@ -148,6 +174,33 @@ def run_reddog_signer_socket_service_config_supply(
     peer_policy, peer_reasons = _peer_policy(peer_uid_to_principal, allowed_gids)
     reasons.extend(peer_reasons)
     reasons.extend(_limit_reasons(max_requests, timeout_s, max_request_bytes, max_response_bytes))
+    try:
+        authorization_now = int(
+            now_epoch if now_epoch is not None else time.time()
+        )
+    except (TypeError, ValueError):
+        authorization_now = 0
+        reasons.append(
+            FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID
+        )
+    verified_proposal_authorization, authorization_reasons = (
+        _proposal_policy_authorization(
+            profile,
+            proposal_authority_policy,
+            proposal_policy_authorization,
+            now_epoch=authorization_now,
+        )
+    )
+    reasons.extend(authorization_reasons)
+    proposal_nonce_path, proposal_reasons = _proposal_runtime_inputs(
+        root,
+        signer_runtime,
+        profile,
+        proposal_authority_policy,
+        proposal_nonce_store_path,
+        reddog_signer_agent_id,
+    )
+    reasons.extend(proposal_reasons)
 
     deduped = _dedupe(reasons)
     if deduped:
@@ -176,7 +229,11 @@ def run_reddog_signer_socket_service_config_supply(
         principal_signer_agent_id=principal_signer_agent_id,
         reddog_signer_agent_id=reddog_signer_agent_id,
         control_loop_anchor_path=anchor,
+        proposal_authority_policy=proposal_authority_policy,
+        proposal_policy_authorization=verified_proposal_authorization,
+        proposal_nonce_store_path=proposal_nonce_path,
     )
+    profile_count = len(tuple(config["key_provider_profiles"]))
     runtime_config_reasons = validate_signer_socket_service_runtime_config(
         SignerSocketServiceRuntimeWiringConfig(
             repo_root=root,
@@ -194,6 +251,11 @@ def run_reddog_signer_socket_service_config_supply(
             key_provider_profiles=tuple(config["key_provider_profiles"]),
             control_loop_anchor_path=anchor,
             control_loop_authority_policy=config["control_loop_authority_policy"],
+            proposal_authority_policy=config.get("proposal_authority_policy"),
+            proposal_policy_authorization=config.get(
+                "proposal_policy_authorization"
+            ),
+            proposal_nonce_store_path=config.get("proposal_nonce_store_path"),
         )
     )
     if runtime_config_reasons:
@@ -207,7 +269,16 @@ def run_reddog_signer_socket_service_config_supply(
         "control_loop_anchor_path": str(anchor),
         "principal_id": str(profile["principal_id"]),
         "reddog_id": str(profile["reddog_id"]),
-        "profile_count": 2,
+        "profile_count": profile_count,
+        "proposal_policy_configured": proposal_authority_policy is not None,
+        "proposal_attestation_id": (
+            proposal_authority_policy.expected_payload.attestation_id
+            if proposal_authority_policy is not None
+            else None
+        ),
+        "proposal_nonce_store_path": (
+            str(proposal_nonce_path) if proposal_nonce_path is not None else None
+        ),
         "no_secret_values_written": True,
         "no_secret_values_resolved": True,
         "no_signer_started": True,
@@ -230,8 +301,17 @@ def run_reddog_signer_socket_service_config_supply(
         socket_path=str(sock),
         principal_id=str(profile["principal_id"]),
         reddog_id=str(profile["reddog_id"]),
-        profile_count=2,
+        profile_count=profile_count,
         rejection_reasons=(),
+        proposal_policy_configured=proposal_authority_policy is not None,
+        proposal_attestation_id=(
+            proposal_authority_policy.expected_payload.attestation_id
+            if proposal_authority_policy is not None
+            else None
+        ),
+        proposal_nonce_store_path=(
+            str(proposal_nonce_path) if proposal_nonce_path is not None else None
+        ),
     )
 
 
@@ -313,6 +393,107 @@ def _runtime_artifact_paths(
     return runtime, signer_runtime, out, sock, anchor, reasons
 
 
+def _proposal_runtime_inputs(
+    repo_root: Path,
+    signer_runtime_root: Path | None,
+    authority_profile: Mapping[str, Any],
+    policy: ArchitectProposalSignerPolicy | None,
+    nonce_store_path: Path | str | None,
+    reddog_signer_agent_id: str,
+) -> tuple[Path | None, list[str]]:
+    if policy is None:
+        return (
+            None,
+            (
+                []
+                if nonce_store_path is None
+                else [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
+            ),
+        )
+    if (
+        not isinstance(policy, ArchitectProposalSignerPolicy)
+        or signer_runtime_root is None
+        or reddog_signer_agent_id
+        != REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID
+    ):
+        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
+    payload = policy.expected_payload
+    identity_matches = (
+        payload.requester_principal_id
+        == str(authority_profile.get("principal_id") or "")
+        and payload.reddog_id
+        == str(authority_profile.get("reddog_id") or "")
+        and payload.signer_public_key
+        == str(authority_profile.get("reddog_public_key") or "")
+        and payload.key_epoch
+        == str(authority_profile.get("key_epoch") or "")
+        and payload.consensus_receipt_digest
+        == str(authority_profile.get("consensus_receipt_digest") or "")
+        and payload.authority_profile_source_receipt_id
+        == str(
+            authority_profile.get("authority_profile_source_receipt_id")
+            or ""
+        )
+    )
+    ttl = int(payload.expires_at) - int(payload.issued_at)
+    if (
+        not identity_matches
+        or policy.max_ttl_seconds <= 0
+        or policy.max_ttl_seconds
+        > DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+        or ttl <= 0
+        or ttl > int(policy.max_ttl_seconds)
+    ):
+        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
+    target_value = (
+        nonce_store_path
+        if nonce_store_path is not None
+        else signer_runtime_root / "architect_proposal_nonce_store.json"
+    )
+    try:
+        target = validate_runtime_artifact_path(
+            target_value,
+            repo_root=repo_root,
+            allowed_root=signer_runtime_root,
+        )
+    except (OSError, TypeError, ValueError):
+        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID]
+    if target.parent != signer_runtime_root or (
+        target.exists() and not target.is_file()
+    ):
+        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID]
+    return target, []
+
+
+def _proposal_policy_authorization(
+    authority_profile: Mapping[str, Any],
+    policy: ArchitectProposalSignerPolicy | None,
+    value: ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None,
+    *,
+    now_epoch: int,
+) -> tuple[ArchitectProposalPolicyAuthorization | None, list[str]]:
+    if policy is None:
+        return (
+            None,
+            []
+            if value is None
+            else [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID],
+        )
+    raw = value.to_dict() if hasattr(value, "to_dict") else value
+    if not isinstance(raw, Mapping):
+        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID]
+    try:
+        verified = verify_architect_proposal_policy_authorization(
+            raw,
+            policy=policy,
+            authority_profile=authority_profile,
+            now_epoch=now_epoch,
+        )
+    except (TypeError, ValueError):
+        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID]
+    return verified, []
+
+
 def _config(
     *,
     authority_profile: Mapping[str, Any],
@@ -331,12 +512,15 @@ def _config(
     principal_signer_agent_id: str,
     reddog_signer_agent_id: str,
     control_loop_anchor_path: Path,
+    proposal_authority_policy: ArchitectProposalSignerPolicy | None,
+    proposal_policy_authorization: ArchitectProposalPolicyAuthorization | None,
+    proposal_nonce_store_path: Path | None,
 ) -> dict[str, Any]:
     principal_public = str(authority_profile["principal_public_key"])
     reddog_public = str(authority_profile["reddog_public_key"])
     permission_digest = str(authority_profile["permission_snapshot_digest"])
     key_epoch = str(authority_profile["key_epoch"])
-    return {
+    config = {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
         "runtime_root": str(runtime_root),
         "signer_runtime_root": str(signer_runtime_root),
@@ -387,6 +571,24 @@ def _config(
         ],
         "peer_policy": dict(peer_policy),
     }
+    if proposal_authority_policy is not None:
+        assert proposal_nonce_store_path is not None
+        assert proposal_policy_authorization is not None
+        config["proposal_authority_policy"] = {
+            "expected_payload": (
+                proposal_authority_policy.expected_payload.to_dict()
+            ),
+            "max_ttl_seconds": int(
+                proposal_authority_policy.max_ttl_seconds
+            ),
+        }
+        config["proposal_nonce_store_path"] = str(
+            proposal_nonce_store_path
+        )
+        config["proposal_policy_authorization"] = (
+            proposal_policy_authorization.to_dict()
+        )
+    return config
 
 
 def _authority_profile_reasons(profile: Mapping[str, Any]) -> list[str]:
@@ -516,6 +718,9 @@ __all__ = [
     "FAIL_SIGNER_CONFIG_OUTPUT_PATH_INVALID",
     "FAIL_SIGNER_CONFIG_CONTROL_ANCHOR_PATH_INVALID",
     "FAIL_SIGNER_CONFIG_PEER_POLICY_INVALID",
+    "FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID",
+    "FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID",
+    "FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID",
     "FAIL_SIGNER_CONFIG_SOCKET_PATH_INVALID",
     "FAIL_SIGNER_CONFIG_WRITE_FAILED",
     "SIGNER_SERVICE_CONFIG_SCHEMA_VERSION",

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_config_supply.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -26,6 +26,8 @@ from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenti
     ArchitectProposalPolicyAuthorization,
     ArchitectProposalSignerPolicy,
     DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS,
+    architect_proposal_replay_store_binding_digest,
+    architect_proposal_signer_instance_id,
     verify_architect_proposal_policy_authorization,
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
@@ -40,7 +42,12 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID,
     SignerSocketServiceRuntimeWiringConfig,
+    architect_proposal_security_context_digest,
     validate_signer_socket_service_runtime_config,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    FailClosedPrincipalKeyResolver,
+    PrincipalKeyResolver,
 )
 from modules.infrastructure.secrets_mcp.src.vault_resolver import parse_op_reference
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
@@ -77,6 +84,7 @@ FAIL_SIGNER_CONFIG_WRITE_FAILED = "signer_config_write_failed"
 
 _REQUIRED_AUTHORITY_FIELDS = (
     "principal_id",
+    "principal_provider",
     "principal_public_key",
     "reddog_id",
     "reddog_public_key",
@@ -147,14 +155,23 @@ def run_reddog_signer_socket_service_config_supply(
         ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None
     ) = None,
     proposal_nonce_store_path: Path | str | None = None,
+    proposal_replay_high_water_store_id: str | None = None,
     now_epoch: int | None = None,
+    principal_key_resolver: PrincipalKeyResolver | None = None,
 ) -> SignerServiceConfigSupplyResult:
     """Write one signer CLI config from existing authority artifacts."""
 
     root = Path(repo_root).resolve()
     profile = _mapping(authority_profile)
     reasons: list[str] = []
-    reasons.extend(_authority_profile_reasons(profile))
+    reasons.extend(
+        _authority_profile_reasons(
+            profile,
+            require_principal_provider=(
+                proposal_authority_policy is not None
+            ),
+        )
+    )
     runtime, signer_runtime, out, sock, anchor, path_reasons = _runtime_artifact_paths(
         root,
         runtime_root,
@@ -165,39 +182,30 @@ def run_reddog_signer_socket_service_config_supply(
     )
     reasons.extend(path_reasons)
     op_refs = (
-        principal_signing_key_ref,
-        principal_audit_mac_key_ref,
-        reddog_signing_key_ref,
-        reddog_audit_mac_key_ref,
+        (reddog_signing_key_ref, reddog_audit_mac_key_ref)
+        if proposal_authority_policy is not None
+        else (
+            principal_signing_key_ref,
+            principal_audit_mac_key_ref,
+            reddog_signing_key_ref,
+            reddog_audit_mac_key_ref,
+        )
     )
     reasons.extend(_op_ref_reasons(op_refs))
     peer_policy, peer_reasons = _peer_policy(peer_uid_to_principal, allowed_gids)
     reasons.extend(peer_reasons)
     reasons.extend(_limit_reasons(max_requests, timeout_s, max_request_bytes, max_response_bytes))
-    try:
-        authorization_now = int(
-            now_epoch if now_epoch is not None else time.time()
-        )
-    except (TypeError, ValueError):
-        authorization_now = 0
-        reasons.append(
-            FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID
-        )
-    verified_proposal_authorization, authorization_reasons = (
-        _proposal_policy_authorization(
-            profile,
-            proposal_authority_policy,
-            proposal_policy_authorization,
-            now_epoch=authorization_now,
-        )
-    )
-    reasons.extend(authorization_reasons)
-    proposal_nonce_path, proposal_reasons = _proposal_runtime_inputs(
+    (
+        proposal_nonce_path,
+        proposal_replay_high_water_store_id,
+        proposal_reasons,
+    ) = _proposal_runtime_inputs(
         root,
         signer_runtime,
         profile,
         proposal_authority_policy,
         proposal_nonce_store_path,
+        proposal_replay_high_water_store_id,
         reddog_signer_agent_id,
     )
     reasons.extend(proposal_reasons)
@@ -212,7 +220,7 @@ def run_reddog_signer_socket_service_config_supply(
     assert runtime is not None
     assert signer_runtime is not None
     assert peer_policy is not None
-    config = _config(
+    unsigned_config = _config(
         authority_profile=profile,
         runtime_root=runtime,
         signer_runtime_root=signer_runtime,
@@ -230,32 +238,110 @@ def run_reddog_signer_socket_service_config_supply(
         reddog_signer_agent_id=reddog_signer_agent_id,
         control_loop_anchor_path=anchor,
         proposal_authority_policy=proposal_authority_policy,
-        proposal_policy_authorization=verified_proposal_authorization,
+        proposal_policy_authorization=None,
         proposal_nonce_store_path=proposal_nonce_path,
+        proposal_replay_high_water_store_id=(
+            proposal_replay_high_water_store_id
+        ),
     )
+    provisional_runtime_config = SignerSocketServiceRuntimeWiringConfig(
+        repo_root=root,
+        runtime_root=runtime,
+        signer_runtime_root=signer_runtime,
+        socket_path=sock,
+        peer_policy=unsigned_config["peer_policy"],
+        provider_mode=str(unsigned_config["provider_mode"]),
+        allow_test_only_key_material=False,
+        permission_snapshot_fresh=True,
+        max_requests=unsigned_config["max_requests"],
+        timeout_s=unsigned_config["timeout_s"],
+        max_request_bytes=unsigned_config["max_request_bytes"],
+        max_response_bytes=unsigned_config["max_response_bytes"],
+        key_provider_profiles=tuple(
+            unsigned_config["key_provider_profiles"]
+        ),
+        control_loop_anchor_path=anchor,
+        control_loop_authority_policy=unsigned_config.get(
+            "control_loop_authority_policy"
+        ),
+        proposal_authority_policy=unsigned_config.get(
+            "proposal_authority_policy"
+        ),
+        proposal_nonce_store_path=proposal_nonce_path,
+        proposal_replay_high_water_store_id=(
+            proposal_replay_high_water_store_id
+        ),
+    )
+    try:
+        security_context_digest = (
+            architect_proposal_security_context_digest(
+                provisional_runtime_config
+            )
+            if proposal_authority_policy is not None
+            else ""
+        )
+    except (OSError, TypeError, ValueError):
+        return _reject(
+            (FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,)
+        )
+    if proposal_authority_policy is not None:
+        signer_instance_id = architect_proposal_signer_instance_id(
+            signer_runtime,
+            str(profile.get("reddog_public_key") or ""),
+            str(profile.get("key_epoch") or ""),
+        )
+        replay_store_binding_digest = (
+            architect_proposal_replay_store_binding_digest(
+                signer_instance_id,
+                proposal_nonce_path,
+                proposal_replay_high_water_store_id,
+            )
+        )
+    else:
+        signer_instance_id = ""
+        replay_store_binding_digest = ""
+    try:
+        authorization_now = int(
+            now_epoch if now_epoch is not None else time.time()
+        )
+    except (TypeError, ValueError):
+        authorization_now = 0
+    verified_proposal_authorization, authorization_reasons = (
+        _proposal_policy_authorization(
+            profile,
+            proposal_authority_policy,
+            proposal_policy_authorization,
+            principal_key_resolver=(
+                principal_key_resolver
+                or FailClosedPrincipalKeyResolver()
+            ),
+            expected_signer_instance_id=signer_instance_id,
+            expected_replay_store_binding_digest=(
+                replay_store_binding_digest
+            ),
+            expected_security_context_digest=security_context_digest,
+            now_epoch=authorization_now,
+        )
+    )
+    if authorization_reasons:
+        return _reject(authorization_reasons)
+    config = dict(unsigned_config)
+    if verified_proposal_authorization is not None:
+        config["proposal_policy_authorization"] = (
+            verified_proposal_authorization.to_dict()
+        )
     profile_count = len(tuple(config["key_provider_profiles"]))
     runtime_config_reasons = validate_signer_socket_service_runtime_config(
-        SignerSocketServiceRuntimeWiringConfig(
-            repo_root=root,
-            runtime_root=runtime,
-            signer_runtime_root=signer_runtime,
-            socket_path=sock,
-            peer_policy=config["peer_policy"],
-            provider_mode=str(config["provider_mode"]),
-            allow_test_only_key_material=False,
-            permission_snapshot_fresh=True,
-            max_requests=config["max_requests"],
-            timeout_s=config["timeout_s"],
-            max_request_bytes=config["max_request_bytes"],
-            max_response_bytes=config["max_response_bytes"],
-            key_provider_profiles=tuple(config["key_provider_profiles"]),
-            control_loop_anchor_path=anchor,
-            control_loop_authority_policy=config["control_loop_authority_policy"],
-            proposal_authority_policy=config.get("proposal_authority_policy"),
+        replace(
+            provisional_runtime_config,
             proposal_policy_authorization=config.get(
                 "proposal_policy_authorization"
             ),
-            proposal_nonce_store_path=config.get("proposal_nonce_store_path"),
+            proposal_security_context_digest=(
+                security_context_digest
+                if proposal_authority_policy is not None
+                else None
+            ),
         )
     )
     if runtime_config_reasons:
@@ -399,24 +485,27 @@ def _proposal_runtime_inputs(
     authority_profile: Mapping[str, Any],
     policy: ArchitectProposalSignerPolicy | None,
     nonce_store_path: Path | str | None,
+    high_water_store_id: str | None,
     reddog_signer_agent_id: str,
-) -> tuple[Path | None, list[str]]:
+) -> tuple[Path | None, str | None, list[str]]:
     if policy is None:
         return (
             None,
+            None,
             (
                 []
-                if nonce_store_path is None
+                if nonce_store_path is None and high_water_store_id is None
                 else [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
             ),
         )
     if (
         not isinstance(policy, ArchitectProposalSignerPolicy)
         or signer_runtime_root is None
+        or not _ascii_string(high_water_store_id)
         or reddog_signer_agent_id
         != REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID
     ):
-        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
+        return None, None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
     payload = policy.expected_payload
     identity_matches = (
         payload.requester_principal_id
@@ -444,12 +533,11 @@ def _proposal_runtime_inputs(
         or ttl <= 0
         or ttl > int(policy.max_ttl_seconds)
     ):
-        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
-    target_value = (
-        nonce_store_path
-        if nonce_store_path is not None
-        else signer_runtime_root / "architect_proposal_nonce_store.json"
+        return None, None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID]
+    canonical_target = (
+        signer_runtime_root / "architect_proposal_nonce_store.json"
     )
+    target_value = nonce_store_path or canonical_target
     try:
         target = validate_runtime_artifact_path(
             target_value,
@@ -457,12 +545,16 @@ def _proposal_runtime_inputs(
             allowed_root=signer_runtime_root,
         )
     except (OSError, TypeError, ValueError):
-        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID]
+        return None, None, [
+            FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID
+        ]
     if target.parent != signer_runtime_root or (
         target.exists() and not target.is_file()
-    ):
-        return None, [FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID]
-    return target, []
+    ) or target != canonical_target.resolve():
+        return None, None, [
+            FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID
+        ]
+    return target, str(high_water_store_id).strip(), []
 
 
 def _proposal_policy_authorization(
@@ -470,6 +562,10 @@ def _proposal_policy_authorization(
     policy: ArchitectProposalSignerPolicy | None,
     value: ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None,
     *,
+    principal_key_resolver: PrincipalKeyResolver,
+    expected_signer_instance_id: str,
+    expected_replay_store_binding_digest: str,
+    expected_security_context_digest: str,
     now_epoch: int,
 ) -> tuple[ArchitectProposalPolicyAuthorization | None, list[str]]:
     if policy is None:
@@ -483,13 +579,29 @@ def _proposal_policy_authorization(
     if not isinstance(raw, Mapping):
         return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID]
     try:
+        trusted_principal_key = principal_key_resolver.resolve(
+            str(authority_profile.get("principal_id") or ""),
+            str(authority_profile.get("principal_provider") or ""),
+        )
         verified = verify_architect_proposal_policy_authorization(
             raw,
             policy=policy,
             authority_profile=authority_profile,
+            trusted_principal_public_key=str(
+                trusted_principal_key or ""
+            ),
+            expected_signer_instance_id=(
+                expected_signer_instance_id
+            ),
+            expected_replay_store_binding_digest=(
+                expected_replay_store_binding_digest
+            ),
+            expected_security_context_digest=(
+                expected_security_context_digest
+            ),
             now_epoch=now_epoch,
         )
-    except (TypeError, ValueError):
+    except Exception:
         return None, [FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID]
     return verified, []
 
@@ -515,6 +627,7 @@ def _config(
     proposal_authority_policy: ArchitectProposalSignerPolicy | None,
     proposal_policy_authorization: ArchitectProposalPolicyAuthorization | None,
     proposal_nonce_store_path: Path | None,
+    proposal_replay_high_water_store_id: str | None,
 ) -> dict[str, Any]:
     principal_public = str(authority_profile["principal_public_key"])
     reddog_public = str(authority_profile["reddog_public_key"])
@@ -573,7 +686,11 @@ def _config(
     }
     if proposal_authority_policy is not None:
         assert proposal_nonce_store_path is not None
-        assert proposal_policy_authorization is not None
+        assert proposal_replay_high_water_store_id is not None
+        config["key_provider_profiles"] = [
+            config["key_provider_profiles"][1]
+        ]
+        config.pop("control_loop_authority_policy", None)
         config["proposal_authority_policy"] = {
             "expected_payload": (
                 proposal_authority_policy.expected_payload.to_dict()
@@ -585,16 +702,33 @@ def _config(
         config["proposal_nonce_store_path"] = str(
             proposal_nonce_store_path
         )
-        config["proposal_policy_authorization"] = (
-            proposal_policy_authorization.to_dict()
+        config["proposal_replay_high_water_store_id"] = (
+            proposal_replay_high_water_store_id
         )
+        if proposal_policy_authorization is not None:
+            config["proposal_policy_authorization"] = (
+                proposal_policy_authorization.to_dict()
+            )
     return config
 
 
-def _authority_profile_reasons(profile: Mapping[str, Any]) -> list[str]:
+def _authority_profile_reasons(
+    profile: Mapping[str, Any],
+    *,
+    require_principal_provider: bool,
+) -> list[str]:
     if not profile or not _ascii_deep(profile):
         return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID]
-    missing = [field for field in _REQUIRED_AUTHORITY_FIELDS if not str(profile.get(field) or "")]
+    required_fields = tuple(
+        field
+        for field in _REQUIRED_AUTHORITY_FIELDS
+        if require_principal_provider or field != "principal_provider"
+    )
+    missing = [
+        field
+        for field in required_fields
+        if not str(profile.get(field) or "")
+    ]
     if missing:
         return [FAIL_SIGNER_CONFIG_AUTHORITY_PROFILE_INVALID + ":" + field for field in missing]
     if str(profile.get("principal_public_key")) == str(profile.get("reddog_public_key")):

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
@@ -46,6 +46,9 @@ FAIL_SIGNER_RUN_PACKET_OP_EXECUTABLE_INVALID = "signer_run_packet_op_executable_
 FAIL_SIGNER_RUN_PACKET_LIMITS_INVALID = "signer_run_packet_limits_invalid"
 FAIL_SIGNER_RUN_PACKET_SESSION_INVALID = "signer_run_packet_session_invalid"
 FAIL_SIGNER_RUN_PACKET_WRITE_FAILED = "signer_run_packet_write_failed"
+FAIL_SIGNER_RUN_PACKET_PROPOSAL_RUNTIME_ADAPTERS_UNAVAILABLE = (
+    "signer_run_packet_proposal_runtime_adapters_unavailable"
+)
 
 _CLI_MODULE = (
     "modules.communication.moltbot_bridge.src."
@@ -115,6 +118,12 @@ def run_reddog_signer_socket_service_run_packet_supply(
     assert config_digest is not None
     assert config_resolved is not None
     assert output_resolved is not None
+    if config.get("proposal_authority_policy") is not None:
+        return _reject(
+            (
+                FAIL_SIGNER_RUN_PACKET_PROPOSAL_RUNTIME_ADAPTERS_UNAVAILABLE,
+            )
+        )
     socket_path = Path(str(config["socket_path"])).resolve()
     profiles = tuple(config.get("key_provider_profiles") or ())
     executable = str(python_executable or sys.executable)

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_run_packet_supply.py
@@ -126,6 +126,8 @@ def run_reddog_signer_socket_service_run_packet_supply(
         str(root),
         "--config",
         str(config_resolved),
+        "--expected-config-digest",
+        config_digest,
         "--op-executable",
         str(op_executable),
         "--op-timeout-s",
@@ -226,6 +228,7 @@ def _config_reasons(
         repo_root,
         expected_runtime_root,
         dict(payload),
+        expected_config_digest=_digest(payload),
     ) is None:
         return (FAIL_SIGNER_RUN_PACKET_CONFIG_MALFORMED,)
     socket_path = str(payload.get("socket_path") or "")

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
@@ -107,6 +107,14 @@ def run_reddog_signer_socket_service_runtime_bootstrap(
         return _reject(*read_reasons, config_path=str(path))
     assert payload is not None
     assert digest is not None
+    if expected_config_digest is not None and not _is_sha256_digest(
+        expected_config_digest
+    ):
+        return _reject(
+            FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH,
+            config_path=str(path),
+            config_digest=digest,
+        )
     if (
         expected_config_digest is not None
         and not hmac.compare_digest(expected_config_digest, digest)
@@ -287,11 +295,17 @@ def rehydrate_signer_socket_service_runtime_config(
         proposal_high_water_store_id = payload.get(
             "proposal_replay_high_water_store_id"
         )
+        proposal_high_water_durability_receipt_id = payload.get(
+            "proposal_replay_high_water_durability_receipt_id"
+        )
         if not (
             (proposal_policy is None)
             == (proposal_policy_authorization is None)
             == (proposal_nonce_path_value is None)
             == (proposal_high_water_store_id is None)
+            == (
+                proposal_high_water_durability_receipt_id is None
+            )
         ):
             return None
         proposal_nonce_path = None
@@ -312,10 +326,14 @@ def rehydrate_signer_socket_service_runtime_config(
                 not isinstance(proposal_high_water_store_id, str)
                 or not proposal_high_water_store_id.strip()
                 or not proposal_high_water_store_id.isascii()
+                or not _is_sha256_digest(
+                    proposal_high_water_durability_receipt_id
+                )
             ):
                 return None
         else:
             proposal_high_water_store_id = None
+            proposal_high_water_durability_receipt_id = None
         peer_policy = payload["peer_policy"]
         key_profile = payload.get("key_provider_profile")
         key_profiles = payload.get("key_provider_profiles") or ()
@@ -358,6 +376,9 @@ def rehydrate_signer_socket_service_runtime_config(
             proposal_replay_high_water_store_id=(
                 proposal_high_water_store_id
             ),
+            proposal_replay_high_water_durability_receipt_id=(
+                proposal_high_water_durability_receipt_id
+            ),
         )
         if proposal_policy is not None:
             config = replace(
@@ -390,6 +411,15 @@ def _reject(
         config_path=config_path,
         config_digest=config_digest,
         runtime_result=runtime_result,
+    )
+
+
+def _is_sha256_digest(value: object) -> bool:
+    text = value if isinstance(value, str) else ""
+    return (
+        len(text) == 71
+        and text.startswith("sha256:")
+        and all(char in "0123456789abcdef" for char in text[7:])
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
@@ -14,12 +14,15 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     SignerKeyResolver,
+)
+from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
+    ProposalReplayHighWaterStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
     SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
@@ -27,8 +30,12 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_confi
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     ServeSignerSocketBounded,
     SignerSocketServiceRuntimeWiringConfig,
+    architect_proposal_security_context_digest,
     run_reddog_signer_socket_service_runtime_wiring,
     validate_signer_socket_service_runtime_config,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PrincipalKeyResolver,
 )
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
     secure_read_confined_text,
@@ -84,6 +91,8 @@ def run_reddog_signer_socket_service_runtime_bootstrap(
     serve_bounded: ServeSignerSocketBounded,
     ready_callback: Optional[Callable[[], None]] = None,
     expected_config_digest: str | None = None,
+    principal_key_resolver: PrincipalKeyResolver | None = None,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
 ) -> SignerSocketServiceRuntimeBootstrapResult:
     """Read a signer-owned outside-repo config and run signer service wiring."""
 
@@ -132,6 +141,10 @@ def run_reddog_signer_socket_service_runtime_bootstrap(
         resolver,
         serve_bounded=serve_bounded,
         ready_callback=ready_callback,
+        principal_key_resolver=principal_key_resolver,
+        proposal_replay_high_water_store=(
+            proposal_replay_high_water_store
+        ),
     )
     runtime_receipt = runtime.to_dict()
     if runtime.accepted is not True:
@@ -228,9 +241,14 @@ def rehydrate_signer_socket_service_runtime_config(
             return None
         if payload.get("schema_version") != SIGNER_SERVICE_CONFIG_SCHEMA_VERSION:
             return None
-        if not payload.get("control_loop_anchor_path") or not isinstance(
-            payload.get("control_loop_authority_policy"),
-            dict,
+        if not payload.get("control_loop_anchor_path"):
+            return None
+        if (
+            not isinstance(
+                payload.get("control_loop_authority_policy"),
+                dict,
+            )
+            and payload.get("proposal_authority_policy") is None
         ):
             return None
         runtime_root = validate_runtime_root_path(
@@ -266,10 +284,14 @@ def rehydrate_signer_socket_service_runtime_config(
             "proposal_policy_authorization"
         )
         proposal_nonce_path_value = payload.get("proposal_nonce_store_path")
+        proposal_high_water_store_id = payload.get(
+            "proposal_replay_high_water_store_id"
+        )
         if not (
             (proposal_policy is None)
             == (proposal_policy_authorization is None)
             == (proposal_nonce_path_value is None)
+            == (proposal_high_water_store_id is None)
         ):
             return None
         proposal_nonce_path = None
@@ -286,6 +308,14 @@ def rehydrate_signer_socket_service_runtime_config(
             )
             if proposal_nonce_path.parent != signer_runtime_root:
                 return None
+            if (
+                not isinstance(proposal_high_water_store_id, str)
+                or not proposal_high_water_store_id.strip()
+                or not proposal_high_water_store_id.isascii()
+            ):
+                return None
+        else:
+            proposal_high_water_store_id = None
         peer_policy = payload["peer_policy"]
         key_profile = payload.get("key_provider_profile")
         key_profiles = payload.get("key_provider_profiles") or ()
@@ -319,11 +349,23 @@ def rehydrate_signer_socket_service_runtime_config(
             max_response_bytes=payload.get("max_response_bytes"),
             key_provider_profiles=key_profiles,
             control_loop_anchor_path=anchor_path,
-            control_loop_authority_policy=payload["control_loop_authority_policy"],
+            control_loop_authority_policy=payload.get(
+                "control_loop_authority_policy"
+            ),
             proposal_authority_policy=proposal_policy,
             proposal_policy_authorization=proposal_policy_authorization,
             proposal_nonce_store_path=proposal_nonce_path,
+            proposal_replay_high_water_store_id=(
+                proposal_high_water_store_id
+            ),
         )
+        if proposal_policy is not None:
+            config = replace(
+                config,
+                proposal_security_context_digest=(
+                    architect_proposal_security_context_digest(config)
+                ),
+            )
     except Exception:
         return None
     if validate_signer_socket_service_runtime_config(config):

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_bootstrap.py
@@ -12,6 +12,7 @@ Hermes, publish PRs, settle rewards, or re-index HoloIndex.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -44,6 +45,9 @@ FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_RELATIVE = "FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_
 FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_INSIDE_REPO = "FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_INSIDE_REPO"
 FAIL_SIGNER_BOOTSTRAP_CONFIG_UNREADABLE = "FAIL_SIGNER_BOOTSTRAP_CONFIG_UNREADABLE"
 FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED = "FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED"
+FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH = (
+    "FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH"
+)
 FAIL_SIGNER_BOOTSTRAP_RUNTIME_REJECTED = "FAIL_SIGNER_BOOTSTRAP_RUNTIME_REJECTED"
 
 
@@ -79,6 +83,7 @@ def run_reddog_signer_socket_service_runtime_bootstrap(
     resolver: SignerKeyResolver,
     serve_bounded: ServeSignerSocketBounded,
     ready_callback: Optional[Callable[[], None]] = None,
+    expected_config_digest: str | None = None,
 ) -> SignerSocketServiceRuntimeBootstrapResult:
     """Read a signer-owned outside-repo config and run signer service wiring."""
 
@@ -93,11 +98,27 @@ def run_reddog_signer_socket_service_runtime_bootstrap(
         return _reject(*read_reasons, config_path=str(path))
     assert payload is not None
     assert digest is not None
+    if (
+        expected_config_digest is not None
+        and not hmac.compare_digest(expected_config_digest, digest)
+    ) or (
+        payload.get("proposal_authority_policy") is not None
+        and (
+            expected_config_digest is None
+            or not hmac.compare_digest(expected_config_digest, digest)
+        )
+    ):
+        return _reject(
+            FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH,
+            config_path=str(path),
+            config_digest=digest,
+        )
 
     config = rehydrate_signer_socket_service_runtime_config(
         root,
         path.parent,
         payload,
+        expected_config_digest=expected_config_digest,
     )
     if config is None:
         return _reject(
@@ -181,10 +202,30 @@ def rehydrate_signer_socket_service_runtime_config(
     repo_root: Path,
     expected_runtime_root: Path,
     payload: dict[str, Any],
+    *,
+    expected_config_digest: str | None = None,
 ) -> Optional[SignerSocketServiceRuntimeWiringConfig]:
     """Validate and rehydrate the canonical schema-v2 signer config."""
 
     try:
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+        actual_digest = (
+            "sha256:"
+            + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        )
+        if payload.get("proposal_authority_policy") is not None and (
+            expected_config_digest is None
+            or not hmac.compare_digest(
+                expected_config_digest,
+                actual_digest,
+            )
+        ):
+            return None
         if payload.get("schema_version") != SIGNER_SERVICE_CONFIG_SCHEMA_VERSION:
             return None
         if not payload.get("control_loop_anchor_path") or not isinstance(
@@ -220,6 +261,31 @@ def rehydrate_signer_socket_service_runtime_config(
         )
         if socket_path.parent != runtime_root or anchor_path.parent != signer_runtime_root:
             return None
+        proposal_policy = payload.get("proposal_authority_policy")
+        proposal_policy_authorization = payload.get(
+            "proposal_policy_authorization"
+        )
+        proposal_nonce_path_value = payload.get("proposal_nonce_store_path")
+        if not (
+            (proposal_policy is None)
+            == (proposal_policy_authorization is None)
+            == (proposal_nonce_path_value is None)
+        ):
+            return None
+        proposal_nonce_path = None
+        if proposal_policy is not None:
+            if not isinstance(proposal_policy, dict) or not isinstance(
+                proposal_policy_authorization,
+                dict,
+            ):
+                return None
+            proposal_nonce_path = validate_runtime_artifact_path(
+                proposal_nonce_path_value,
+                repo_root=repo_root,
+                allowed_root=signer_runtime_root,
+            )
+            if proposal_nonce_path.parent != signer_runtime_root:
+                return None
         peer_policy = payload["peer_policy"]
         key_profile = payload.get("key_provider_profile")
         key_profiles = payload.get("key_provider_profiles") or ()
@@ -254,6 +320,9 @@ def rehydrate_signer_socket_service_runtime_config(
             key_provider_profiles=key_profiles,
             control_loop_anchor_path=anchor_path,
             control_loop_authority_policy=payload["control_loop_authority_policy"],
+            proposal_authority_policy=proposal_policy,
+            proposal_policy_authorization=proposal_policy_authorization,
+            proposal_nonce_store_path=proposal_nonce_path,
         )
     except Exception:
         return None
@@ -289,6 +358,7 @@ def _is_inside(child: Path, parent: Path) -> bool:
 
 
 __all__ = [
+    "FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH",
     "FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED",
     "FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_INSIDE_REPO",
     "FAIL_SIGNER_BOOTSTRAP_CONFIG_PATH_MISSING",

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_cli.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_cli.py
@@ -26,7 +26,14 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runti
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     ServeSignerSocketBounded,
 )
+from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
+    ProposalReplayHighWaterStore,
+)
 from modules.infrastructure.secrets_mcp.src.op_cli_secret_resolver import OpCliSecretResolver
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    FailClosedPrincipalKeyResolver,
+    PrincipalKeyResolver,
+)
 
 
 SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT = "SIGNER_SOCKET_SERVICE_RUNTIME_CLI_ACCEPT"
@@ -73,6 +80,8 @@ def run_reddog_signer_socket_service_runtime_cli(
     resolver_factory: ResolverFactory = OpCliSecretResolver,
     serve_bounded: ServeSignerSocketBounded = serve_reddog_isolated_signer_socket_bounded,
     emit: Callable[[str], None] = print,
+    principal_key_resolver: PrincipalKeyResolver | None = None,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
 ) -> int:
     """Run the signer service CLI and emit an audit-safe JSON receipt."""
 
@@ -90,6 +99,13 @@ def run_reddog_signer_socket_service_runtime_cli(
         resolver=resolver,  # type: ignore[arg-type]
         serve_bounded=serve_bounded,
         expected_config_digest=args.expected_config_digest,
+        principal_key_resolver=(
+            principal_key_resolver
+            or FailClosedPrincipalKeyResolver()
+        ),
+        proposal_replay_high_water_store=(
+            proposal_replay_high_water_store
+        ),
     )
     emit(_receipt_json(result))
     return 0 if result.accepted else 2

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_cli.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_cli.py
@@ -56,6 +56,10 @@ def build_reddog_signer_socket_service_runtime_cli_parser() -> argparse.Argument
     )
     parser.add_argument("--repo-root", required=True, help="Repository root used for path containment checks.")
     parser.add_argument("--config", required=True, help="Outside-repo signer service JSON config.")
+    parser.add_argument(
+        "--expected-config-digest",
+        help="Launch-authorized sha256 digest for proposal-enabled config.",
+    )
     parser.add_argument("--op-executable", default="op", help="1Password CLI executable path/name.")
     parser.add_argument("--op-timeout-s", type=float, default=10.0, help="op read timeout in seconds.")
     parser.add_argument("--ttl-seconds", type=int, default=300, help="Credential TTL for resolver receipts.")
@@ -85,6 +89,7 @@ def run_reddog_signer_socket_service_runtime_cli(
         config_path=Path(args.config),
         resolver=resolver,  # type: ignore[arg-type]
         serve_bounded=serve_bounded,
+        expected_config_digest=args.expected_config_digest,
     )
     emit(_receipt_json(result))
     return 0 if result.accepted else 2

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -330,7 +330,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
     if proposal_policy is not None and proposal_authorization is None:
         return _reject(
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
     (
         proposal_nonce_store_path,
@@ -343,7 +343,9 @@ def run_reddog_signer_socket_service_runtime_wiring(
     if proposal_store_reasons:
         return _reject(
             *proposal_store_reasons,
-            no_file_io_performed=(proposal_policy is None),
+            injected_dependency_effects_unobserved=(
+                proposal_policy is not None
+            ),
         )
     if proposal_policy is not None:
         try:
@@ -383,7 +385,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
         if not high_water_authority_valid:
             return _reject(
                 FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
-                no_file_io_performed=False,
+                injected_dependency_effects_unobserved=True,
             )
 
     backend, proposal_nonce_store, key_receipt, key_reasons = _build_backend(
@@ -417,7 +419,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             *key_reasons,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
     authorization_reservation = _reserve_policy_authorization(
         proposal_nonce_store,
@@ -428,7 +430,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
     if not _commit_policy_authorization(
         proposal_nonce_store,
@@ -438,7 +440,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
 
     try:
@@ -458,14 +460,14 @@ def run_reddog_signer_socket_service_runtime_wiring(
             FAIL_SIGNER_RUNTIME_SERVICE_REJECTED,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
     if not isinstance(service, IsolatedSignerSocketResidentServiceResult):
         return _reject(
             FAIL_SIGNER_RUNTIME_SERVICE_INVALID,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
     service_receipt = service.to_dict()
     if service.accepted is not True or service.status != SIGNER_SOCKET_RESIDENT_SERVICE_SERVED:
@@ -474,7 +476,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             key_provider_receipt=key_receipt,
             service_result=service_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=False,
+            injected_dependency_effects_unobserved=True,
         )
 
     return SignerSocketServiceRuntimeWiringResult(
@@ -484,7 +486,15 @@ def run_reddog_signer_socket_service_runtime_wiring(
         key_provider_receipt=key_receipt,
         service_result=service_receipt,
         max_requests=config.max_requests,
+        no_env_parsed=False,
         no_file_io_performed=False,
+        no_process_spawned=False,
+        no_repo_mutation_performed=False,
+        no_openclaw_enqueue_performed=False,
+        no_hermes_dispatch_performed=False,
+        no_pr_created=False,
+        no_reward_settlement_performed=False,
+        no_holoindex_reindex_performed=False,
     )
 
 
@@ -1155,7 +1165,9 @@ def _reject(
     service_result: Optional[dict[str, Any]] = None,
     max_requests: int = 0,
     no_file_io_performed: bool = True,
+    injected_dependency_effects_unobserved: bool = False,
 ) -> SignerSocketServiceRuntimeWiringResult:
+    no_unobserved_effect = not injected_dependency_effects_unobserved
     return SignerSocketServiceRuntimeWiringResult(
         accepted=False,
         status=SIGNER_SOCKET_RUNTIME_WIRING_REJECT,
@@ -1163,7 +1175,17 @@ def _reject(
         key_provider_receipt=key_provider_receipt or {},
         service_result=service_result,
         max_requests=max_requests,
-        no_file_io_performed=no_file_io_performed,
+        no_env_parsed=no_unobserved_effect,
+        no_file_io_performed=(
+            no_file_io_performed and no_unobserved_effect
+        ),
+        no_process_spawned=no_unobserved_effect,
+        no_repo_mutation_performed=no_unobserved_effect,
+        no_openclaw_enqueue_performed=no_unobserved_effect,
+        no_hermes_dispatch_performed=no_unobserved_effect,
+        no_pr_created=no_unobserved_effect,
+        no_reward_settlement_performed=no_unobserved_effect,
+        no_holoindex_reindex_performed=no_unobserved_effect,
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -141,6 +141,7 @@ class SignerSocketServiceRuntimeWiringConfig:
     proposal_policy_authorization: ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None = None
     proposal_nonce_store_path: Path | str | None = None
     proposal_replay_high_water_store_id: str | None = None
+    proposal_replay_high_water_durability_receipt_id: str | None = None
     proposal_security_context_digest: str | None = None
 
 
@@ -156,6 +157,7 @@ class SignerSocketServiceRuntimeWiringResult:
     max_requests: int = 0
     no_env_parsed: bool = True
     no_file_io_performed: bool = True
+    no_repo_file_io_performed: bool = True
     no_process_spawned: bool = True
     no_repo_mutation_performed: bool = True
     no_openclaw_enqueue_performed: bool = True
@@ -212,7 +214,14 @@ def architect_proposal_security_context_digest(
     high_water_store_id = str(
         config.proposal_replay_high_water_store_id or ""
     ).strip()
-    if not high_water_store_id or not _ascii(high_water_store_id):
+    durability_receipt_id = str(
+        config.proposal_replay_high_water_durability_receipt_id or ""
+    ).strip()
+    if (
+        not high_water_store_id
+        or not _ascii(high_water_store_id)
+        or not _is_sha256_digest(durability_receipt_id)
+    ):
         raise ValueError("architect_proposal_security_context_invalid")
     control_anchor_path = validate_runtime_artifact_path(
         config.control_loop_anchor_path,
@@ -264,6 +273,9 @@ def architect_proposal_security_context_digest(
         },
         "proposal_nonce_store_path": str(nonce_path),
         "proposal_replay_high_water_store_id": high_water_store_id,
+        "proposal_replay_high_water_durability_receipt_id": (
+            durability_receipt_id
+        ),
     }
     raw = json.dumps(
         payload,
@@ -316,7 +328,8 @@ def run_reddog_signer_socket_service_runtime_wiring(
     )
     if proposal_policy is not None and proposal_authorization is None:
         return _reject(
-            FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID
+            FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+            no_file_io_performed=False,
         )
     (
         proposal_nonce_store_path,
@@ -327,7 +340,10 @@ def run_reddog_signer_socket_service_runtime_wiring(
         proposal_policy=proposal_policy,
     )
     if proposal_store_reasons:
-        return _reject(*proposal_store_reasons)
+        return _reject(
+            *proposal_store_reasons,
+            no_file_io_performed=(proposal_policy is None),
+        )
     if proposal_policy is not None:
         try:
             high_water_authority_valid = bool(
@@ -339,12 +355,34 @@ def run_reddog_signer_socket_service_runtime_wiring(
                     proposal_replay_high_water_store.store_id,
                     str(proposal_replay_high_water_store_id),
                 )
+                and (
+                    config.provider_mode
+                    != PROVIDER_MODE_WSP71_PERMISSIONED
+                    or (
+                        proposal_replay_high_water_store.durable is True
+                        and _is_sha256_digest(
+                            proposal_replay_high_water_store
+                            .durability_receipt_id
+                        )
+                        and hmac.compare_digest(
+                            str(
+                                proposal_replay_high_water_store
+                                .durability_receipt_id
+                            ),
+                            str(
+                                config
+                                .proposal_replay_high_water_durability_receipt_id
+                            ),
+                        )
+                    )
+                )
             )
         except Exception:
             high_water_authority_valid = False
         if not high_water_authority_valid:
             return _reject(
-                FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID
+                FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+                no_file_io_performed=False,
             )
 
     backend, proposal_nonce_store, key_receipt, key_reasons = _build_backend(
@@ -371,7 +409,12 @@ def run_reddog_signer_socket_service_runtime_wiring(
         ),
     )
     if key_reasons:
-        return _reject(*key_reasons, key_provider_receipt=key_receipt, max_requests=config.max_requests)
+        return _reject(
+            *key_reasons,
+            key_provider_receipt=key_receipt,
+            max_requests=config.max_requests,
+            no_file_io_performed=(proposal_policy is None),
+        )
     authorization_reservation = _reserve_policy_authorization(
         proposal_nonce_store,
         proposal_authorization,
@@ -381,6 +424,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
+            no_file_io_performed=False,
         )
     if not _commit_policy_authorization(
         proposal_nonce_store,
@@ -390,6 +434,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
+            no_file_io_performed=False,
         )
 
     try:
@@ -409,12 +454,14 @@ def run_reddog_signer_socket_service_runtime_wiring(
             FAIL_SIGNER_RUNTIME_SERVICE_REJECTED,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
+            no_file_io_performed=False,
         )
     if not isinstance(service, IsolatedSignerSocketResidentServiceResult):
         return _reject(
             FAIL_SIGNER_RUNTIME_SERVICE_INVALID,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
+            no_file_io_performed=False,
         )
     service_receipt = service.to_dict()
     if service.accepted is not True or service.status != SIGNER_SOCKET_RESIDENT_SERVICE_SERVED:
@@ -423,6 +470,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             key_provider_receipt=key_receipt,
             service_result=service_receipt,
             max_requests=config.max_requests,
+            no_file_io_performed=False,
         )
 
     return SignerSocketServiceRuntimeWiringResult(
@@ -432,6 +480,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
         key_provider_receipt=key_receipt,
         service_result=service_receipt,
         max_requests=config.max_requests,
+        no_file_io_performed=(proposal_policy is None),
     )
 
 
@@ -918,11 +967,15 @@ def _proposal_nonce_store(
     high_water_store_id = str(
         config.proposal_replay_high_water_store_id or ""
     ).strip()
+    durability_receipt_id = str(
+        config.proposal_replay_high_water_durability_receipt_id or ""
+    ).strip()
     security_digest = config.proposal_security_context_digest
     if (
         proposal_policy is None
         and path is None
         and not high_water_store_id
+        and not durability_receipt_id
         and security_digest is None
     ):
         return None, None, ()
@@ -932,6 +985,7 @@ def _proposal_nonce_store(
         path is None
         or not high_water_store_id
         or not _ascii(high_water_store_id)
+        or not _is_sha256_digest(durability_receipt_id)
         or not _is_sha256_digest(security_digest)
     ):
         return None, None, (
@@ -1092,6 +1146,7 @@ def _reject(
     key_provider_receipt: Optional[dict[str, Any]] = None,
     service_result: Optional[dict[str, Any]] = None,
     max_requests: int = 0,
+    no_file_io_performed: bool = True,
 ) -> SignerSocketServiceRuntimeWiringResult:
     return SignerSocketServiceRuntimeWiringResult(
         accepted=False,
@@ -1100,6 +1155,7 @@ def _reject(
         key_provider_receipt=key_provider_receipt or {},
         service_result=service_result,
         max_requests=max_requests,
+        no_file_io_performed=no_file_io_performed,
     )
 
 

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -3,10 +3,11 @@
 Slice: REDDOG_SIGNER_SOCKET_SERVICE_RUNTIME_WIRING_PHASE1
 
 This module composes the existing signer key-provider boundary, kernel peer
-credential attestor, and bounded signer socket service. It is intentionally
-dependency-injected: no environment parsing, file IO, process spawning, repo
-mutation, OpenClaw/Hermes dispatch, PR publication, reward settlement, or
-HoloIndex re-indexing happens here.
+credential attestor, and bounded signer socket service. It does not parse the
+environment, spawn processes, mutate repository files, dispatch OpenClaw or
+Hermes, publish PRs, settle rewards, or re-index HoloIndex. Injected resolvers
+and replay authorities may perform signer-runtime I/O; proposal mode also
+persists the canonical signer-owned nonce state.
 """
 
 from __future__ import annotations
@@ -52,6 +53,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     PROVIDER_MODE_WSP71_PERMISSIONED,
     SignerKeyProviderProfile,
     SignerKeyResolver,
+    _build_proposal_signer_backend_from_verified_runtime,
     build_signer_backend_from_provider,
     validate_signer_key_provider_profile,
 )
@@ -157,7 +159,6 @@ class SignerSocketServiceRuntimeWiringResult:
     max_requests: int = 0
     no_env_parsed: bool = True
     no_file_io_performed: bool = True
-    no_repo_file_io_performed: bool = True
     no_process_spawned: bool = True
     no_repo_mutation_performed: bool = True
     no_openclaw_enqueue_performed: bool = True
@@ -402,6 +403,9 @@ def run_reddog_signer_socket_service_runtime_wiring(
         proposal_replay_high_water_store_id=(
             proposal_replay_high_water_store_id
         ),
+        proposal_replay_high_water_durability_receipt_id=str(
+            config.proposal_replay_high_water_durability_receipt_id or ""
+        ),
         repo_root=Path(config.repo_root).resolve(),
         signer_runtime_root=validate_runtime_root_path(
             config.signer_runtime_root,
@@ -413,7 +417,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
             *key_reasons,
             key_provider_receipt=key_receipt,
             max_requests=config.max_requests,
-            no_file_io_performed=(proposal_policy is None),
+            no_file_io_performed=False,
         )
     authorization_reservation = _reserve_policy_authorization(
         proposal_nonce_store,
@@ -480,7 +484,7 @@ def run_reddog_signer_socket_service_runtime_wiring(
         key_provider_receipt=key_receipt,
         service_result=service_receipt,
         max_requests=config.max_requests,
-        no_file_io_performed=(proposal_policy is None),
+        no_file_io_performed=False,
     )
 
 
@@ -684,6 +688,7 @@ def _build_backend(
     proposal_nonce_store_path: Path | None,
     proposal_replay_high_water_store: ProposalReplayHighWaterStore | None,
     proposal_replay_high_water_store_id: str | None,
+    proposal_replay_high_water_durability_receipt_id: str,
     repo_root: Path,
     signer_runtime_root: Path,
 ) -> tuple[
@@ -695,55 +700,58 @@ def _build_backend(
     receipts: list[dict[str, Any]] = []
     backends: dict[str, IsolatedSignerBackend] = {}
     for profile in profiles:
-        key_result = build_signer_backend_from_provider(
+        if _is_proposal_signer_profile(
             profile,
-            resolver,
-            provider_mode=provider_mode,
-            allow_test_only_key_material=allow_test_only_key_material,
-            permission_snapshot_fresh=permission_snapshot_fresh,
-            control_loop_anchor_store=control_loop_anchor_store,
-            control_loop_authority_policy=(
-                control_loop_authority_policy
-                if control_loop_authority_policy is not None
-                and profile.expected_public_key
-                == control_loop_authority_policy.signer_public_key
-                else None
-            ),
-            proposal_authority_policy=(
-                proposal_authority_policy
-                if _is_proposal_signer_profile(
-                    profile,
-                    proposal_authority_policy,
+            proposal_authority_policy,
+        ):
+            if (
+                proposal_policy_authorization is None
+                or proposal_nonce_store_path is None
+                or proposal_replay_high_water_store is None
+                or proposal_replay_high_water_store_id is None
+            ):
+                return None, None, _key_provider_receipt(False, receipts), (
+                    FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
                 )
-                else None
-            ),
-            proposal_nonce_store_path=(
-                proposal_nonce_store_path
-                if _is_proposal_signer_profile(
-                    profile,
-                    proposal_authority_policy,
-                )
-                else None
-            ),
-            proposal_replay_high_water_store=(
-                proposal_replay_high_water_store
-                if _is_proposal_signer_profile(
-                    profile,
-                    proposal_authority_policy,
-                )
-                else None
-            ),
-            proposal_replay_high_water_store_id=(
-                proposal_replay_high_water_store_id
-                if _is_proposal_signer_profile(
-                    profile,
-                    proposal_authority_policy,
-                )
-                else None
-            ),
-            proposal_nonce_store_allowed_root=signer_runtime_root,
-            proposal_nonce_store_repo_root=repo_root,
-        )
+            key_result = _build_proposal_signer_backend_from_verified_runtime(
+                profile,
+                resolver,
+                provider_mode=provider_mode,
+                allow_test_only_key_material=allow_test_only_key_material,
+                permission_snapshot_fresh=permission_snapshot_fresh,
+                proposal_authority_policy=proposal_authority_policy,
+                proposal_policy_authorization=(
+                    proposal_policy_authorization
+                ),
+                proposal_nonce_store_path=proposal_nonce_store_path,
+                proposal_replay_high_water_store=(
+                    proposal_replay_high_water_store
+                ),
+                proposal_replay_high_water_store_id=(
+                    proposal_replay_high_water_store_id
+                ),
+                proposal_replay_high_water_durability_receipt_id=(
+                    proposal_replay_high_water_durability_receipt_id
+                ),
+                proposal_nonce_store_allowed_root=signer_runtime_root,
+                proposal_nonce_store_repo_root=repo_root,
+            )
+        else:
+            key_result = build_signer_backend_from_provider(
+                profile,
+                resolver,
+                provider_mode=provider_mode,
+                allow_test_only_key_material=allow_test_only_key_material,
+                permission_snapshot_fresh=permission_snapshot_fresh,
+                control_loop_anchor_store=control_loop_anchor_store,
+                control_loop_authority_policy=(
+                    control_loop_authority_policy
+                    if control_loop_authority_policy is not None
+                    and profile.expected_public_key
+                    == control_loop_authority_policy.signer_public_key
+                    else None
+                ),
+            )
         receipt = key_result.to_receipt()
         receipts.append(receipt)
         if not key_result.ok or key_result.backend is None:

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -11,6 +11,9 @@ HoloIndex re-indexing happens here.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -38,6 +41,9 @@ from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenti
     ArchitectProposalPolicyAuthorization,
     ArchitectProposalSignerPolicy,
     DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS,
+    ProposalAuthenticityNonceStore,
+    architect_proposal_replay_store_binding_digest,
+    architect_proposal_signer_instance_id,
     rehydrate_architect_proposal_authenticity_payload,
     verify_architect_proposal_policy_authorization,
 )
@@ -65,6 +71,13 @@ from modules.communication.moltbot_bridge.src.reddog_signer_control_loop_anchor 
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     KernelPeerCredentialAttestor,
     PeerCredentialPolicy,
+)
+from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
+    ProposalReplayHighWaterStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    FailClosedPrincipalKeyResolver,
+    PrincipalKeyResolver,
 )
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
     validate_runtime_artifact_path,
@@ -127,6 +140,8 @@ class SignerSocketServiceRuntimeWiringConfig:
     proposal_authority_policy: ArchitectProposalSignerPolicy | Mapping[str, Any] | None = None
     proposal_policy_authorization: ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None = None
     proposal_nonce_store_path: Path | str | None = None
+    proposal_replay_high_water_store_id: str | None = None
+    proposal_security_context_digest: str | None = None
 
 
 @dataclass(frozen=True)
@@ -154,12 +169,120 @@ class SignerSocketServiceRuntimeWiringResult:
         return asdict(self)
 
 
+def architect_proposal_security_context_digest(
+    config: SignerSocketServiceRuntimeWiringConfig,
+) -> str:
+    """Digest the normalized signer configuration excluding its authorization."""
+
+    if not isinstance(config, SignerSocketServiceRuntimeWiringConfig):
+        raise ValueError("architect_proposal_security_context_invalid")
+    profiles, profile_reasons = _profiles(config)
+    peer_policy = _peer_policy(config.peer_policy)
+    proposal_policy = _proposal_authority_policy(
+        config.proposal_authority_policy
+    )
+    control_policy = _control_loop_authority_policy(
+        config.control_loop_authority_policy
+    )
+    if (
+        profile_reasons
+        or peer_policy is None
+        or proposal_policy is None
+    ):
+        raise ValueError("architect_proposal_security_context_invalid")
+    repo_root = Path(config.repo_root).resolve()
+    runtime_root = validate_runtime_root_path(
+        config.runtime_root,
+        repo_root=repo_root,
+    )
+    signer_root = validate_runtime_root_path(
+        config.signer_runtime_root,
+        repo_root=repo_root,
+    )
+    socket_path = validate_runtime_artifact_path(
+        config.socket_path,
+        repo_root=repo_root,
+        allowed_root=runtime_root,
+    )
+    nonce_path = validate_runtime_artifact_path(
+        config.proposal_nonce_store_path,
+        repo_root=repo_root,
+        allowed_root=signer_root,
+    )
+    high_water_store_id = str(
+        config.proposal_replay_high_water_store_id or ""
+    ).strip()
+    if not high_water_store_id or not _ascii(high_water_store_id):
+        raise ValueError("architect_proposal_security_context_invalid")
+    control_anchor_path = validate_runtime_artifact_path(
+        config.control_loop_anchor_path,
+        repo_root=repo_root,
+        allowed_root=signer_root,
+    )
+    payload = {
+        "schema_version": "reddog_architect_proposal_security_context.v1",
+        "repo_root": str(repo_root),
+        "runtime_root": str(runtime_root),
+        "signer_runtime_root": str(signer_root),
+        "socket_path": str(socket_path),
+        "provider_mode": str(config.provider_mode),
+        "allow_test_only_key_material": bool(
+            config.allow_test_only_key_material
+        ),
+        "permission_snapshot_fresh": bool(
+            config.permission_snapshot_fresh
+        ),
+        "max_requests": int(config.max_requests),
+        "timeout_s": float(config.timeout_s),
+        "max_request_bytes": int(config.max_request_bytes),
+        "max_response_bytes": int(config.max_response_bytes),
+        "peer_policy": {
+            "uid_to_principal": {
+                str(uid): principal
+                for uid, principal in sorted(
+                    peer_policy.uid_to_principal.items()
+                )
+            },
+            "allowed_gids": sorted(peer_policy.allowed_gids),
+            "transport": peer_policy.transport,
+            "credential_source_prefix": (
+                peer_policy.credential_source_prefix
+            ),
+        },
+        "key_provider_profiles": [
+            asdict(profile) for profile in profiles
+        ],
+        "control_loop_anchor_path": str(control_anchor_path),
+        "control_loop_authority_policy": (
+            asdict(control_policy) if control_policy is not None else None
+        ),
+        "proposal_authority_policy": {
+            "expected_payload": (
+                proposal_policy.expected_payload.to_dict()
+            ),
+            "max_ttl_seconds": int(proposal_policy.max_ttl_seconds),
+        },
+        "proposal_nonce_store_path": str(nonce_path),
+        "proposal_replay_high_water_store_id": high_water_store_id,
+    }
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
 def run_reddog_signer_socket_service_runtime_wiring(
     config: SignerSocketServiceRuntimeWiringConfig,
     resolver: SignerKeyResolver,
     *,
     serve_bounded: ServeSignerSocketBounded = serve_reddog_isolated_signer_socket_bounded,
     ready_callback: Optional[Callable[[], None]] = None,
+    principal_key_resolver: PrincipalKeyResolver | None = None,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None = None,
 ) -> SignerSocketServiceRuntimeWiringResult:
     """Build a signer backend and serve a bounded signer socket service."""
 
@@ -185,19 +308,46 @@ def run_reddog_signer_socket_service_runtime_wiring(
         config,
         profiles=profiles,
         proposal_policy=proposal_policy,
+        principal_key_resolver=(
+            principal_key_resolver
+            or FailClosedPrincipalKeyResolver()
+        ),
+        require_trusted_principal=True,
     )
     if proposal_policy is not None and proposal_authorization is None:
         return _reject(
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID
         )
-    proposal_nonce_store_path, proposal_store_reasons = _proposal_nonce_store(
+    (
+        proposal_nonce_store_path,
+        proposal_replay_high_water_store_id,
+        proposal_store_reasons,
+    ) = _proposal_nonce_store(
         config,
         proposal_policy=proposal_policy,
     )
     if proposal_store_reasons:
         return _reject(*proposal_store_reasons)
+    if proposal_policy is not None:
+        try:
+            high_water_authority_valid = bool(
+                isinstance(
+                    proposal_replay_high_water_store,
+                    ProposalReplayHighWaterStore,
+                )
+                and hmac.compare_digest(
+                    proposal_replay_high_water_store.store_id,
+                    str(proposal_replay_high_water_store_id),
+                )
+            )
+        except Exception:
+            high_water_authority_valid = False
+        if not high_water_authority_valid:
+            return _reject(
+                FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID
+            )
 
-    backend, key_receipt, key_reasons = _build_backend(
+    backend, proposal_nonce_store, key_receipt, key_reasons = _build_backend(
         profiles,
         resolver,
         provider_mode=config.provider_mode,
@@ -208,6 +358,12 @@ def run_reddog_signer_socket_service_runtime_wiring(
         proposal_authority_policy=proposal_policy,
         proposal_policy_authorization=proposal_authorization,
         proposal_nonce_store_path=proposal_nonce_store_path,
+        proposal_replay_high_water_store=(
+            proposal_replay_high_water_store
+        ),
+        proposal_replay_high_water_store_id=(
+            proposal_replay_high_water_store_id
+        ),
         repo_root=Path(config.repo_root).resolve(),
         signer_runtime_root=validate_runtime_root_path(
             config.signer_runtime_root,
@@ -216,6 +372,25 @@ def run_reddog_signer_socket_service_runtime_wiring(
     )
     if key_reasons:
         return _reject(*key_reasons, key_provider_receipt=key_receipt, max_requests=config.max_requests)
+    authorization_reservation = _reserve_policy_authorization(
+        proposal_nonce_store,
+        proposal_authorization,
+    )
+    if proposal_authorization is not None and not authorization_reservation:
+        return _reject(
+            FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+            key_provider_receipt=key_receipt,
+            max_requests=config.max_requests,
+        )
+    if not _commit_policy_authorization(
+        proposal_nonce_store,
+        authorization_reservation,
+    ):
+        return _reject(
+            FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+            key_provider_receipt=key_receipt,
+            max_requests=config.max_requests,
+        )
 
     try:
         service = serve_bounded(
@@ -285,11 +460,21 @@ def validate_signer_socket_service_runtime_config(
     control_authority_policy = _control_loop_authority_policy(
         config.control_loop_authority_policy
     )
-    if config.control_loop_anchor_path is not None and control_authority_policy is None:
+    if (
+        config.control_loop_anchor_path is not None
+        and control_authority_policy is None
+        and config.proposal_authority_policy is None
+    ):
         return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
     if (
         config.provider_mode == PROVIDER_MODE_WSP71_PERMISSIONED
-        and (anchor_store is None or control_authority_policy is None)
+        and (
+            anchor_store is None
+            or (
+                control_authority_policy is None
+                and config.proposal_authority_policy is None
+            )
+        )
     ):
         return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
     if (
@@ -310,6 +495,8 @@ def validate_signer_socket_service_runtime_config(
         config,
         profiles=profiles,
         proposal_policy=proposal_policy,
+        principal_key_resolver=None,
+        require_trusted_principal=False,
     )
     if (
         (proposal_policy is None)
@@ -322,30 +509,30 @@ def validate_signer_socket_service_runtime_config(
         return (
             FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
         )
-    _, proposal_store_reasons = _proposal_nonce_store(
+    _, _, proposal_store_reasons = _proposal_nonce_store(
         config,
         proposal_policy=proposal_policy,
     )
     if proposal_store_reasons:
         return proposal_store_reasons
     if proposal_policy is not None:
-        if len(profiles) != 2:
-            return (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
-        principal_profiles = [
-            profile
-            for profile in profiles
-            if (
-                profile.signer_profile_id
-                == PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID
-                and profile.signer_agent_id
-                == PRINCIPAL_IDENTITY_SIGNER_AGENT_ID
-                and proposal_authorization is not None
-                and profile.expected_public_key
-                == proposal_authorization.principal_public_key
-                and profile.expected_key_epoch
-                == proposal_authorization.key_epoch
+        try:
+            expected_security_digest = (
+                architect_proposal_security_context_digest(config)
             )
-        ]
+        except (OSError, TypeError, ValueError):
+            return (
+                FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+            )
+        if not hmac.compare_digest(
+            str(config.proposal_security_context_digest or ""),
+            expected_security_digest,
+        ):
+            return (
+                FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+            )
+        if len(profiles) != 1:
+            return (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
         proposal_profiles = [
             profile
             for profile in profiles
@@ -360,7 +547,7 @@ def validate_signer_socket_service_runtime_config(
                 == proposal_policy.expected_payload.key_epoch
             )
         ]
-        if len(principal_profiles) != 1 or len(proposal_profiles) != 1:
+        if len(proposal_profiles) != 1:
             return (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
     limit_reasons = validate_resident_signer_socket_limits(
         max_requests=config.max_requests,
@@ -446,9 +633,16 @@ def _build_backend(
     proposal_authority_policy: ArchitectProposalSignerPolicy | None,
     proposal_policy_authorization: ArchitectProposalPolicyAuthorization | None,
     proposal_nonce_store_path: Path | None,
+    proposal_replay_high_water_store: ProposalReplayHighWaterStore | None,
+    proposal_replay_high_water_store_id: str | None,
     repo_root: Path,
     signer_runtime_root: Path,
-) -> tuple[Optional[IsolatedSignerBackend], dict[str, Any], tuple[str, ...]]:
+) -> tuple[
+    Optional[IsolatedSignerBackend],
+    ProposalAuthenticityNonceStore | None,
+    dict[str, Any],
+    tuple[str, ...],
+]:
     receipts: list[dict[str, Any]] = []
     backends: dict[str, IsolatedSignerBackend] = {}
     for profile in profiles:
@@ -482,30 +676,34 @@ def _build_backend(
                 )
                 else None
             ),
+            proposal_replay_high_water_store=(
+                proposal_replay_high_water_store
+                if _is_proposal_signer_profile(
+                    profile,
+                    proposal_authority_policy,
+                )
+                else None
+            ),
+            proposal_replay_high_water_store_id=(
+                proposal_replay_high_water_store_id
+                if _is_proposal_signer_profile(
+                    profile,
+                    proposal_authority_policy,
+                )
+                else None
+            ),
             proposal_nonce_store_allowed_root=signer_runtime_root,
             proposal_nonce_store_repo_root=repo_root,
         )
         receipt = key_result.to_receipt()
         receipts.append(receipt)
         if not key_result.ok or key_result.backend is None:
-            return None, _key_provider_receipt(False, receipts), (
+            return None, None, _key_provider_receipt(False, receipts), (
                 FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
             )
         public_key = str(key_result.public_key or "")
-        if (
-            proposal_policy_authorization is not None
-            and profile.signer_profile_id
-            == PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID
-            and profile.signer_agent_id
-            == PRINCIPAL_IDENTITY_SIGNER_AGENT_ID
-        ):
-            if public_key != proposal_policy_authorization.principal_public_key:
-                return None, _key_provider_receipt(False, receipts), (
-                    FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
-                )
-            continue
         if public_key in backends:
-            return None, _key_provider_receipt(False, receipts), (
+            return None, None, _key_provider_receipt(False, receipts), (
                 FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE,
             )
         backends[public_key] = key_result.backend
@@ -514,7 +712,12 @@ def _build_backend(
         backend = next(iter(backends.values()))
     else:
         backend = _RoutingSignerBackend(backends)
-    return backend, _key_provider_receipt(True, receipts), ()
+    nonce_store = (
+        getattr(backend, "proposal_nonce_store", None)
+        if proposal_policy_authorization is not None
+        else None
+    )
+    return backend, nonce_store, _key_provider_receipt(True, receipts), ()
 
 
 def _control_loop_anchor_store(
@@ -625,6 +828,8 @@ def _proposal_policy_authorization(
     *,
     profiles: list[SignerKeyProviderProfile],
     proposal_policy: ArchitectProposalSignerPolicy | None,
+    principal_key_resolver: PrincipalKeyResolver | None,
+    require_trusted_principal: bool,
 ) -> ArchitectProposalPolicyAuthorization | None:
     value = config.proposal_policy_authorization
     if proposal_policy is None:
@@ -632,26 +837,54 @@ def _proposal_policy_authorization(
     raw = value.to_dict() if hasattr(value, "to_dict") else value
     if not isinstance(raw, Mapping):
         return None
-    principal_profiles = [
-        profile
-        for profile in profiles
-        if (
-            profile.signer_profile_id
-            == PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID
-            and profile.signer_agent_id
-            == PRINCIPAL_IDENTITY_SIGNER_AGENT_ID
-        )
-    ]
     proposal_profiles = [
         profile
         for profile in profiles
         if _is_proposal_signer_profile(profile, proposal_policy)
     ]
-    if len(principal_profiles) != 1 or len(proposal_profiles) != 1:
+    if len(proposal_profiles) != 1:
         return None
+    signer_root = Path(config.signer_runtime_root).resolve()
+    nonce_path = config.proposal_nonce_store_path
+    high_water_store_id = str(
+        config.proposal_replay_high_water_store_id or ""
+    ).strip()
+    if nonce_path is None or not high_water_store_id:
+        return None
+    signer_instance_id = architect_proposal_signer_instance_id(
+        signer_root,
+        proposal_profiles[0].expected_public_key,
+        proposal_profiles[0].expected_key_epoch,
+    )
+    replay_binding = architect_proposal_replay_store_binding_digest(
+        signer_instance_id,
+        nonce_path,
+        high_water_store_id,
+    )
+    principal_id = str(raw.get("principal_id") or "")
+    principal_provider = str(raw.get("principal_provider") or "")
+    trusted_principal_key = str(
+        raw.get("principal_public_key") or ""
+    )
+    if require_trusted_principal:
+        if principal_key_resolver is None:
+            return None
+        try:
+            trusted_principal_key = str(
+                principal_key_resolver.resolve(
+                    principal_id,
+                    principal_provider,
+                )
+                or ""
+            )
+        except Exception:
+            return None
     authority_profile = {
         "principal_id": proposal_policy.expected_payload.requester_principal_id,
-        "principal_public_key": principal_profiles[0].expected_public_key,
+        "principal_provider": principal_provider,
+        "principal_public_key": str(
+            raw.get("principal_public_key") or ""
+        ),
         "reddog_id": proposal_policy.expected_payload.reddog_id,
         "reddog_public_key": proposal_profiles[0].expected_public_key,
         "key_epoch": proposal_policy.expected_payload.key_epoch,
@@ -664,6 +897,12 @@ def _proposal_policy_authorization(
             raw,
             policy=proposal_policy,
             authority_profile=authority_profile,
+            trusted_principal_public_key=trusted_principal_key,
+            expected_signer_instance_id=signer_instance_id,
+            expected_replay_store_binding_digest=replay_binding,
+            expected_security_context_digest=str(
+                config.proposal_security_context_digest or ""
+            ),
             now_epoch=int(time.time()),
         )
     except (TypeError, ValueError):
@@ -674,14 +913,30 @@ def _proposal_nonce_store(
     config: SignerSocketServiceRuntimeWiringConfig,
     *,
     proposal_policy: ArchitectProposalSignerPolicy | None,
-) -> tuple[Path | None, tuple[str, ...]]:
+) -> tuple[Path | None, Path | None, tuple[str, ...]]:
     path = config.proposal_nonce_store_path
-    if proposal_policy is None and path is None:
-        return None, ()
+    high_water_store_id = str(
+        config.proposal_replay_high_water_store_id or ""
+    ).strip()
+    security_digest = config.proposal_security_context_digest
+    if (
+        proposal_policy is None
+        and path is None
+        and not high_water_store_id
+        and security_digest is None
+    ):
+        return None, None, ()
     if proposal_policy is None:
-        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
-    if path is None:
-        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,)
+        return None, None, (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
+    if (
+        path is None
+        or not high_water_store_id
+        or not _ascii(high_water_store_id)
+        or not _is_sha256_digest(security_digest)
+    ):
+        return None, None, (
+            FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+        )
     try:
         repo_root = Path(config.repo_root).resolve()
         signer_root = validate_runtime_root_path(
@@ -694,10 +949,54 @@ def _proposal_nonce_store(
             allowed_root=signer_root,
         )
     except (OSError, TypeError, ValueError):
-        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,)
-    if target.parent != signer_root:
-        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,)
-    return target, ()
+        return None, None, (
+            FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+        )
+    if (
+        target.parent != signer_root
+        or target
+        != (signer_root / "architect_proposal_nonce_store.json")
+    ):
+        return None, None, (
+            FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+        )
+    return target, high_water_store_id, ()
+
+
+def _reserve_policy_authorization(
+    store: ProposalAuthenticityNonceStore | None,
+    authorization: ArchitectProposalPolicyAuthorization | None,
+) -> str | None:
+    if authorization is None:
+        return None
+    if store is None:
+        return None
+    try:
+        return store.reserve(
+            authorization.nonce,
+            expires_at=authorization.expires_at,
+            subject=(
+                "proposal-policy-authorization:"
+                + authorization.principal_id
+            ),
+        )
+    except Exception:
+        return None
+
+
+def _commit_policy_authorization(
+    store: ProposalAuthenticityNonceStore | None,
+    reservation: str | None,
+) -> bool:
+    if store is None and reservation is None:
+        return True
+    if store is None or not reservation:
+        return False
+    try:
+        store.commit(reservation)
+        return True
+    except Exception:
+        return False
 
 
 def _is_proposal_signer_profile(
@@ -825,6 +1124,7 @@ __all__ = [
     "SIGNER_SOCKET_RUNTIME_WIRING_SERVED",
     "SignerSocketServiceRuntimeWiringConfig",
     "SignerSocketServiceRuntimeWiringResult",
+    "architect_proposal_security_context_digest",
     "run_reddog_signer_socket_service_runtime_wiring",
     "validate_signer_socket_service_runtime_config",
 ]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_socket_service_runtime_wiring.py
@@ -11,6 +11,7 @@ HoloIndex re-indexing happens here.
 
 from __future__ import annotations
 
+import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional
@@ -32,6 +33,13 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_prot
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_service import (
     DEFAULT_SIGNER_SOCKET_SERVICE_MAX_RESPONSE_BYTES,
     DEFAULT_SIGNER_SOCKET_SERVICE_TIMEOUT_S,
+)
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalPolicyAuthorization,
+    ArchitectProposalSignerPolicy,
+    DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS,
+    rehydrate_architect_proposal_authenticity_payload,
+    verify_architect_proposal_policy_authorization,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
@@ -78,6 +86,19 @@ FAIL_SIGNER_RUNTIME_SERVICE_INVALID = "FAIL_SIGNER_RUNTIME_SERVICE_INVALID"
 FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID = (
     "FAIL_SIGNER_RUNTIME_CONTROL_ANCHOR_INVALID"
 )
+FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID = (
+    "FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID"
+)
+FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID = (
+    "FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID"
+)
+FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID = (
+    "FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID"
+)
+REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID = "signer:reddog"
+REDDOG_WORK_AUTHORITY_SIGNER_PROFILE_ID = "reddog-work-authority"
+PRINCIPAL_IDENTITY_SIGNER_AGENT_ID = "signer:principal"
+PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID = "principal-identity"
 
 
 ServeSignerSocketBounded = Callable[..., IsolatedSignerSocketResidentServiceResult]
@@ -103,6 +124,9 @@ class SignerSocketServiceRuntimeWiringConfig:
     key_provider_profiles: tuple[SignerKeyProviderProfile | Mapping[str, Any], ...] = ()
     control_loop_anchor_path: Path | str | None = None
     control_loop_authority_policy: ControlLoopAuthorityPolicy | Mapping[str, Any] | None = None
+    proposal_authority_policy: ArchitectProposalSignerPolicy | Mapping[str, Any] | None = None
+    proposal_policy_authorization: ArchitectProposalPolicyAuthorization | Mapping[str, Any] | None = None
+    proposal_nonce_store_path: Path | str | None = None
 
 
 @dataclass(frozen=True)
@@ -154,6 +178,24 @@ def run_reddog_signer_socket_service_runtime_wiring(
     control_authority_policy = _control_loop_authority_policy(
         config.control_loop_authority_policy
     )
+    proposal_policy = _proposal_authority_policy(
+        config.proposal_authority_policy
+    )
+    proposal_authorization = _proposal_policy_authorization(
+        config,
+        profiles=profiles,
+        proposal_policy=proposal_policy,
+    )
+    if proposal_policy is not None and proposal_authorization is None:
+        return _reject(
+            FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID
+        )
+    proposal_nonce_store_path, proposal_store_reasons = _proposal_nonce_store(
+        config,
+        proposal_policy=proposal_policy,
+    )
+    if proposal_store_reasons:
+        return _reject(*proposal_store_reasons)
 
     backend, key_receipt, key_reasons = _build_backend(
         profiles,
@@ -163,6 +205,14 @@ def run_reddog_signer_socket_service_runtime_wiring(
         permission_snapshot_fresh=config.permission_snapshot_fresh,
         control_loop_anchor_store=anchor_store,
         control_loop_authority_policy=control_authority_policy,
+        proposal_authority_policy=proposal_policy,
+        proposal_policy_authorization=proposal_authorization,
+        proposal_nonce_store_path=proposal_nonce_store_path,
+        repo_root=Path(config.repo_root).resolve(),
+        signer_runtime_root=validate_runtime_root_path(
+            config.signer_runtime_root,
+            repo_root=Path(config.repo_root).resolve(),
+        ),
     )
     if key_reasons:
         return _reject(*key_reasons, key_provider_receipt=key_receipt, max_requests=config.max_requests)
@@ -248,6 +298,70 @@ def validate_signer_socket_service_runtime_config(
         not in set(profile_public_keys)
     ):
         return (FAIL_SIGNER_RUNTIME_CONFIG_INVALID,)
+    proposal_policy = _proposal_authority_policy(
+        config.proposal_authority_policy
+    )
+    if (
+        config.proposal_authority_policy is not None
+        and proposal_policy is None
+    ):
+        return (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
+    proposal_authorization = _proposal_policy_authorization(
+        config,
+        profiles=profiles,
+        proposal_policy=proposal_policy,
+    )
+    if (
+        (proposal_policy is None)
+        != (config.proposal_policy_authorization is None)
+        or (
+            proposal_policy is not None
+            and proposal_authorization is None
+        )
+    ):
+        return (
+            FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+        )
+    _, proposal_store_reasons = _proposal_nonce_store(
+        config,
+        proposal_policy=proposal_policy,
+    )
+    if proposal_store_reasons:
+        return proposal_store_reasons
+    if proposal_policy is not None:
+        if len(profiles) != 2:
+            return (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
+        principal_profiles = [
+            profile
+            for profile in profiles
+            if (
+                profile.signer_profile_id
+                == PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID
+                and profile.signer_agent_id
+                == PRINCIPAL_IDENTITY_SIGNER_AGENT_ID
+                and proposal_authorization is not None
+                and profile.expected_public_key
+                == proposal_authorization.principal_public_key
+                and profile.expected_key_epoch
+                == proposal_authorization.key_epoch
+            )
+        ]
+        proposal_profiles = [
+            profile
+            for profile in profiles
+            if (
+                profile.signer_profile_id
+                == REDDOG_WORK_AUTHORITY_SIGNER_PROFILE_ID
+                and profile.signer_agent_id
+                == REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID
+                and profile.expected_public_key
+                == proposal_policy.expected_payload.signer_public_key
+                and profile.expected_key_epoch
+                == proposal_policy.expected_payload.key_epoch
+            )
+        ]
+        if len(principal_profiles) != 1 or len(proposal_profiles) != 1:
+            return (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
     limit_reasons = validate_resident_signer_socket_limits(
         max_requests=config.max_requests,
         timeout_s=config.timeout_s,
@@ -329,6 +443,11 @@ def _build_backend(
     permission_snapshot_fresh: bool,
     control_loop_anchor_store: ControlLoopAnchorStore | None,
     control_loop_authority_policy: ControlLoopAuthorityPolicy | None,
+    proposal_authority_policy: ArchitectProposalSignerPolicy | None,
+    proposal_policy_authorization: ArchitectProposalPolicyAuthorization | None,
+    proposal_nonce_store_path: Path | None,
+    repo_root: Path,
+    signer_runtime_root: Path,
 ) -> tuple[Optional[IsolatedSignerBackend], dict[str, Any], tuple[str, ...]]:
     receipts: list[dict[str, Any]] = []
     backends: dict[str, IsolatedSignerBackend] = {}
@@ -347,6 +466,24 @@ def _build_backend(
                 == control_loop_authority_policy.signer_public_key
                 else None
             ),
+            proposal_authority_policy=(
+                proposal_authority_policy
+                if _is_proposal_signer_profile(
+                    profile,
+                    proposal_authority_policy,
+                )
+                else None
+            ),
+            proposal_nonce_store_path=(
+                proposal_nonce_store_path
+                if _is_proposal_signer_profile(
+                    profile,
+                    proposal_authority_policy,
+                )
+                else None
+            ),
+            proposal_nonce_store_allowed_root=signer_runtime_root,
+            proposal_nonce_store_repo_root=repo_root,
         )
         receipt = key_result.to_receipt()
         receipts.append(receipt)
@@ -355,6 +492,18 @@ def _build_backend(
                 FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED,
             )
         public_key = str(key_result.public_key or "")
+        if (
+            proposal_policy_authorization is not None
+            and profile.signer_profile_id
+            == PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID
+            and profile.signer_agent_id
+            == PRINCIPAL_IDENTITY_SIGNER_AGENT_ID
+        ):
+            if public_key != proposal_policy_authorization.principal_public_key:
+                return None, _key_provider_receipt(False, receipts), (
+                    FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+                )
+            continue
         if public_key in backends:
             return None, _key_provider_receipt(False, receipts), (
                 FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE,
@@ -438,6 +587,133 @@ def _control_loop_authority_policy(
         if not _is_sha256_digest(digest):
             return None
     return policy
+
+
+def _proposal_authority_policy(
+    value: ArchitectProposalSignerPolicy | Mapping[str, Any] | None,
+) -> ArchitectProposalSignerPolicy | None:
+    if isinstance(value, ArchitectProposalSignerPolicy):
+        return (
+            value
+            if 0 < int(value.max_ttl_seconds)
+            <= DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+            else None
+        )
+    if not isinstance(value, Mapping):
+        return None
+    expected = value.get("expected_payload")
+    try:
+        payload = rehydrate_architect_proposal_authenticity_payload(
+            expected if isinstance(expected, Mapping) else {}
+        )
+        max_ttl = int(value.get("max_ttl_seconds"))
+    except (TypeError, ValueError):
+        return None
+    if (
+        max_ttl <= 0
+        or max_ttl > DEFAULT_PROPOSAL_AUTHENTICITY_MAX_TTL_SECONDS
+    ):
+        return None
+    return ArchitectProposalSignerPolicy(
+        expected_payload=payload,
+        max_ttl_seconds=max_ttl,
+    )
+
+
+def _proposal_policy_authorization(
+    config: SignerSocketServiceRuntimeWiringConfig,
+    *,
+    profiles: list[SignerKeyProviderProfile],
+    proposal_policy: ArchitectProposalSignerPolicy | None,
+) -> ArchitectProposalPolicyAuthorization | None:
+    value = config.proposal_policy_authorization
+    if proposal_policy is None:
+        return None if value is None else None
+    raw = value.to_dict() if hasattr(value, "to_dict") else value
+    if not isinstance(raw, Mapping):
+        return None
+    principal_profiles = [
+        profile
+        for profile in profiles
+        if (
+            profile.signer_profile_id
+            == PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID
+            and profile.signer_agent_id
+            == PRINCIPAL_IDENTITY_SIGNER_AGENT_ID
+        )
+    ]
+    proposal_profiles = [
+        profile
+        for profile in profiles
+        if _is_proposal_signer_profile(profile, proposal_policy)
+    ]
+    if len(principal_profiles) != 1 or len(proposal_profiles) != 1:
+        return None
+    authority_profile = {
+        "principal_id": proposal_policy.expected_payload.requester_principal_id,
+        "principal_public_key": principal_profiles[0].expected_public_key,
+        "reddog_id": proposal_policy.expected_payload.reddog_id,
+        "reddog_public_key": proposal_profiles[0].expected_public_key,
+        "key_epoch": proposal_policy.expected_payload.key_epoch,
+        "authority_profile_source_receipt_id": (
+            proposal_policy.expected_payload.authority_profile_source_receipt_id
+        ),
+    }
+    try:
+        return verify_architect_proposal_policy_authorization(
+            raw,
+            policy=proposal_policy,
+            authority_profile=authority_profile,
+            now_epoch=int(time.time()),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _proposal_nonce_store(
+    config: SignerSocketServiceRuntimeWiringConfig,
+    *,
+    proposal_policy: ArchitectProposalSignerPolicy | None,
+) -> tuple[Path | None, tuple[str, ...]]:
+    path = config.proposal_nonce_store_path
+    if proposal_policy is None and path is None:
+        return None, ()
+    if proposal_policy is None:
+        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,)
+    if path is None:
+        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,)
+    try:
+        repo_root = Path(config.repo_root).resolve()
+        signer_root = validate_runtime_root_path(
+            config.signer_runtime_root,
+            repo_root=repo_root,
+        )
+        target = validate_runtime_artifact_path(
+            path,
+            repo_root=repo_root,
+            allowed_root=signer_root,
+        )
+    except (OSError, TypeError, ValueError):
+        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,)
+    if target.parent != signer_root:
+        return None, (FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,)
+    return target, ()
+
+
+def _is_proposal_signer_profile(
+    profile: SignerKeyProviderProfile,
+    policy: ArchitectProposalSignerPolicy | None,
+) -> bool:
+    return bool(
+        policy is not None
+        and profile.signer_profile_id
+        == REDDOG_WORK_AUTHORITY_SIGNER_PROFILE_ID
+        and profile.signer_agent_id
+        == REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID
+        and profile.expected_public_key
+        == policy.expected_payload.signer_public_key
+        and profile.expected_key_epoch == policy.expected_payload.key_epoch
+    )
 
 
 def _is_sha256_digest(value: object) -> bool:
@@ -535,9 +811,16 @@ __all__ = [
     "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_DUPLICATE",
     "FAIL_SIGNER_RUNTIME_KEY_PROVIDER_REJECTED",
     "FAIL_SIGNER_RUNTIME_PEER_POLICY_INVALID",
+    "FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID",
+    "FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID",
+    "FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID",
     "FAIL_SIGNER_RUNTIME_PROFILE_INVALID",
     "FAIL_SIGNER_RUNTIME_SERVICE_INVALID",
     "FAIL_SIGNER_RUNTIME_SERVICE_REJECTED",
+    "PRINCIPAL_IDENTITY_SIGNER_AGENT_ID",
+    "PRINCIPAL_IDENTITY_SIGNER_PROFILE_ID",
+    "REDDOG_WORK_AUTHORITY_SIGNER_AGENT_ID",
+    "REDDOG_WORK_AUTHORITY_SIGNER_PROFILE_ID",
     "SIGNER_SOCKET_RUNTIME_WIRING_REJECT",
     "SIGNER_SOCKET_RUNTIME_WIRING_SERVED",
     "SignerSocketServiceRuntimeWiringConfig",

--- a/modules/communication/moltbot_bridge/tests/reddog_resident_live_canary_test_support.py
+++ b/modules/communication/moltbot_bridge/tests/reddog_resident_live_canary_test_support.py
@@ -122,7 +122,7 @@ _AUTHORITY_PROFILE_SOURCE = {
     "schema_version": "reddog_authority_profile_source.v1",
     "principal_id": "github:mjtrout",
     "principal_provider": "github",
-    "principal_public_key": "ed25519-pub-v1:" + "B" * 43,
+    "principal_public_key": encode_ed25519_public_key(b"B" * 32),
     "reddog_id": "reddog:architect",
     "reddog_public_key": _PUBLIC_KEY,
     "repo_full_name": "FOUNDUPS/Foundups-Agent",

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -10,6 +10,7 @@ import inspect
 import json
 import multiprocessing
 import sqlite3
+import tempfile
 import threading
 import time
 from concurrent.futures import ProcessPoolExecutor
@@ -473,9 +474,11 @@ def _peer() -> SignerPeerAttestation:
 
 
 def _reserve_nonce_process(
-    values: tuple[str, str, str, str, int],
+    values: tuple[str, str, str, str, int, str],
 ) -> bool:
-    repo, runtime, high_water_path, nonce, expires_at = values
+    repo, runtime, high_water_path, nonce, expires_at, temp_root = values
+    Path(temp_root).mkdir(parents=True, exist_ok=True)
+    tempfile.tempdir = temp_root
     store = AtomicProposalAuthenticityNonceStore(
         Path(runtime) / "proposal-nonces.json",
         allowed_root=runtime,
@@ -694,10 +697,10 @@ def test_atomic_nonce_store_survives_restart_and_rejects_replay(
         store_path,
         **_nonce_store_kwargs(repo, runtime),
     )
-    assert first._operation_lock_identity == (
-        str(store_path.resolve()) + ".proposal-transaction"
+    assert first._transaction_lock_path == Path(
+        str(store_path.resolve()) + ".proposal-transaction.lock"
     )
-    assert first._operation_lock_identity != (
+    assert first._transaction_lock_path != Path(
         str(store_path.resolve()) + ".operation"
     )
 
@@ -908,6 +911,7 @@ def test_atomic_nonce_store_serializes_cross_process_reservation(
             str(high_water_path),
             "process-race",
             NOW + 60,
+            str(tmp_path / "temp-a"),
         ),
         (
             str(repo),
@@ -915,6 +919,7 @@ def test_atomic_nonce_store_serializes_cross_process_reservation(
             str(high_water_path),
             "process-race",
             NOW + 60,
+            str(tmp_path / "temp-b"),
         ),
     ]
     with ProcessPoolExecutor(
@@ -924,6 +929,8 @@ def test_atomic_nonce_store_serializes_cross_process_reservation(
         results = list(executor.map(_reserve_nonce_process, jobs))
     assert sum(results) == 1
     assert not (runtime / "proposal-nonces.json.lock").exists()
+    transaction_lock = runtime / "proposal-nonces.json.proposal-transaction.lock"
+    assert transaction_lock.is_file()
 
 
 def test_atomic_nonce_store_rejects_state_rollback_and_deletion(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -6,6 +6,7 @@ import base64
 import dataclasses
 import hashlib
 import hmac
+import inspect
 import json
 import multiprocessing
 import sqlite3
@@ -59,6 +60,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun 
     PROVIDER_MODE_WSP71_PERMISSIONED,
     SIGNING_KEY_PREFIX,
     SignerKeyProviderProfile,
+    build_signer_backend_from_provider,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     PeerCredentialPolicy,
@@ -86,6 +88,10 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runti
     architect_proposal_security_context_digest,
     run_reddog_signer_socket_service_runtime_wiring,
     validate_signer_socket_service_runtime_config,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_run_packet_supply import (
+    FAIL_SIGNER_RUN_PACKET_PROPOSAL_RUNTIME_ADAPTERS_UNAVAILABLE,
+    run_reddog_signer_socket_service_run_packet_supply,
 )
 from modules.infrastructure.secrets_mcp.src.vault_resolver import (
     ResolveResult,
@@ -688,6 +694,12 @@ def test_atomic_nonce_store_survives_restart_and_rejects_replay(
         store_path,
         **_nonce_store_kwargs(repo, runtime),
     )
+    assert first._operation_lock_identity == (
+        str(store_path.resolve()) + ".proposal-transaction"
+    )
+    assert first._operation_lock_identity != (
+        str(store_path.resolve()) + ".operation"
+    )
 
     reservation = first.reserve(
         "nonce-1",
@@ -1055,6 +1067,15 @@ def test_ed25519_signature_decoder_rejects_noncanonical_suffix() -> None:
     assert decode_ed25519_signature(canonical + "=") is None
 
 
+def test_public_key_provider_has_no_proposal_authority_parameters() -> None:
+    parameters = inspect.signature(
+        build_signer_backend_from_provider
+    ).parameters
+    assert "proposal_authority_policy" not in parameters
+    assert "proposal_nonce_store" not in parameters
+    assert "proposal_nonce_store_path" not in parameters
+
+
 def test_config_supply_binds_exact_policy_and_confined_nonce_store(
     tmp_path: Path,
 ) -> None:
@@ -1107,6 +1128,15 @@ def test_config_supply_binds_exact_policy_and_confined_nonce_store(
     assert nonce_path.parent == (tmp_path / "signer-state").resolve()
     assert result.proposal_nonce_store_path == str(nonce_path)
     assert not nonce_path.exists()
+    run_packet = run_reddog_signer_socket_service_run_packet_supply(
+        repo_root=repo,
+        config_path=runtime / "signer-service.json",
+        output_path=tmp_path / "proposal-run-packet.json",
+    )
+    assert run_packet.accepted is False
+    assert run_packet.rejection_reasons == (
+        FAIL_SIGNER_RUN_PACKET_PROPOSAL_RUNTIME_ADAPTERS_UNAVAILABLE,
+    )
 
     rehydrated = rehydrate_signer_socket_service_runtime_config(
         repo,
@@ -1504,7 +1534,6 @@ def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
 
     assert result.accepted is True
     assert result.no_file_io_performed is False
-    assert result.no_repo_file_io_performed is True
     backend = captured["backend"]
     assert backend.proposal_authority_policy == policy
     assert isinstance(
@@ -1655,7 +1684,6 @@ def test_runtime_consumes_policy_authorization_nonce_once(
         FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
     )
     assert second.no_file_io_performed is False
-    assert second.no_repo_file_io_performed is True
 
 
 def test_runtime_requires_matching_independent_high_water_authority(
@@ -1711,8 +1739,6 @@ def test_runtime_requires_matching_independent_high_water_authority(
     )
     assert missing.no_file_io_performed is False
     assert mismatched.no_file_io_performed is False
-    assert missing.no_repo_file_io_performed is True
-    assert mismatched.no_repo_file_io_performed is True
 
 
 def test_runtime_never_reuses_authorization_after_service_signs_then_raises(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -99,6 +99,7 @@ NOW = int(time.time())
 PRINCIPAL_PUBLIC = encode_ed25519_public_key(bytes(range(32)))
 INTEGRITY_KEY = b"proposal-integrity-key-32-bytes!"
 HIGH_WATER_STORE_ID = "proposal-replay-authority:test"
+HIGH_WATER_DURABILITY_RECEIPT_ID = "sha256:" + "d" * 64
 
 
 class _SqliteProposalReplayHighWaterStore:
@@ -118,6 +119,14 @@ class _SqliteProposalReplayHighWaterStore:
     @property
     def store_id(self) -> str:
         return HIGH_WATER_STORE_ID
+
+    @property
+    def durable(self) -> bool:
+        return True
+
+    @property
+    def durability_receipt_id(self) -> str:
+        return HIGH_WATER_DURABILITY_RECEIPT_ID
 
     def load(
         self,
@@ -195,6 +204,14 @@ class _FailOnceProposalReplayHighWaterStore:
     @property
     def store_id(self) -> str:
         return self._delegate.store_id
+
+    @property
+    def durable(self) -> bool:
+        return False
+
+    @property
+    def durability_receipt_id(self) -> None:
+        return None
 
     def load(self, replay_store_binding_digest: str):
         return self._delegate.load(replay_store_binding_digest)
@@ -535,6 +552,9 @@ def _config_kwargs(
             signer_runtime / "architect_proposal_nonce_store.json"
         ).resolve(),
         proposal_replay_high_water_store_id=HIGH_WATER_STORE_ID,
+        proposal_replay_high_water_durability_receipt_id=(
+            HIGH_WATER_DURABILITY_RECEIPT_ID
+        ),
     )
     security_context_digest = architect_proposal_security_context_digest(
         SignerSocketServiceRuntimeWiringConfig(
@@ -562,6 +582,9 @@ def _config_kwargs(
                 / "architect_proposal_nonce_store.json"
             ).resolve(),
             proposal_replay_high_water_store_id=HIGH_WATER_STORE_ID,
+            proposal_replay_high_water_durability_receipt_id=(
+                HIGH_WATER_DURABILITY_RECEIPT_ID
+            ),
         )
     )
     values: dict[str, object] = {
@@ -578,6 +601,9 @@ def _config_kwargs(
         "peer_uid_to_principal": {1001: "github:mjtrout"},
         "proposal_authority_policy": policy,
         "proposal_replay_high_water_store_id": HIGH_WATER_STORE_ID,
+        "proposal_replay_high_water_durability_receipt_id": (
+            HIGH_WATER_DURABILITY_RECEIPT_ID
+        ),
         "proposal_policy_authorization": _policy_authorization(
             policy,
             principal_private=principal_private,
@@ -627,6 +653,9 @@ def _runtime_proposal_config(
             signer_runtime / "architect_proposal_nonce_store.json"
         ),
         proposal_replay_high_water_store_id=HIGH_WATER_STORE_ID,
+        proposal_replay_high_water_durability_receipt_id=(
+            HIGH_WATER_DURABILITY_RECEIPT_ID
+        ),
     )
     security_digest = architect_proposal_security_context_digest(
         provisional
@@ -880,6 +909,7 @@ def test_atomic_nonce_store_serializes_cross_process_reservation(
     ) as executor:
         results = list(executor.map(_reserve_nonce_process, jobs))
     assert sum(results) == 1
+    assert not (runtime / "proposal-nonces.json.lock").exists()
 
 
 def test_atomic_nonce_store_rejects_state_rollback_and_deletion(
@@ -985,6 +1015,38 @@ def test_atomic_nonce_store_recovers_state_commit_before_high_water_advance(
     assert recovered.sequence == 1
 
 
+def test_atomic_nonce_store_rechecks_expiry_at_reserve_and_commit(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    now = [NOW]
+    store = AtomicProposalAuthenticityNonceStore(
+        runtime / "proposal-nonces.json",
+        **_nonce_store_kwargs(repo, runtime),
+        clock=lambda: now[0],
+    )
+
+    assert (
+        store.reserve(
+            "already-expired",
+            expires_at=NOW,
+            subject="github:mjtrout",
+        )
+        is None
+    )
+    reservation = store.reserve(
+        "expires-before-commit",
+        expires_at=NOW + 1,
+        subject="github:mjtrout",
+    )
+    assert reservation
+    now[0] = NOW + 1
+    with pytest.raises(ValueError, match="reservation_expired"):
+        store.commit(reservation)
+
+
 def test_ed25519_signature_decoder_rejects_noncanonical_suffix() -> None:
     canonical = encode_ed25519_signature(b"s" * 64)
     assert decode_ed25519_signature(canonical) == b"s" * 64
@@ -1061,6 +1123,31 @@ def test_config_supply_binds_exact_policy_and_confined_nonce_store(
         architect_proposal_security_context_digest(rehydrated),
         str(rehydrated.proposal_security_context_digest),
     )
+    rejected_in_memory = (
+        run_reddog_signer_socket_service_runtime_bootstrap(
+            repo_root=repo,
+            config_path=runtime / "signer-service.json",
+            resolver=_Resolver(private_key),
+            serve_bounded=lambda **kwargs: pytest.fail(
+                "production signer accepted volatile replay authority"
+            ),
+            expected_config_digest=result.config_digest,
+            principal_key_resolver=_PrincipalKeyResolver(
+                _public_text(principal_private)
+            ),
+            proposal_replay_high_water_store=(
+                InMemoryProposalReplayHighWaterStore(
+                    HIGH_WATER_STORE_ID
+                )
+            ),
+        )
+    )
+    assert rejected_in_memory.accepted is False
+    assert (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID
+        in rejected_in_memory.rejection_reasons
+    )
+
     bootstrap = run_reddog_signer_socket_service_runtime_bootstrap(
         repo_root=repo,
         config_path=runtime / "signer-service.json",
@@ -1081,8 +1168,8 @@ def test_config_supply_binds_exact_policy_and_confined_nonce_store(
             _public_text(principal_private)
         ),
         proposal_replay_high_water_store=(
-            InMemoryProposalReplayHighWaterStore(
-                HIGH_WATER_STORE_ID
+            _SqliteProposalReplayHighWaterStore(
+                tmp_path / "production-high-water.sqlite3"
             )
         ),
     )
@@ -1415,6 +1502,8 @@ def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
     )
 
     assert result.accepted is True
+    assert result.no_file_io_performed is False
+    assert result.no_repo_file_io_performed is True
     backend = captured["backend"]
     assert backend.proposal_authority_policy == policy
     assert isinstance(
@@ -1564,6 +1653,8 @@ def test_runtime_consumes_policy_authorization_nonce_once(
     assert second.rejection_reasons == (
         FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
     )
+    assert second.no_file_io_performed is False
+    assert second.no_repo_file_io_performed is True
 
 
 def test_runtime_requires_matching_independent_high_water_authority(
@@ -1617,6 +1708,10 @@ def test_runtime_requires_matching_independent_high_water_authority(
     assert mismatched.rejection_reasons == (
         FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
     )
+    assert missing.no_file_io_performed is False
+    assert mismatched.no_file_io_performed is False
+    assert missing.no_repo_file_io_performed is True
+    assert mismatched.no_repo_file_io_performed is True
 
 
 def test_runtime_never_reuses_authorization_after_service_signs_then_raises(
@@ -1675,6 +1770,7 @@ def test_runtime_never_reuses_authorization_after_service_signs_then_raises(
 
     assert signed and signed[0].accepted is True
     assert first.accepted is False
+    assert first.no_file_io_performed is False
     assert second.accepted is False
     assert service_calls == 1
     assert second.rejection_reasons == (
@@ -1704,6 +1800,19 @@ def test_bootstrap_rejects_tampered_serialized_proposal_policy(
     assert result.accepted is True
     config_path = runtime / "signer-service.json"
     config = json.loads(config_path.read_text(encoding="utf-8"))
+    malformed_digest = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=config_path,
+        resolver=_Resolver(private_key),
+        serve_bounded=lambda **kwargs: pytest.fail(
+            "malformed digest reached signer service"
+        ),
+        expected_config_digest=123,  # type: ignore[arg-type]
+    )
+    assert malformed_digest.accepted is False
+    assert malformed_digest.rejection_reasons == (
+        FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH,
+    )
     replacement_proposal = {
         **{
             "receipt_id": "sha256:" + "1" * 64,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import base64
 import dataclasses
 import hashlib
+import hmac
 import json
 import multiprocessing
+import sqlite3
 import threading
 import time
 from concurrent.futures import ProcessPoolExecutor
@@ -23,12 +25,15 @@ from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenti
     build_architect_proposal_policy_authorization_payload,
     canonical_architect_proposal_policy_authorization_input,
     canonical_architect_proposal_signing_input,
+    architect_proposal_replay_store_binding_digest,
+    architect_proposal_signer_instance_id,
 )
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
     REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY,
     REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY,
 )
 from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    decode_ed25519_signature,
     encode_ed25519_public_key,
     encode_ed25519_signature,
 )
@@ -41,6 +46,8 @@ from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resi
 )
 from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
     AtomicProposalAuthenticityNonceStore,
+    InMemoryProposalReplayHighWaterStore,
+    ProposalReplayHighWater,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     SigningRequest,
@@ -49,11 +56,15 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     AUDIT_KEY_PREFIX,
     PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    PROVIDER_MODE_WSP71_PERMISSIONED,
     SIGNING_KEY_PREFIX,
     SignerKeyProviderProfile,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
     PeerCredentialPolicy,
+)
+from modules.communication.moltbot_bridge.src import (
+    reddog_signer_socket_service_config_supply as config_supply,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
     FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID,
@@ -72,6 +83,7 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runti
     FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
     FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,
     SignerSocketServiceRuntimeWiringConfig,
+    architect_proposal_security_context_digest,
     run_reddog_signer_socket_service_runtime_wiring,
     validate_signer_socket_service_runtime_config,
 )
@@ -86,6 +98,122 @@ pytest.importorskip("cryptography")
 NOW = int(time.time())
 PRINCIPAL_PUBLIC = encode_ed25519_public_key(bytes(range(32)))
 INTEGRITY_KEY = b"proposal-integrity-key-32-bytes!"
+HIGH_WATER_STORE_ID = "proposal-replay-authority:test"
+
+
+class _SqliteProposalReplayHighWaterStore:
+    """Cross-process test authority kept outside the signer-state directory."""
+
+    def __init__(self, path: Path | str) -> None:
+        self._path = str(Path(path))
+        Path(self._path).parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self._path) as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS replay_high_water ("
+                "binding_digest TEXT PRIMARY KEY,"
+                "sequence INTEGER NOT NULL,"
+                "state_revision TEXT NOT NULL)"
+            )
+
+    @property
+    def store_id(self) -> str:
+        return HIGH_WATER_STORE_ID
+
+    def load(
+        self,
+        replay_store_binding_digest: str,
+    ) -> ProposalReplayHighWater | None:
+        with sqlite3.connect(self._path) as connection:
+            row = connection.execute(
+                "SELECT sequence, state_revision FROM replay_high_water "
+                "WHERE binding_digest = ?",
+                (replay_store_binding_digest,),
+            ).fetchone()
+        return (
+            ProposalReplayHighWater(
+                sequence=int(row[0]),
+                state_revision=str(row[1]),
+            )
+            if row is not None
+            else None
+        )
+
+    def advance(
+        self,
+        replay_store_binding_digest: str,
+        *,
+        expected: ProposalReplayHighWater | None,
+        next_value: ProposalReplayHighWater,
+    ) -> None:
+        with sqlite3.connect(
+            self._path,
+            timeout=10.0,
+            isolation_level=None,
+        ) as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT sequence, state_revision FROM replay_high_water "
+                "WHERE binding_digest = ?",
+                (replay_store_binding_digest,),
+            ).fetchone()
+            current = (
+                ProposalReplayHighWater(
+                    sequence=int(row[0]),
+                    state_revision=str(row[1]),
+                )
+                if row is not None
+                else None
+            )
+            if current != expected:
+                connection.execute("ROLLBACK")
+                raise RuntimeError("proposal_replay_high_water_conflict")
+            if next_value.sequence != (
+                current.sequence + 1 if current is not None else 1
+            ):
+                connection.execute("ROLLBACK")
+                raise ValueError("proposal_replay_high_water_invalid")
+            connection.execute(
+                "INSERT INTO replay_high_water "
+                "(binding_digest, sequence, state_revision) VALUES (?, ?, ?) "
+                "ON CONFLICT(binding_digest) DO UPDATE SET "
+                "sequence = excluded.sequence, "
+                "state_revision = excluded.state_revision",
+                (
+                    replay_store_binding_digest,
+                    next_value.sequence,
+                    next_value.state_revision,
+                ),
+            )
+            connection.execute("COMMIT")
+
+
+class _FailOnceProposalReplayHighWaterStore:
+    def __init__(self, store_id: str) -> None:
+        self._delegate = InMemoryProposalReplayHighWaterStore(store_id)
+        self._failed = False
+
+    @property
+    def store_id(self) -> str:
+        return self._delegate.store_id
+
+    def load(self, replay_store_binding_digest: str):
+        return self._delegate.load(replay_store_binding_digest)
+
+    def advance(
+        self,
+        replay_store_binding_digest: str,
+        *,
+        expected: ProposalReplayHighWater | None,
+        next_value: ProposalReplayHighWater,
+    ) -> None:
+        if not self._failed:
+            self._failed = True
+            raise OSError("simulated_high_water_outage")
+        self._delegate.advance(
+            replay_store_binding_digest,
+            expected=expected,
+            next_value=next_value,
+        )
 
 
 def _private_key():
@@ -172,6 +300,7 @@ def _profile(
 ) -> dict[str, object]:
     return {
         "principal_id": "github:mjtrout",
+        "principal_provider": "github",
         "principal_public_key": principal_public_key,
         "reddog_id": "reddog:foundups-agent",
         "reddog_public_key": public_key,
@@ -182,11 +311,30 @@ def _profile(
     }
 
 
+class _PrincipalKeyResolver:
+    def __init__(self, public_key: str) -> None:
+        self._public_key = public_key
+
+    def resolve(
+        self,
+        principal_id: str,
+        principal_provider: str,
+    ) -> str | None:
+        if (
+            principal_id == "github:mjtrout"
+            and principal_provider == "github"
+        ):
+            return self._public_key
+        return None
+
+
 def _policy_authorization(
     policy: ArchitectProposalSignerPolicy,
     *,
     principal_private,
     public_key: str,
+    signer_runtime_root: Path,
+    security_context_digest: str,
     profile: dict[str, object] | None = None,
     issued_at: int = NOW - 5,
     expires_at: int = NOW + 120,
@@ -198,6 +346,7 @@ def _policy_authorization(
     payload = build_architect_proposal_policy_authorization_payload(
         policy,
         principal_id=str(authority_profile["principal_id"]),
+        principal_provider=str(authority_profile["principal_provider"]),
         principal_public_key=str(
             authority_profile["principal_public_key"]
         ),
@@ -207,6 +356,24 @@ def _policy_authorization(
         authority_profile_source_receipt_id=str(
             authority_profile["authority_profile_source_receipt_id"]
         ),
+        signer_instance_id=architect_proposal_signer_instance_id(
+            signer_runtime_root,
+            public_key,
+            str(authority_profile["key_epoch"]),
+        ),
+        replay_store_binding_digest=(
+            architect_proposal_replay_store_binding_digest(
+                architect_proposal_signer_instance_id(
+                    signer_runtime_root,
+                    public_key,
+                    str(authority_profile["key_epoch"]),
+                ),
+                signer_runtime_root
+                / "architect_proposal_nonce_store.json",
+                HIGH_WATER_STORE_ID,
+            )
+        ),
+        security_context_digest=security_context_digest,
         nonce="proposal-policy-authorization-nonce-1",
         issued_at=issued_at,
         expires_at=expires_at,
@@ -226,10 +393,8 @@ def _policy_authorization(
 
 def _provider_profiles(
     *,
-    principal_private,
     reddog_private,
-) -> tuple[SignerKeyProviderProfile, SignerKeyProviderProfile]:
-    principal_public = _public_text(principal_private)
+) -> tuple[SignerKeyProviderProfile]:
     reddog_public = _public_text(reddog_private)
     common = {
         "expected_key_epoch": "epoch-1",
@@ -237,17 +402,6 @@ def _provider_profiles(
         "ttl_seconds": 60,
     }
     return (
-        SignerKeyProviderProfile(
-            signer_profile_id="principal-identity",
-            signer_agent_id="signer:principal",
-            signing_key_ref="op://test/principal/private",
-            audit_mac_key_ref="op://test/principal/audit",
-            expected_public_key=principal_public,
-            expected_key_fingerprint=public_key_fingerprint(
-                principal_public
-            ),
-            **common,
-        ),
         SignerKeyProviderProfile(
             signer_profile_id="reddog-work-authority",
             signer_agent_id="signer:reddog",
@@ -296,14 +450,18 @@ def _peer() -> SignerPeerAttestation:
 
 
 def _reserve_nonce_process(
-    values: tuple[str, str, str, int],
+    values: tuple[str, str, str, str, int],
 ) -> bool:
-    repo, runtime, nonce, expires_at = values
+    repo, runtime, high_water_path, nonce, expires_at = values
     store = AtomicProposalAuthenticityNonceStore(
         Path(runtime) / "proposal-nonces.json",
         allowed_root=runtime,
         repo_root=repo,
         integrity_key=INTEGRITY_KEY,
+        replay_store_binding_digest="sha256:" + "b" * 64,
+        high_water_store=_SqliteProposalReplayHighWaterStore(
+            high_water_path
+        ),
     )
     return bool(
         store.reserve(
@@ -312,6 +470,26 @@ def _reserve_nonce_process(
             subject="github:mjtrout",
         )
     )
+
+
+def _nonce_store_kwargs(
+    repo: Path,
+    runtime: Path,
+    *,
+    high_water_store=None,
+) -> dict[str, object]:
+    return {
+        "allowed_root": runtime,
+        "repo_root": repo,
+        "integrity_key": INTEGRITY_KEY,
+        "replay_store_binding_digest": "sha256:" + "b" * 64,
+        "high_water_store": (
+            high_water_store
+            or _SqliteProposalReplayHighWaterStore(
+                runtime.parent / "proposal-high-water.sqlite3"
+            )
+        ),
+    }
 
 
 def _config_kwargs(
@@ -326,10 +504,70 @@ def _config_kwargs(
         public_key,
         principal_public_key=_public_text(principal_private),
     )
+    signer_runtime = runtime.parent / "signer-state"
+    peer_policy, peer_reasons = config_supply._peer_policy(
+        {1001: "github:mjtrout"},
+        (),
+    )
+    assert not peer_reasons and peer_policy is not None
+    unsigned_config = config_supply._config(
+        authority_profile=profile,
+        runtime_root=runtime.resolve(),
+        signer_runtime_root=signer_runtime.resolve(),
+        socket_path=(runtime / "reddog-signer.sock").resolve(),
+        principal_signing_key_ref="op://prod/principal/private",
+        principal_audit_mac_key_ref="op://prod/principal/audit",
+        reddog_signing_key_ref="op://prod/reddog/private",
+        reddog_audit_mac_key_ref="op://prod/reddog/audit",
+        peer_policy=peer_policy,
+        max_requests=2,
+        timeout_s=5.0,
+        max_request_bytes=16384,
+        max_response_bytes=16384,
+        principal_signer_agent_id="signer:principal",
+        reddog_signer_agent_id="signer:reddog",
+        control_loop_anchor_path=(
+            signer_runtime / "signer_control_loop_anchor.json"
+        ).resolve(),
+        proposal_authority_policy=policy,
+        proposal_policy_authorization=None,
+        proposal_nonce_store_path=(
+            signer_runtime / "architect_proposal_nonce_store.json"
+        ).resolve(),
+        proposal_replay_high_water_store_id=HIGH_WATER_STORE_ID,
+    )
+    security_context_digest = architect_proposal_security_context_digest(
+        SignerSocketServiceRuntimeWiringConfig(
+            repo_root=repo,
+            runtime_root=runtime.resolve(),
+            signer_runtime_root=signer_runtime.resolve(),
+            socket_path=(runtime / "reddog-signer.sock").resolve(),
+            peer_policy=peer_policy,
+            provider_mode=PROVIDER_MODE_WSP71_PERMISSIONED,
+            allow_test_only_key_material=False,
+            permission_snapshot_fresh=True,
+            max_requests=2,
+            timeout_s=5.0,
+            max_request_bytes=16384,
+            max_response_bytes=16384,
+            key_provider_profiles=tuple(
+                unsigned_config["key_provider_profiles"]
+            ),
+            control_loop_anchor_path=(
+                signer_runtime / "signer_control_loop_anchor.json"
+            ).resolve(),
+            proposal_authority_policy=policy,
+            proposal_nonce_store_path=(
+                signer_runtime
+                / "architect_proposal_nonce_store.json"
+            ).resolve(),
+            proposal_replay_high_water_store_id=HIGH_WATER_STORE_ID,
+        )
+    )
     values: dict[str, object] = {
         "repo_root": repo,
         "runtime_root": runtime,
-        "signer_runtime_root": runtime.parent / "signer-state",
+        "signer_runtime_root": signer_runtime,
         "authority_profile": profile,
         "output_path": runtime / "signer-service.json",
         "socket_path": runtime / "reddog-signer.sock",
@@ -339,17 +577,72 @@ def _config_kwargs(
         "reddog_audit_mac_key_ref": "op://prod/reddog/audit",
         "peer_uid_to_principal": {1001: "github:mjtrout"},
         "proposal_authority_policy": policy,
+        "proposal_replay_high_water_store_id": HIGH_WATER_STORE_ID,
         "proposal_policy_authorization": _policy_authorization(
             policy,
             principal_private=principal_private,
             public_key=public_key,
+            signer_runtime_root=signer_runtime,
+            security_context_digest=security_context_digest,
             profile=profile,
+        ),
+        "principal_key_resolver": _PrincipalKeyResolver(
+            _public_text(principal_private)
         ),
         "now_epoch": NOW,
         "max_requests": 2,
     }
     values.update(overrides)
     return values
+
+
+def _runtime_proposal_config(
+    *,
+    repo: Path,
+    runtime: Path,
+    signer_runtime: Path,
+    policy: ArchitectProposalSignerPolicy,
+    principal_private,
+    reddog_private,
+) -> SignerSocketServiceRuntimeWiringConfig:
+    profiles = _provider_profiles(reddog_private=reddog_private)
+    provisional = SignerSocketServiceRuntimeWiringConfig(
+        repo_root=repo,
+        runtime_root=runtime,
+        signer_runtime_root=signer_runtime,
+        socket_path=runtime / "signer.sock",
+        peer_policy=PeerCredentialPolicy(
+            uid_to_principal={1001: "github:mjtrout"},
+            allowed_gids=(),
+        ),
+        key_provider_profiles=profiles,
+        provider_mode=PROVIDER_MODE_TEST_ONLY_DRYRUN,
+        allow_test_only_key_material=True,
+        permission_snapshot_fresh=True,
+        control_loop_anchor_path=(
+            signer_runtime / "signer_control_loop_anchor.json"
+        ),
+        proposal_authority_policy=policy,
+        proposal_nonce_store_path=(
+            signer_runtime / "architect_proposal_nonce_store.json"
+        ),
+        proposal_replay_high_water_store_id=HIGH_WATER_STORE_ID,
+    )
+    security_digest = architect_proposal_security_context_digest(
+        provisional
+    )
+    authorization = _policy_authorization(
+        policy,
+        principal_private=principal_private,
+        public_key=_public_text(reddog_private),
+        signer_runtime_root=signer_runtime,
+        security_context_digest=security_digest,
+    )
+    return dataclasses.replace(
+        provisional,
+        proposal_policy_authorization=authorization,
+        proposal_security_context_digest=security_digest,
+    )
 
 
 def test_atomic_nonce_store_survives_restart_and_rejects_replay(
@@ -361,9 +654,7 @@ def test_atomic_nonce_store_survives_restart_and_rejects_replay(
     store_path = runtime / "proposal-nonces.json"
     first = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
 
     reservation = first.reserve(
@@ -376,9 +667,7 @@ def test_atomic_nonce_store_survives_restart_and_rejects_replay(
 
     restarted = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
     assert (
         restarted.reserve(
@@ -402,15 +691,11 @@ def test_atomic_nonce_store_rollback_and_racing_reservations(
     store_path = runtime / "proposal-nonces.json"
     first = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
     second = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
     initial = first.reserve(
         "rollback-nonce",
@@ -458,9 +743,13 @@ def test_atomic_nonce_store_rejects_repo_path_and_malformed_state(
     with pytest.raises(ValueError):
         AtomicProposalAuthenticityNonceStore(
             repo / "nonce.json",
-            allowed_root=repo,
+            allowed_root=runtime,
             repo_root=repo,
             integrity_key=INTEGRITY_KEY,
+            replay_store_binding_digest="sha256:" + "b" * 64,
+            high_water_store=InMemoryProposalReplayHighWaterStore(
+                HIGH_WATER_STORE_ID
+            ),
         )
 
     store_path = runtime / "proposal-nonces.json"
@@ -468,9 +757,7 @@ def test_atomic_nonce_store_rejects_repo_path_and_malformed_state(
     store_path.write_text('{"schema_version":"wrong"}', encoding="utf-8")
     store = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
     with pytest.raises(ValueError):
         store.reserve(
@@ -489,9 +776,7 @@ def test_atomic_nonce_store_rejects_structurally_valid_state_tampering(
     store_path = runtime / "proposal-nonces.json"
     store = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
     reservation = store.reserve(
         "tamper-nonce",
@@ -509,9 +794,7 @@ def test_atomic_nonce_store_rejects_structurally_valid_state_tampering(
 
     restarted = AtomicProposalAuthenticityNonceStore(
         store_path,
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
     )
     with pytest.raises(
         ValueError,
@@ -533,9 +816,7 @@ def test_atomic_nonce_store_prunes_expired_crash_state_and_is_bounded(
     now = [NOW]
     store = AtomicProposalAuthenticityNonceStore(
         runtime / "proposal-nonces.json",
-        allowed_root=runtime,
-        repo_root=repo,
-        integrity_key=INTEGRITY_KEY,
+        **_nonce_store_kwargs(repo, runtime),
         clock=lambda: now[0],
         clock_skew_seconds=2,
         retention_seconds=4,
@@ -576,9 +857,22 @@ def test_atomic_nonce_store_serializes_cross_process_reservation(
     repo = tmp_path / "repo"
     runtime = tmp_path / "signer-state"
     repo.mkdir()
+    high_water_path = tmp_path / "proposal-high-water.sqlite3"
     jobs = [
-        (str(repo), str(runtime), "process-race", NOW + 60),
-        (str(repo), str(runtime), "process-race", NOW + 60),
+        (
+            str(repo),
+            str(runtime),
+            str(high_water_path),
+            "process-race",
+            NOW + 60,
+        ),
+        (
+            str(repo),
+            str(runtime),
+            str(high_water_path),
+            "process-race",
+            NOW + 60,
+        ),
     ]
     with ProcessPoolExecutor(
         max_workers=2,
@@ -586,6 +880,116 @@ def test_atomic_nonce_store_serializes_cross_process_reservation(
     ) as executor:
         results = list(executor.map(_reserve_nonce_process, jobs))
     assert sum(results) == 1
+
+
+def test_atomic_nonce_store_rejects_state_rollback_and_deletion(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    store_path = runtime / "proposal-nonces.json"
+    high_water = InMemoryProposalReplayHighWaterStore(
+        HIGH_WATER_STORE_ID
+    )
+    store = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        **_nonce_store_kwargs(
+            repo,
+            runtime,
+            high_water_store=high_water,
+        ),
+    )
+    first = store.reserve(
+        "nonce-1",
+        expires_at=NOW + 60,
+        subject="github:mjtrout",
+    )
+    assert first
+    store.commit(first)
+    old_state = store_path.read_bytes()
+
+    second = store.reserve(
+        "nonce-2",
+        expires_at=NOW + 60,
+        subject="github:mjtrout",
+    )
+    assert second
+    store.commit(second)
+    current_state = store_path.read_bytes()
+
+    store_path.write_bytes(old_state)
+    with pytest.raises(ValueError, match="rollback_detected"):
+        store.reserve(
+            "nonce-3",
+            expires_at=NOW + 60,
+            subject="github:mjtrout",
+        )
+
+    store_path.write_bytes(current_state)
+    store_path.unlink()
+    with pytest.raises(ValueError, match="rollback_detected"):
+        store.reserve(
+            "nonce-4",
+            expires_at=NOW + 60,
+            subject="github:mjtrout",
+        )
+
+    store_path.write_bytes(current_state)
+
+
+def test_atomic_nonce_store_recovers_state_commit_before_high_water_advance(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    high_water = _FailOnceProposalReplayHighWaterStore(
+        HIGH_WATER_STORE_ID
+    )
+    store_path = runtime / "proposal-nonces.json"
+    store = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        **_nonce_store_kwargs(
+            repo,
+            runtime,
+            high_water_store=high_water,
+        ),
+    )
+
+    with pytest.raises(OSError, match="simulated_high_water_outage"):
+        store.reserve(
+            "crash-window-nonce",
+            expires_at=NOW + 60,
+            subject="github:mjtrout",
+        )
+
+    restarted = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        **_nonce_store_kwargs(
+            repo,
+            runtime,
+            high_water_store=high_water,
+        ),
+    )
+    assert (
+        restarted.reserve(
+            "crash-window-nonce",
+            expires_at=NOW + 60,
+            subject="github:mjtrout",
+        )
+        is None
+    )
+    recovered = high_water.load("sha256:" + "b" * 64)
+    assert recovered is not None
+    assert recovered.sequence == 1
+
+
+def test_ed25519_signature_decoder_rejects_noncanonical_suffix() -> None:
+    canonical = encode_ed25519_signature(b"s" * 64)
+    assert decode_ed25519_signature(canonical) == b"s" * 64
+    assert decode_ed25519_signature(canonical + "A") is None
+    assert decode_ed25519_signature(canonical + "=") is None
 
 
 def test_config_supply_binds_exact_policy_and_confined_nonce_store(
@@ -599,15 +1003,19 @@ def test_config_supply_binds_exact_policy_and_confined_nonce_store(
     runtime = tmp_path / "runtime"
     repo.mkdir()
 
-    result = run_reddog_signer_socket_service_config_supply(
-        **_config_kwargs(
-            repo,
-            runtime,
-            public_key,
-            policy,
-            principal_private,
-        )
+    kwargs = _config_kwargs(
+        repo,
+        runtime,
+        public_key,
+        policy,
+        principal_private,
     )
+    authorization = kwargs["proposal_policy_authorization"]
+    assert isinstance(
+        authorization,
+        ArchitectProposalPolicyAuthorization,
+    )
+    result = run_reddog_signer_socket_service_config_supply(**kwargs)
 
     assert result.accepted is True
     assert result.proposal_policy_configured is True
@@ -619,20 +1027,18 @@ def test_config_supply_binds_exact_policy_and_confined_nonce_store(
         config["proposal_authority_policy"]["expected_payload"]
         == policy.expected_payload.to_dict()
     )
-    assert result.profile_count == 2
+    assert result.profile_count == 1
     assert [
         item["signer_profile_id"]
         for item in config["key_provider_profiles"]
-    ] == ["principal-identity", "reddog-work-authority"]
+    ] == ["reddog-work-authority"]
+    assert "principal/private" not in json.dumps(config, sort_keys=True)
+    assert "control_loop_authority_policy" not in config
     assert (
         config["proposal_policy_authorization"][
             "proposal_policy_digest"
         ]
-        == _policy_authorization(
-            policy,
-            principal_private=principal_private,
-            public_key=public_key,
-        ).proposal_policy_digest
+        == authorization.proposal_policy_digest
     )
     nonce_path = Path(config["proposal_nonce_store_path"])
     assert nonce_path.parent == (tmp_path / "signer-state").resolve()
@@ -647,6 +1053,41 @@ def test_config_supply_binds_exact_policy_and_confined_nonce_store(
     )
     assert rehydrated is not None
     assert rehydrated.proposal_nonce_store_path == nonce_path
+    assert (
+        rehydrated.proposal_replay_high_water_store_id
+        == HIGH_WATER_STORE_ID
+    )
+    assert hmac.compare_digest(
+        architect_proposal_security_context_digest(rehydrated),
+        str(rehydrated.proposal_security_context_digest),
+    )
+    bootstrap = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=runtime / "signer-service.json",
+        resolver=_Resolver(private_key),
+        serve_bounded=lambda **kwargs: (
+            IsolatedSignerSocketResidentServiceResult(
+                accepted=True,
+                status=SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
+                rejection_reasons=(),
+                socket_path=str(kwargs["socket_path"]),
+                requests_handled=0,
+                response_digests=(),
+                socket_removed=True,
+            )
+        ),
+        expected_config_digest=result.config_digest,
+        principal_key_resolver=_PrincipalKeyResolver(
+            _public_text(principal_private)
+        ),
+        proposal_replay_high_water_store=(
+            InMemoryProposalReplayHighWaterStore(
+                HIGH_WATER_STORE_ID
+            )
+        ),
+    )
+    assert bootstrap.rejection_reasons == ()
+    assert bootstrap.accepted is True
 
 
 def test_config_supply_requires_valid_principal_signed_policy_authorization(
@@ -734,6 +1175,14 @@ def test_config_supply_requires_valid_principal_signed_policy_authorization(
             policy,
             principal_private=principal_private,
             public_key=public_key,
+            signer_runtime_root=(
+                tmp_path / "expired" / ".." / "signer-state"
+            ).resolve(),
+            security_context_digest=str(
+                expired_kwargs[
+                    "proposal_policy_authorization"
+                ].security_context_digest
+            ),
             issued_at=NOW - 400,
             expires_at=NOW - 1,
         )
@@ -745,6 +1194,76 @@ def test_config_supply_requires_valid_principal_signed_policy_authorization(
     assert expired.rejection_reasons == (
         FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
     )
+
+
+def test_config_supply_rejects_self_asserted_principal_and_config_substitution(
+    tmp_path: Path,
+) -> None:
+    reddog_private = _private_key()
+    attacker_private = _private_key()
+    trusted_private = _private_key()
+    public_key = _public_text(reddog_private)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    self_asserted = _config_kwargs(
+        repo,
+        tmp_path / "self-asserted",
+        public_key,
+        policy,
+        attacker_private,
+    )
+    self_asserted["principal_key_resolver"] = _PrincipalKeyResolver(
+        _public_text(trusted_private)
+    )
+    rejected = run_reddog_signer_socket_service_config_supply(
+        **self_asserted
+    )
+    assert rejected.accepted is False
+    assert rejected.rejection_reasons == (
+        FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+    missing_resolver = _config_kwargs(
+        repo,
+        tmp_path / "missing-resolver",
+        public_key,
+        policy,
+        trusted_private,
+    )
+    missing_resolver.pop("principal_key_resolver")
+    rejected = run_reddog_signer_socket_service_config_supply(
+        **missing_resolver
+    )
+    assert rejected.accepted is False
+    assert rejected.rejection_reasons == (
+        FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+    for field, replacement in (
+        ("max_requests", 3),
+        ("reddog_signing_key_ref", "op://prod/reddog/other-private"),
+        ("signer_runtime_root", tmp_path / "other-signer-state"),
+    ):
+        substituted = _config_kwargs(
+            repo,
+            tmp_path / ("substituted-" + field),
+            public_key,
+            policy,
+            trusted_private,
+        )
+        substituted[field] = replacement
+        result = run_reddog_signer_socket_service_config_supply(
+            **substituted
+        )
+        assert result.accepted is False
+        assert (
+            FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID
+            in result.rejection_reasons
+            or FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID
+            in result.rejection_reasons
+        )
 
 
 @pytest.mark.parametrize(
@@ -803,7 +1322,12 @@ class _Resolver:
     def __init__(self, private_key, principal_private=None) -> None:
         self._values = {
             "op://test/reddog/private": _private_key_secret(private_key),
+            "op://prod/reddog/private": _private_key_secret(private_key),
             "op://test/reddog/audit": (
+                AUDIT_KEY_PREFIX
+                + base64.b64encode(b"a" * 32).decode("ascii")
+            ),
+            "op://prod/reddog/audit": (
                 AUDIT_KEY_PREFIX
                 + base64.b64encode(b"a" * 32).decode("ascii")
             ),
@@ -814,7 +1338,14 @@ class _Resolver:
                     "op://test/principal/private": (
                         _private_key_secret(principal_private)
                     ),
+                    "op://prod/principal/private": (
+                        _private_key_secret(principal_private)
+                    ),
                     "op://test/principal/audit": (
+                        AUDIT_KEY_PREFIX
+                        + base64.b64encode(b"p" * 32).decode("ascii")
+                    ),
+                    "op://prod/principal/audit": (
                         AUDIT_KEY_PREFIX
                         + base64.b64encode(b"p" * 32).decode("ascii")
                     ),
@@ -848,6 +1379,9 @@ def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
     signer_runtime = tmp_path / "signer-state"
     repo.mkdir()
     captured: dict[str, object] = {}
+    proposal_high_water_store = InMemoryProposalReplayHighWaterStore(
+        HIGH_WATER_STORE_ID
+    )
 
     def serve(**kwargs):
         captured.update(kwargs)
@@ -861,44 +1395,23 @@ def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
             socket_removed=True,
         )
 
-    profiles = _provider_profiles(
+    config = _runtime_proposal_config(
+        repo=repo,
+        runtime=runtime,
+        signer_runtime=signer_runtime,
+        policy=policy,
         principal_private=principal_private,
         reddog_private=private_key,
-    )
-    authority_profile = _profile(
-        public_key,
-        principal_public_key=_public_text(principal_private),
-    )
-    authorization = _policy_authorization(
-        policy,
-        principal_private=principal_private,
-        public_key=public_key,
-        profile=authority_profile,
-    )
-    config = SignerSocketServiceRuntimeWiringConfig(
-        repo_root=repo,
-        runtime_root=runtime,
-        signer_runtime_root=signer_runtime,
-        socket_path=runtime / "signer.sock",
-        peer_policy=PeerCredentialPolicy(
-            uid_to_principal={1001: "github:mjtrout"},
-            allowed_gids=(),
-        ),
-        key_provider_profiles=profiles,
-        provider_mode=PROVIDER_MODE_TEST_ONLY_DRYRUN,
-        allow_test_only_key_material=True,
-        permission_snapshot_fresh=True,
-        control_loop_anchor_path=None,
-        control_loop_authority_policy=None,
-        proposal_authority_policy=policy,
-        proposal_policy_authorization=authorization,
-        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
     )
 
     result = run_reddog_signer_socket_service_runtime_wiring(
         config,
-        _Resolver(private_key, principal_private),
+        _Resolver(private_key),
         serve_bounded=serve,
+        principal_key_resolver=_PrincipalKeyResolver(
+            _public_text(principal_private)
+        ),
+        proposal_replay_high_water_store=proposal_high_water_store,
     )
 
     assert result.accepted is True
@@ -915,10 +1428,23 @@ def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
     restarted = dataclasses.replace(
         backend,
         proposal_nonce_store=AtomicProposalAuthenticityNonceStore(
-            signer_runtime / "proposal-nonces.json",
+            signer_runtime / "architect_proposal_nonce_store.json",
             allowed_root=signer_runtime,
             repo_root=repo,
             integrity_key=b"a" * 32,
+            high_water_store=proposal_high_water_store,
+            replay_store_binding_digest=(
+                architect_proposal_replay_store_binding_digest(
+                    architect_proposal_signer_instance_id(
+                        signer_runtime,
+                        public_key,
+                        "epoch-1",
+                    ),
+                    signer_runtime
+                    / "architect_proposal_nonce_store.json",
+                    HIGH_WATER_STORE_ID,
+                )
+            ),
         ),
     )
     replay = restarted.sign(
@@ -979,6 +1505,181 @@ def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
     assert failed.signature == ""
     assert failed.audit_mac == ""
     assert fail_store.rolled_back is True
+
+
+def test_runtime_consumes_policy_authorization_nonce_once(
+    tmp_path: Path,
+) -> None:
+    reddog_private = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(reddog_private)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    config = _runtime_proposal_config(
+        repo=repo,
+        runtime=runtime,
+        signer_runtime=signer_runtime,
+        policy=policy,
+        principal_private=principal_private,
+        reddog_private=reddog_private,
+    )
+
+    def serve(**kwargs):
+        return IsolatedSignerSocketResidentServiceResult(
+            accepted=True,
+            status=SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
+            rejection_reasons=(),
+            socket_path=str(kwargs["socket_path"]),
+            requests_handled=0,
+            response_digests=(),
+            socket_removed=True,
+        )
+
+    principal_resolver = _PrincipalKeyResolver(
+        _public_text(principal_private)
+    )
+    high_water_store = InMemoryProposalReplayHighWaterStore(
+        HIGH_WATER_STORE_ID
+    )
+    first = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(reddog_private),
+        serve_bounded=serve,
+        principal_key_resolver=principal_resolver,
+        proposal_replay_high_water_store=high_water_store,
+    )
+    second = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(reddog_private),
+        serve_bounded=serve,
+        principal_key_resolver=principal_resolver,
+        proposal_replay_high_water_store=high_water_store,
+    )
+
+    assert first.accepted is True
+    assert second.accepted is False
+    assert second.rejection_reasons == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+
+def test_runtime_requires_matching_independent_high_water_authority(
+    tmp_path: Path,
+) -> None:
+    reddog_private = _private_key()
+    principal_private = _private_key()
+    policy = ArchitectProposalSignerPolicy(
+        _payload(_public_text(reddog_private))
+    )
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    config = _runtime_proposal_config(
+        repo=repo,
+        runtime=runtime,
+        signer_runtime=signer_runtime,
+        policy=policy,
+        principal_private=principal_private,
+        reddog_private=reddog_private,
+    )
+    common = {
+        "serve_bounded": lambda **kwargs: pytest.fail(
+            "signer service reached without matching high-water authority"
+        ),
+        "principal_key_resolver": _PrincipalKeyResolver(
+            _public_text(principal_private)
+        ),
+    }
+
+    missing = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(reddog_private),
+        **common,
+    )
+    mismatched = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(reddog_private),
+        proposal_replay_high_water_store=(
+            InMemoryProposalReplayHighWaterStore("wrong-authority")
+        ),
+        **common,
+    )
+
+    assert missing.accepted is False
+    assert mismatched.accepted is False
+    assert missing.rejection_reasons == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+    )
+    assert mismatched.rejection_reasons == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+    )
+
+
+def test_runtime_never_reuses_authorization_after_service_signs_then_raises(
+    tmp_path: Path,
+) -> None:
+    reddog_private = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(reddog_private)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    config = _runtime_proposal_config(
+        repo=repo,
+        runtime=runtime,
+        signer_runtime=signer_runtime,
+        policy=policy,
+        principal_private=principal_private,
+        reddog_private=reddog_private,
+    )
+    high_water = InMemoryProposalReplayHighWaterStore(
+        HIGH_WATER_STORE_ID
+    )
+    service_calls = 0
+    signed = []
+
+    def sign_then_raise(**kwargs):
+        nonlocal service_calls
+        service_calls += 1
+        signed.append(
+            kwargs["backend"].sign(
+                _signing_request(policy.expected_payload),
+                _peer(),
+            )
+        )
+        raise RuntimeError("service_failed_after_signing")
+
+    principal_resolver = _PrincipalKeyResolver(
+        _public_text(principal_private)
+    )
+    first = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(reddog_private),
+        serve_bounded=sign_then_raise,
+        principal_key_resolver=principal_resolver,
+        proposal_replay_high_water_store=high_water,
+    )
+    second = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(reddog_private),
+        serve_bounded=sign_then_raise,
+        principal_key_resolver=principal_resolver,
+        proposal_replay_high_water_store=high_water,
+    )
+
+    assert signed and signed[0].accepted is True
+    assert first.accepted is False
+    assert second.accepted is False
+    assert service_calls == 1
+    assert second.rejection_reasons == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
 
 
 def test_bootstrap_rejects_tampered_serialized_proposal_policy(
@@ -1093,67 +1794,44 @@ def test_runtime_config_rejects_partial_or_mismatched_proposal_wiring(
     runtime = tmp_path / "runtime"
     signer_runtime = tmp_path / "signer-state"
     repo.mkdir()
-    profiles = _provider_profiles(
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    valid = _runtime_proposal_config(
+        repo=repo,
+        runtime=runtime,
+        signer_runtime=signer_runtime,
+        policy=policy,
         principal_private=principal_private,
         reddog_private=private_key,
     )
-    policy = ArchitectProposalSignerPolicy(_payload(public_key))
-    authorization = _policy_authorization(
-        policy,
-        principal_private=principal_private,
-        public_key=public_key,
+    missing_store = dataclasses.replace(
+        valid,
+        proposal_nonce_store_path=None,
     )
-    base = {
-        "repo_root": repo,
-        "runtime_root": runtime,
-        "signer_runtime_root": signer_runtime,
-        "socket_path": runtime / "signer.sock",
-        "peer_policy": PeerCredentialPolicy(
-            uid_to_principal={1001: "github:mjtrout"},
-            allowed_gids=(),
-        ),
-        "key_provider_profiles": profiles,
-        "provider_mode": PROVIDER_MODE_TEST_ONLY_DRYRUN,
-        "allow_test_only_key_material": True,
-        "permission_snapshot_fresh": True,
-        "proposal_policy_authorization": authorization,
-    }
-    missing_store = SignerSocketServiceRuntimeWiringConfig(
-        **base,
-        proposal_authority_policy=policy,
-    )
-    mismatched_key = SignerSocketServiceRuntimeWiringConfig(
-        **base,
+    mismatched_key = dataclasses.replace(
+        valid,
         proposal_authority_policy=ArchitectProposalSignerPolicy(
             _payload(other_key)
         ),
-        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
     )
-    substituted_profile = SignerSocketServiceRuntimeWiringConfig(
-        **{
-            **base,
-            "key_provider_profiles": (
-                profiles[0],
-                dataclasses.replace(
-                    profiles[1],
-                    signer_profile_id="principal-identity",
-                ),
+    substituted_profile = dataclasses.replace(
+        valid,
+        key_provider_profiles=(
+            dataclasses.replace(
+                valid.key_provider_profiles[0],
+                signer_profile_id="principal-identity",
             ),
-        },
-        proposal_authority_policy=policy,
-        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
+        ),
     )
-    excessive_ttl = SignerSocketServiceRuntimeWiringConfig(
-        **base,
+    excessive_ttl = dataclasses.replace(
+        valid,
         proposal_authority_policy=ArchitectProposalSignerPolicy(
             _payload(public_key),
             max_ttl_seconds=301,
         ),
-        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
     )
 
     assert validate_signer_socket_service_runtime_config(missing_store) == (
-        FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+        FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
     )
     assert validate_signer_socket_service_runtime_config(mismatched_key) == (
         FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -479,6 +479,7 @@ def _reserve_nonce_process(
         high_water_store=_SqliteProposalReplayHighWaterStore(
             high_water_path
         ),
+        clock=lambda: expires_at - 60,
     )
     return bool(
         store.reserve(
@@ -494,6 +495,7 @@ def _nonce_store_kwargs(
     runtime: Path,
     *,
     high_water_store=None,
+    clock=None,
 ) -> dict[str, object]:
     return {
         "allowed_root": runtime,
@@ -506,6 +508,7 @@ def _nonce_store_kwargs(
                 runtime.parent / "proposal-high-water.sqlite3"
             )
         ),
+        "clock": clock or (lambda: NOW),
     }
 
 
@@ -845,8 +848,7 @@ def test_atomic_nonce_store_prunes_expired_crash_state_and_is_bounded(
     now = [NOW]
     store = AtomicProposalAuthenticityNonceStore(
         runtime / "proposal-nonces.json",
-        **_nonce_store_kwargs(repo, runtime),
-        clock=lambda: now[0],
+        **_nonce_store_kwargs(repo, runtime, clock=lambda: now[0]),
         clock_skew_seconds=2,
         retention_seconds=4,
         max_entries=2,
@@ -1024,8 +1026,7 @@ def test_atomic_nonce_store_rechecks_expiry_at_reserve_and_commit(
     now = [NOW]
     store = AtomicProposalAuthenticityNonceStore(
         runtime / "proposal-nonces.json",
-        **_nonce_store_kwargs(repo, runtime),
-        clock=lambda: now[0],
+        **_nonce_store_kwargs(repo, runtime, clock=lambda: now[0]),
     )
 
     assert (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -1,0 +1,1166 @@
+"""Runtime tests for durable architect-proposal signer policy provisioning."""
+
+from __future__ import annotations
+
+import base64
+import dataclasses
+import hashlib
+import json
+import multiprocessing
+import threading
+import time
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_architect_proposal_authenticity import (
+    ArchitectProposalPolicyAuthorization,
+    ArchitectProposalSignerPolicy,
+    PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+    PROPOSAL_AUTHENTICITY_SIGNER_ROLE,
+    build_architect_proposal_authenticity_payload,
+    build_architect_proposal_policy_authorization_payload,
+    canonical_architect_proposal_policy_authorization_input,
+    canonical_architect_proposal_signing_input,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend import (
+    REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY,
+    REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY,
+)
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+    encode_ed25519_signature,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
+    SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
+    SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
+    IsolatedSignerSocketResidentServiceResult,
+)
+from modules.communication.moltbot_bridge.src.reddog_proposal_authenticity_nonce_store import (
+    AtomicProposalAuthenticityNonceStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    SigningRequest,
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    AUDIT_KEY_PREFIX,
+    PROVIDER_MODE_TEST_ONLY_DRYRUN,
+    SIGNING_KEY_PREFIX,
+    SignerKeyProviderProfile,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_peer_credential_attestor import (
+    PeerCredentialPolicy,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID,
+    FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID,
+    run_reddog_signer_socket_service_config_supply,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_bootstrap import (
+    FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH,
+    FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED,
+    rehydrate_signer_socket_service_runtime_config,
+    run_reddog_signer_socket_service_runtime_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
+    FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+    FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,
+    SignerSocketServiceRuntimeWiringConfig,
+    run_reddog_signer_socket_service_runtime_wiring,
+    validate_signer_socket_service_runtime_config,
+)
+from modules.infrastructure.secrets_mcp.src.vault_resolver import (
+    ResolveResult,
+    hash_reference,
+)
+
+
+pytest.importorskip("cryptography")
+
+NOW = int(time.time())
+PRINCIPAL_PUBLIC = encode_ed25519_public_key(bytes(range(32)))
+INTEGRITY_KEY = b"proposal-integrity-key-32-bytes!"
+
+
+def _private_key():
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+
+    return Ed25519PrivateKey.generate()
+
+
+def _private_key_secret(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    raw = private_key.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return SIGNING_KEY_PREFIX + base64.b64encode(raw).decode("ascii")
+
+
+def _public_text(private_key) -> str:
+    from cryptography.hazmat.primitives import serialization
+
+    raw = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return encode_ed25519_public_key(raw)
+
+
+def _payload(public_key: str, **overrides: object):
+    proposal = {
+        "receipt_id": "sha256:" + "1" * 64,
+        "snapshot_receipt_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:" + "2" * 64,
+        "repo_head_sha": "a" * 40,
+        "work_state_revision": "revision-1",
+        "report_bundle_id": "report-bundle-1",
+        "wsp15_allocation_receipt_id": "wsp15-1",
+        "wsp15_allocation_digest": "sha256:" + "3" * 64,
+        "holoindex_generation_id": "generation-1",
+        "holoindex_freshness_receipt_digest": "sha256:" + "4" * 64,
+        "policy_digest": "sha256:" + "5" * 64,
+        "allowed_paths": ["modules/example.py"],
+        "denied_paths": [".env"],
+        "required_tests": ["pytest focused"],
+        "required_policy_gates": ["WSP_97"],
+        "target_effect_plane": "REPOSITORY_CODE_CHANGE",
+    }
+    candidate = {
+        "queue_candidate_id": "sha256:" + "6" * 64,
+        "status": "CANDIDATE",
+        "slice_id": "REDDOG_EXAMPLE_PHASE1",
+    }
+    determination = {
+        "determination_receipt_id": "sha256:" + "7" * 64,
+        "action": "FIX",
+        "next_slice_name": "REDDOG_EXAMPLE_PHASE1",
+        "queue_candidate": candidate,
+    }
+    values = {
+        "proposal_admission": proposal,
+        "determination": determination,
+        "queue_candidate": candidate,
+        "requester_principal_id": "github:mjtrout",
+        "reddog_id": "reddog:foundups-agent",
+        "signer_public_key": public_key,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:" + "8" * 64,
+        "authority_profile_source_receipt_id": "sha256:" + "9" * 64,
+        "nonce": "proposal-runtime-nonce-1",
+        "issued_at": NOW - 5,
+        "expires_at": NOW + 120,
+    }
+    values.update(overrides)
+    return build_architect_proposal_authenticity_payload(**values)
+
+
+def _profile(
+    public_key: str,
+    *,
+    principal_public_key: str = PRINCIPAL_PUBLIC,
+) -> dict[str, object]:
+    return {
+        "principal_id": "github:mjtrout",
+        "principal_public_key": principal_public_key,
+        "reddog_id": "reddog:foundups-agent",
+        "reddog_public_key": public_key,
+        "permission_snapshot_digest": "sha256:" + "a" * 64,
+        "key_epoch": "epoch-1",
+        "consensus_receipt_digest": "sha256:" + "8" * 64,
+        "authority_profile_source_receipt_id": "sha256:" + "9" * 64,
+    }
+
+
+def _policy_authorization(
+    policy: ArchitectProposalSignerPolicy,
+    *,
+    principal_private,
+    public_key: str,
+    profile: dict[str, object] | None = None,
+    issued_at: int = NOW - 5,
+    expires_at: int = NOW + 120,
+) -> ArchitectProposalPolicyAuthorization:
+    authority_profile = profile or _profile(
+        public_key,
+        principal_public_key=_public_text(principal_private),
+    )
+    payload = build_architect_proposal_policy_authorization_payload(
+        policy,
+        principal_id=str(authority_profile["principal_id"]),
+        principal_public_key=str(
+            authority_profile["principal_public_key"]
+        ),
+        reddog_id=str(authority_profile["reddog_id"]),
+        reddog_public_key=str(authority_profile["reddog_public_key"]),
+        key_epoch=str(authority_profile["key_epoch"]),
+        authority_profile_source_receipt_id=str(
+            authority_profile["authority_profile_source_receipt_id"]
+        ),
+        nonce="proposal-policy-authorization-nonce-1",
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+    signature = encode_ed25519_signature(
+        principal_private.sign(
+            canonical_architect_proposal_policy_authorization_input(
+                payload
+            ).encode("utf-8")
+        )
+    )
+    return ArchitectProposalPolicyAuthorization(
+        **payload,
+        signature=signature,
+    )
+
+
+def _provider_profiles(
+    *,
+    principal_private,
+    reddog_private,
+) -> tuple[SignerKeyProviderProfile, SignerKeyProviderProfile]:
+    principal_public = _public_text(principal_private)
+    reddog_public = _public_text(reddog_private)
+    common = {
+        "expected_key_epoch": "epoch-1",
+        "permission_snapshot_digest": "sha256:" + "a" * 64,
+        "ttl_seconds": 60,
+    }
+    return (
+        SignerKeyProviderProfile(
+            signer_profile_id="principal-identity",
+            signer_agent_id="signer:principal",
+            signing_key_ref="op://test/principal/private",
+            audit_mac_key_ref="op://test/principal/audit",
+            expected_public_key=principal_public,
+            expected_key_fingerprint=public_key_fingerprint(
+                principal_public
+            ),
+            **common,
+        ),
+        SignerKeyProviderProfile(
+            signer_profile_id="reddog-work-authority",
+            signer_agent_id="signer:reddog",
+            signing_key_ref="op://test/reddog/private",
+            audit_mac_key_ref="op://test/reddog/audit",
+            expected_public_key=reddog_public,
+            expected_key_fingerprint=public_key_fingerprint(
+                reddog_public
+            ),
+            **common,
+        ),
+    )
+
+
+def _signing_request(payload) -> SigningRequest:
+    signing_input = canonical_architect_proposal_signing_input(payload)
+    payload_digest = "sha256:" + hashlib.sha256(
+        json.dumps(
+            {"signing_input": signing_input},
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    return SigningRequest(
+        signing_input=signing_input,
+        payload_digest=payload_digest,
+        signer_role=PROPOSAL_AUTHENTICITY_SIGNER_ROLE,
+        signer_public_key=payload.signer_public_key,
+        requester_principal_id=payload.requester_principal_id,
+        nonce=payload.nonce,
+        key_epoch=payload.key_epoch,
+        requested_operation=PROPOSAL_AUTHENTICITY_SIGNING_OPERATION,
+        authority_tier="ULTRA",
+        consensus_receipt_digest=payload.consensus_receipt_digest,
+    )
+
+
+def _peer() -> SignerPeerAttestation:
+    return SignerPeerAttestation(
+        peer_principal_id="github:mjtrout",
+        transport="unix_socket",
+        credential_source="kernel_peer_credential",
+        boundary_attested=True,
+    )
+
+
+def _reserve_nonce_process(
+    values: tuple[str, str, str, int],
+) -> bool:
+    repo, runtime, nonce, expires_at = values
+    store = AtomicProposalAuthenticityNonceStore(
+        Path(runtime) / "proposal-nonces.json",
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    return bool(
+        store.reserve(
+            nonce,
+            expires_at=expires_at,
+            subject="github:mjtrout",
+        )
+    )
+
+
+def _config_kwargs(
+    repo: Path,
+    runtime: Path,
+    public_key: str,
+    policy: ArchitectProposalSignerPolicy,
+    principal_private,
+    **overrides: object,
+) -> dict[str, object]:
+    profile = _profile(
+        public_key,
+        principal_public_key=_public_text(principal_private),
+    )
+    values: dict[str, object] = {
+        "repo_root": repo,
+        "runtime_root": runtime,
+        "signer_runtime_root": runtime.parent / "signer-state",
+        "authority_profile": profile,
+        "output_path": runtime / "signer-service.json",
+        "socket_path": runtime / "reddog-signer.sock",
+        "principal_signing_key_ref": "op://prod/principal/private",
+        "principal_audit_mac_key_ref": "op://prod/principal/audit",
+        "reddog_signing_key_ref": "op://prod/reddog/private",
+        "reddog_audit_mac_key_ref": "op://prod/reddog/audit",
+        "peer_uid_to_principal": {1001: "github:mjtrout"},
+        "proposal_authority_policy": policy,
+        "proposal_policy_authorization": _policy_authorization(
+            policy,
+            principal_private=principal_private,
+            public_key=public_key,
+            profile=profile,
+        ),
+        "now_epoch": NOW,
+        "max_requests": 2,
+    }
+    values.update(overrides)
+    return values
+
+
+def test_atomic_nonce_store_survives_restart_and_rejects_replay(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    store_path = runtime / "proposal-nonces.json"
+    first = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+
+    reservation = first.reserve(
+        "nonce-1",
+        expires_at=NOW + 60,
+        subject="github:mjtrout",
+    )
+    assert reservation
+    first.commit(reservation)
+
+    restarted = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    assert (
+        restarted.reserve(
+            "nonce-1",
+            expires_at=NOW + 120,
+            subject="github:mjtrout",
+        )
+        is None
+    )
+    state = json.loads(store_path.read_text(encoding="utf-8"))
+    assert state["consumed"]
+    assert "nonce-1" not in json.dumps(state, sort_keys=True)
+
+
+def test_atomic_nonce_store_rollback_and_racing_reservations(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    store_path = runtime / "proposal-nonces.json"
+    first = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    second = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    initial = first.reserve(
+        "rollback-nonce",
+        expires_at=NOW + 60,
+        subject="github:mjtrout",
+    )
+    assert initial
+    first.rollback(initial)
+    assert second.reserve(
+        "rollback-nonce",
+        expires_at=NOW + 60,
+        subject="github:mjtrout",
+    )
+
+    barrier = threading.Barrier(2)
+    results: list[str | None] = []
+
+    def reserve(store: AtomicProposalAuthenticityNonceStore) -> None:
+        barrier.wait()
+        results.append(
+            store.reserve(
+                "race-nonce",
+                expires_at=NOW + 60,
+                subject="github:mjtrout",
+            )
+        )
+
+    threads = [
+        threading.Thread(target=reserve, args=(first,)),
+        threading.Thread(target=reserve, args=(second,)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert sum(result is not None for result in results) == 1
+
+
+def test_atomic_nonce_store_rejects_repo_path_and_malformed_state(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    with pytest.raises(ValueError):
+        AtomicProposalAuthenticityNonceStore(
+            repo / "nonce.json",
+            allowed_root=repo,
+            repo_root=repo,
+            integrity_key=INTEGRITY_KEY,
+        )
+
+    store_path = runtime / "proposal-nonces.json"
+    store_path.parent.mkdir()
+    store_path.write_text('{"schema_version":"wrong"}', encoding="utf-8")
+    store = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    with pytest.raises(ValueError):
+        store.reserve(
+            "nonce",
+            expires_at=NOW + 60,
+            subject="github:mjtrout",
+        )
+
+
+def test_atomic_nonce_store_rejects_structurally_valid_state_tampering(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    store_path = runtime / "proposal-nonces.json"
+    store = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    reservation = store.reserve(
+        "tamper-nonce",
+        expires_at=NOW + 60,
+        subject="github:mjtrout",
+    )
+    assert reservation
+    store.commit(reservation)
+    state = json.loads(store_path.read_text(encoding="utf-8"))
+    state["consumed"] = {}
+    store_path.write_text(
+        json.dumps(state, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    restarted = AtomicProposalAuthenticityNonceStore(
+        store_path,
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+    )
+    with pytest.raises(
+        ValueError,
+        match="proposal_authenticity_nonce_store_integrity_invalid",
+    ):
+        restarted.reserve(
+            "tamper-nonce",
+            expires_at=NOW + 120,
+            subject="github:mjtrout",
+        )
+
+
+def test_atomic_nonce_store_prunes_expired_crash_state_and_is_bounded(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    now = [NOW]
+    store = AtomicProposalAuthenticityNonceStore(
+        runtime / "proposal-nonces.json",
+        allowed_root=runtime,
+        repo_root=repo,
+        integrity_key=INTEGRITY_KEY,
+        clock=lambda: now[0],
+        clock_skew_seconds=2,
+        retention_seconds=4,
+        max_entries=2,
+    )
+    stranded = store.reserve(
+        "crash-nonce",
+        expires_at=NOW + 1,
+        subject="github:mjtrout",
+    )
+    assert stranded
+    now[0] = NOW + 4
+    reclaimed = store.reserve(
+        "crash-nonce",
+        expires_at=NOW + 20,
+        subject="github:mjtrout",
+    )
+    assert reclaimed
+    store.commit(reclaimed)
+    assert store.reserve(
+        "second-nonce",
+        expires_at=NOW + 20,
+        subject="github:mjtrout",
+    )
+    assert (
+        store.reserve(
+            "over-capacity",
+            expires_at=NOW + 20,
+            subject="github:mjtrout",
+        )
+        is None
+    )
+
+
+def test_atomic_nonce_store_serializes_cross_process_reservation(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    jobs = [
+        (str(repo), str(runtime), "process-race", NOW + 60),
+        (str(repo), str(runtime), "process-race", NOW + 60),
+    ]
+    with ProcessPoolExecutor(
+        max_workers=2,
+        mp_context=multiprocessing.get_context("spawn"),
+    ) as executor:
+        results = list(executor.map(_reserve_nonce_process, jobs))
+    assert sum(results) == 1
+
+
+def test_config_supply_binds_exact_policy_and_confined_nonce_store(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(private_key)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    repo.mkdir()
+
+    result = run_reddog_signer_socket_service_config_supply(
+        **_config_kwargs(
+            repo,
+            runtime,
+            public_key,
+            policy,
+            principal_private,
+        )
+    )
+
+    assert result.accepted is True
+    assert result.proposal_policy_configured is True
+    assert result.proposal_attestation_id == policy.expected_payload.attestation_id
+    config = json.loads(
+        (runtime / "signer-service.json").read_text(encoding="utf-8")
+    )
+    assert (
+        config["proposal_authority_policy"]["expected_payload"]
+        == policy.expected_payload.to_dict()
+    )
+    assert result.profile_count == 2
+    assert [
+        item["signer_profile_id"]
+        for item in config["key_provider_profiles"]
+    ] == ["principal-identity", "reddog-work-authority"]
+    assert (
+        config["proposal_policy_authorization"][
+            "proposal_policy_digest"
+        ]
+        == _policy_authorization(
+            policy,
+            principal_private=principal_private,
+            public_key=public_key,
+        ).proposal_policy_digest
+    )
+    nonce_path = Path(config["proposal_nonce_store_path"])
+    assert nonce_path.parent == (tmp_path / "signer-state").resolve()
+    assert result.proposal_nonce_store_path == str(nonce_path)
+    assert not nonce_path.exists()
+
+    rehydrated = rehydrate_signer_socket_service_runtime_config(
+        repo,
+        runtime,
+        config,
+        expected_config_digest=result.config_digest,
+    )
+    assert rehydrated is not None
+    assert rehydrated.proposal_nonce_store_path == nonce_path
+
+
+def test_config_supply_requires_valid_principal_signed_policy_authorization(
+    tmp_path: Path,
+) -> None:
+    reddog_private = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(reddog_private)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    missing_kwargs = _config_kwargs(
+        repo,
+        tmp_path / "missing",
+        public_key,
+        policy,
+        principal_private,
+    )
+    missing_kwargs.pop("proposal_policy_authorization")
+    missing = run_reddog_signer_socket_service_config_supply(
+        **missing_kwargs
+    )
+    assert missing.accepted is False
+    assert missing.rejection_reasons == (
+        FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+    tampered_kwargs = _config_kwargs(
+        repo,
+        tmp_path / "tampered",
+        public_key,
+        policy,
+        principal_private,
+    )
+    authorization = tampered_kwargs["proposal_policy_authorization"]
+    assert isinstance(
+        authorization,
+        ArchitectProposalPolicyAuthorization,
+    )
+    tampered_kwargs["proposal_policy_authorization"] = dataclasses.replace(
+        authorization,
+        signature=encode_ed25519_signature(b"x" * 64),
+    )
+    tampered = run_reddog_signer_socket_service_config_supply(
+        **tampered_kwargs
+    )
+    assert tampered.accepted is False
+    assert tampered.rejection_reasons == (
+        FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+    altered_policy_kwargs = _config_kwargs(
+        repo,
+        tmp_path / "altered-policy",
+        public_key,
+        policy,
+        principal_private,
+    )
+    altered_policy_kwargs["proposal_authority_policy"] = (
+        ArchitectProposalSignerPolicy(
+            dataclasses.replace(
+                policy.expected_payload,
+                nonce="different-proposal-nonce",
+            )
+        )
+    )
+    altered = run_reddog_signer_socket_service_config_supply(
+        **altered_policy_kwargs
+    )
+    assert altered.accepted is False
+    assert altered.rejection_reasons == (
+        FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+    expired_kwargs = _config_kwargs(
+        repo,
+        tmp_path / "expired",
+        public_key,
+        policy,
+        principal_private,
+    )
+    expired_kwargs["proposal_policy_authorization"] = (
+        _policy_authorization(
+            policy,
+            principal_private=principal_private,
+            public_key=public_key,
+            issued_at=NOW - 400,
+            expires_at=NOW - 1,
+        )
+    )
+    expired = run_reddog_signer_socket_service_config_supply(
+        **expired_kwargs
+    )
+    assert expired.accepted is False
+    assert expired.rejection_reasons == (
+        FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload_override", "call_override", "reason"),
+    [
+        (
+            {"requester_principal_id": "github:attacker"},
+            {},
+            FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID,
+        ),
+        (
+            {"reddog_id": "reddog:attacker"},
+            {},
+            FAIL_SIGNER_CONFIG_PROPOSAL_POLICY_INVALID,
+        ),
+        (
+            {},
+            {"proposal_nonce_store_path": Path("relative/nonce.json")},
+            FAIL_SIGNER_CONFIG_PROPOSAL_NONCE_PATH_INVALID,
+        ),
+    ],
+)
+def test_config_supply_rejects_identity_or_nonce_path_substitution(
+    tmp_path: Path,
+    payload_override: dict[str, object],
+    call_override: dict[str, object],
+    reason: str,
+) -> None:
+    private_key = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(private_key)
+    policy = ArchitectProposalSignerPolicy(
+        _payload(public_key, **payload_override)
+    )
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    repo.mkdir()
+
+    result = run_reddog_signer_socket_service_config_supply(
+        **_config_kwargs(
+            repo,
+            runtime,
+            public_key,
+            policy,
+            principal_private,
+            **call_override,
+        )
+    )
+
+    assert result.accepted is False
+    assert reason in result.rejection_reasons
+    assert not (runtime / "signer-service.json").exists()
+
+
+class _Resolver:
+    def __init__(self, private_key, principal_private=None) -> None:
+        self._values = {
+            "op://test/reddog/private": _private_key_secret(private_key),
+            "op://test/reddog/audit": (
+                AUDIT_KEY_PREFIX
+                + base64.b64encode(b"a" * 32).decode("ascii")
+            ),
+        }
+        if principal_private is not None:
+            self._values.update(
+                {
+                    "op://test/principal/private": (
+                        _private_key_secret(principal_private)
+                    ),
+                    "op://test/principal/audit": (
+                        AUDIT_KEY_PREFIX
+                        + base64.b64encode(b"p" * 32).decode("ascii")
+                    ),
+                }
+            )
+
+    def resolve(
+        self,
+        reference: str,
+        requester_id: str | None = None,
+    ) -> ResolveResult:
+        return ResolveResult(
+            success=True,
+            reference=reference,
+            reference_hash=hash_reference(reference),
+            ttl_remaining=60,
+            session_id="test-session",
+            _secret_value=self._values[reference],
+        )
+
+
+def test_runtime_wiring_injects_policy_and_durable_store_into_backend(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(private_key)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    captured: dict[str, object] = {}
+
+    def serve(**kwargs):
+        captured.update(kwargs)
+        return IsolatedSignerSocketResidentServiceResult(
+            accepted=True,
+            status=SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
+            rejection_reasons=(),
+            socket_path=str(kwargs["socket_path"]),
+            requests_handled=0,
+            response_digests=(),
+            socket_removed=True,
+        )
+
+    profiles = _provider_profiles(
+        principal_private=principal_private,
+        reddog_private=private_key,
+    )
+    authority_profile = _profile(
+        public_key,
+        principal_public_key=_public_text(principal_private),
+    )
+    authorization = _policy_authorization(
+        policy,
+        principal_private=principal_private,
+        public_key=public_key,
+        profile=authority_profile,
+    )
+    config = SignerSocketServiceRuntimeWiringConfig(
+        repo_root=repo,
+        runtime_root=runtime,
+        signer_runtime_root=signer_runtime,
+        socket_path=runtime / "signer.sock",
+        peer_policy=PeerCredentialPolicy(
+            uid_to_principal={1001: "github:mjtrout"},
+            allowed_gids=(),
+        ),
+        key_provider_profiles=profiles,
+        provider_mode=PROVIDER_MODE_TEST_ONLY_DRYRUN,
+        allow_test_only_key_material=True,
+        permission_snapshot_fresh=True,
+        control_loop_anchor_path=None,
+        control_loop_authority_policy=None,
+        proposal_authority_policy=policy,
+        proposal_policy_authorization=authorization,
+        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
+    )
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        config,
+        _Resolver(private_key, principal_private),
+        serve_bounded=serve,
+    )
+
+    assert result.accepted is True
+    backend = captured["backend"]
+    assert backend.proposal_authority_policy == policy
+    assert isinstance(
+        backend.proposal_nonce_store,
+        AtomicProposalAuthenticityNonceStore,
+    )
+
+    first = backend.sign(_signing_request(policy.expected_payload), _peer())
+    assert first.accepted is True
+
+    restarted = dataclasses.replace(
+        backend,
+        proposal_nonce_store=AtomicProposalAuthenticityNonceStore(
+            signer_runtime / "proposal-nonces.json",
+            allowed_root=signer_runtime,
+            repo_root=repo,
+            integrity_key=b"a" * 32,
+        ),
+    )
+    replay = restarted.sign(
+        _signing_request(policy.expected_payload),
+        _peer(),
+    )
+    assert replay.accepted is False
+    assert (
+        replay.rejection_code
+        == REJECT_ED25519_SIGNER_PROPOSAL_NONCE_REPLAY
+    )
+    generic = backend.sign(
+        dataclasses.replace(
+            _signing_request(policy.expected_payload),
+            signing_input="reddog-workauth.v1.{}",
+            requested_operation="create_foundup",
+        ),
+        _peer(),
+    )
+    assert generic.accepted is False
+    assert (
+        generic.rejection_code
+        == REJECT_ED25519_SIGNER_PROPOSAL_DOMAIN_ONLY
+    )
+    principal_key_request = backend.sign(
+        dataclasses.replace(
+            _signing_request(policy.expected_payload),
+            signer_public_key=_public_text(principal_private),
+        ),
+        _peer(),
+    )
+    assert principal_key_request.accepted is False
+
+    class _FailCommitStore:
+        rolled_back = False
+
+        def reserve(
+            self,
+            nonce: str,
+            *,
+            expires_at: int,
+            subject: str,
+        ) -> str:
+            return "reservation"
+
+        def commit(self, reservation: str) -> None:
+            raise RuntimeError("commit_failed")
+
+        def rollback(self, reservation: str) -> None:
+            self.rolled_back = True
+
+    fail_store = _FailCommitStore()
+    failed = dataclasses.replace(
+        backend,
+        proposal_nonce_store=fail_store,
+    ).sign(_signing_request(policy.expected_payload), _peer())
+    assert failed.accepted is False
+    assert failed.signature == ""
+    assert failed.audit_mac == ""
+    assert fail_store.rolled_back is True
+
+
+def test_bootstrap_rejects_tampered_serialized_proposal_policy(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(private_key)
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    repo.mkdir()
+    result = run_reddog_signer_socket_service_config_supply(
+        **_config_kwargs(
+            repo,
+            runtime,
+            public_key,
+            policy,
+            principal_private,
+        )
+    )
+    assert result.accepted is True
+    config_path = runtime / "signer-service.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    replacement_proposal = {
+        **{
+            "receipt_id": "sha256:" + "1" * 64,
+            "snapshot_receipt_id": "snapshot-1",
+            "snapshot_content_digest": "sha256:" + "2" * 64,
+            "repo_head_sha": "a" * 40,
+            "work_state_revision": "revision-1",
+            "report_bundle_id": "report-bundle-1",
+            "wsp15_allocation_receipt_id": "wsp15-1",
+            "wsp15_allocation_digest": "sha256:" + "3" * 64,
+            "holoindex_generation_id": "generation-1",
+            "holoindex_freshness_receipt_digest": (
+                "sha256:" + "4" * 64
+            ),
+            "policy_digest": "sha256:" + "5" * 64,
+            "denied_paths": [".env"],
+            "required_tests": ["pytest focused"],
+            "required_policy_gates": ["WSP_97"],
+            "target_effect_plane": "REPOSITORY_CODE_CHANGE",
+        },
+        "allowed_paths": ["modules/attacker.py"],
+    }
+    replacement = _payload(
+        public_key,
+        proposal_admission=replacement_proposal,
+    )
+    config["proposal_authority_policy"]["expected_payload"] = (
+        replacement.to_dict()
+    )
+
+    assert (
+        rehydrate_signer_socket_service_runtime_config(
+            repo,
+            runtime,
+            config,
+            expected_config_digest=result.config_digest,
+        )
+        is None
+    )
+    config_path.write_text(
+        json.dumps(config, sort_keys=True),
+        encoding="utf-8",
+    )
+    bootstrap = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=config_path,
+        resolver=_Resolver(private_key),
+        serve_bounded=lambda **kwargs: pytest.fail(
+            "tampered config reached signer service"
+        ),
+        expected_config_digest=result.config_digest,
+    )
+    assert bootstrap.accepted is False
+    assert bootstrap.rejection_reasons == (
+        FAIL_SIGNER_BOOTSTRAP_CONFIG_DIGEST_MISMATCH,
+    )
+    replacement_digest = "sha256:" + hashlib.sha256(
+        json.dumps(
+            config,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    self_consistent = run_reddog_signer_socket_service_runtime_bootstrap(
+        repo_root=repo,
+        config_path=config_path,
+        resolver=_Resolver(private_key, principal_private),
+        serve_bounded=lambda **kwargs: pytest.fail(
+            "self-consistent unauthorized policy reached signer service"
+        ),
+        expected_config_digest=replacement_digest,
+    )
+    assert self_consistent.accepted is False
+    assert self_consistent.rejection_reasons == (
+        FAIL_SIGNER_BOOTSTRAP_CONFIG_MALFORMED,
+    )
+
+
+def test_runtime_config_rejects_partial_or_mismatched_proposal_wiring(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    principal_private = _private_key()
+    public_key = _public_text(private_key)
+    other_key = _public_text(_private_key())
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "signer-state"
+    repo.mkdir()
+    profiles = _provider_profiles(
+        principal_private=principal_private,
+        reddog_private=private_key,
+    )
+    policy = ArchitectProposalSignerPolicy(_payload(public_key))
+    authorization = _policy_authorization(
+        policy,
+        principal_private=principal_private,
+        public_key=public_key,
+    )
+    base = {
+        "repo_root": repo,
+        "runtime_root": runtime,
+        "signer_runtime_root": signer_runtime,
+        "socket_path": runtime / "signer.sock",
+        "peer_policy": PeerCredentialPolicy(
+            uid_to_principal={1001: "github:mjtrout"},
+            allowed_gids=(),
+        ),
+        "key_provider_profiles": profiles,
+        "provider_mode": PROVIDER_MODE_TEST_ONLY_DRYRUN,
+        "allow_test_only_key_material": True,
+        "permission_snapshot_fresh": True,
+        "proposal_policy_authorization": authorization,
+    }
+    missing_store = SignerSocketServiceRuntimeWiringConfig(
+        **base,
+        proposal_authority_policy=policy,
+    )
+    mismatched_key = SignerSocketServiceRuntimeWiringConfig(
+        **base,
+        proposal_authority_policy=ArchitectProposalSignerPolicy(
+            _payload(other_key)
+        ),
+        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
+    )
+    substituted_profile = SignerSocketServiceRuntimeWiringConfig(
+        **{
+            **base,
+            "key_provider_profiles": (
+                profiles[0],
+                dataclasses.replace(
+                    profiles[1],
+                    signer_profile_id="principal-identity",
+                ),
+            ),
+        },
+        proposal_authority_policy=policy,
+        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
+    )
+    excessive_ttl = SignerSocketServiceRuntimeWiringConfig(
+        **base,
+        proposal_authority_policy=ArchitectProposalSignerPolicy(
+            _payload(public_key),
+            max_ttl_seconds=301,
+        ),
+        proposal_nonce_store_path=signer_runtime / "proposal-nonces.json",
+    )
+
+    assert validate_signer_socket_service_runtime_config(missing_store) == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_NONCE_STORE_INVALID,
+    )
+    assert validate_signer_socket_service_runtime_config(mismatched_key) == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,
+    )
+    assert validate_signer_socket_service_runtime_config(
+        substituted_profile
+    ) == (FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_AUTHORIZATION_INVALID,)
+    assert validate_signer_socket_service_runtime_config(excessive_ttl) == (
+        FAIL_SIGNER_RUNTIME_PROPOSAL_POLICY_INVALID,
+    )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_signing_context.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_control_loop_signing_context.py
@@ -8,6 +8,9 @@ from pathlib import Path
 
 import pytest
 
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
 from modules.communication.moltbot_bridge.src.reddog_resident_control_loop_signing_context import (
     build_control_loop_receipt_signing_context,
 )
@@ -18,9 +21,9 @@ def _source_profile(**overrides: object) -> dict[str, object]:
         "schema_version": "reddog_authority_profile_source.v1",
         "principal_id": "github:mjtrout",
         "principal_provider": "github",
-        "principal_public_key": "ed25519-pub-v1:" + "B" * 43,
+        "principal_public_key": encode_ed25519_public_key(b"B" * 32),
         "reddog_id": "reddog:architect",
-        "reddog_public_key": "ed25519-pub-v1:" + "A" * 43,
+        "reddog_public_key": encode_ed25519_public_key(b"A" * 32),
         "repo_full_name": "FOUNDUPS/Foundups-Agent",
         "foundup_id": "paccess_001",
         "allowed_paths": ["modules/foundups/paccess_001/src/**"],

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_config_supply.py
@@ -54,6 +54,7 @@ def _repo(tmp_path: Path) -> Path:
 def _authority_profile(**overrides: object) -> dict[str, object]:
     profile: dict[str, object] = {
         "principal_id": "github:mjtrout",
+        "principal_provider": "github",
         "principal_public_key": _PRINCIPAL_PUBLIC_KEY,
         "reddog_id": "reddog:foundups-agent",
         "reddog_public_key": _REDDOG_PUBLIC_KEY,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_healthcheck.py
@@ -6,6 +6,12 @@ import ast
 import json
 from pathlib import Path
 
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
 from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
     PROVIDER_MODE_WSP71_PERMISSIONED,
 )
@@ -36,6 +42,8 @@ MODULE_PATH = (
     / "src"
     / "reddog_signer_socket_service_healthcheck.py"
 )
+_PRINCIPAL_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32)))
+_REDDOG_PUBLIC_KEY = encode_ed25519_public_key(bytes(range(32, 64)))
 
 
 def _repo(tmp_path: Path) -> Path:
@@ -51,9 +59,26 @@ def _write_json(path: Path, payload: object) -> Path:
 
 
 def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
+    runtime_root = socket_path.parent.resolve()
+    signer_runtime_root = (
+        runtime_root.parent / f"{runtime_root.name}-signer-state"
+    ).resolve()
     payload: dict[str, object] = {
         "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
-        "socket_path": str(socket_path),
+        "runtime_root": str(runtime_root),
+        "signer_runtime_root": str(signer_runtime_root),
+        "socket_path": str(socket_path.resolve()),
+        "control_loop_anchor_path": str(
+            signer_runtime_root / "signer_control_loop_anchor.json"
+        ),
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "github:mjtrout",
+            "signer_public_key": _REDDOG_PUBLIC_KEY,
+            "key_epoch": "epoch-1",
+            "consensus_receipt_digest": "sha256:" + "1" * 64,
+            "authority_profile_digest": "sha256:" + "2" * 64,
+            "authority_profile_source_receipt_id": "sha256:" + "3" * 64,
+        },
         "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
         "allow_test_only_key_material": False,
         "permission_snapshot_fresh": True,
@@ -67,10 +92,12 @@ def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
                 "signer_agent_id": "signer:principal",
                 "signing_key_ref": "op://prod-vault/principal/private",
                 "audit_mac_key_ref": "op://prod-vault/principal/audit",
-                "expected_public_key": "pub:principal",
-                "expected_key_fingerprint": "sha256:principal",
+                "expected_public_key": _PRINCIPAL_PUBLIC_KEY,
+                "expected_key_fingerprint": public_key_fingerprint(
+                    _PRINCIPAL_PUBLIC_KEY
+                ),
                 "expected_key_epoch": "epoch-1",
-                "permission_snapshot_digest": "sha256:permission",
+                "permission_snapshot_digest": "sha256:" + "4" * 64,
                 "ttl_seconds": 60,
             },
             {
@@ -78,10 +105,12 @@ def _config(socket_path: Path, **overrides: object) -> dict[str, object]:
                 "signer_agent_id": "signer:reddog",
                 "signing_key_ref": "op://prod-vault/reddog/private",
                 "audit_mac_key_ref": "op://prod-vault/reddog/audit",
-                "expected_public_key": "pub:reddog",
-                "expected_key_fingerprint": "sha256:reddog",
+                "expected_public_key": _REDDOG_PUBLIC_KEY,
+                "expected_key_fingerprint": public_key_fingerprint(
+                    _REDDOG_PUBLIC_KEY
+                ),
                 "expected_key_epoch": "epoch-1",
-                "permission_snapshot_digest": "sha256:permission",
+                "permission_snapshot_digest": "sha256:" + "4" * 64,
                 "ttl_seconds": 60,
             },
         ],
@@ -153,7 +182,7 @@ def test_healthcheck_validates_run_packet_config_and_returns_digests_only(tmp_pa
     assert result.config_digest and result.config_digest.startswith("sha256:")
     assert result.socket_path == str((runtime / "signer.sock").resolve())
     assert result.signer_profile_id == "reddog-work-authority"
-    assert result.signer_public_key == "pub:reddog"
+    assert result.signer_public_key == _REDDOG_PUBLIC_KEY
     assert result.requester_principal_id == "github:mjtrout"
     assert result.request_digest and result.request_digest.startswith("sha256:")
     assert result.response_digest and result.response_digest.startswith("sha256:")
@@ -205,6 +234,9 @@ def test_healthcheck_rejects_missing_profile_and_signer_rejection(tmp_path: Path
     runtime = tmp_path / "runtime"
     no_reddog = _config(runtime / "signer.sock")
     no_reddog["key_provider_profiles"] = [no_reddog["key_provider_profiles"][0]]
+    no_reddog["control_loop_authority_policy"]["signer_public_key"] = (
+        _PRINCIPAL_PUBLIC_KEY
+    )
     missing_profile = run_reddog_signer_socket_service_healthcheck(
         repo_root=repo,
         run_packet_path=_packet(repo, runtime, config_payload=no_reddog),

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
@@ -88,6 +88,20 @@ class FakeResolver:
         )
 
 
+class RepoMutatingResolver(FakeResolver):
+    def __init__(
+        self,
+        values: dict[str, str],
+        marker_path: Path,
+    ) -> None:
+        super().__init__(values)
+        self.marker_path = marker_path
+
+    def resolve(self, reference: str, requester_id: str | None = None) -> ResolveResult:
+        self.marker_path.write_text("injected effect", encoding="utf-8")
+        return super().resolve(reference, requester_id)
+
+
 class CapturingBoundedService:
     def __init__(self, result: IsolatedSignerSocketResidentServiceResult | object | None = None) -> None:
         self.result = result
@@ -249,8 +263,9 @@ def test_runtime_wiring_composes_provider_attestor_and_bounded_service() -> None
     assert result.key_provider_receipt["ok"] is True
     assert result.service_result["status"] == SIGNER_SOCKET_RESIDENT_SERVICE_SERVED
     assert result.max_requests == 3
-    assert result.no_env_parsed is True
-    assert result.no_process_spawned is True
+    assert result.no_env_parsed is False
+    assert result.no_process_spawned is False
+    assert result.no_repo_mutation_performed is False
     assert len(service.calls) == 1
     assert service.calls[0]["max_requests"] == 3
     assert service.calls[0]["timeout_s"] == 2.5
@@ -258,6 +273,44 @@ def test_runtime_wiring_composes_provider_attestor_and_bounded_service() -> None
     response = backend.sign(_request(public_key), _peer())
     assert response.accepted is True
     assert Ed25519SignatureVerifier().verify(public_key, _request(public_key).signing_input, response.signature) is True
+
+
+def test_runtime_receipt_does_not_overclaim_injected_dependency_effects(
+    tmp_path: Path,
+) -> None:
+    private_key = _private_key()
+    public_key = _public_text(private_key)
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    signer_runtime = tmp_path / "signer-runtime"
+    repo.mkdir()
+    marker = repo / "resolver-side-effect.txt"
+    resolver = RepoMutatingResolver(_resolver(private_key).values, marker)
+
+    result = run_reddog_signer_socket_service_runtime_wiring(
+        _config(
+            public_key,
+            repo_root=repo,
+            runtime_root=runtime,
+            signer_runtime_root=signer_runtime,
+            socket_path=runtime / "reddog-signer.sock",
+            control_loop_anchor_path=signer_runtime / "anchor.json",
+        ),
+        resolver,
+        serve_bounded=CapturingBoundedService(),
+    )
+
+    assert result.accepted is True
+    assert marker.is_file()
+    assert result.no_env_parsed is False
+    assert result.no_file_io_performed is False
+    assert result.no_process_spawned is False
+    assert result.no_repo_mutation_performed is False
+    assert result.no_openclaw_enqueue_performed is False
+    assert result.no_hermes_dispatch_performed is False
+    assert result.no_pr_created is False
+    assert result.no_reward_settlement_performed is False
+    assert result.no_holoindex_reindex_performed is False
 
 
 def test_runtime_wiring_accepts_wsp71_permissioned_provider_mode_without_test_override() -> None:
@@ -642,7 +695,9 @@ def test_result_serialization_contains_no_secret_material_or_backend() -> None:
     assert AUDIT_KEY_PREFIX not in text
     assert "0123456789abcdef" not in text
     assert result.no_file_io_performed is False
-    assert result.no_holoindex_reindex_performed is True
+    assert result.no_process_spawned is False
+    assert result.no_repo_mutation_performed is False
+    assert result.no_holoindex_reindex_performed is False
 
 
 def test_module_has_no_env_shell_file_repo_openclaw_hermes_or_holoindex_surface() -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_socket_service_runtime_wiring.py
@@ -641,7 +641,7 @@ def test_result_serialization_contains_no_secret_material_or_backend() -> None:
     assert SIGNING_KEY_PREFIX not in text
     assert AUDIT_KEY_PREFIX not in text
     assert "0123456789abcdef" not in text
-    assert result.no_file_io_performed is True
+    assert result.no_file_io_performed is False
     assert result.no_holoindex_reindex_performed is True
 
 

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -26,7 +26,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1270
+    threshold_override: 1281
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -384,7 +384,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 9032
+    threshold_override: 9037
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -26,7 +26,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1261
+    threshold_override: 1270
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -384,7 +384,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 9025
+    threshold_override: 9032
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -26,7 +26,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1281
+    threshold_override: 1292
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -384,7 +384,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 9037
+    threshold_override: 9043
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -23,9 +23,10 @@ exemptions:
     reason: >-
       Legacy module interface registry. The independent-assurance public
       contract records the required yield, separate author/verifier claims,
-      revocation, and bounded renewal semantics; splitting the historical
-      registry remains separate documentation-maintenance work.
-    threshold_override: 1246
+      revocation, bounded renewal, and proposal signer-policy runtime
+      boundaries; splitting the historical registry remains separate
+      documentation-maintenance work.
+    threshold_override: 1261
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -209,7 +210,7 @@ exemptions:
       Module-local WSP 62 registry. Provider-evidence review adds exact,
       review-dated ceilings for the touched legacy surfaces; splitting the
       registry would break the canonical module-level exemption lookup.
-    threshold_override: 404
+    threshold_override: 405
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -383,7 +384,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 8993
+    threshold_override: 9025
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -26,7 +26,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1292
+    threshold_override: 1294
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -384,7 +384,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 9043
+    threshold_override: 9045
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -26,7 +26,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1294
+    threshold_override: 1298
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -384,7 +384,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 9045
+    threshold_override: 9047
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"

--- a/modules/infrastructure/shared_utilities/ModLog.md
+++ b/modules/infrastructure/shared_utilities/ModLog.md
@@ -1,6 +1,13 @@
 # WSP Module ModLog: Shared Utilities
 **WSP Compliance**: WSP 22 (Module ModLog and Roadmap Protocol)
 
+## 2026-07-27 - Cross-Session Runtime Operation Lock
+
+- Moved the Windows runtime-operation mutex from the session-local namespace
+  to the machine-global mutex namespace so signer-side serialization remains
+  effective across service and interactive Windows sessions.
+- Preserved the existing identity digest and POSIX confined lock-file behavior.
+
 ## 2026-07-25 - Stable Descriptor-Confined Runtime Text Reads
 
 - Added a bounded UTF-8 reader that opens one descriptor, verifies its final

--- a/modules/infrastructure/shared_utilities/ModLog.md
+++ b/modules/infrastructure/shared_utilities/ModLog.md
@@ -7,6 +7,9 @@
   to the machine-global mutex namespace so signer-side serialization remains
   effective across service and interactive Windows sessions.
 - Preserved the existing identity digest and POSIX confined lock-file behavior.
+- Added a descriptor-verified confined lock-file primitive for authorities
+  that require one canonical runtime-root lock independent of temporary
+  directory configuration.
 
 ## 2026-07-25 - Stable Descriptor-Confined Runtime Text Reads
 

--- a/modules/infrastructure/shared_utilities/ModLog.md
+++ b/modules/infrastructure/shared_utilities/ModLog.md
@@ -9,7 +9,8 @@
 - Preserved the existing identity digest and POSIX confined lock-file behavior.
 - Added a descriptor-verified confined lock-file primitive for authorities
   that require one canonical runtime-root lock independent of temporary
-  directory configuration.
+  directory configuration. Descriptor verification is supported on Windows
+  and Linux with procfs; other POSIX environments fail closed.
 
 ## 2026-07-25 - Stable Descriptor-Confined Runtime Text Reads
 

--- a/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
@@ -253,6 +253,62 @@ def runtime_operation_lock(identity: Path | str) -> Iterator[None]:
         yield
 
 
+@contextmanager
+def confined_runtime_operation_lock(
+    path: Path | str,
+    *,
+    repo_root: Path | str,
+    allowed_root: Path | str,
+) -> Iterator[None]:
+    """Lock one canonical runtime file after confinement and descriptor checks."""
+
+    target = validate_runtime_artifact_path(
+        path,
+        repo_root=repo_root,
+        allowed_root=allowed_root,
+    )
+    target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    target = validate_runtime_artifact_path(
+        target,
+        repo_root=repo_root,
+        allowed_root=allowed_root,
+    )
+    descriptor, _ = _open_runtime_file(target)
+    try:
+        opened_stat = os.fstat(descriptor)
+        _require_private_regular_file(opened_stat)
+        final_path = _descriptor_final_path(descriptor)
+        _verify_descriptor_path(
+            final_path,
+            expected=target,
+            repo_root=repo_root,
+            allowed_root=allowed_root,
+        )
+        if opened_stat.st_size == 0:
+            os.write(descriptor, b"\0")
+            os.fsync(descriptor)
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
 def redact_runtime_text(value: object, *, max_chars: int = 4096) -> RuntimeTextRedaction:
     """Normalize, bound, and redact secret-shaped text before runtime persistence."""
 
@@ -682,6 +738,7 @@ def _windows_runtime_mutex_name(lock_key: str) -> str:
 
 __all__ = [
     "RuntimeTextRedaction",
+    "confined_runtime_operation_lock",
     "redact_runtime_text",
     "redact_runtime_value",
     "runtime_operation_lock",

--- a/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
@@ -639,7 +639,7 @@ def _exclusive_lock(path: Path) -> Iterator[None]:
         close_handle = kernel32.CloseHandle
         close_handle.argtypes = [wintypes.HANDLE]
         close_handle.restype = wintypes.BOOL
-        handle = create_mutex(None, False, f"Local\\FoundupsRuntime-{lock_key}")
+        handle = create_mutex(None, False, _windows_runtime_mutex_name(lock_key))
         if not handle:
             raise OSError("runtime_artifact_mutex_create_failed")
         wait_result = wait_for_single(handle, 0xFFFFFFFF)
@@ -672,6 +672,12 @@ def _exclusive_lock(path: Path) -> Iterator[None]:
             fcntl.flock(descriptor, fcntl.LOCK_UN)
     finally:
         os.close(descriptor)
+
+
+def _windows_runtime_mutex_name(lock_key: str) -> str:
+    """Return one machine-global mutex name for cross-session serialization."""
+
+    return f"Global\\FoundupsRuntime-{lock_key}"
 
 
 __all__ = [

--- a/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/runtime_artifact_safety.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import stat
+import sys
 import tempfile
 import unicodedata
 from contextlib import contextmanager
@@ -632,6 +633,12 @@ def _descriptor_final_path(descriptor: int) -> Path:
         if length <= 0 or length >= len(buffer):
             raise OSError("runtime_artifact_final_path_unavailable")
         return _without_windows_extended_prefix(Path(buffer.value))
+    return _linux_descriptor_final_path(descriptor)
+
+
+def _linux_descriptor_final_path(descriptor: int) -> Path:
+    if not sys.platform.startswith("linux"):
+        raise OSError("runtime_artifact_final_path_unsupported_platform")
     proc_path = Path(f"/proc/self/fd/{descriptor}")
     if proc_path.exists():
         return proc_path.resolve(strict=True)

--- a/modules/infrastructure/shared_utilities/tests/test_runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/tests/test_runtime_artifact_safety.py
@@ -9,6 +9,7 @@ import pytest
 
 from modules.infrastructure.shared_utilities import runtime_artifact_safety
 from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    confined_runtime_operation_lock,
     redact_runtime_text,
     redact_runtime_value,
     secure_append_runtime_text,
@@ -22,6 +23,65 @@ from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
 def test_windows_runtime_mutex_uses_machine_global_namespace() -> None:
     name = runtime_artifact_safety._windows_runtime_mutex_name("a" * 64)
     assert name == "Global\\FoundupsRuntime-" + "a" * 64
+
+
+def test_confined_runtime_operation_lock_uses_canonical_runtime_file(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    repo.mkdir()
+    lock_path = runtime / "authority.transaction.lock"
+
+    with confined_runtime_operation_lock(
+        lock_path,
+        repo_root=repo,
+        allowed_root=runtime,
+    ):
+        assert lock_path.is_file()
+
+    assert lock_path.read_bytes() == b"\0"
+
+
+def test_confined_runtime_operation_lock_persists_and_recovers_after_failure(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    runtime = tmp_path / "runtime"
+    repo.mkdir()
+    lock_path = runtime / "authority.transaction.lock"
+
+    with pytest.raises(RuntimeError, match="injected"):
+        with confined_runtime_operation_lock(
+            lock_path,
+            repo_root=repo,
+            allowed_root=runtime,
+        ):
+            raise RuntimeError("injected")
+
+    assert lock_path.is_file()
+    with confined_runtime_operation_lock(
+        lock_path,
+        repo_root=repo,
+        allowed_root=runtime,
+    ):
+        assert lock_path.is_file()
+    assert lock_path.read_bytes() == b"\0"
+
+
+def test_confined_runtime_operation_lock_rejects_repository_path(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    with pytest.raises(ValueError, match="inside_repo"):
+        with confined_runtime_operation_lock(
+            repo / "authority.transaction.lock",
+            repo_root=repo,
+            allowed_root=repo,
+        ):
+            raise AssertionError("unreachable")
 
 
 def test_runtime_artifact_path_rejects_source_and_runtime_root_escape(tmp_path: Path) -> None:

--- a/modules/infrastructure/shared_utilities/tests/test_runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/tests/test_runtime_artifact_safety.py
@@ -19,6 +19,11 @@ from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
 )
 
 
+def test_windows_runtime_mutex_uses_machine_global_namespace() -> None:
+    name = runtime_artifact_safety._windows_runtime_mutex_name("a" * 64)
+    assert name == "Global\\FoundupsRuntime-" + "a" * 64
+
+
 def test_runtime_artifact_path_rejects_source_and_runtime_root_escape(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     runtime = tmp_path / "runtime"

--- a/modules/infrastructure/shared_utilities/tests/test_runtime_artifact_safety.py
+++ b/modules/infrastructure/shared_utilities/tests/test_runtime_artifact_safety.py
@@ -25,6 +25,15 @@ def test_windows_runtime_mutex_uses_machine_global_namespace() -> None:
     assert name == "Global\\FoundupsRuntime-" + "a" * 64
 
 
+def test_descriptor_final_path_rejects_unsupported_posix_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(runtime_artifact_safety.sys, "platform", "darwin")
+
+    with pytest.raises(OSError, match="unsupported_platform"):
+        runtime_artifact_safety._linux_descriptor_final_path(0)
+
+
 def test_confined_runtime_operation_lock_uses_canonical_runtime_file(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- provision one exact RedDog 0102 architect-proposal signer policy only after principal-signed authorization and normalized security-context validation
- add a MAC-authenticated atomic nonce store with independently durable high-water rollback protection and canonical runtime-root transaction locking
- keep proposal signing internal, proposal-domain-only, and unavailable through the public generic provider or production run-packet CLI until runtime adapters exist
- make signer runtime receipts conservative after opaque dependency invocation

## WSP_97 truth boundary
- OBSERVED: proposal policy, authorization, replay state, durability receipt, key profile, and runtime paths are validated before backend exposure
- OBSERVED: public provider APIs cannot inject proposal policy or volatile nonce state
- OBSERVED: proposal-enabled run packets fail closed because production principal/high-water adapters are not yet supplied by the CLI sidecar
- SPECIFIED_NOT_IMPLEMENTED: proposal attestation promotion into queue/work-order authority
- NO queue promotion, worker execution, repository mutation, PR authority, merge authority, reward settlement, or HoloIndex reindex is added

## Validation
- 252 passed, 8 skipped: complete signer/proposal/WSP62 matrix
- 19 passed, 1 skipped: shared runtime artifact safety
- Ruff and py_compile passed
- git diff --check clean
- two independent exact-SHA WSP_97 reviews: GO / GO, no findings
- HoloIndex feature-checkout query failed closed with REPO_HEAD_MISMATCH; no branch reindex was performed

## Security notes
- replay transaction lock is canonical beside signer nonce state, descriptor-path verified, and independent of TMPDIR
- Windows and Linux+procfs are supported; other POSIX environments fail closed
- injected dependency effects are never represented as observed negative side-effect attestations