### PR TITLE
fix(holoindex): preserve owner watchdog in Windows venv

### DIFF
--- a/modules/infrastructure/foundups_mcp_bridge/INTERFACE.md
+++ b/modules/infrastructure/foundups_mcp_bridge/INTERFACE.md
@@ -78,6 +78,11 @@ Requests are size-, query-, result-, and
 timeout-bounded. The service serializes one cached semantic backend and has no
 indexing API.
 
+On Windows, a supervisor running inside the current repository virtualenv
+launches the base Python interpreter as its direct child and prepends only that
+virtualenv's resolved site-packages directory. This avoids the transient venv
+redirector without weakening the exact-parent lifecycle watchdog.
+
 The first authenticated health canary has a separate 270-second cold-model
 warmup budget. Once warm, health and query work use the ordinary owner budget
 (15 seconds by default, never more than 30); the supervising process has a

--- a/modules/infrastructure/foundups_mcp_bridge/ModLog.md
+++ b/modules/infrastructure/foundups_mcp_bridge/ModLog.md
@@ -1,5 +1,17 @@
 # foundups_mcp_bridge - ModLog
 
+## 2026-07-29 - Windows virtualenv owner launch correction
+
+- OBSERVED: RedDog's repository virtualenv launched the HoloIndex owner through
+  a transient Windows redirector, so the real service process did not have the
+  supervisor as its direct parent and the fail-closed watchdog exited before
+  semantic health could complete.
+- The supervisor now launches the base interpreter as its direct child only
+  for the current Windows virtualenv and explicitly carries that virtualenv's
+  approved site-packages path.
+- Exact parent-process monitoring, authenticated loopback health, generation
+  binding, and no-reindex authority are unchanged.
+
 ## 2026-07-27 - Promotion-time HoloIndex owner binding
 
 - Added a read-only exact-binding verifier for RedDog promotion gates.

--- a/modules/infrastructure/foundups_mcp_bridge/src/holo_query_service_supervisor.py
+++ b/modules/infrastructure/foundups_mcp_bridge/src/holo_query_service_supervisor.py
@@ -348,7 +348,50 @@ def _owner_token() -> str:
     return token
 
 
