### PR TITLE
test(reddog): restore exact-SHA draft PR stage

### DIFF
--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,10 @@
+## 2026-07-30: REDDOG_DRAFT_PR_EXACT_SHA_FIXTURE_REPAIR
+- Restored the mandatory `exact_sha_commit` result in the verified draft-PR
+  handler test chain after the exact-SHA stage was inserted before independent
+  verification.
+- Added a fail-closed regression proving a future verifier result cannot skip
+  the missing exact-SHA stage or reach the draft-PR runner.
+
 ## 2026-07-29: REDDOG_START_OPERATIONS_HOLO_REPAIR_RESUME_PHASE1
 - Proved the canonical operations profile performs a real semantic owner query,
   making failed/stale Holo evidence reachable by the repair state machine.

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_verified_draft_pr_publish_handler.py
@@ -18,6 +18,7 @@ from modules.communication.moltbot_bridge.src.reddog_resident_queue_next_stage_d
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_orchestration_plan import (
     NEXT_QUEUE_VERIFIED_DRAFT_PR_PUBLISH_INVOKE,
     NEXT_QUEUE_VERIFIED_OUTCOME_RATCHET_INVOKE,
+    RESIDENT_QUEUE_EXACT_SHA_COMMIT_ACCEPT,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_queue_verified_draft_pr_publish_handler import (
     FAIL_DRAFT_PR_PUBLISH_REQUEST_BINDING_REJECTED,
@@ -136,6 +137,7 @@ def _seeded_store(**stage_overrides: object) -> InMemoryResidentQueueChainResult
         "worktree_create": {"decision": QUEUE_AUTHORIZED_WORKTREE_CREATE_INVOKE_ACCEPT},
         "assurance_capacity_admission": ASSURANCE_CAPACITY_ADMISSION_STAGE_RESULT,
         "bounded_worker_pilot": _queue_pilot_result(),
+        "exact_sha_commit": {"decision": RESIDENT_QUEUE_EXACT_SHA_COMMIT_ACCEPT},
         SLICE_VERIFIER_STAGE_KEY: _queue_verifier_result(),
     }
     stage_results.update(stage_overrides)
@@ -445,6 +447,30 @@ def test_publish_rejection_is_not_recorded_by_dispatcher() -> None:
     assert FAIL_RECORD_REJECTED in result.rejection_reasons
     assert QueueAuthorizedVerifiedDraftPrPublishInvokeReason.PUBLISH_NOT_ACCEPTED in result.rejection_reasons
     assert "FAIL_HEAD_MISMATCH" in result.rejection_reasons
+    assert VERIFIED_DRAFT_PR_PUBLISH_STAGE_KEY not in chain_store.load()["stage_results"]
+
+
+def test_dispatcher_rejects_slice_verifier_that_skips_exact_sha_commit() -> None:
+    chain_store = _seeded_store(exact_sha_commit={})
+    runner = FakeDraftPrRunner()
+
+    result = invoke_reddog_resident_queue_next_stage_dispatch(
+        explicit_resident_queue_stage_dispatch_requested=True,
+        work_state_snapshot=_snapshot(),
+        store=chain_store,
+        handlers={
+            VERIFIED_DRAFT_PR_PUBLISH_STAGE_KEY: _handler(
+                chain_store=chain_store,
+                runner=runner,
+            )
+        },
+        now_iso=NOW_ISO,
+    )
+
+    assert result.accepted is False
+    assert "FAIL_OUT_OF_ORDER_STAGE_RESULT:exact_sha_commit" in result.rejection_reasons
+    assert "future_stage_present:slice_verifier" in result.rejection_reasons
+    assert runner.calls == []
     assert VERIFIED_DRAFT_PR_PUBLISH_STAGE_KEY not in chain_store.load()["stage_results"]
 
 


### PR DESCRIPTION
## What changed
- Restore the mandatory `exact_sha_commit` stage in the verified draft-PR handler fixture.
- Add a fail-closed regression proving a future verifier result cannot skip exact-SHA commit or invoke the draft-PR runner.
- Record the focused test change in the bridge TestModLog.

## Root cause
The production resident queue gained an exact-SHA commit stage before independent verification, but this pre-seeded publish-handler fixture still modeled the older stage order. The planner correctly rejected the stale fixture.

## Validation
- Focused publish-handler suite: 11 passed.
- Resident coding-chain matrix: 136 passed, 2 platform skips.
- Independent exact-commit review: GO, no findings; expanded matrix 180 passed, 2 platform skips.
- `git diff --check`: passed (line-ending notices only).

## Boundary
Test fixtures and TestModLog only. No production runtime, authority, shell, worktree, PR, merge, HoloIndex, or PatternMemory behavior changed.