### PR TITLE
feat(reddog): admit owner-controlled signer E0 composition

### DIFF
--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -47,7 +47,14 @@ now verifies one request-bound secret-access grant, atomically consumes durable
 replay state, resolves WSP71 keys for that sign only, and rechecks revocation,
 expiry, provider identity, and the returned signature. The stable entrypoint
 does not yet supply or compose this boundary, so production signing remains
-fail-closed. RedDog and `main.py` remain clients and cannot spawn the signer.
+fail-closed. The owner-controlled E0 admission layer now binds one signed
+policy to the exact current signer generation, key-reference digests,
+manifest-bound grant/revocation authorities, disjoint durable-state roots,
+operation/tier consensus rules, and rate limits. Its opaque one-use capability
+cannot be copied or serialized. Consumption revalidates while the canonical
+current-generation fence is held and returns only a non-authoritative receipt;
+it does not release signer composition authority or grant an effect.
+RedDog and `main.py` remain clients and cannot spawn the signer.
 
 `start operations` binds the production `reddog_operations` Skillz from the
 manifest-authenticated runtime before model selection or grounding. The

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -12,12 +12,19 @@
   ephemeral backend construction. Its signature is independently verified
   while one signer-owned revocation fence covers the complete sign operation;
   missing stores and backend-authored rejection payloads fail closed.
+- COMPLETE: owner-controlled E0 composition admission consumes one opaque
+  current-generation selection, requires that signed generation to pin the
+  complete E0 authority-scope digest and principal artifact, independently
+  verifies the signed owner policy and both authority keys, and releases one
+  process-local capability. Capability consumption revalidates under the
+  shared generation fence and returns only a non-authoritative receipt. It
+  performs no secret resolution, socket binding, or signer start.
 - NEXT: independently administered grant and revocation supply, WSP 71
   permissioned resolver composition, and native-memory zeroization evidence
   entrypoint. Socket v1 remains compatible but cannot reach the resolve-per-sign
   backend.
 - BLOCKED: durable system-service deployment and no-work-authority Linux
-  canary until grant supply, secret resolution, zeroization, and lifecycle
+  canary until grant/revocation supply, secret resolution, zeroization, and lifecycle
   supervision slices pass.
 
 ## RedDog provider-call evidence follow-ups

--- a/modules/communication/moltbot_bridge/src/reddog_current_generation_manifest_launch_selection.py
+++ b/modules/communication/moltbot_bridge/src/reddog_current_generation_manifest_launch_selection.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Mapping, Protocol
+from typing import Any, Iterator, Mapping, Protocol
 from weakref import WeakKeyDictionary
 
 from modules.communication.moltbot_bridge.src.reddog_runtime_artifact_manifest_contract import (
@@ -59,6 +60,7 @@ from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
 )
 
 SELECTION_TTL_SECONDS = 30
+PRINCIPAL_AUTHORITY_RECORDS_FILENAME = "principal_authority_records.json"
 
 
 @dataclass(frozen=True)
@@ -155,7 +157,7 @@ def create_current_generation_manifest_launch_selection_boundary(
         trust=owner.trust,
         owner_config_id=owner.owner_config_id,
     )