-def _owner_environment(token: str, ssd_path: Path | None) -> dict[str, str]:
+def _owner_python_runtime(
+    python_executable: str,
+    *,
+    platform_name: str | None = None,
+    current_executable: str | None = None,
+    base_executable: str | None = None,
+    current_prefix: str | None = None,
+    base_prefix: str | None = None,
+    site_packages_path: str | None = None,
+) -> tuple[str, tuple[str, ...]]:
+    """Avoid the transient Windows venv launcher in the parent watchdog chain."""
+
+    platform = platform_name or os.name
+    current = current_executable or sys.executable
+    base = base_executable or str(getattr(sys, "_base_executable", "") or "")
+    prefix = current_prefix or sys.prefix
+    root_prefix = base_prefix or sys.base_prefix
+    requested = os.path.normcase(os.path.abspath(python_executable))
+    running = os.path.normcase(os.path.abspath(current))
+    if (
+        platform != "nt"
+        or requested != running
+        or os.path.normcase(prefix) == os.path.normcase(root_prefix)
+        or not base
+    ):
+        return python_executable, ()
+    prefix_path = Path(prefix).resolve(strict=False)
+    site_path = Path(
+        site_packages_path or (prefix_path / "Lib" / "site-packages")
+    ).resolve(strict=False)
+    if (
+        not Path(base).is_file()
+        or not site_path.is_dir()
+        or not site_path.is_relative_to(prefix_path)
+    ):
+        return python_executable, ()
+    return str(Path(base).resolve(strict=True)), (str(site_path),)
+
+
+def _owner_environment(
+    token: str,
+    ssd_path: Path | None,
+    pythonpath_entries: tuple[str, ...] = (),
+) -> dict[str, str]:
     environment = dict(os.environ)
     environment.update(
         {
@@ -360,6 +403,8 @@ def _owner_environment(token: str, ssd_path: Path | None) -> dict[str, str]:
     )
     if ssd_path is not None:
         environment[SSD_PATH_ENV] = str(ssd_path)
+    if pythonpath_entries:
+        environment["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
     return environment
 
 
@@ -418,7 +463,11 @@ class HoloQueryServiceSupervisor:
             self.probe_interval_seconds,
             self.shutdown_timeout_seconds,
         ) = limits
-        self.python_executable = str(python_executable or sys.executable)
+        requested_python = str(python_executable or sys.executable)
+        (
+            self.python_executable,
+            self._pythonpath_entries,
+        ) = _owner_python_runtime(requested_python)
         self._process: subprocess.Popen[bytes] | None = None
         self._token = ""
         self._ready = False
@@ -453,7 +502,11 @@ class HoloQueryServiceSupervisor:
         if not _owner_port_available(OWNER_HOST, self.port):
             raise HoloQueryServiceSupervisorError(PORT_IN_USE_ERROR)
         token = _owner_token()
-        owner_environment = _owner_environment(token, self.ssd_path)
+        owner_environment = _owner_environment(
+            token,
+            self.ssd_path,
+            self._pythonpath_entries,
+        )
         try:
             process = subprocess.Popen(
                 _owner_command(self.python_executable, self.port, os.getpid()),

--- a/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_supervisor.py
+++ b/modules/infrastructure/foundups_mcp_bridge/tests/test_holo_query_service_supervisor.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import socket
 import subprocess
+import sys
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -146,7 +148,7 @@ def test_start_uses_argv_loopback_secret_and_authenticated_health(
 
     assert owner.is_ready is True
     assert launch["command"] == [
-        supervisor_module.sys.executable,
+        owner.python_executable,
         "-B",
         "-m",
         OWNER_MODULE,
@@ -173,6 +175,169 @@ def test_start_uses_argv_loopback_secret_and_authenticated_health(
     assert process.terminated is True
     assert unregistered
     assert owner.is_ready is False
+
+
+def test_windows_venv_runtime_keeps_direct_parent_and_site_packages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    venv = tmp_path / ".venv"
+    scripts = venv / "Scripts"
+    site_packages = venv / "Lib" / "site-packages"
+    scripts.mkdir(parents=True)
+    site_packages.mkdir(parents=True)
+    launcher = scripts / "python.exe"
+    base = tmp_path / "Python312" / "python.exe"
+    launcher.write_bytes(b"launcher")
+    base.parent.mkdir()
+    base.write_bytes(b"python")
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path / "attacker-controlled"))
+
+    executable, pythonpath = supervisor_module._owner_python_runtime(
+        str(launcher),
+        platform_name="nt",
+        current_executable=str(launcher),
+        base_executable=str(base),
+        current_prefix=str(venv),
+        base_prefix=str(base.parent),
+    )
+
+    assert executable == str(base.resolve())
+    assert pythonpath == (str(site_packages.resolve()),)
+    environment = supervisor_module._owner_environment(
+        TOKEN,
+        None,
+        pythonpath,
+    )
+    assert environment["PYTHONPATH"].split(supervisor_module.os.pathsep)[0] == str(
+        site_packages.resolve()
+    )
+    assert environment["PYTHONPATH"] == str(site_packages.resolve())
+
+
+def test_non_current_or_non_windows_interpreter_is_not_rewritten(
+    tmp_path: Path,
+) -> None:
+    requested = tmp_path / "other" / "python"
+
+    assert supervisor_module._owner_python_runtime(
+        str(requested),
+        platform_name="posix",
+        current_executable=str(tmp_path / "venv" / "python"),
+        base_executable=str(tmp_path / "base" / "python"),
+        current_prefix=str(tmp_path / "venv"),
+        base_prefix=str(tmp_path / "base"),
+    ) == (str(requested), ())
+
+
+@pytest.mark.parametrize("missing", ["base", "site_packages"])
+def test_windows_venv_runtime_fails_closed_when_runtime_path_missing(
+    tmp_path: Path,
+    missing: str,
+) -> None:
+    venv = tmp_path / ".venv"
+    launcher = venv / "Scripts" / "python.exe"
+    site_packages = venv / "Lib" / "site-packages"
+    base = tmp_path / "Python312" / "python.exe"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_bytes(b"launcher")
+    if missing != "site_packages":
+        site_packages.mkdir(parents=True)
+    if missing != "base":
+        base.parent.mkdir()
+        base.write_bytes(b"python")
+
+    assert supervisor_module._owner_python_runtime(
+        str(launcher),
+        platform_name="nt",
+        current_executable=str(launcher),
+        base_executable=str(base),
+        current_prefix=str(venv),
+        base_prefix=str(base.parent),
+    ) == (str(launcher), ())
+
+
+def test_windows_venv_runtime_rejects_out_of_prefix_site_packages(
+    tmp_path: Path,
+) -> None:
+    venv = tmp_path / ".venv"
+    launcher = venv / "Scripts" / "python.exe"
+    base = tmp_path / "Python312" / "python.exe"
+    outside = tmp_path / "outside" / "site-packages"
+    launcher.parent.mkdir(parents=True)
+    launcher.write_bytes(b"launcher")
+    base.parent.mkdir()
+    base.write_bytes(b"python")
+    outside.mkdir(parents=True)
+
+    assert supervisor_module._owner_python_runtime(
+        str(launcher),
+        platform_name="nt",
+        current_executable=str(launcher),
+        base_executable=str(base),
+        current_prefix=str(venv),
+        base_prefix=str(base.parent),
+        site_packages_path=str(outside),
+    ) == (str(launcher), ())
+
+
+def test_windows_venv_runtime_does_not_rewrite_other_interpreter(
+    tmp_path: Path,
+) -> None:
+    current = tmp_path / ".venv" / "Scripts" / "python.exe"
+    requested = tmp_path / "other" / "python.exe"
+    base = tmp_path / "Python312" / "python.exe"
+    site_packages = tmp_path / ".venv" / "Lib" / "site-packages"
+    current.parent.mkdir(parents=True)
+    current.write_bytes(b"launcher")
+    requested.parent.mkdir()
+    requested.write_bytes(b"other")
+    base.parent.mkdir()
+    base.write_bytes(b"python")
+    site_packages.mkdir(parents=True)
+
+    assert supervisor_module._owner_python_runtime(
+        str(requested),
+        platform_name="nt",
+        current_executable=str(current),
+        base_executable=str(base),
+        current_prefix=str(tmp_path / ".venv"),
+        base_prefix=str(base.parent),
+    ) == (str(requested), ())
+
+
+@pytest.mark.skipif(
+    os.name != "nt" or sys.prefix == sys.base_prefix,
+    reason="Windows virtualenv redirector regression",
+)
+def test_current_windows_venv_runtime_creates_direct_child() -> None:
+    executable, pythonpath = supervisor_module._owner_python_runtime(
+        sys.executable,
+    )
+    environment = supervisor_module._owner_environment(
+        TOKEN,
+        None,
+        pythonpath,
+    )
+    child = subprocess.Popen(
+        [
+            executable,
+            "-B",
+            "-c",
+            "import os; print(os.getppid(), flush=True)",
+        ],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        shell=False,
+    )
+    stdout, stderr = child.communicate(timeout=10)
+
+    assert child.returncode == 0, stderr
+    assert int(stdout.strip()) == os.getpid()
+    assert executable != sys.executable
+    assert pythonpath
 
 
 def test_start_proves_exact_binding_in_its_single_authoritative_health_loop(


### PR DESCRIPTION
## Summary
- launch the HoloIndex owner as a direct child when RedDog runs under the Windows repository virtualenv
- carry only the resolved current virtualenv site-packages path and replace inherited PYTHONPATH
- preserve exact-parent watchdog, authenticated health, generation binding, and no-reindex authority

## Validation
- 84 focused owner/bootstrap/query tests passed
- live repository-.venv owner query returned CURRENT with 5 code and 5 WSP hits
- independent security review: GO after PYTHONPATH allowlist hardening
- git diff --check clean

## Truth boundary
- no HoloIndex re-index or mutation
- no RedDog authority expansion
- no watchdog weakening
