### PR TITLE
fix(holoindex): bound large-store reconciliation and proof

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -4,8 +4,10 @@
 
 - Replaced the unbounded persisted symbol-ID snapshot with deterministic
   `limit`/`offset` pages before stale-record reconciliation.
+- Applied the same bounded paging to collection content/embedding snapshots
+  used by the canonical freshness proof.
 - Added a large-state regression that rejects unbounded collection reads and
-  verifies complete stale-record deletion without exceeding publish batches.
+  verifies complete stale-record deletion and proof construction.
 
 ## [2026-07-26] Exact-SHA post-merge authority primitives
 

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -8,6 +8,8 @@
   used by the canonical freshness proof.
 - Added a large-state regression that rejects unbounded collection reads and
   verifies complete stale-record deletion and proof construction.
+- Fail closed when a collection ignores pagination or returns short,
+  oversized, duplicate, or overlapping symbol-ID pages.
 
 ## [2026-07-26] Exact-SHA post-merge authority primitives
 

--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,12 @@
 # HoloIndex Package ModLog
 
+## [2026-07-29] Bounded symbol reconciliation
+
+- Replaced the unbounded persisted symbol-ID snapshot with deterministic
+  `limit`/`offset` pages before stale-record reconciliation.
+- Added a large-state regression that rejects unbounded collection reads and
+  verifies complete stale-record deletion without exceeding publish batches.
+
 ## [2026-07-26] Exact-SHA post-merge authority primitives
 
 - Added a separate cross-process authority-update lease that can safely wrap

