### PR TITLE
feat(reddog): add authenticated signer secret access gate

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,17 @@
 # ModLog - moltbot_bridge
+- `REDDOG_SIGNER_E0_AUTHENTICATED_SECRET_LEASE_GATE_PHASE1`: added a
+  verifier-only, process-local boundary for one signed signer secret-access
+  grant. The grant binds the independently resolved issuer key, signer agent
+  and profile, exact signing/audit reference hashes, permission snapshot,
+  owner configuration, signer generation, key epoch, nonce, and bounded
+  lifetime. Verification is strict, domain-separated, revocation-aware, and
+  consumes the nonce only after every binding and signature check passes.
+  Successful admission yields one immutable, noncopyable, nonserializable
+  capability that can be consumed once. This is the first E0 authorization
+  layer only: no vault provider, secret resolution, key loading, signing,
+  per-request material lease, system-service activation, OpenClaw work,
+  Hermes dispatch, or repository effect was added. The stable production
+  signer therefore remains fail closed.
 - `REDDOG_SIGNER_SYSTEM_SERVICE_STABLE_ENTRYPOINT_PHASE1`: replaced the
   generation-specific signer launch command with a v2 run packet that binds a
   stable signer-owned system-service entrypoint and the exact root-owned owner

--- a/modules/communication/moltbot_bridge/src/reddog_signer_secret_access_grant.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_secret_access_grant.py
@@ -1,0 +1,157 @@
+"""Authenticated one-shot E0 signer secret-access grant boundary."""
+
+from __future__ import annotations
+
+import threading
+from types import MappingProxyType
+from typing import Any, Callable, Mapping, Protocol
+from weakref import WeakKeyDictionary
+
+from modules.communication.moltbot_bridge.src.reddog_signer_secret_access_grant_contract import (
+    ExpectedSignerSecretGrantBinding,
+    GRANT_PREFIX,
+    GRANT_SCHEMA,
+    MAX_GRANT_TTL_SECONDS,
+    REJECT_BINDING,
+    REJECT_CAPABILITY,
+    REJECT_DIGEST,
+    REJECT_GRANT_ID,
+    REJECT_ISSUER,
+    REJECT_MALFORMED,
+    REJECT_NONCE,
+    REJECT_NON_ASCII,
+    REJECT_REVOKED,
+    REJECT_SIGNATURE,
+    REJECT_TIME,
+    SignerSecretAccessGrantRejected,
+    canonical_signer_secret_access_grant_input,
+    signer_secret_access_grant_id,
+    validated_signer_secret_grant,
+    verify_expected_signer_secret_grant,
+    verify_signer_secret_grant_issuer,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    NonceStore,
+    PrincipalKeyResolver,
+    SignatureVerifier,
+    constant_time_compare,
+)
+
+
+class SignerSecretGrantRevocationOracle(Protocol):
+    def is_revoked(
+        self, *, grant_id: str, key_epoch: str, at_epoch: int
+    ) -> bool: ...
+
+
+class SignerSecretAccessGrantBoundary:
+    """Process-local issuer and one-shot consumer for verified grants."""
+
+    def __init__(
+        self,
+        *,
+        nonce_store: NonceStore,
+        revocation_oracle: SignerSecretGrantRevocationOracle,
+        clock: Callable[[], int],
+    ) -> None:
+        self._seal = object()
+        self._capability_type = _capability_type(self._seal)
+        self._issued: WeakKeyDictionary[object, Mapping[str, Any]] = WeakKeyDictionary()
+        self._lock = threading.Lock()
+        self._nonce_store = nonce_store
+        self._revocation_oracle = revocation_oracle
+        self._clock = clock
+
+    def verify(
+        self, grant: Mapping[str, Any], *, expected: ExpectedSignerSecretGrantBinding,
+        signature_verifier: SignatureVerifier, principal_key_resolver: PrincipalKeyResolver,
+    ) -> object:
+        raw = validated_signer_secret_grant(grant, self._now())
+        if not constant_time_compare(
+            str(raw["grant_id"]), signer_secret_access_grant_id(raw)
+        ):
+            raise SignerSecretAccessGrantRejected(REJECT_GRANT_ID)
+        verify_expected_signer_secret_grant(raw, expected)
+        verify_signer_secret_grant_issuer(raw, principal_key_resolver)
+        try:
+            valid = signature_verifier.verify(
+                str(raw["issuer_public_key"]),
+                canonical_signer_secret_access_grant_input(raw), str(raw["signature"]),
+            ) is True
+        except Exception:
+            valid = False
+        if not valid:
+            raise SignerSecretAccessGrantRejected(REJECT_SIGNATURE)
+        self._require_not_revoked(raw)
+        values = MappingProxyType(dict(raw))
+        capability = self._capability_type()
+        with self._lock:
+            self._issued[capability] = values
+        return capability
+
+    def consume(self, capability: object) -> Mapping[str, Any]:
+        if not isinstance(capability, self._capability_type):
+            raise SignerSecretAccessGrantRejected(REJECT_CAPABILITY)
+        with self._lock:
+            expected = self._issued.pop(capability, None)
+        if expected is None or getattr(capability, "_seal", None) is not self._seal:
+            raise SignerSecretAccessGrantRejected(REJECT_CAPABILITY)
+        validated_signer_secret_grant(expected, self._now())
+        self._require_not_revoked(expected)
+        try:
+            consumed = self._nonce_store.consume(str(expected["nonce"])) is True
+        except Exception:
+            consumed = False
+        if not consumed:
+            raise SignerSecretAccessGrantRejected(REJECT_NONCE)
+        return expected
+
+    def _now(self) -> int:
+        try:
+            value = self._clock()
+        except Exception:
+            raise SignerSecretAccessGrantRejected(REJECT_TIME) from None
+        if type(value) is not int:
+            raise SignerSecretAccessGrantRejected(REJECT_TIME)
+        return value
+
+    def _require_not_revoked(self, grant: Mapping[str, Any]) -> None:
+        try:
+            verdict = self._revocation_oracle.is_revoked(
+                grant_id=str(grant["grant_id"]),
+                key_epoch=str(grant["key_epoch"]),
+                at_epoch=self._now(),
+            )
+        except Exception:
+            raise SignerSecretAccessGrantRejected(REJECT_REVOKED) from None
+        if type(verdict) is not bool or verdict is not False:
+            raise SignerSecretAccessGrantRejected(REJECT_REVOKED)
+
+
+def _capability_type(seal: object) -> type:
+    class Capability:
+        __slots__ = ("_seal", "__weakref__")
+
+        def __init__(self) -> None:
+            object.__setattr__(self, "_seal", seal)
+
+        def __setattr__(self, _name: str, _value: Any) -> None:
+            raise TypeError(REJECT_CAPABILITY)
+
+        def __copy__(self):
+            raise TypeError(REJECT_CAPABILITY)
+
+        def __deepcopy__(self, _memo: Any):
+            raise TypeError(REJECT_CAPABILITY)
+
+        def __reduce__(self):
+            raise TypeError(REJECT_CAPABILITY)
+
+    return Capability
+__all__ = [
+    "ExpectedSignerSecretGrantBinding", "GRANT_PREFIX", "GRANT_SCHEMA",
+    "MAX_GRANT_TTL_SECONDS", "SignerSecretAccessGrantBoundary",
+    "SignerSecretGrantRevocationOracle",
+    "SignerSecretAccessGrantRejected", "canonical_signer_secret_access_grant_input",
+    "signer_secret_access_grant_id",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_secret_access_grant_contract.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_secret_access_grant_contract.py
@@ -1,0 +1,154 @@
+"""Canonical contract for signed E0 signer secret-access grants."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, fields
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_runtime_artifact_manifest_contract import (
+    ascii_deep,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_optional_authority_bindings import (
+    is_sha256_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PrincipalKeyResolver,
+    canonical_signing_input,
+    constant_time_compare,
+)
+
+GRANT_SCHEMA = "reddog-signer-secret-access-grant.v1"
+GRANT_PREFIX = "reddog-signer-secret-access-grant.v1"
+MAX_GRANT_TTL_SECONDS = 300
+
+REJECT_MALFORMED = "REJECT_SECRET_GRANT_MALFORMED"
+REJECT_NON_ASCII = "REJECT_SECRET_GRANT_NON_ASCII"
+REJECT_DIGEST = "REJECT_SECRET_GRANT_DIGEST_INVALID"
+REJECT_TIME = "REJECT_SECRET_GRANT_TIME_INVALID"
+REJECT_ISSUER = "REJECT_SECRET_GRANT_ISSUER_UNTRUSTED"
+REJECT_BINDING = "REJECT_SECRET_GRANT_BINDING_MISMATCH"
+REJECT_GRANT_ID = "REJECT_SECRET_GRANT_ID_MISMATCH"
+REJECT_SIGNATURE = "REJECT_SECRET_GRANT_SIGNATURE_INVALID"
+REJECT_REVOKED = "REJECT_SECRET_GRANT_REVOKED"
+REJECT_NONCE = "REJECT_SECRET_GRANT_NONCE_REPLAY"
+REJECT_CAPABILITY = "REJECT_SECRET_GRANT_CAPABILITY_INVALID"
+
+_STRING_FIELDS = (
+    "schema_version", "issuer_principal_id", "issuer_principal_provider",
+    "issuer_public_key", "signer_agent_id", "signer_profile_id",
+    "signing_key_ref_hash", "audit_mac_key_ref_hash", "key_epoch",
+    "permission_snapshot_digest", "owner_config_id", "signer_generation_id",
+    "nonce", "grant_id", "signature",
+)
+_TIME_FIELDS = ("issued_at", "expires_at")
+GRANT_FIELDS = frozenset(_STRING_FIELDS + _TIME_FIELDS)
+_DIGEST_FIELDS = (
+    "signing_key_ref_hash", "audit_mac_key_ref_hash",
+    "permission_snapshot_digest", "owner_config_id", "signer_generation_id",
+)
+
+
+class SignerSecretAccessGrantRejected(Exception):
+    """Fail-closed rejection carrying one static reason code."""
+
+    def __init__(self, reason_code: str) -> None:
+        self.reason_code = reason_code
+        super().__init__(reason_code)
+
+
+@dataclass(frozen=True)
+class ExpectedSignerSecretGrantBinding:
+    issuer_principal_id: str
+    issuer_principal_provider: str
+    issuer_public_key: str
+    signer_agent_id: str
+    signer_profile_id: str
+    signing_key_ref_hash: str
+    audit_mac_key_ref_hash: str
+    key_epoch: str
+    permission_snapshot_digest: str
+    owner_config_id: str
+    signer_generation_id: str
+
+
+def signer_secret_access_grant_id(grant: Mapping[str, Any]) -> str:
+    core = {
+        key: grant[key]
+        for key in sorted(GRANT_FIELDS - {"grant_id", "signature"})
+    }
+    raw = json.dumps(
+        core, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def canonical_signer_secret_access_grant_input(
+    grant: Mapping[str, Any],
+) -> str:
+    return canonical_signing_input(grant, GRANT_PREFIX)
+
+
+def validated_signer_secret_grant(
+    grant: Mapping[str, Any], now: int
+) -> dict[str, Any]:
+    if not isinstance(grant, Mapping) or type(now) is not int:
+        raise SignerSecretAccessGrantRejected(REJECT_MALFORMED)
+    try:
+        raw = dict(grant)
+    except Exception:
+        raise SignerSecretAccessGrantRejected(REJECT_MALFORMED) from None
+    if frozenset(raw) != GRANT_FIELDS or raw.get("schema_version") != GRANT_SCHEMA:
+        raise SignerSecretAccessGrantRejected(REJECT_MALFORMED)
+    if any(not isinstance(raw.get(key), str) or not raw[key] for key in _STRING_FIELDS):
+        raise SignerSecretAccessGrantRejected(REJECT_MALFORMED)
+    if any(type(raw.get(key)) is not int for key in _TIME_FIELDS):
+        raise SignerSecretAccessGrantRejected(REJECT_MALFORMED)
+    if not ascii_deep(raw):
+        raise SignerSecretAccessGrantRejected(REJECT_NON_ASCII)
+    if any(len(raw[key]) > 4096 for key in _STRING_FIELDS) or len(raw["nonce"]) > 256:
+        raise SignerSecretAccessGrantRejected(REJECT_MALFORMED)
+    if any(not is_sha256_digest(raw[key]) for key in _DIGEST_FIELDS + ("grant_id",)):
+        raise SignerSecretAccessGrantRejected(REJECT_DIGEST)
+    issued, expires = int(raw["issued_at"]), int(raw["expires_at"])
+    if (
+        any(value < 0 for value in (now, issued, expires))
+        or issued > now
+        or expires <= now
+        or not 0 < expires - issued <= MAX_GRANT_TTL_SECONDS
+    ):
+        raise SignerSecretAccessGrantRejected(REJECT_TIME)
+    return raw
+
+
+def verify_expected_signer_secret_grant(
+    grant: Mapping[str, Any], expected: ExpectedSignerSecretGrantBinding
+) -> None:
+    if not isinstance(expected, ExpectedSignerSecretGrantBinding):
+        raise SignerSecretAccessGrantRejected(REJECT_BINDING)
+    values = {item.name: getattr(expected, item.name) for item in fields(expected)}
+    if any(
+        not isinstance(value, str) or not value or not ascii_deep(value)
+        for value in values.values()
+    ):
+        raise SignerSecretAccessGrantRejected(REJECT_BINDING)
+    for item in fields(expected):
+        if not constant_time_compare(str(grant[item.name]), values[item.name]):
+            raise SignerSecretAccessGrantRejected(REJECT_BINDING)
+
+
+def verify_signer_secret_grant_issuer(
+    grant: Mapping[str, Any], resolver: PrincipalKeyResolver
+) -> None:
+    try:
+        trusted = resolver.resolve(
+            str(grant["issuer_principal_id"]),
+            str(grant["issuer_principal_provider"]),
+        )
+    except Exception:
+        trusted = None
+    if not isinstance(trusted, str) or not constant_time_compare(
+        trusted, str(grant["issuer_public_key"])
+    ):
+        raise SignerSecretAccessGrantRejected(REJECT_ISSUER)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_secret_access_grant.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_secret_access_grant.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+import ast
+import copy
+import pickle
+import threading
+from dataclasses import replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_signer_secret_access_grant import (
+    ExpectedSignerSecretGrantBinding,
+    GRANT_SCHEMA,
+    REJECT_BINDING,
+    REJECT_CAPABILITY,
+    REJECT_DIGEST,
+    REJECT_GRANT_ID,
+    REJECT_ISSUER,
+    REJECT_MALFORMED,
+    REJECT_NONCE,
+    REJECT_REVOKED,
+    REJECT_SIGNATURE,
+    REJECT_TIME,
+    SignerSecretAccessGrantBoundary,
+    SignerSecretAccessGrantRejected,
+    canonical_signer_secret_access_grant_input,
+    signer_secret_access_grant_id,
+)
+
+NOW = 1_780_000_000
+SOURCE = Path(__file__).parents[1] / "src" / "reddog_signer_secret_access_grant.py"
+CONTRACT_SOURCE = (
+    Path(__file__).parents[1]
+    / "src"
+    / "reddog_signer_secret_access_grant_contract.py"
+)
+
+
+def _digest(character: str) -> str:
+    return "sha256:" + (character * 64)
+
+
+def _grant(**overrides: Any) -> dict[str, Any]:
+    value = {
+        "schema_version": GRANT_SCHEMA,
+        "issuer_principal_id": "principal:founder",
+        "issuer_principal_provider": "github",
+        "issuer_public_key": "public-key-v1:issuer",
+        "signer_agent_id": "signer:reddog",
+        "signer_profile_id": "reddog-work-authority",
+        "signing_key_ref_hash": _digest("1"),
+        "audit_mac_key_ref_hash": _digest("2"),
+        "key_epoch": "epoch-1",
+        "permission_snapshot_digest": _digest("3"),
+        "owner_config_id": _digest("4"),
+        "signer_generation_id": _digest("5"),
+        "nonce": "grant-nonce-1",
+        "issued_at": NOW - 10,
+        "expires_at": NOW + 100,
+        "grant_id": "",
+        "signature": "fixture-signature-v1",
+    }
+    value.update(overrides)
+    value["grant_id"] = signer_secret_access_grant_id(value)
+    return value
+
+
+def _binding(grant: Mapping[str, Any]) -> ExpectedSignerSecretGrantBinding:
+    names = {field.name for field in ExpectedSignerSecretGrantBinding.__dataclass_fields__.values()}
+    return ExpectedSignerSecretGrantBinding(**{name: str(grant[name]) for name in names})
+
+
+class _Verifier:
+    def __init__(self) -> None:
+        self.allowed: set[tuple[str, str, str]] = set()
+
+    def allow(self, grant: Mapping[str, Any]) -> None:
+        self.allowed.add((
+            str(grant["issuer_public_key"]),
+            canonical_signer_secret_access_grant_input(grant),
+            str(grant["signature"]),
+        ))
+
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        return (public_key, signing_input, signature) in self.allowed
+
+
+class _RaisingVerifier(_Verifier):
+    def verify(self, public_key: str, signing_input: str, signature: str) -> bool:
+        raise RuntimeError("unavailable")
+
+
+class _Resolver:
+    def __init__(self, public_key: str = "public-key-v1:issuer") -> None:
+        self.public_key = public_key
+
+    def resolve(self, principal_id: str, principal_provider: str) -> str | None:
+        if (principal_id, principal_provider) == ("principal:founder", "github"):
+            return self.public_key
+        return None
+
+
+class _RaisingResolver(_Resolver):
+    def resolve(self, principal_id: str, principal_provider: str) -> str | None:
+        raise RuntimeError("unavailable")
+
+
+class _NonceStore:
+    def __init__(self) -> None:
+        self.seen: set[str] = set()
+        self.calls: list[str] = []
+        self.lock = threading.Lock()
+
+    def consume(self, nonce: str) -> bool:
+        with self.lock:
+            self.calls.append(nonce)
+            if nonce in self.seen:
+                return False
+            self.seen.add(nonce)
+            return True
+
+
+class _Clock:
+    def __init__(self, now: int = NOW) -> None:
+        self.now = now
+        self.raise_error = False
+
+    def __call__(self) -> int:
+        if self.raise_error:
+            raise RuntimeError("unavailable")
+        return self.now
+
+
+class _RevocationOracle:
+    def __init__(self) -> None:
+        self.grant_ids: set[str] = set()
+        self.key_epochs: set[str] = set()
+        self.raise_error = False
+        self.override = False
+        self.verdict: object | None = None
+
+    def is_revoked(self, *, grant_id: str, key_epoch: str, at_epoch: int) -> bool:
+        if self.raise_error:
+            raise RuntimeError("unavailable")
+        if self.override:
+            return self.verdict  # type: ignore[return-value]
+        return grant_id in self.grant_ids or key_epoch in self.key_epochs
+
+
+def _verify(
+    grant: Mapping[str, Any], *, expected: ExpectedSignerSecretGrantBinding | None = None,
+    verifier: _Verifier | None = None, resolver: _Resolver | None = None,
+    nonce_store: _NonceStore | None = None, clock: _Clock | None = None,
+    revocation: _RevocationOracle | None = None,
+) -> tuple[
+    SignerSecretAccessGrantBoundary, object, _NonceStore, _Clock,
+    _RevocationOracle,
+]:
+    effective_verifier = verifier or _Verifier()
+    effective_verifier.allow(grant)
+    store = nonce_store or _NonceStore()
+    effective_clock = clock or _Clock()
+    effective_revocation = revocation or _RevocationOracle()
+    boundary = SignerSecretAccessGrantBoundary(
+        nonce_store=store,
+        revocation_oracle=effective_revocation,
+        clock=effective_clock,
+    )
+    capability = boundary.verify(
+        grant, expected=expected or _binding(grant),
+        signature_verifier=effective_verifier,
+        principal_key_resolver=resolver or _Resolver(),
+    )
+    return boundary, capability, store, effective_clock, effective_revocation
+
+
+def _rejection(call: Any, code: str) -> None:
+    with pytest.raises(SignerSecretAccessGrantRejected) as raised:
+        call()
+    assert raised.value.reason_code == code
+    assert str(raised.value) == code
+
+
+def test_valid_grant_verifies_and_consumes_to_immutable_mapping() -> None:
+    grant = _grant()
+    boundary, capability, store, _clock, _revocation = _verify(grant)
+    assert store.calls == []
+    consumed = boundary.consume(capability)
+    assert type(consumed) is MappingProxyType
+    assert dict(consumed) == grant
+    assert store.calls == ["grant-nonce-1"]
+    with pytest.raises(TypeError):
+        consumed["key_epoch"] = "changed"  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("signing_key_ref_hash", _digest("a")),
+        ("audit_mac_key_ref_hash", _digest("b")),
+        ("signer_agent_id", "signer:other"),
+        ("signer_profile_id", "other-profile"),
+        ("key_epoch", "epoch-2"),
+        ("signer_generation_id", _digest("c")),
+        ("owner_config_id", _digest("d")),
+        ("permission_snapshot_digest", _digest("e")),
+        ("issuer_principal_id", "principal:other"),
+        ("issuer_principal_provider", "intake_session"),
+        ("issuer_public_key", "public-key-v1:other"),
+    ],
+)
+def test_changed_expected_binding_rejects(field: str, value: str) -> None:
+    grant = _grant()
+    changed = _grant(**{field: value})
+    store = _NonceStore()
+    _rejection(
+        lambda: _verify(changed, expected=_binding(grant), nonce_store=store),
+        REJECT_BINDING,
+    )
+    assert store.calls == []
+
+
+def test_forged_issuer_key_rejects_before_nonce() -> None:
+    forged = _grant(issuer_public_key="public-key-v1:forged")
+    store = _NonceStore()
+    _rejection(lambda: _verify(forged, nonce_store=store), REJECT_ISSUER)
+    assert store.calls == []
+
+
+def test_invalid_signature_rejects_without_consuming_nonce() -> None:
+    grant = _grant()
+    store = _NonceStore()
+    boundary = SignerSecretAccessGrantBoundary(
+        nonce_store=store, revocation_oracle=_RevocationOracle(), clock=_Clock()
+    )
+    _rejection(
+        lambda: boundary.verify(
+            grant, expected=_binding(grant), signature_verifier=_Verifier(),
+            principal_key_resolver=_Resolver(),
+        ),
+        REJECT_SIGNATURE,
+    )
+    assert store.calls == []
+
+
+@pytest.mark.parametrize(
+    ("resolver", "verifier"),
+    [(_RaisingResolver(), _Verifier()), (_Resolver(), _RaisingVerifier())],
+)
+def test_dependency_failure_rejects_without_consuming_nonce(
+    resolver: _Resolver, verifier: _Verifier
+) -> None:
+    grant = _grant()
+    if type(verifier) is _Verifier:
+        verifier.allow(grant)
+    store = _NonceStore()
+    code = REJECT_ISSUER if isinstance(resolver, _RaisingResolver) else REJECT_SIGNATURE
+    _rejection(
+        lambda: _verify(
+            grant, resolver=resolver, verifier=verifier, nonce_store=store
+        ),
+        code,
+    )
+    assert store.calls == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"issued_at": NOW - 100, "expires_at": NOW},
+        {"issued_at": NOW + 1, "expires_at": NOW + 100},
+        {"issued_at": NOW - 10, "expires_at": NOW + 291},
+    ],
+)
+def test_expired_future_and_overlong_grants_reject(overrides: dict[str, int]) -> None:
+    grant = _grant(**overrides)
+    _rejection(lambda: _verify(grant), REJECT_TIME)
+
+
+def test_recomputed_grant_id_does_not_repair_old_signature() -> None:
+    original = _grant()
+    verifier = _Verifier()
+    verifier.allow(original)
+    attacked = _grant(signing_key_ref_hash=_digest("a"), signature=original["signature"])
+    store = _NonceStore()
+    boundary = SignerSecretAccessGrantBoundary(
+        nonce_store=store, revocation_oracle=_RevocationOracle(), clock=_Clock()
+    )
+    _rejection(
+        lambda: boundary.verify(
+            attacked, expected=_binding(attacked), signature_verifier=verifier,
+            principal_key_resolver=_Resolver(),
+        ),
+        REJECT_SIGNATURE,
+    )
+    assert store.calls == []
+
+
+def test_stale_grant_id_rejects_before_signature_and_nonce() -> None:
+    grant = _grant()
+    grant["grant_id"] = _digest("f")
+    store = _NonceStore()
+    _rejection(lambda: _verify(grant, nonce_store=store), REJECT_GRANT_ID)
+    assert store.calls == []
+
+
+def test_nonce_replay_rejects() -> None:
+    grant = _grant()
+    store = _NonceStore()
+    first, first_capability, *_ = _verify(grant, nonce_store=store)
+    second, second_capability, *_ = _verify(grant, nonce_store=store)
+    assert dict(first.consume(first_capability)) == grant
+    _rejection(lambda: second.consume(second_capability), REJECT_NONCE)
+    assert store.calls == ["grant-nonce-1", "grant-nonce-1"]
+
+
+@pytest.mark.parametrize("revocation_kind", ["key_epoch", "grant_id"])
+def test_revoked_key_epoch_or_grant_rejects_before_nonce(
+    revocation_kind: str,
+) -> None:
+    grant = _grant()
+    store = _NonceStore()
+    revocation = _RevocationOracle()
+    boundary, capability, *_ = _verify(
+        grant, nonce_store=store, revocation=revocation
+    )
+    target = (
+        revocation.key_epochs
+        if revocation_kind == "key_epoch"
+        else revocation.grant_ids
+    )
+    target.add(
+        str(
+            grant[
+                "key_epoch" if revocation_kind == "key_epoch" else "grant_id"
+            ]
+        )
+    )
+    _rejection(
+        lambda: boundary.consume(capability),
+        REJECT_REVOKED,
+    )
+    assert store.calls == []
+
+
+def test_expiry_or_revocation_failure_at_use_burns_capability() -> None:
+    grant = _grant()
+    clock = _Clock()
+    boundary, capability, store, *_ = _verify(grant, clock=clock)
+    clock.now = int(grant["expires_at"])
+    _rejection(lambda: boundary.consume(capability), REJECT_TIME)
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+    assert store.calls == []
+
+    revocation = _RevocationOracle()
+    boundary, capability, store, *_ = _verify(grant, revocation=revocation)
+    revocation.raise_error = True
+    _rejection(lambda: boundary.consume(capability), REJECT_REVOKED)
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+    assert store.calls == []
+
+
+@pytest.mark.parametrize("verdict", [None, 1, "revoked", object()])
+def test_malformed_revocation_verdict_fails_closed(
+    verdict: object,
+) -> None:
+    grant = _grant()
+    revocation = _RevocationOracle()
+    revocation.override = True
+    revocation.verdict = verdict
+    store = _NonceStore()
+    _rejection(
+        lambda: _verify(grant, revocation=revocation, nonce_store=store),
+        REJECT_REVOKED,
+    )
+    assert store.calls == []
+
+    revocation.override = False
+    boundary, capability, store, *_ = _verify(
+        grant, revocation=revocation, nonce_store=store
+    )
+    revocation.override = True
+    revocation.verdict = verdict
+    _rejection(lambda: boundary.consume(capability), REJECT_REVOKED)
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+    assert store.calls == []
+
+
+def test_clock_failure_fails_closed_and_burns_issued_capability() -> None:
+    grant = _grant()
+    clock = _Clock()
+    clock.raise_error = True
+    _rejection(lambda: _verify(grant, clock=clock), REJECT_TIME)
+
+    clock.raise_error = False
+    boundary, capability, store, *_ = _verify(grant, clock=clock)
+    clock.raise_error = True
+    _rejection(lambda: boundary.consume(capability), REJECT_TIME)
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+    assert store.calls == []
+
+
+def test_nonce_store_failure_at_use_burns_capability() -> None:
+    class RaisingNonceStore(_NonceStore):
+        def consume(self, nonce: str) -> bool:
+            raise RuntimeError("unavailable")
+
+    grant = _grant()
+    boundary, capability, *_ = _verify(grant, nonce_store=RaisingNonceStore())
+    _rejection(lambda: boundary.consume(capability), REJECT_NONCE)
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+
+
+def test_concurrent_capability_consumption_has_one_authoritative_use() -> None:
+    grant = _grant()
+    boundary, capability, store, *_ = _verify(grant)
+    barrier = threading.Barrier(3)
+    outcomes: list[str] = []
+
+    def consume() -> None:
+        barrier.wait()
+        try:
+            boundary.consume(capability)
+            outcomes.append("accepted")
+        except SignerSecretAccessGrantRejected as exc:
+            outcomes.append(exc.reason_code)
+
+    threads = [threading.Thread(target=consume) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+    assert sorted(outcomes) == [REJECT_CAPABILITY, "accepted"]
+    assert store.calls == ["grant-nonce-1"]
+
+
+def test_two_capabilities_with_one_nonce_have_one_authoritative_use() -> None:
+    grant = _grant()
+    store = _NonceStore()
+    first, first_capability, *_ = _verify(grant, nonce_store=store)
+    second, second_capability, *_ = _verify(grant, nonce_store=store)
+    barrier = threading.Barrier(3)
+    outcomes: list[str] = []
+
+    def consume(boundary: SignerSecretAccessGrantBoundary, capability: object) -> None:
+        barrier.wait()
+        try:
+            boundary.consume(capability)
+            outcomes.append("accepted")
+        except SignerSecretAccessGrantRejected as exc:
+            outcomes.append(exc.reason_code)
+
+    threads = [
+        threading.Thread(target=consume, args=(first, first_capability)),
+        threading.Thread(target=consume, args=(second, second_capability)),
+    ]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+    assert sorted(outcomes) == [REJECT_NONCE, "accepted"]
+
+
+def test_negative_clock_or_timestamps_reject() -> None:
+    grant = _grant(issued_at=-1, expires_at=NOW + 10)
+    _rejection(lambda: _verify(grant), REJECT_TIME)
+    valid = _grant()
+    verifier = _Verifier()
+    verifier.allow(valid)
+    clock = _Clock(-1)
+    boundary = SignerSecretAccessGrantBoundary(
+        nonce_store=_NonceStore(),
+        revocation_oracle=_RevocationOracle(),
+        clock=clock,
+    )
+    _rejection(
+        lambda: boundary.verify(
+            valid,
+            expected=_binding(valid),
+            signature_verifier=verifier,
+            principal_key_resolver=_Resolver(),
+        ),
+        REJECT_TIME,
+    )
+
+
+def test_capability_is_process_local_immutable_and_one_shot() -> None:
+    grant = _grant()
+    boundary, capability, _store, _clock, _revocation = _verify(grant)
+    fabricated = capability.__class__()
+    _rejection(lambda: boundary.consume(fabricated), REJECT_CAPABILITY)
+    with pytest.raises(TypeError):
+        copy.copy(capability)
+    with pytest.raises(TypeError):
+        copy.deepcopy(capability)
+    with pytest.raises(TypeError):
+        pickle.dumps(capability)
+    with pytest.raises(TypeError):
+        setattr(capability, "_seal", object())
+    assert dict(boundary.consume(capability)) == grant
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+
+
+def test_object_level_mutation_invalidates_capability() -> None:
+    grant = _grant()
+    boundary, capability, _store, _clock, _revocation = _verify(grant)
+    object.__setattr__(capability, "_seal", object())
+    _rejection(lambda: boundary.consume(capability), REJECT_CAPABILITY)
+
+
+def test_malformed_expected_binding_rejects_before_nonce() -> None:
+    grant = _grant()
+    store = _NonceStore()
+    expected = replace(_binding(grant), signer_agent_id="")
+    _rejection(
+        lambda: _verify(grant, expected=expected, nonce_store=store), REJECT_BINDING
+    )
+    assert store.calls == []
+
+
+def test_exact_fields_ascii_and_sha256_formats_are_enforced() -> None:
+    missing = _grant()
+    missing.pop("nonce")
+    extra = _grant()
+    extra["unexpected"] = "value"
+    non_ascii = _grant(signer_agent_id="signer:\u2603")
+    bad_digest = _grant(permission_snapshot_digest="sha256:not-a-digest")
+    wrong_schema = _grant(schema_version="reddog-signer-secret-access-grant.v2")
+    boolean_time = _grant(issued_at=True)
+    oversized = _grant(signer_agent_id="s" * 4097)
+    oversized_nonce = _grant(nonce="n" * 257)
+    _rejection(lambda: _verify(missing), REJECT_MALFORMED)
+    _rejection(lambda: _verify(extra), REJECT_MALFORMED)
+    _rejection(lambda: _verify(non_ascii), "REJECT_SECRET_GRANT_NON_ASCII")
+    _rejection(lambda: _verify(bad_digest), REJECT_DIGEST)
+    _rejection(lambda: _verify(wrong_schema), REJECT_MALFORMED)
+    _rejection(lambda: _verify(boolean_time), REJECT_MALFORMED)
+    _rejection(lambda: _verify(oversized), REJECT_MALFORMED)
+    _rejection(lambda: _verify(oversized_nonce), REJECT_MALFORMED)
+
+
+def test_canonicalization_is_mapping_order_independent() -> None:
+    grant = _grant()
+    reordered = dict(reversed(tuple(grant.items())))
+    assert signer_secret_access_grant_id(reordered) == grant["grant_id"]
+    assert (
+        canonical_signer_secret_access_grant_input(reordered)
+        == canonical_signer_secret_access_grant_input(grant)
+    )
+
+
+def test_ast_has_no_secret_provider_or_execution_side_effects() -> None:
+    sources = [
+        SOURCE.read_text(encoding="utf-8"),
+        CONTRACT_SOURCE.read_text(encoding="utf-8"),
+    ]
+    tree = ast.parse("\n".join(sources))
+    imports = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    calls = {
+        node.func.id if isinstance(node.func, ast.Name) else node.func.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, (ast.Name, ast.Attribute))
+    }
+    assert not imports.intersection({"os", "subprocess", "pathlib", "socket", "requests"})
+    assert not calls.intersection({
+        "open", "eval", "exec", "system", "popen", "run", "get_secret",
+        "resolve_secret", "sign", "generate_key", "write_text", "write_bytes",
+    })
+    for source in sources:
+        logical = [
+            line for line in source.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        assert len(logical) <= 200
+        assert all(ord(character) < 128 for character in source)
+        assert "\x00" not in source


### PR DESCRIPTION
## Summary
- add a strict signed E0 signer secret-access grant contract
- mint one process-local capability only after issuer, binding, signature, time, and revocation checks
- recheck trusted time and revocation at authoritative use, then consume the nonce exactly once

## Truth boundary
This is a verification gate only. It does not add a vault provider, secret retrieval, per-request key handling, signing, system-service activation, OpenClaw, Hermes, shell, PR, merge, or HoloIndex mutation authority.

## Validation
- 116 focused signer/manifest/entrypoint tests passed
- independent review GO after three correction rounds
- backend manifest generator check passed
- py_compile and git diff --check passed
- both implementation modules remain below the WSP 62 200-line threshold