-    return _Boundary(state.select, state.consume)
+    return _Boundary(state.select, state.consume, state.current_selection_lease)
 
 
 def _require_owner_authority(
@@ -207,6 +209,14 @@ class _SelectionState:
         return capability
 
     def consume(self, value: object) -> Mapping[str, Any]:
+        with self.current_selection_lease(value) as selected:
+            return _legacy_launch_values(selected)
+
+    @contextmanager
+    def current_selection_lease(
+        self, value: object
+    ) -> Iterator[Mapping[str, Any]]:
+        """Yield one current selection while its generation is fenced."""
         expected = _claim_capability(
             value,
             self.capability_type,
@@ -215,54 +225,64 @@ class _SelectionState:
             self.issue_lock,
         )
         _require_selection_fresh(expected)
-        current = self._current_values(
-            selected_at=int(expected["selection_issued_at"])
-        )
-        if dict(current) != dict(expected):
-            raise RuntimeArtifactManifestError(
-                "manifest_launch_selection_stale"
+        with reddog_runtime_artifact_generation_lock(
+            self.runtime, repo_root=self.repo, allow_sealed=True
+        ):
+            _require_selection_fresh(expected)
+            current = self._current_values_locked(
+                selected_at=int(expected["selection_issued_at"])
             )
-        return MappingProxyType(dict(current))
+            if dict(current) != dict(expected):
+                raise RuntimeArtifactManifestError(
+                    "manifest_launch_selection_stale"
+                )
+            yield MappingProxyType(dict(current))
 
     def _current_values(self, *, selected_at: int) -> Mapping[str, Any]:
         with reddog_runtime_artifact_generation_lock(
             self.runtime, repo_root=self.repo, allow_sealed=True
         ):
-            activation = self.reader.load()
-            if activation is None:
-                raise RuntimeArtifactManifestError(
-                    "current_generation_not_activated"
-                )
-            _require_activation_trust(activation, self.trust)
-            manifest = _read_manifest(self.repo, self.runtime, activation)
-            validate_freshness(
-                manifest,
-                now_epoch=_now_epoch(),
-                max_ttl_seconds=DEFAULT_MAX_TTL_SECONDS,
+            return self._current_values_locked(selected_at=selected_at)
+
+    def _current_values_locked(self, *, selected_at: int) -> Mapping[str, Any]:
+        activation = self.reader.load()
+        if activation is None:
+            raise RuntimeArtifactManifestError(
+                "current_generation_not_activated"
             )
-            _verify_manifest(
-                manifest,
-                activation,
-                self.repo,
-                self.runtime,
-                Ed25519SignatureVerifier(),
-            )
-            return _launch_values(
-                manifest,
-                activation,
-                self.repo,
-                self.runtime,
-                selected_at=selected_at,
-                owner_config_id=self.owner_config_id,
-            )
+        _require_activation_trust(activation, self.trust)
+        manifest = _read_manifest(self.repo, self.runtime, activation)
+        validate_freshness(
+            manifest,
+            now_epoch=_now_epoch(),
+            max_ttl_seconds=DEFAULT_MAX_TTL_SECONDS,
+        )
+        _verify_manifest(
+            manifest,
+            activation,
+            self.repo,
+            self.runtime,
+            Ed25519SignatureVerifier(),
+        )
+        return _launch_values(
+            manifest,
+            activation,
+            self.repo,
+            self.runtime,
+            selected_at=selected_at,
+            owner_config_id=self.owner_config_id,
+        )
 
 
 class _Boundary:
-    __slots__ = ("_select", "_consume")
+    __slots__ = ("_select", "_consume", "_current_selection_lease")
 
-    def __init__(self, select: Any, consume: Any) -> None:
+    def __init__(
+        self, select: Any, consume: Any, current_selection_lease: Any
+    ) -> None:
         self._select = select
         self._consume = consume
+        self._current_selection_lease = current_selection_lease
 
     def select(
         self, manifest: Mapping[str, Any], *, now_epoch: int
@@ -271,6 +291,9 @@ class _Boundary:
 
     def consume(self, value: object) -> Mapping[str, Any]:
         return self._consume(value)
+
+    def _lease_current(self, value: object) -> Any:
+        return self._current_selection_lease(value)
 
 
 def _read_manifest(
@@ -427,6 +450,10 @@ def _launch_values(
     selected_at: int,
     owner_config_id: str,
 ) -> Mapping[str, Any]:
+    descriptors = {
+        str(item["filename"]): item for item in manifest["artifacts"]
+    }
+    principal = descriptors[PRINCIPAL_AUTHORITY_RECORDS_FILENAME]
     return MappingProxyType(
         {
             "manifest_id": activation.manifest_id,
@@ -443,6 +470,10 @@ def _launch_values(
             "runtime_root": str(runtime),
             "config_path": str(runtime / CONFIG_FILENAME),
             "run_packet_path": str(runtime / RUN_PACKET_FILENAME),
+            "principal_authority_records_path": str(
+                runtime / PRINCIPAL_AUTHORITY_RECORDS_FILENAME
+            ),
+            "principal_authority_records_digest": principal["content_digest"],
         }
     )
 
@@ -470,6 +501,16 @@ def _capability_type(seal: object) -> type:
             raise TypeError("manifest_launch_selection_not_copyable")
 
     return Capability
+
+
+def _legacy_launch_values(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    hidden = {
+        "principal_authority_records_path",
+        "principal_authority_records_digest",
+    }
+    return MappingProxyType(
+        {key: item for key, item in value.items() if key not in hidden}
+    )
 
 
 def _claim_capability(

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_controlled_e0_admission.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_controlled_e0_admission.py
@@ -1,0 +1,99 @@
+"""Opaque admission boundary for owner-controlled signer E0 composition."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Mapping
+from weakref import WeakKeyDictionary
+
+from .reddog_signer_owner_e0_capability_state import (
+    owner_e0_capability_type,
+)
+from .reddog_signer_owner_e0_admission_contract import (
+    ADMISSION_ACCEPT,
+    ADMISSION_REJECT,
+    FAIL_ADMISSION_INPUT,
+    FAIL_ADMISSION_POLICY,
+    IssuedAdmission,
+    OwnerControlledE0AdmissionResult,
+    OwnerControlledE0ConsumptionReceipt,
+)
+from .reddog_signer_owner_e0_current_selection import (
+    validate_owner_e0_current_admission,
+)
+
+
+class OwnerControlledE0AdmissionBoundary:
+    """Consume current-generation proof and issue one process-local capability."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | str,
+    ) -> None:
+        self._repo_root = Path(repo_root).resolve()
+        self._seal = object()
+        self._capability_type = owner_e0_capability_type(self._seal)
+        self._issued: WeakKeyDictionary[object, IssuedAdmission] = (
+            WeakKeyDictionary()
+        )
+        self._lock = threading.Lock()
+
+    def admit(
+        self, owner_config_path: Path | str, policy: Mapping[str, Any]
+    ) -> OwnerControlledE0AdmissionResult:
+        """Revalidate the current signed generation and owner policy."""
+
+        try:
+            path = Path(owner_config_path).resolve()
+            _receipt, checked = self._validate(path, policy)
+        except Exception:
+            return _reject(FAIL_ADMISSION_POLICY)
+        capability = self._capability_type()
+        with self._lock:
+            self._issued[capability] = IssuedAdmission(path, checked)
+        return OwnerControlledE0AdmissionResult(
+            accepted=True,
+            status=ADMISSION_ACCEPT,
+            rejection_reasons=(),
+            policy_id=str(checked["policy_id"]),
+            capability=capability,
+        )
+
+    def consume(self, capability: object) -> OwnerControlledE0ConsumptionReceipt:
+        if not isinstance(capability, self._capability_type):
+            raise ValueError(FAIL_ADMISSION_INPUT)
+        with self._lock:
+            issued = self._issued.pop(capability, None)
+        if (
+            issued is None
+            or object.__getattribute__(capability, "_seal") is not self._seal
+        ):
+            raise ValueError(FAIL_ADMISSION_INPUT)
+        receipt, _checked = self._validate(
+            issued.owner_config_path, issued.policy
+        )
+        return receipt
+
+    def _validate(
+        self,
+        owner_config_path: Path,
+        policy: Mapping[str, Any],
+    ) -> tuple[OwnerControlledE0ConsumptionReceipt, Mapping[str, Any]]:
+        return validate_owner_e0_current_admission(
+            owner_config_path=owner_config_path,
+            repo_root=self._repo_root,
+            policy=policy,
+        )
+
+
+def _reject(reason: str) -> OwnerControlledE0AdmissionResult:
+    return OwnerControlledE0AdmissionResult(False, ADMISSION_REJECT, (reason,))
+
+
+__all__ = [
+    "OwnerControlledE0AdmissionBoundary",
+    "OwnerControlledE0AdmissionResult",
+    "OwnerControlledE0ConsumptionReceipt",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_admission_contract.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_admission_contract.py
@@ -1,0 +1,54 @@
+"""Types and statuses for owner-controlled signer E0 admission."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+ADMISSION_ACCEPT = "SIGNER_OWNER_E0_ADMISSION_ACCEPT"
+ADMISSION_REJECT = "SIGNER_OWNER_E0_ADMISSION_REJECT"
+FAIL_ADMISSION_INPUT = "signer_owner_e0_admission_input_invalid"
+FAIL_ADMISSION_POLICY = "signer_owner_e0_policy_invalid"
+
+
+@dataclass(frozen=True)
+class OwnerControlledE0ConsumptionReceipt:
+    policy_id: str
+    manifest_id: str
+    artifact_generation_digest: str
+    config_digest: str
+    target_signer_agent_id: str
+    target_signer_profile_id: str
+    generation_fenced_during_validation: bool = True
+    no_composition_authority_released: bool = True
+
+
+@dataclass(frozen=True)
+class OwnerControlledE0AdmissionResult:
+    accepted: bool
+    status: str
+    rejection_reasons: tuple[str, ...]
+    policy_id: str = ""
+    capability: object | None = None
+    no_secret_resolution_performed: bool = True
+    no_socket_bound: bool = True
+    no_signer_started: bool = True
+    no_repo_mutation_performed: bool = True
+
+
+@dataclass(frozen=True)
+class IssuedAdmission:
+    owner_config_path: Path
+    policy: Mapping[str, Any]
+
+
+__all__ = [
+    "ADMISSION_ACCEPT",
+    "ADMISSION_REJECT",
+    "FAIL_ADMISSION_INPUT",
+    "FAIL_ADMISSION_POLICY",
+    "IssuedAdmission",
+    "OwnerControlledE0AdmissionResult",
+    "OwnerControlledE0ConsumptionReceipt",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_admission_validation.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_admission_validation.py
@@ -1,0 +1,199 @@
+"""Validation helpers for owner-controlled E0 composition admission."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+    SignerKeyProviderProfile,
+    validate_signer_key_provider_profile,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_bootstrap import (
+    rehydrate_signer_socket_service_runtime_config,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    PrincipalKeyResolver,
+    SignatureVerifier,
+    constant_time_compare,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    secure_read_confined_text,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
+)
+
+from .reddog_signer_owner_e0_policy_contract import (
+    canonical_signer_owner_e0_policy_input,
+    signer_key_reference_digest,
+)
+
+
+def load_selected_signer_config(
+    *,
+    repo_root: Path,
+    selection: Mapping[str, Any],
+    expected_authority_binding_digest: str,
+) -> Any:
+    runtime = validate_runtime_root_path(selection["runtime_root"], repo_root=repo_root)
+    path = validate_runtime_artifact_path(
+        selection["config_path"], repo_root=repo_root, allowed_root=runtime
+    )
+    if path.parent != runtime:
+        raise ValueError("e0_selected_config_path_invalid")
+    text = secure_read_confined_text(path, allowed_root=runtime, max_bytes=256 * 1024)
+    payload = json.loads(text, parse_constant=_reject_constant)
+    if not isinstance(payload, dict):
+        raise ValueError("e0_selected_config_invalid")
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = "sha256:" + hashlib.sha256(canonical.encode("ascii")).hexdigest()
+    if not constant_time_compare(digest, str(selection["config_digest"])):
+        raise ValueError("e0_selected_config_digest_mismatch")
+    if not constant_time_compare(
+        str(payload.get("owner_e0_authority_binding_digest") or ""),
+        expected_authority_binding_digest,
+    ):
+        raise ValueError("e0_policy_authority_binding_mismatch")
+    config = rehydrate_signer_socket_service_runtime_config(
+        repo_root, runtime, payload, expected_config_digest=digest
+    )
+    if config is None:
+        raise ValueError("e0_selected_config_invalid")
+    return config
+
+
+def require_policy_selection_binding(
+    policy: Mapping[str, Any], selection: Mapping[str, Any]
+) -> None:
+    bindings = {
+        "owner_config_id": "owner_config_id",
+        "manifest_id": "manifest_id",
+        "artifact_generation_digest": "artifact_generation_digest",
+        "config_digest": "config_digest",
+        "generation": "generation",
+        "generation_revision": "generation_revision",
+    }
+    if any(policy[left] != selection[right] for left, right in bindings.items()):
+        raise ValueError("e0_policy_generation_binding_mismatch")
+
+
+def require_policy_authorities(
+    policy: Mapping[str, Any],
+    *,
+    principal_key_resolver: PrincipalKeyResolver,
+    signature_verifier: SignatureVerifier,
+) -> None:
+    for prefix in ("grant_authority", "revocation_authority"):
+        principal = str(policy[f"{prefix}_principal_id"])
+        provider = str(policy[f"{prefix}_principal_provider"])
+        public_key = str(policy[f"{prefix}_public_key"])
+        try:
+            trusted = principal_key_resolver.resolve(principal, provider)
+        except Exception:
+            trusted = None
+        if not isinstance(trusted, str) or not constant_time_compare(trusted, public_key):
+            raise ValueError("e0_policy_authority_untrusted")
+        if constant_time_compare(public_key, str(policy["target_signer_public_key"])):
+            raise ValueError("e0_policy_self_authority_rejected")
+    try:
+        verified = signature_verifier.verify(
+            str(policy["grant_authority_public_key"]),
+            canonical_signer_owner_e0_policy_input(policy),
+            str(policy["signature"]),
+        ) is True
+    except Exception:
+        verified = False
+    if not verified:
+        raise ValueError("e0_policy_signature_invalid")
+
+
+def require_policy_config_binding(policy: Mapping[str, Any], config: Any) -> Any:
+    if (
+        config.provider_mode != PROVIDER_MODE_WSP71_PERMISSIONED
+        or config.allow_test_only_key_material is not False
+        or config.permission_snapshot_fresh is not True
+    ):
+        raise ValueError("e0_config_not_production")
+    profiles = _profiles(config)
+    matches = [
+        item for item in profiles
+        if item.signer_agent_id == policy["target_signer_agent_id"]
+        and item.signer_profile_id == policy["target_signer_profile_id"]
+    ]
+    if len(matches) != 1:
+        raise ValueError("e0_target_profile_invalid")
+    profile = matches[0]
+    expected = (
+        (profile.expected_public_key, policy["target_signer_public_key"]),
+        (profile.expected_key_fingerprint, policy["target_signer_key_fingerprint"]),
+        (profile.expected_key_epoch, policy["target_signer_key_epoch"]),
+        (policy["target_signer_generation_id"], policy["artifact_generation_digest"]),
+        (profile.permission_snapshot_digest, policy["permission_snapshot_digest"]),
+        (
+            signer_key_reference_digest(profile.signing_key_ref),
+            policy["signing_key_ref_hash"],
+        ),
+        (
+            signer_key_reference_digest(profile.audit_mac_key_ref),
+            policy["audit_mac_key_ref_hash"],
+        ),
+    )
+    if any(not constant_time_compare(str(left), str(right)) for left, right in expected):
+        raise ValueError("e0_target_profile_binding_mismatch")
+    if not constant_time_compare(
+        public_key_fingerprint(profile.expected_public_key),
+        str(policy["target_signer_key_fingerprint"]),
+    ):
+        raise ValueError("e0_target_profile_binding_mismatch")
+    return profile
+
+
+def require_policy_runtime_paths(
+    policy: Mapping[str, Any], *, repo_root: Path, signer_runtime_root: Path
+) -> None:
+    roots: list[Path] = []
+    for prefix in ("replay", "revocation"):
+        root = validate_runtime_root_path(policy[f"{prefix}_root"], repo_root=repo_root)
+        path = validate_runtime_artifact_path(
+            policy[f"{prefix}_path"], repo_root=repo_root, allowed_root=root
+        )
+        overlaps_signer_root = (
+            root == signer_runtime_root
+            or root in signer_runtime_root.parents
+            or signer_runtime_root in root.parents
+        )
+        if path.parent != root or overlaps_signer_root:
+            raise ValueError("e0_policy_runtime_path_invalid")
+        roots.append(root)
+    if roots[0] == roots[1] or roots[0] in roots[1].parents or roots[1] in roots[0].parents:
+        raise ValueError("e0_policy_runtime_roots_not_disjoint")
+
+
+def _profiles(config: Any) -> tuple[SignerKeyProviderProfile, ...]:
+    values = tuple(config.key_provider_profiles) or (config.key_provider_profile,)
+    profiles: list[SignerKeyProviderProfile] = []
+    for value in values:
+        profile = value if type(value) is SignerKeyProviderProfile else SignerKeyProviderProfile(**dict(value))
+        if validate_signer_key_provider_profile(profile):
+            raise ValueError("e0_target_profile_invalid")
+        profiles.append(profile)
+    return tuple(profiles)
+
+
+def _reject_constant(_value: str) -> None:
+    raise ValueError("e0_selected_config_invalid")
+
+
+__all__ = [
+    "load_selected_signer_config",
+    "require_policy_authorities",
+    "require_policy_config_binding",
+    "require_policy_runtime_paths",
+    "require_policy_selection_binding",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_capability_state.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_capability_state.py
@@ -1,0 +1,51 @@
+"""Immutable internal policy state for owner-controlled E0 capabilities."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Any, Mapping
+
+
+def freeze_owner_e0_policy(policy: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType(
+        {
+            key: tuple(value) if isinstance(value, list) else value
+            for key, value in policy.items()
+        }
+    )
+
+
+def thaw_owner_e0_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: list(value) if isinstance(value, tuple) else value
+        for key, value in policy.items()
+    }
+
+
+def owner_e0_capability_type(seal: object) -> type:
+    class Capability:
+        __slots__ = ("_seal", "__weakref__")
+
+        def __init__(self) -> None:
+            object.__setattr__(self, "_seal", seal)
+
+        def __setattr__(self, _name: str, _value: Any) -> None:
+            raise TypeError("signer_owner_e0_capability_immutable")
+
+        def __copy__(self) -> object:
+            raise TypeError("signer_owner_e0_capability_not_copyable")
+
+        def __deepcopy__(self, _memo: Any) -> object:
+            raise TypeError("signer_owner_e0_capability_not_copyable")
+
+        def __reduce__(self) -> object:
+            raise TypeError("signer_owner_e0_capability_not_serializable")
+
+    return Capability
+
+
+__all__ = [
+    "freeze_owner_e0_policy",
+    "owner_e0_capability_type",
+    "thaw_owner_e0_policy",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_current_selection.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_current_selection.py
@@ -1,0 +1,128 @@
+"""Root-owned current-generation selection for signer E0 admission."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    Ed25519SignatureVerifier,
+)
+
+from modules.communication.moltbot_bridge.src.reddog_signer_system_service_manifest_selection_loader import (
+    load_system_service_manifest_selection,
+)
+
+from .reddog_signer_owner_e0_admission_contract import (
+    OwnerControlledE0ConsumptionReceipt,
+)
+from .reddog_signer_owner_e0_admission_validation import (
+    load_selected_signer_config,
+    require_policy_authorities,
+    require_policy_config_binding,
+    require_policy_runtime_paths,
+    require_policy_selection_binding,
+)
+from .reddog_signer_owner_e0_capability_state import (
+    freeze_owner_e0_policy,
+    thaw_owner_e0_policy,
+)
+from .reddog_signer_owner_e0_policy_contract import (
+    signer_owner_e0_authority_binding_digest,
+    validated_signer_owner_e0_policy,
+)
+from .reddog_signer_owner_e0_principal_authority import (
+    load_current_generation_principal_key_resolver,
+)
+
+
+def load_owner_e0_current_selection(
+    *, owner_config_path: Path | str, repo_root: Path
+) -> Mapping[str, Any]:
+    capability, boundary = load_system_service_manifest_selection(
+        owner_config_path=owner_config_path,
+        repo_root=repo_root,
+    )
+    selected = boundary.consume(capability)
+    if Path(str(selected.get("repo_root") or "")).resolve() != repo_root.resolve():
+        raise ValueError("e0_selection_repo_root_mismatch")
+    return selected
+
+
+def validate_owner_e0_current_admission(
+    *,
+    owner_config_path: Path | str,
+    repo_root: Path,
+    policy: Mapping[str, Any],
+) -> tuple[OwnerControlledE0ConsumptionReceipt, Mapping[str, Any]]:
+    """Validate E0 inputs under the private current-generation lease."""
+
+    capability, boundary = load_system_service_manifest_selection(
+        owner_config_path=owner_config_path,
+        repo_root=repo_root,
+    )
+    with boundary._lease_current(capability) as selected:
+        if Path(str(selected.get("repo_root") or "")).resolve() != repo_root.resolve():
+            raise ValueError("e0_selection_repo_root_mismatch")
+        return _validate_selected(repo_root.resolve(), selected, policy)
+
+
+def _validate_selected(
+    repo_root: Path,
+    selection: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> tuple[OwnerControlledE0ConsumptionReceipt, Mapping[str, Any]]:
+    checked = validated_signer_owner_e0_policy(
+        thaw_owner_e0_policy(policy), now_epoch=int(time.time())
+    )
+    require_policy_selection_binding(checked, selection)
+    config = load_selected_signer_config(
+        repo_root=repo_root,
+        selection=selection,
+        expected_authority_binding_digest=(
+            signer_owner_e0_authority_binding_digest(checked)
+        ),
+    )
+    profile = require_policy_config_binding(checked, config)
+    resolver = load_current_generation_principal_key_resolver(
+        repo_root=repo_root, selection=selection
+    )
+    require_policy_authorities(
+        checked,
+        principal_key_resolver=resolver,
+        signature_verifier=Ed25519SignatureVerifier(),
+    )
+    require_policy_runtime_paths(
+        checked,
+        repo_root=repo_root,
+        signer_runtime_root=Path(config.signer_runtime_root).resolve(),
+    )
+    _require_consensus_policy(checked)
+    return _receipt(checked, selection, profile), freeze_owner_e0_policy(checked)
+
+
+def _receipt(
+    policy: Mapping[str, Any], selection: Mapping[str, Any], profile: Any
+) -> OwnerControlledE0ConsumptionReceipt:
+    return OwnerControlledE0ConsumptionReceipt(
+        policy_id=str(policy["policy_id"]),
+        manifest_id=str(selection["manifest_id"]),
+        artifact_generation_digest=str(selection["artifact_generation_digest"]),
+        config_digest=str(selection["config_digest"]),
+        target_signer_agent_id=profile.signer_agent_id,
+        target_signer_profile_id=profile.signer_profile_id,
+    )
+
+
+def _require_consensus_policy(policy: Mapping[str, Any]) -> None:
+    tiers = set(policy["allowed_authority_tiers"])
+    consensus = set(policy["consensus_required_tiers"])
+    if tiers.intersection({"HIGH", "SOVEREIGN"}) - consensus:
+        raise ValueError("signer_owner_e0_consensus_policy_invalid")
+
+
+__all__ = [
+    "load_owner_e0_current_selection",
+    "validate_owner_e0_current_admission",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_policy_contract.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_policy_contract.py
@@ -1,0 +1,198 @@
+"""Signed owner policy contract for production E0 signer composition."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_runtime_artifact_manifest_contract import (
+    ascii_deep,
+    is_sha256,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    canonical_signing_input,
+)
+
+
+POLICY_SCHEMA = "reddog-signer-owner-e0-policy.v1"
+POLICY_PREFIX = POLICY_SCHEMA
+MAX_POLICY_TTL_SECONDS = 900
+POLICY_FIELDS = frozenset(
+    {
+        "schema_version",
+        "policy_id",
+        "owner_config_id",
+        "manifest_id",
+        "artifact_generation_digest",
+        "config_digest",
+        "generation",
+        "generation_revision",
+        "grant_authority_principal_id",
+        "grant_authority_principal_provider",
+        "grant_authority_public_key",
+        "revocation_authority_principal_id",
+        "revocation_authority_principal_provider",
+        "revocation_authority_public_key",
+        "target_signer_agent_id",
+        "target_signer_profile_id",
+        "target_signer_public_key",
+        "target_signer_key_fingerprint",
+        "target_signer_key_epoch",
+        "target_signer_generation_id",
+        "signing_key_ref_hash",
+        "audit_mac_key_ref_hash",
+        "permission_snapshot_digest",
+        "permission_snapshot_receipt_id",
+        "replay_root",
+        "replay_path",
+        "replay_store_id",
+        "replay_store_durability_receipt_id",
+        "revocation_root",
+        "revocation_path",
+        "revocation_store_id",
+        "revocation_store_durability_receipt_id",
+        "allowed_operations",
+        "allowed_authority_tiers",
+        "consensus_required_tiers",
+        "rate_limit_window_seconds",
+        "rate_limit_max_requests",
+        "issued_at",
+        "expires_at",
+        "signature",
+    }
+)
+_DIGEST_FIELDS = (
+    "policy_id",
+    "owner_config_id",
+    "manifest_id",
+    "artifact_generation_digest",
+    "config_digest",
+    "target_signer_key_fingerprint",
+    "target_signer_generation_id",
+    "signing_key_ref_hash",
+    "audit_mac_key_ref_hash",
+    "permission_snapshot_digest",
+    "permission_snapshot_receipt_id",
+    "replay_store_durability_receipt_id",
+    "revocation_store_durability_receipt_id",
+)
+_LIST_FIELDS = (
+    "allowed_operations",
+    "allowed_authority_tiers",
+    "consensus_required_tiers",
+)
+_AUTHORITY_BINDING_FIELDS = POLICY_FIELDS - {
+    "schema_version",
+    "policy_id",
+    "owner_config_id",
+    "manifest_id",
+    "artifact_generation_digest",
+    "config_digest",
+    "generation",
+    "generation_revision",
+    "issued_at",
+    "expires_at",
+    "signature",
+}
+
+
+def signer_owner_e0_policy_id(value: Mapping[str, Any]) -> str:
+    core = {
+        key: value[key]
+        for key in sorted(POLICY_FIELDS - {"policy_id", "signature"})
+    }
+    raw = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(raw.encode("ascii")).hexdigest()
+
+
+def signer_key_reference_digest(reference: str) -> str:
+    if type(reference) is not str or not reference or not reference.isascii():
+        raise ValueError("signer_owner_e0_key_reference_invalid")
+    return "sha256:" + hashlib.sha256(reference.encode("ascii")).hexdigest()
+
+
+def signer_owner_e0_authority_binding_digest(value: Mapping[str, Any]) -> str:
+    try:
+        core = {key: value[key] for key in sorted(_AUTHORITY_BINDING_FIELDS)}
+        raw = json.dumps(core, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        encoded = raw.encode("ascii")
+    except (KeyError, TypeError, UnicodeEncodeError) as exc:
+        raise ValueError("signer_owner_e0_authority_binding_invalid") from exc
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def canonical_signer_owner_e0_policy_input(value: Mapping[str, Any]) -> str:
+    return canonical_signing_input(value, POLICY_PREFIX)
+
+
+def validated_signer_owner_e0_policy(value: Mapping[str, Any], *, now_epoch: int) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or type(now_epoch) is not int:
+        raise ValueError("signer_owner_e0_policy_malformed")
+    raw = {key: list(item) if isinstance(item, list) else item for key, item in value.items()}
+    if set(raw) != POLICY_FIELDS or raw.get("schema_version") != POLICY_SCHEMA:
+        raise ValueError("signer_owner_e0_policy_malformed")
+    if not ascii_deep(raw) or not _types_valid(raw):
+        raise ValueError("signer_owner_e0_policy_malformed")
+    if any(not is_sha256(str(raw[name])) for name in _DIGEST_FIELDS):
+        raise ValueError("signer_owner_e0_policy_digest_invalid")
+    if raw["policy_id"] != signer_owner_e0_policy_id(raw):
+        raise ValueError("signer_owner_e0_policy_id_invalid")
+    _require_time(raw, now_epoch)
+    _require_lists(raw)
+    return raw
+
+
+def _types_valid(raw: Mapping[str, Any]) -> bool:
+    integers = {
+        "generation",
+        "rate_limit_window_seconds",
+        "rate_limit_max_requests",
+        "issued_at",
+        "expires_at",
+    }
+    strings = POLICY_FIELDS - integers - set(_LIST_FIELDS)
+    return bool(
+        all(type(raw.get(name)) is int for name in integers)
+        and all(type(raw.get(name)) is str and raw[name] for name in strings)
+        and all(type(raw.get(name)) is list for name in _LIST_FIELDS)
+    )
+
+
+def _require_time(raw: Mapping[str, Any], now_epoch: int) -> None:
+    issued = raw["issued_at"]
+    expires = raw["expires_at"]
+    if (
+        raw["generation"] < 1
+        or not 0 <= issued <= now_epoch < expires
+        or not 0 < expires - issued <= MAX_POLICY_TTL_SECONDS
+        or not 1 <= raw["rate_limit_window_seconds"] <= 3600
+        or not 1 <= raw["rate_limit_max_requests"] <= 1000
+    ):
+        raise ValueError("signer_owner_e0_policy_time_invalid")
+
+
+def _require_lists(raw: Mapping[str, Any]) -> None:
+    for name in _LIST_FIELDS:
+        values = raw[name]
+        if (
+            not values
+            or len(values) > 64
+            or values != sorted(set(values))
+            or any(type(item) is not str or not item or not item.isascii() for item in values)
+        ):
+            raise ValueError("signer_owner_e0_policy_scope_invalid")
+    if not set(raw["consensus_required_tiers"]).issubset(
+        raw["allowed_authority_tiers"]
+    ):
+        raise ValueError("signer_owner_e0_policy_scope_invalid")
+
+__all__ = [
+    "POLICY_FIELDS",
+    "POLICY_SCHEMA",
+    "canonical_signer_owner_e0_policy_input",
+    "signer_key_reference_digest",
+    "signer_owner_e0_authority_binding_digest",
+    "signer_owner_e0_policy_id",
+    "validated_signer_owner_e0_policy",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_principal_authority.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_owner_e0_principal_authority.py
@@ -1,0 +1,191 @@
+"""Current-generation principal authority for signer E0 admission."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
+    PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_runtime_artifact_manifest_contract import (
+    MAX_ARTIFACT_BYTES,
+    ascii_deep,
+    is_sha256,
+    raw_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
+    constant_time_compare,
+)
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    secure_read_confined_bytes,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
+)
+
+
+SCHEMA_VERSION = "reddog_authority_runtime_resolver_supply.v1"
+TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "principals",
+        "principal_count",
+        "resolver_supply_receipt_id",
+        "no_holoindex_reindex_performed",
+    }
+)
+RECORD_FIELDS = frozenset(
+    {
+        "principal_id",
+        "principal_provider",
+        "principal_public_key",
+        "repo_scope",
+        "foundup_scope",
+        "verified_subject_digest",
+        "reward_account",
+        "owner_dae",
+        "principal_wallet",
+    }
+)
+
+
+class CurrentGenerationPrincipalKeyResolver:
+    """Resolve keys only from a manifest-bound principal artifact."""
+
+    def __init__(self, records: Mapping[str, PrincipalAuthorityRecord]) -> None:
+        self._records = dict(records)
+
+    def resolve(self, principal_id: str, principal_provider: str) -> str | None:
+        record = self._records.get(_key(principal_id, principal_provider))
+        return record.principal_public_key if record is not None else None
+
+
+def load_current_generation_principal_key_resolver(
+    *, repo_root: Path, selection: Mapping[str, Any]
+) -> CurrentGenerationPrincipalKeyResolver:
+    """Read and verify the principal artifact selected by the signed manifest."""
+
+    runtime = validate_runtime_root_path(
+        selection["runtime_root"], repo_root=repo_root
+    )
+    target = validate_runtime_artifact_path(
+        selection["principal_authority_records_path"],
+        repo_root=repo_root,
+        allowed_root=runtime,
+    )
+    if target != runtime / "principal_authority_records.json":
+        raise ValueError("e0_principal_authority_path_invalid")
+    raw, _ = secure_read_confined_bytes(
+        target, allowed_root=runtime, max_bytes=MAX_ARTIFACT_BYTES
+    )
+    if not constant_time_compare(
+        raw_digest(raw),
+        str(selection["principal_authority_records_digest"]),
+    ):
+        raise ValueError("e0_principal_authority_digest_mismatch")
+    return CurrentGenerationPrincipalKeyResolver(_parse_records(raw))
+
+
+def _parse_records(raw: bytes) -> Mapping[str, PrincipalAuthorityRecord]:
+    try:
+        payload = json.loads(
+            raw.decode("ascii"), object_pairs_hook=_unique_object
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError("e0_principal_authority_malformed") from exc
+    values = payload.get("principals") if isinstance(payload, Mapping) else None
+    if (
+        set(payload) != TOP_LEVEL_FIELDS
+        or payload.get("schema_version") != SCHEMA_VERSION
+        or not isinstance(values, Mapping)
+        or type(payload.get("principal_count")) is not int
+        or payload.get("principal_count") != len(values)
+        or not is_sha256(payload.get("resolver_supply_receipt_id"))
+        or payload.get("no_holoindex_reindex_performed") is not True
+    ):
+        raise ValueError("e0_principal_authority_shape_invalid")
+    records: dict[str, PrincipalAuthorityRecord] = {}
+    try:
+        for claimed_key, value in values.items():
+            if not isinstance(value, Mapping):
+                raise ValueError("e0_principal_authority_shape_invalid")
+            if set(value) != RECORD_FIELDS or not ascii_deep(value):
+                raise ValueError("e0_principal_authority_shape_invalid")
+            record = _record(value)
+            canonical_key = _key(record.principal_id, record.principal_provider)
+            if str(claimed_key) != canonical_key:
+                raise ValueError("e0_principal_authority_key_invalid")
+            if canonical_key in records:
+                raise ValueError("e0_principal_authority_duplicate")
+            records[canonical_key] = record
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("e0_principal_authority_record_invalid") from exc
+    return records
+
+
+def _record(value: Mapping[str, Any]) -> PrincipalAuthorityRecord:
+    text = (
+        value["principal_id"],
+        value["principal_provider"],
+        value["principal_public_key"],
+    )
+    repo_scope = tuple(value.get("repo_scope") or ())
+    foundup_scope = tuple(value.get("foundup_scope") or ())
+    if (
+        any(not _text(item) for item in text)
+        or not repo_scope
+        or not foundup_scope
+        or any(not _text(item) for item in (*repo_scope, *foundup_scope))
+        or not is_sha256(value.get("verified_subject_digest"))
+    ):
+        raise ValueError("e0_principal_authority_value_invalid")
+    return PrincipalAuthorityRecord(
+        principal_id=str(value["principal_id"]),
+        principal_provider=str(value["principal_provider"]),
+        principal_public_key=str(value["principal_public_key"]),
+        repo_scope=tuple(str(item) for item in value.get("repo_scope") or ()),
+        foundup_scope=tuple(
+            str(item) for item in value.get("foundup_scope") or ()
+        ),
+        verified_subject_digest=str(value["verified_subject_digest"]),
+        reward_account=_optional(value.get("reward_account")),
+        owner_dae=_optional(value.get("owner_dae")),
+        principal_wallet=_optional(value.get("principal_wallet")),
+    )
+
+
+def _optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not _text(value):
+        raise ValueError("e0_principal_authority_value_invalid")
+    return str(value)
+
+
+def _text(value: Any) -> bool:
+    return bool(
+        isinstance(value, str)
+        and value.strip()
+        and value.isascii()
+        and len(value) <= 1024
+    )
+
+
+def _key(principal_id: str, principal_provider: str) -> str:
+    return f"{principal_provider}|{principal_id}"
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("e0_principal_authority_duplicate_json_key")
+        value[key] = item
+    return value
+
+
+__all__ = [
+    "CurrentGenerationPrincipalKeyResolver",
+    "load_current_generation_principal_key_resolver",
+]

--- a/modules/communication/moltbot_bridge/tests/README.md
+++ b/modules/communication/moltbot_bridge/tests/README.md
@@ -28,6 +28,17 @@ Optional custom args:
 .\modules\communication\moltbot_bridge\tests\run_tests.ps1 -PytestArgs @("-q", "-k", "skill_safety")
 ```
 
+Focused owner-controlled signer E0 admission:
+```powershell
+python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_controlled_e0_admission.py modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_e0_static_contract.py -q
+```
+
+This suite uses only temporary runtime roots and generated public/private test
+keys. It proves exact selection-tuple binding and fail-closed admission;
+manifest-bound principal authority and generation-fenced consumption are also
+covered. It does not resolve secrets, start a signer, bind a socket, or write
+the repo.
+
 Focused RedDog WRE operational spine:
 ```powershell
 python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_wre_operational_spine.py modules/communication/moltbot_bridge/tests/test_reddog_wre_worktree_create.py modules/communication/moltbot_bridge/tests/test_reddog_wre_execution_valve.py modules/communication/moltbot_bridge/tests/test_reddog_wre_executor_dryrun.py modules/communication/moltbot_bridge/tests/test_reddog_work_order_runtime_invocation.py -q

--- a/modules/communication/moltbot_bridge/tests/test_reddog_current_generation_manifest_launch_selection.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_current_generation_manifest_launch_selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import copy
 import json
+from contextlib import contextmanager
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
@@ -105,6 +106,30 @@ def test_current_generation_mints_one_shot_selection(tmp_path: Path) -> None:
         subject.consume(capability)
 
 
+def test_trusted_consumer_runs_inside_generation_fence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _harness, _manifest, subject = _prepared(tmp_path)
+    state = {"active": False}
+
+    @contextmanager
+    def fence(*_args: object, **_kwargs: object):
+        state["active"] = True
+        try:
+            yield
+        finally:
+            state["active"] = False
+
+    monkeypatch.setattr(
+        selection_module, "reddog_runtime_artifact_generation_lock", fence
+    )
+    capability = subject.select({}, now_epoch=NOW)
+
+    with subject._lease_current(capability) as _selected:
+        assert state["active"] is True
+    assert state["active"] is False
+
+
 def test_selection_expires_before_consumption(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -112,6 +137,22 @@ def test_selection_expires_before_consumption(
     monkeypatch.setattr(selection_module, "_now_epoch", lambda: NOW)
     capability = subject.select({}, now_epoch=NOW)
     monkeypatch.setattr(selection_module, "_now_epoch", lambda: NOW + 31)
+
+    with pytest.raises(
+        RuntimeArtifactManifestError,
+        match="manifest_launch_selection_expired",
+    ):
+        subject.consume(capability)
+
+
+def test_selection_freshness_rechecks_after_generation_lock_wait(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _harness, _manifest, subject = _prepared(tmp_path)
+    monkeypatch.setattr(selection_module, "_now_epoch", lambda: NOW)
+    capability = subject.select({}, now_epoch=NOW)
+    times = iter((NOW, NOW + 31))
+    monkeypatch.setattr(selection_module, "_now_epoch", lambda: next(times))
 
     with pytest.raises(
         RuntimeArtifactManifestError,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_controlled_e0_admission.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_controlled_e0_admission.py
@@ -1,0 +1,668 @@
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_backend import (
+    encode_ed25519_public_key,
+    encode_ed25519_signature,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
+    public_key_fingerprint,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_key_provider_dryrun import (
+    PROVIDER_MODE_WSP71_PERMISSIONED,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_owner_controlled_e0_admission import (
+    OwnerControlledE0AdmissionBoundary,
+)
+from modules.communication.moltbot_bridge.src import (
+    reddog_signer_owner_e0_current_selection as current_selection_module,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_owner_e0_policy_contract import (
+    POLICY_SCHEMA,
+    canonical_signer_owner_e0_policy_input,
+    signer_key_reference_digest,
+    signer_owner_e0_authority_binding_digest,
+    signer_owner_e0_policy_id,
+)
+from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_config_supply import (
+    SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+)
+
+
+pytest.importorskip("cryptography")
+
+DIGEST_A = "sha256:" + "a" * 64
+DIGEST_B = "sha256:" + "b" * 64
+DIGEST_C = "sha256:" + "c" * 64
+DIGEST_D = "sha256:" + "d" * 64
+DIGEST_E = "sha256:" + "e" * 64
+_CURRENT_SELECTION: dict[str, object] = {}
+SLICE_MODULES = (
+    "reddog_signer_owner_e0_policy_contract.py",
+    "reddog_signer_owner_e0_admission_contract.py",
+    "reddog_signer_owner_e0_admission_validation.py",
+    "reddog_signer_owner_e0_capability_state.py",
+    "reddog_signer_owner_e0_current_selection.py",
+    "reddog_signer_owner_e0_principal_authority.py",
+    "reddog_signer_owner_controlled_e0_admission.py",
+)
+
+
+class _SelectionBoundary:
+    def __init__(self, capability: object, selection: dict[str, object]) -> None:
+        self.capability = capability
+        self.selection = selection
+        self.used = False
+
+    def consume(self, value: object) -> dict[str, object]:
+        if value is not self.capability or self.used:
+            raise ValueError("selection_unverified")
+        self.used = True
+        return dict(self.selection)
+
+    @contextmanager
+    def _lease_current(self, value: object):
+        selected = self.consume(value)
+        try:
+            yield selected
+        finally:
+            if selected != dict(self.selection):
+                raise ValueError("selection_changed_during_consumer")
+
+
+@pytest.fixture(autouse=True)
+def _root_owned_selection_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    def load(**_kwargs: object) -> tuple[object, _SelectionBoundary]:
+        capability = object()
+        return capability, _SelectionBoundary(capability, _CURRENT_SELECTION)
+
+    monkeypatch.setattr(
+        current_selection_module,
+        "load_system_service_manifest_selection",
+        load,
+    )
+
+
+def _keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private = Ed25519PrivateKey.generate()
+    public = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    return private, encode_ed25519_public_key(public)
+
+
+def _canonical_digest(value: object) -> str:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return "sha256:" + hashlib.sha256(raw.encode("ascii")).hexdigest()
+
+
+def _fixture_roots(tmp_path: Path) -> dict[str, Path]:
+    roots = {
+        name: tmp_path / name
+        for name in ("repo", "runtime", "signer", "replay", "revocation")
+    }
+    for path in roots.values():
+        path.mkdir()
+    return roots
+
+
+def _write_fixture_config(
+    roots: dict[str, Path],
+    policy: dict[str, object],
+    target_public: str,
+    signing_ref: str,
+    audit_ref: str,
+) -> tuple[dict[str, object], Path, str]:
+    config = _config(
+        repo=roots["repo"],
+        runtime=roots["runtime"],
+        signer=roots["signer"],
+        target_public=target_public,
+        signing_ref=signing_ref,
+        audit_ref=audit_ref,
+        authority_binding_digest=signer_owner_e0_authority_binding_digest(policy),
+    )
+    config_path = roots["runtime"] / "reddog-signer-service.json"
+    config_path.write_text(json.dumps(config, sort_keys=True), encoding="ascii")
+    return config, config_path, _canonical_digest(config)
+
+
+def _write_fixture_principals(
+    runtime_root: Path, grant_public: str, revocation_public: str
+) -> tuple[dict[str, object], Path]:
+    payload = _principals(grant_public, revocation_public)
+    path = runtime_root / "principal_authority_records.json"
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="ascii")
+    return payload, path
+
+
+def _fixture_selection(
+    roots: dict[str, Path], config_path: Path, config_digest: str, principal_path: Path
+) -> dict[str, object]:
+    return {
+        "owner_config_id": DIGEST_A,
+        "manifest_id": DIGEST_B,
+        "artifact_generation_digest": DIGEST_C,
+        "config_digest": config_digest,
+        "generation": 4,
+        "generation_revision": "revision-4",
+        "repo_root": str(roots["repo"].resolve()),
+        "runtime_root": str(roots["runtime"].resolve()),
+        "config_path": str(config_path.resolve()),
+        "principal_authority_records_path": str(principal_path.resolve()),
+        "principal_authority_records_digest": _raw_file_digest(principal_path),
+    }
+
+
+def _fixture(tmp_path: Path) -> dict[str, object]:
+    roots = _fixture_roots(tmp_path)
+    target_private, target_public = _keypair()
+    grant_private, grant_public = _keypair()
+    _, revocation_public = _keypair()
+    signing_ref = "op://Foundups/reddog-signing/private"
+    audit_ref = "op://Foundups/reddog-signing/audit"
+    policy = _policy(
+        selection={
+            "owner_config_id": DIGEST_A,
+            "manifest_id": DIGEST_B,
+            "artifact_generation_digest": DIGEST_C,
+            "config_digest": DIGEST_E,
+            "generation": 4,
+            "generation_revision": "revision-4",
+        },
+        signer=roots["signer"],
+        replay=roots["replay"],
+        revocation=roots["revocation"],
+        target_public=target_public,
+        grant_public=grant_public,
+        revocation_public=revocation_public,
+        signing_ref=signing_ref,
+        audit_ref=audit_ref,
+    )
+    config, config_path, config_digest = _write_fixture_config(
+        roots, policy, target_public, signing_ref, audit_ref
+    )
+    principal_payload, principal_path = _write_fixture_principals(
+        roots["runtime"], grant_public, revocation_public
+    )
+    selection = _fixture_selection(roots, config_path, config_digest, principal_path)
+    policy["config_digest"] = config_digest
+    policy["policy_id"] = signer_owner_e0_policy_id(policy)
+    policy["signature"] = encode_ed25519_signature(
+        grant_private.sign(canonical_signer_owner_e0_policy_input(policy).encode("ascii"))
+    )
+    _CURRENT_SELECTION.clear()
+    _CURRENT_SELECTION.update(selection)
+    return {
+        "boundary": OwnerControlledE0AdmissionBoundary(repo_root=roots["repo"]),
+        "owner_config_path": tmp_path / "owner-config.json",
+        "policy": policy,
+        "selection": selection,
+        "config": config,
+        "config_path": config_path,
+        "principal_payload": principal_payload,
+        "principal_path": principal_path,
+        "grant_private": grant_private,
+        "grant_public": grant_public,
+        "target_private": target_private,
+        "target_public": target_public,
+    }
+
+
+def _principals(grant_public: str, revocation_public: str) -> dict[str, object]:
+    records = {}
+    for principal_id, public_key in (
+        ("principal:grant-admin", grant_public),
+        ("principal:revocation-admin", revocation_public),
+    ):
+        records[f"github|{principal_id}"] = {
+            "principal_id": principal_id,
+            "principal_provider": "github",
+            "principal_public_key": public_key,
+            "repo_scope": ["FOUNDUPS/Foundups-Agent"],
+            "foundup_scope": ["*"],
+            "verified_subject_digest": DIGEST_A,
+            "reward_account": None,
+            "owner_dae": None,
+            "principal_wallet": None,
+        }
+    return {
+        "schema_version": "reddog_authority_runtime_resolver_supply.v1",
+        "principal_count": len(records),
+        "principals": records,
+        "resolver_supply_receipt_id": DIGEST_B,
+        "no_holoindex_reindex_performed": True,
+    }
+
+
+def _raw_file_digest(path: Path) -> str:
+    return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _config(
+    *, repo: Path, runtime: Path, signer: Path, target_public: str,
+    signing_ref: str, audit_ref: str, authority_binding_digest: str,
+) -> dict[str, object]:
+    del repo
+    return {
+        "schema_version": SIGNER_SERVICE_CONFIG_SCHEMA_VERSION,
+        "runtime_root": str(runtime.resolve()),
+        "signer_runtime_root": str(signer.resolve()),
+        "socket_path": str((runtime / "signer.sock").resolve()),
+        "control_loop_anchor_path": str((signer / "anchor.json").resolve()),
+        "control_loop_authority_policy": {
+            "issuer_principal_id": "principal:grant-admin",
+            "signer_public_key": target_public,
+            "key_epoch": "target-epoch-1",
+            "consensus_receipt_digest": DIGEST_D,
+            "authority_profile_digest": DIGEST_E,
+            "authority_profile_source_receipt_id": DIGEST_A,
+        },
+        "provider_mode": PROVIDER_MODE_WSP71_PERMISSIONED,
+        "allow_test_only_key_material": False,
+        "permission_snapshot_fresh": True,
+        "owner_e0_authority_binding_digest": authority_binding_digest,
+        "max_requests": 3,
+        "timeout_s": 2.5,
+        "max_request_bytes": 4096,
+        "max_response_bytes": 8192,
+        "key_provider_profiles": [{
+            "signer_profile_id": "reddog-work-authority",
+            "signer_agent_id": "signer:reddog",
+            "signing_key_ref": signing_ref,
+            "audit_mac_key_ref": audit_ref,
+            "expected_public_key": target_public,
+            "expected_key_fingerprint": public_key_fingerprint(target_public),
+            "expected_key_epoch": "target-epoch-1",
+            "permission_snapshot_digest": DIGEST_D,
+            "ttl_seconds": 60,
+        }],
+        "peer_policy": {
+            "uid_to_principal": {"1001": "principal:grant-admin"},
+            "allowed_gids": [1002],
+            "transport": "unix_socket",
+            "credential_source_prefix": "kernel_peer_credential",
+        },
+    }
+
+
+def _policy(
+    *, selection: dict[str, object], signer: Path, replay: Path,
+    revocation: Path, target_public: str, grant_public: str,
+    revocation_public: str, signing_ref: str, audit_ref: str,
+) -> dict[str, object]:
+    return {
+        "schema_version": POLICY_SCHEMA,
+        "policy_id": DIGEST_A,
+        **{name: selection[name] for name in (
+            "owner_config_id", "manifest_id", "artifact_generation_digest",
+            "config_digest", "generation", "generation_revision",
+        )},
+        "grant_authority_principal_id": "principal:grant-admin",
+        "grant_authority_principal_provider": "github",
+        "grant_authority_public_key": grant_public,
+        "revocation_authority_principal_id": "principal:revocation-admin",
+        "revocation_authority_principal_provider": "github",
+        "revocation_authority_public_key": revocation_public,
+        "target_signer_agent_id": "signer:reddog",
+        "target_signer_profile_id": "reddog-work-authority",
+        "target_signer_public_key": target_public,
+        "target_signer_key_fingerprint": public_key_fingerprint(target_public),
+        "target_signer_key_epoch": "target-epoch-1",
+        "target_signer_generation_id": selection["artifact_generation_digest"],
+        "signing_key_ref_hash": signer_key_reference_digest(signing_ref),
+        "audit_mac_key_ref_hash": signer_key_reference_digest(audit_ref),
+        "permission_snapshot_digest": DIGEST_D,
+        "permission_snapshot_receipt_id": DIGEST_E,
+        "replay_root": str(replay.resolve()),
+        "replay_path": str((replay / "grant-nonces.db").resolve()),
+        "replay_store_id": "signer-grant-replay",
+        "replay_store_durability_receipt_id": DIGEST_A,
+        "revocation_root": str(revocation.resolve()),
+        "revocation_path": str((revocation / "revocations.db").resolve()),
+        "revocation_store_id": "signer-grant-revocations",
+        "revocation_store_durability_receipt_id": DIGEST_B,
+        "allowed_operations": ["issue_work_authority"],
+        "allowed_authority_tiers": ["HIGH", "SOVEREIGN"],
+        "consensus_required_tiers": ["HIGH", "SOVEREIGN"],
+        "rate_limit_window_seconds": 60,
+        "rate_limit_max_requests": 10,
+        "issued_at": int(time.time()) - 10,
+        "expires_at": int(time.time()) + 200,
+        "signature": "pending",
+    }
+
+
+def _resign(fixture: dict[str, object]) -> None:
+    policy = fixture["policy"]
+    assert isinstance(policy, dict)
+    policy["policy_id"] = signer_owner_e0_policy_id(policy)
+    private = fixture["grant_private"]
+    policy["signature"] = encode_ed25519_signature(
+        private.sign(canonical_signer_owner_e0_policy_input(policy).encode("ascii"))
+    )
+
+
+def _write_principal_artifact(fixture: dict[str, object]) -> None:
+    path = fixture["principal_path"]
+    path.write_text(
+        json.dumps(fixture["principal_payload"], sort_keys=True),
+        encoding="ascii",
+    )
+    digest = _raw_file_digest(path)
+    fixture["selection"]["principal_authority_records_digest"] = digest
+    _CURRENT_SELECTION["principal_authority_records_digest"] = digest
+
+
+def _rebind_config_and_sign(fixture: dict[str, object], private: object) -> None:
+    policy = fixture["policy"]
+    config = fixture["config"]
+    config["owner_e0_authority_binding_digest"] = (
+        signer_owner_e0_authority_binding_digest(policy)
+    )
+    fixture["config_path"].write_text(
+        json.dumps(config, sort_keys=True), encoding="ascii"
+    )
+    config_digest = _canonical_digest(config)
+    fixture["selection"]["config_digest"] = config_digest
+    _CURRENT_SELECTION["config_digest"] = config_digest
+    policy["config_digest"] = config_digest
+    policy["policy_id"] = signer_owner_e0_policy_id(policy)
+    policy["signature"] = encode_ed25519_signature(
+        private.sign(canonical_signer_owner_e0_policy_input(policy).encode("ascii"))
+    )
+
+
+def test_current_signed_generation_and_policy_issue_one_opaque_capability(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(fixture["owner_config_path"], fixture["policy"])
+    assert result.accepted is True
+    assert result.no_secret_resolution_performed is True
+    receipt = fixture["boundary"].consume(result.capability)
+    assert receipt.target_signer_agent_id == "signer:reddog"
+    assert receipt.policy_id == result.policy_id
+    assert receipt.no_composition_authority_released is True
+    with pytest.raises(ValueError):
+        fixture["boundary"].consume(result.capability)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("manifest_id", DIGEST_E),
+        ("config_digest", DIGEST_E),
+        ("owner_config_id", DIGEST_E),
+        ("generation_revision", "revision-3"),
+        ("permission_snapshot_digest", DIGEST_E),
+        ("signing_key_ref_hash", DIGEST_E),
+        ("target_signer_generation_id", DIGEST_E),
+        ("allowed_operations", ["issue_principal_identity"]),
+        ("rate_limit_max_requests", 11),
+    ],
+)
+def test_attacker_recomputed_policy_still_rejects_bound_drift(
+    tmp_path: Path, field: str, value: object
+) -> None:
+    fixture = _fixture(tmp_path)
+    fixture["policy"][field] = value
+    _resign(fixture)
+    result = fixture["boundary"].admit(fixture["owner_config_path"], fixture["policy"])
+    assert result.accepted is False
+
+
+def test_self_authority_rejects_even_with_valid_signature(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    policy = fixture["policy"]
+    policy["grant_authority_public_key"] = fixture["target_public"]
+    record = fixture["principal_payload"]["principals"][
+        "github|principal:grant-admin"
+    ]
+    record["principal_public_key"] = fixture["target_public"]
+    _write_principal_artifact(fixture)
+    _rebind_config_and_sign(fixture, fixture["target_private"])
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], policy
+    ).accepted is False
+
+
+def test_untrusted_revocation_authority_rejects(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    fixture["principal_payload"]["principals"].pop(
+        "github|principal:revocation-admin"
+    )
+    fixture["principal_payload"]["principal_count"] = 1
+    _write_principal_artifact(fixture)
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+@pytest.mark.parametrize("mutation", ["wrong_key", "wrong_provider", "extra", "duplicate"])
+def test_manifest_bound_principal_records_fail_closed(
+    tmp_path: Path, mutation: str
+) -> None:
+    fixture = _fixture(tmp_path)
+    records = fixture["principal_payload"]["principals"]
+    grant = records["github|principal:grant-admin"]
+    if mutation == "wrong_key":
+        grant["principal_public_key"] = fixture["target_public"]
+    elif mutation == "wrong_provider":
+        grant["principal_provider"] = "gitlab"
+    elif mutation == "extra":
+        grant["authority"] = "self-asserted"
+    else:
+        records["principal:grant-admin"] = dict(grant)
+        fixture["principal_payload"]["principal_count"] = 3
+    _write_principal_artifact(fixture)
+
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+@pytest.mark.parametrize(
+    "mutation", ["top_level", "principal_only_index", "float_count", "bool_count"]
+)
+def test_principal_artifact_requires_exact_canonical_shape(
+    tmp_path: Path, mutation: str
+) -> None:
+    fixture = _fixture(tmp_path)
+    payload = fixture["principal_payload"]
+    if mutation == "top_level":
+        payload["unexpected"] = "self-asserted"
+    elif mutation == "principal_only_index":
+        records = payload["principals"]
+        records["principal:grant-admin"] = records.pop(
+            "github|principal:grant-admin"
+        )
+    elif mutation == "float_count":
+        payload["principal_count"] = 2.0
+    else:
+        payload["principal_count"] = True
+    _write_principal_artifact(fixture)
+
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_principal_artifact_duplicate_json_key_rejects(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    serialized = json.dumps(fixture["principal_payload"], sort_keys=True)
+    duplicate = (
+        '{"schema_version":"reddog_authority_runtime_resolver_supply.v1",'
+        + serialized[1:]
+    )
+    fixture["principal_path"].write_text(duplicate, encoding="ascii")
+    digest = _raw_file_digest(fixture["principal_path"])
+    fixture["selection"]["principal_authority_records_digest"] = digest
+    _CURRENT_SELECTION["principal_authority_records_digest"] = digest
+
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_production_boundary_has_no_injected_verifier_or_clock() -> None:
+    parameters = inspect.signature(OwnerControlledE0AdmissionBoundary).parameters
+    assert "selection_boundary" not in parameters
+    assert "principal_key_resolver" not in parameters
+    assert "signature_verifier" not in parameters
+    assert "now_epoch" not in parameters
+    assert "consumer" not in inspect.signature(
+        OwnerControlledE0AdmissionBoundary.consume
+    ).parameters
+
+
+def test_expired_policy_rejects_using_system_time(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    fixture["policy"]["issued_at"] = int(time.time()) - 200
+    fixture["policy"]["expires_at"] = int(time.time()) - 1
+    _resign(fixture)
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_consume_rechecks_policy_expiry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is True
+    monkeypatch.setattr(
+        current_selection_module.time,
+        "time",
+        lambda: int(fixture["policy"]["expires_at"]) + 1,
+    )
+    with pytest.raises(ValueError):
+        fixture["boundary"].consume(result.capability)
+
+
+def test_consume_rechecks_current_generation(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is True
+    _CURRENT_SELECTION["generation_revision"] = "revision-5"
+    with pytest.raises(ValueError):
+        fixture["boundary"].consume(result.capability)
+
+
+def test_consume_rechecks_config_bytes(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is True
+    fixture["config"]["permission_snapshot_fresh"] = False
+    fixture["config_path"].write_text(
+        json.dumps(fixture["config"], sort_keys=True), encoding="ascii"
+    )
+    with pytest.raises(ValueError):
+        fixture["boundary"].consume(result.capability)
+
+
+def test_manifest_bound_principal_artifact_tamper_rejects(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    fixture["principal_payload"]["principals"][
+        "github|principal:grant-admin"
+    ]["principal_public_key"] = fixture["target_public"]
+    fixture["principal_path"].write_text(
+        json.dumps(fixture["principal_payload"], sort_keys=True),
+        encoding="ascii",
+    )
+
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_generation_rotation_during_validation_rejects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = _fixture(tmp_path)
+    original = current_selection_module.load_selected_signer_config
+
+    def rotate(**kwargs: object) -> object:
+        config = original(**kwargs)
+        _CURRENT_SELECTION["generation_revision"] = "revision-5"
+        return config
+
+    monkeypatch.setattr(
+        current_selection_module, "load_selected_signer_config", rotate
+    )
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_selection_must_match_constructor_repo_root(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    _CURRENT_SELECTION["repo_root"] = str((tmp_path / "other-repo").resolve())
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_config_tampering_rejects_before_capability(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    config = fixture["config"]
+    config["permission_snapshot_fresh"] = False
+    fixture["config_path"].write_text(json.dumps(config, sort_keys=True), encoding="ascii")
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_config_without_authority_binding_rejects(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    config = fixture["config"]
+    config.pop("owner_e0_authority_binding_digest")
+    fixture["config_path"].write_text(json.dumps(config, sort_keys=True), encoding="ascii")
+    fixture["selection"]["config_digest"] = _canonical_digest(config)
+    fixture["policy"]["config_digest"] = fixture["selection"]["config_digest"]
+    _resign(fixture)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is False
+    assert result.no_secret_resolution_performed is True
+    assert result.no_socket_bound is True
+    assert result.no_signer_started is True
+
+
+def test_runtime_root_nested_under_signer_root_rejects(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    nested = Path(str(fixture["config"]["signer_runtime_root"])) / "replay"
+    nested.mkdir()
+    fixture["policy"]["replay_root"] = str(nested.resolve())
+    fixture["policy"]["replay_path"] = str((nested / "nonces.db").resolve())
+    _resign(fixture)
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_high_authority_without_consensus_policy_rejects(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    fixture["policy"]["consensus_required_tiers"] = ["HIGH"]
+    _resign(fixture)
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_e0_static_contract.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_e0_static_contract.py
@@ -1,0 +1,151 @@
+"""Static and capability-state tests for signer owner E0 admission."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import pickle
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.tests.test_reddog_signer_owner_controlled_e0_admission import (
+    SLICE_MODULES,
+    _CURRENT_SELECTION,
+    _SelectionBoundary,
+    _fixture,
+    _resign,
+)
+from modules.communication.moltbot_bridge.src import (
+    reddog_signer_owner_e0_current_selection as current_selection_module,
+)
+
+
+@pytest.fixture(autouse=True)
+def _root_owned_selection_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    def load(**_kwargs: object) -> tuple[object, _SelectionBoundary]:
+        capability = object()
+        return capability, _SelectionBoundary(capability, _CURRENT_SELECTION)
+
+    monkeypatch.setattr(
+        current_selection_module,
+        "load_system_service_manifest_selection",
+        load,
+    )
+
+
+def test_caller_cannot_mutate_policy_after_admission(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is True
+    fixture["policy"]["allowed_operations"].append("issue_principal_identity")
+    receipt = fixture["boundary"].consume(result.capability)
+    assert receipt.policy_id == result.policy_id
+
+
+def test_admission_capability_is_one_use(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is True
+    fixture["boundary"].consume(result.capability)
+    with pytest.raises(ValueError):
+        fixture["boundary"].consume(result.capability)
+
+
+def test_runtime_roots_must_be_disjoint(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    fixture["policy"]["revocation_root"] = fixture["policy"]["replay_root"]
+    fixture["policy"]["revocation_path"] = str(
+        Path(str(fixture["policy"]["replay_root"])) / "revocations.db"
+    )
+    _resign(fixture)
+    assert fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    ).accepted is False
+
+
+def test_capability_cannot_be_copied_or_pickled(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    result = fixture["boundary"].admit(
+        fixture["owner_config_path"], fixture["policy"]
+    )
+    assert result.accepted is True
+    with pytest.raises(TypeError):
+        copy.copy(result.capability)
+    with pytest.raises(TypeError):
+        copy.deepcopy(result.capability)
+    with pytest.raises(TypeError):
+        pickle.dumps(result.capability)
+
+
+def test_slice_has_no_effect_runtime_imports_or_calls() -> None:
+    source_root = Path(__file__).parents[1] / "src"
+    banned_imports = {
+        "subprocess",
+        "socket",
+        "secrets_mcp.src.op_cli_secret_resolver",
+    }
+    banned_calls = {
+        "bind",
+        "connect",
+        "listen",
+        "popen",
+        "run",
+        "start",
+        "resolve_signer_key",
+        "build_signer_backend_from_provider",
+    }
+    for filename in SLICE_MODULES:
+        tree = ast.parse((source_root / filename).read_text(encoding="ascii"))
+        imports = {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        }
+        imports.update(
+            str(node.module or "")
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+        )
+        calls = {
+            node.func.attr if isinstance(node.func, ast.Attribute) else node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, (ast.Attribute, ast.Name))
+        }
+        assert not any(
+            item == banned or item.endswith("." + banned)
+            for item in imports
+            for banned in banned_imports
+        )
+        assert calls.isdisjoint(banned_calls)
+
+
+def test_slice_obeys_wsp62_module_and_function_limits() -> None:
+    source_root = Path(__file__).parents[1] / "src"
+    for filename in SLICE_MODULES:
+        text = (source_root / filename).read_text(encoding="ascii")
+        assert len(text.splitlines()) <= 200
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                assert (node.end_lineno or node.lineno) - node.lineno + 1 <= 50
+
+
+def test_slice_test_helpers_obey_wsp62_function_limit() -> None:
+    test_root = Path(__file__).parent
+    for filename in (
+        "test_reddog_signer_owner_controlled_e0_admission.py",
+        "test_reddog_signer_owner_e0_static_contract.py",
+    ):
+        text = (test_root / filename).read_text(encoding="ascii")
+        assert len(text.splitlines()) <= 675
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                assert (node.end_lineno or node.lineno) - node.lineno + 1 <= 60


### PR DESCRIPTION
## Summary
- add a root-owned, generation-fenced E0 admission boundary for signer composition policy
- validate exact principal-authority artifacts and issue one-use opaque admission capabilities
- preserve the stable signer selection API and introduce no signer start, socket, secret resolution, or repository effect

## WSP 97 truth boundary
OBSERVED:
- current-generation and config digests are revalidated under the canonical generation lock
- principal authority is loaded from the manifest-bound artifact with exact schema, duplicate-key, digest, and count checks
- admission capabilities are immutable, non-copyable, non-serializable, and one-use
- no production/startup path consumes this E0 boundary

SPECIFIED_NOT_IMPLEMENTED:
- production signer composition and start
- secret resolution and socket binding
- work-order, repository, PR, or merge effects

## Validation
- focused/current-generation/WSP62: 75 passed
- full signer family: 591 passed, 19 skipped
- full bridge differential already established before the test-only WSP62 split: branch 5126 passed / 31 failed / 31 skipped; parent reproduced the same inherited failure set except one known order-dependent grant cleanup test that passes alone
- ruff and git diff --check: pass
- independent security review: GO on 44e69cc20f1adf58807b73aed8ef48ae784bced9
- independent integration/WSP review: GO on 44e69cc20f1adf58807b73aed8ef48ae784bced9

## HoloIndex
Pre-edit semantic retrieval failed closed with REPO_HEAD_MISMATCH. Direct-read evidence was used. No runtime self-reindex was performed; post-merge maintenance is assigned to the governed HoloIndex owner path.