--- a/holo_index/freshness_receipt.py
+++ b/holo_index/freshness_receipt.py
@@ -25,6 +25,7 @@ from holo_index.verified_collection_carry_forward import (
 
 SCHEMA_VERSION = "holoindex_freshness_receipt.v2"
 COLLECTION_SCHEMA_VERSION = "holoindex_collection_freshness.v2"
+SNAPSHOT_PAGE_SIZE = 500
 FRESHNESS_RECEIPT_FILENAME = "holoindex_freshness_receipt.json"
 
 COLLECTION_ATTRS: dict[str, str] = {
@@ -235,6 +236,30 @@ def _canonical_snapshot_value(value: Any) -> Any:
     raise TypeError(f"unsupported_snapshot_value:{type(value).__name__}")
 
 
+def _paged_collection_snapshot(collection: Any, *, count: int) -> dict[str, list[Any]]:
+    combined = {
+        "ids": [],
+        "documents": [],
+        "metadatas": [],
+        "embeddings": [],
+    }
+    include = ["documents", "metadatas", "embeddings"]
+    for offset in range(0, count, SNAPSHOT_PAGE_SIZE):
+        try:
+            page = collection.get(
+                include=include,
+                limit=min(SNAPSHOT_PAGE_SIZE, count - offset),
+                offset=offset,
+            )
+        except TypeError:
+            if count > SNAPSHOT_PAGE_SIZE or offset:
+                raise
+            page = collection.get(include=include)
+        for key in combined:
+            combined[key].extend(_snapshot_list(page, key))
+    return combined
+
+
 def _collection_snapshot_manifest(
     collection: Any,
     *,
@@ -253,7 +278,7 @@ def _collection_snapshot_manifest(
         return _empty_snapshot_manifest(name)
 
     try:
-        snapshot = collection.get(include=["documents", "metadatas", "embeddings"])
+        snapshot = _paged_collection_snapshot(collection, count=count)
     except Exception:
         return _unavailable_snapshot_manifest("UNVERIFIED")
 

--- a/holo_index/symbol_indexer.py
+++ b/holo_index/symbol_indexer.py
@@ -344,15 +344,21 @@ def _existing_record_ids(collection: Any) -> set[str]:
     total = int(collection.count())
     existing: set[str] = set()
     for offset in range(0, total, SNAPSHOT_PAGE_SIZE):
+        requested = min(SNAPSHOT_PAGE_SIZE, total - offset)
         snapshot = collection.get(
             include=[],
-            limit=min(SNAPSHOT_PAGE_SIZE, total - offset),
+            limit=requested,
             offset=offset,
         )
         page_ids = [str(value) for value in _flat_list(snapshot, "ids")]
-        if not page_ids:
+        page_id_set = set(page_ids)
+        if len(page_ids) != requested:
             raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_PAGE_INCOMPLETE")
-        existing.update(page_ids)
+        if len(page_id_set) != len(page_ids):
+            raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_PAGE_DUPLICATE")
+        if existing.intersection(page_id_set):
+            raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_PAGE_OVERLAP")
+        existing.update(page_id_set)
     if len(existing) != total:
         raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_SNAPSHOT_MISMATCH")
     return existing

--- a/holo_index/symbol_indexer.py
+++ b/holo_index/symbol_indexer.py
@@ -48,6 +48,7 @@ PreparedSymbolRecords = tuple[
 ]
 DEFAULT_EMBED_BATCH_SIZE = 512
 PUBLISH_BATCH_SIZE = 1000
+SNAPSHOT_PAGE_SIZE = 500
 SYMBOL_DOCSTRING_MAX_CHARS = 8192
 
 
@@ -337,6 +338,26 @@ def _reconciliation_capable(collection: Any) -> bool:
     )
 
 
+def _existing_record_ids(collection: Any) -> set[str]:
+    """Read collection IDs in bounded pages for large persisted stores."""
+
+    total = int(collection.count())
+    existing: set[str] = set()
+    for offset in range(0, total, SNAPSHOT_PAGE_SIZE):
+        snapshot = collection.get(
+            include=[],
+            limit=min(SNAPSHOT_PAGE_SIZE, total - offset),
+            offset=offset,
+        )
+        page_ids = [str(value) for value in _flat_list(snapshot, "ids")]
+        if not page_ids:
+            raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_PAGE_INCOMPLETE")
+        existing.update(page_ids)
+    if len(existing) != total:
+        raise ValueError("HOLOINDEX_SYMBOL_RECONCILIATION_SNAPSHOT_MISMATCH")
+    return existing
+
+
 def _reconcile_records(
     holo: Any,
     collection: Any,
@@ -346,8 +367,7 @@ def _reconcile_records(
 ) -> int:
     """Retain embeddings only for exact documents in the same embedding space."""
 
-    snapshot = collection.get(include=["metadatas"])
-    existing_ids = {str(value) for value in _flat_list(snapshot, "ids")}
+    existing_ids = _existing_record_ids(collection)
     desired_ids = set(ids)
     reused = 0
     for start in range(0, len(ids), PUBLISH_BATCH_SIZE):

--- a/holo_index/tests/test_complete_source_indexing.py
+++ b/holo_index/tests/test_complete_source_indexing.py
@@ -12,6 +12,7 @@ from holo_index.symbol_indexer import (
     PUBLISH_BATCH_SIZE,
     SNAPSHOT_PAGE_SIZE,
     SYMBOL_DOCSTRING_MAX_CHARS,
+    _existing_record_ids,
     index_symbol_entries,
 )
 
@@ -335,6 +336,53 @@ def test_symbol_reconciliation_pages_large_existing_snapshot(tmp_path: Path) -> 
     assert all(
         len(batch) <= PUBLISH_BATCH_SIZE for batch in collection.delete_calls
     )
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_error"),
+    [
+        ("ignored_pagination", "PAGE_INCOMPLETE"),
+        ("oversized", "PAGE_INCOMPLETE"),
+        ("short", "PAGE_INCOMPLETE"),
+        ("duplicate", "PAGE_DUPLICATE"),
+        ("overlap", "PAGE_OVERLAP"),
+    ],
+)
+def test_symbol_reconciliation_rejects_unverified_page_boundaries(
+    mode: str,
+    expected_error: str,
+) -> None:
+    class _HostileCollection:
+        def count(self) -> int:
+            return SNAPSHOT_PAGE_SIZE + 1
+
+        def get(
+            self,
+            *,
+            include: list[str],
+            limit: int,
+            offset: int,
+        ) -> dict[str, list[str]]:
+            assert include == []
+            if mode == "ignored_pagination":
+                ids = [f"id-{index}" for index in range(self.count())]
+            elif mode == "oversized":
+                ids = [f"id-{offset + index}" for index in range(limit + 1)]
+            elif mode == "short":
+                ids = [f"id-{offset + index}" for index in range(max(0, limit - 1))]
+            elif mode == "duplicate":
+                ids = [f"id-{offset + index}" for index in range(limit)]
+                ids[-1] = ids[0]
+            else:
+                ids = (
+                    [f"id-{index}" for index in range(limit)]
+                    if offset == 0
+                    else ["id-0"]
+                )
+            return {"ids": ids}
+
+    with pytest.raises(ValueError, match=expected_error):
+        _existing_record_ids(_HostileCollection())
 
 
 def test_embedding_space_mismatch_forces_reset_and_reembedding(tmp_path: Path) -> None:

--- a/holo_index/tests/test_complete_source_indexing.py
+++ b/holo_index/tests/test_complete_source_indexing.py
@@ -10,6 +10,7 @@ import pytest
 from holo_index.core.indexing_engine import index_skillz_entries
 from holo_index.symbol_indexer import (
     PUBLISH_BATCH_SIZE,
+    SNAPSHOT_PAGE_SIZE,
     SYMBOL_DOCSTRING_MAX_CHARS,
     index_symbol_entries,
 )
@@ -44,12 +45,16 @@ class _StatefulCollection:
         *,
         ids: list[str] | None = None,
         include: list[str] | None = None,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> dict[str, Any]:
         selected = (
             list(self.records)
             if ids is None
             else [value for value in ids if value in self.records]
         )
+        if ids is None and limit is not None:
+            selected = selected[offset : offset + limit]
         return {
             "ids": selected,
             "documents": [self.records[value]["document"] for value in selected],
@@ -291,6 +296,45 @@ def test_stale_stable_record_is_deleted_after_reconciliation(tmp_path: Path) -> 
     assert result.indexed_count == 0
     assert stale_id not in holo.symbol_collection.records
     assert holo.symbol_collection.delete_calls == [[stale_id]]
+
+
+def test_symbol_reconciliation_pages_large_existing_snapshot(tmp_path: Path) -> None:
+    class _BoundedCollection(_StatefulCollection):
+        def __init__(self, metadata: dict[str, str]) -> None:
+            super().__init__(metadata)
+            self.snapshot_pages: list[tuple[int, int]] = []
+
+        def get(self, **kwargs: Any) -> dict[str, Any]:
+            if kwargs.get("ids") is None:
+                assert kwargs.get("include") == []
+                assert isinstance(kwargs.get("limit"), int)
+                self.snapshot_pages.append((kwargs["offset"], kwargs["limit"]))
+            return super().get(**kwargs)
+
+    source = tmp_path / "source.py"
+    source.write_text("def retained():\n    return True\n", encoding="utf-8")
+    holo = _StatefulHolo(tmp_path, _BatchModel())
+    collection = _BoundedCollection(holo.embedding_metadata)
+    for index in range(SNAPSHOT_PAGE_SIZE * 2 + 7):
+        collection.records[f"stale-{index:04d}"] = {
+            "document": "stale",
+            "metadata": {},
+            "embedding": [0.0],
+        }
+    holo.symbol_collection = collection
+
+    result = index_symbol_entries(holo, roots=[tmp_path])
+
+    assert result.complete is True
+    assert collection.snapshot_pages == [
+        (0, SNAPSHOT_PAGE_SIZE),
+        (SNAPSHOT_PAGE_SIZE, SNAPSHOT_PAGE_SIZE),
+        (SNAPSHOT_PAGE_SIZE * 2, 7),
+    ]
+    assert collection.count() == 1
+    assert all(
+        len(batch) <= PUBLISH_BATCH_SIZE for batch in collection.delete_calls
+    )
 
 
 def test_embedding_space_mismatch_forces_reset_and_reembedding(tmp_path: Path) -> None:

--- a/holo_index/tests/test_holoindex_freshness_receipt.py
+++ b/holo_index/tests/test_holoindex_freshness_receipt.py
@@ -14,6 +14,7 @@ import pytest
 from holo_index.freshness_receipt import (
     ALL_COLLECTIONS,
     SCHEMA_VERSION,
+    SNAPSHOT_PAGE_SIZE,
     build_freshness_receipt,
     build_maintenance_invalidation,
     collections_for_changed_paths,
@@ -149,6 +150,47 @@ def test_receipt_contains_all_expected_collections(tmp_path: Path) -> None:
         _assert_sha256_digest(entry.source_manifest_digest)
         _assert_sha256_digest(entry.indexed_paths_digest)
         _assert_sha256_digest(entry.removed_paths_digest)
+
+
+def test_large_snapshot_manifest_reads_bounded_pages(tmp_path: Path) -> None:
+    class PagedSnapshotCollection(SnapshotCollection):
+        def __init__(self, name: str, count: int):
+            super().__init__(name, count)
+            self.pages: list[tuple[int, int]] = []
+
+        def get(self, *, include=None, limit=None, offset=0):
+            assert include == ["documents", "metadatas", "embeddings"]
+            assert isinstance(limit, int)
+            self.pages.append((offset, limit))
+            snapshot = super().get(include=include)
+            return {
+                key: value[offset : offset + limit]
+                for key, value in snapshot.items()
+            }
+
+    count = SNAPSHOT_PAGE_SIZE * 2 + 3
+    collection = PagedSnapshotCollection("navigation_code", count)
+    holo = _holo()
+    holo.code_collection = collection
+
+    receipt = build_freshness_receipt(
+        holo,
+        ssd_path=tmp_path,
+        repo_root=REPO_ROOT,
+        source="manual_index",
+        repo_head_sha="abc123",
+    )
+
+    entry = next(
+        value for value in receipt.collections if value.name == "navigation_code"
+    )
+    assert entry.verification == "PASS"
+    assert entry.count == count
+    assert collection.pages == [
+        (0, SNAPSHOT_PAGE_SIZE),
+        (SNAPSHOT_PAGE_SIZE, SNAPSHOT_PAGE_SIZE),
+        (SNAPSHOT_PAGE_SIZE * 2, 3),
+    ]
 
 
 def test_snapshot_verification_uses_fresh_client_collection_handle(


### PR DESCRIPTION
## Summary
- page persisted symbol-ID reconciliation instead of issuing one unbounded Chroma `get()`
- page freshness proof snapshots for documents, metadata, and embeddings
- reject short, oversized, duplicate, overlapping, and pagination-ignoring pages before reconciliation mutation

## WSP_97 observed evidence
- legacy symbol read against 46,265 records failed with `too many SQL variables`
- legacy freshness proof read failed with the same Chroma/SQLite error
- repaired live snapshot used 93 pages, max 500 records, final page 265
- canonical exact-SHA handshake: `READY`, generation `sha256:a221fa7d...`, receipt `sha256:c6ee18b...`
- generation-bound semantic query succeeded without logical index mutation

## Validation
- 183 focused owner/maintenance tests passed locally
- independent security review: GO on `5effdcb38`
- independent integration/scaling review: GO on `5effdcb38`
- integration reviewer: 215 passed, 1 platform skip
- `git diff --check` clean

## Boundary
This PR repairs the existing canonical HoloIndex writer/proof path. It does not add query-path mutation, RedDog authority, OpenClaw dispatch, or a second indexer. RedDog repair/resume orchestration remains the next isolated slice.