### PR TITLE
fix(reddog): authenticate operational Memex supply

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -27,6 +27,13 @@ is the immutable admission SHA, not a branch. INDEX_GAP blocks ordinary work;
 the maintenance exception requires exact supporting direct-read paths.
 
 The receipt's SHA is integrity evidence, not authentication.
+Operational Memex supply receipts are exact-schema rehydrated before resident
+artifact handoff, authority-profile seed creation, proposal signing, and final
+promotion. The gate recomputes the receipt ID, enforces principal, FoundUp,
+snapshot, HoloIndex-generation, and source-revision bindings, and applies a
+300-second maximum age plus 600-second maximum policy lifetime. The complete
+canonical receipt digest is covered by the signed proposal attestation; a
+syntactically valid or attacker-rehashed `sha256:` identifier is not authority.
 `reddog_architect_proposal_authenticity.py` defines a domain-separated Ed25519
 attestation, an exact signer-owned proposal policy, transactional signer-side
 nonce reservation, and strict serialized-attestation integrity validation.
@@ -46,6 +53,14 @@ profile. There is no process-local authority registry or serializable promotion
 capability. Production startup remains fail closed until it receives the
 attestation, a current signer-runtime configuration, and an independently
 administered principal-key resolver.
+
+Architect proposal attestation v2 additionally requires a typed
+`OperationalMemexSupplyReceipt`. Promotion rehydrates the complete serialized
+receipt, recomputes its canonical ID, rejects unknown fields and stale or
+scope/lineage-mismatched inputs, and rebuilds the signed proposal over the full
+receipt digest. A caller-recomputed Memex self-hash is therefore integrity only;
+it cannot become promotion authority without the independently signed proposal
+attestation matching that exact receipt.
 `reddog_architect_fix_promotion_transaction.py` isolates record construction and publication; `reddog_architect_fix_promotion_publication.py` confines all artifacts, while `reddog_architect_fix_publication_effect_binding.py` binds current COMMITTED lineage into signer and worker-dispatch admission. Queue authority verification derives a canonical receipt from the recorded signed authority and accepted verification result. The dry-run receipt, each intent, the runtime receipt, and each AgentDB task retain that receipt ID/digest and exact work-authority digest. Immediately before AgentDB publication, the runtime reloads both stages, recomputes the lineage, obtains fresh time from a required production clock, binds the effective work order, FoundUp, operation, and exact worker roles to the signed authority plus authoritative WSP 15 plan, and re-verifies the principal and work-authority signatures, revocation, permission snapshot, scope, paths, freshness, and valve binding. Final admission uses `AUTHORITATIVE_USE` and consumes the durable nonce once before the writer; any later writer failure requires freshly signed authority. Static validation failures do not consume the nonce. Missing verifier/clock dependencies, forged signatures or substituted operations with attacker-recomputed local receipts, role/capability substitution, replay, expired authority reopened with an old environment epoch, synthetic dry-runs, and substituted authority all reject before the writer.
 AgentDB publication persists a canonical `reddog_signed_worker_agentdb_envelope.v1` containing the complete signed authority runtime, authoritative WSP 15 allocation, exact dispatch receipt, and exact worker intent. Both `OpenClawSupervisor` and direct `scripts/run_task.py` execution independently rehydrate and reverify it before runner selection; runner context comes from verified evidence, outer metadata is not authority, and inconsistent routing cannot fall through to generic WRE. The optional signed Memex supply ID/digest pair remains bound through profile materialization, dispatch, restart, claim, executor, read-only 0102 assignment, and independent slice verification; half-pairs, malformed digests, or conflicts reject and absence remains valid. `AuthoritativeWorkStateStore.locked_snapshot()` is the shared mutation fence for refresh, promotion, and AgentDB publication; its file-backed implementation is confined to an explicit outside-repository runtime root and uses a sibling operation lock.
 Canonical rehydration returns an opaque process-local verification proof that

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,18 @@
 # ModLog - moltbot_bridge
 
+## 2026-08-04: Memex supply authenticity gate
+- Replaced the promotion path's `sha256:` prefix check with exact typed Memex
+  supply receipt rehydration, canonical digest verification, scope/lineage and
+  freshness checks, and strict unknown-field/type rejection.
+- Upgraded architect proposal attestations to v2 so the isolated signer binds
+  the exact full Memex receipt digest. Attacker-rehashed substitutions now fail
+  against independently signed proposal authority before artifact, seed,
+  queue, profile, or state mutation. Proposal signing rehydrates even a
+  manually constructed typed receipt; receipt age is capped at 300 seconds and
+  policy lifetime at 600 seconds. No learning-candidate, default-supplier,
+  HoloIndex maintenance, or repository execution behavior was added
+  (WSP 00/15/22/50/62/97).
+
 ## 2026-08-03: Extension resident model-runtime authority binding
 - Reused the `main.py` authenticated BOUND model-runtime loader in the extension
   bridge; invalid audit/architect receipts reject before client construction,

--- a/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -79,6 +79,10 @@ from modules.communication.moltbot_bridge.src.reddog_authority_profile_safety im
 from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runtime_wiring import (
     SignerSocketServiceRuntimeWiringConfig,
 )
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    OperationalMemexSupplyReceipt,
+    rehydrate_operational_memex_supply_receipt,
+)
 from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
     PrincipalKeyResolver,
 )
@@ -221,7 +225,10 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
         model_runtime_binding_verification_capability,
         reasons,
     )
-    memex_payload = _validate_memex_supply(memex_supply_receipt, determination, reasons)
+    memex_verified = _rehydrate_memex_supply(
+        memex_supply_receipt, determination, authority_profile,
+        current_holoindex_receipt, now_iso, reasons,
+    )
     profile_reasons = _validate_authority_profile(authority_profile)
     reasons.extend(profile_reasons)
     holoindex_evidence = _mapping(authority_profile.get("holoindex_evidence"))
@@ -231,11 +238,8 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
     if reasons:
         return _reject(reasons)
 
-    assert freshness_id
-    assert selection_payload
-    assert memex_payload
-    assert proposal_admission is not None
-    assert selected_slice
+    assert freshness_id and selection_payload and memex_verified is not None
+    assert proposal_admission is not None and selected_slice
     now = _parse_iso(now_iso)
     try:
         expires_at = (
@@ -251,6 +255,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
             proposal_admission=proposal_admission.to_dict(),
             determination=determination,
             queue_candidate=candidate,
+            memex_supply_receipt=memex_verified,
             authority_profile=authority_profile,
             signer_runtime_config=signer_runtime_config,
             principal_key_resolver=principal_key_resolver,
@@ -286,7 +291,7 @@ def promote_reddog_architect_fix_to_signed_wsp15_work_order(
             model_selection=selection_payload,
             model_runtime_binding_receipt=model_runtime_binding_receipt,
             model_runtime_binding=runtime_binding_payload,
-            memex_supply=memex_payload,
+            memex_supply=memex_verified.to_dict(),
             proposal_admission=proposal_admission.to_dict(),
             proposal_authority=proposal_authority,
             selected_slice=selected_slice,
@@ -515,27 +520,40 @@ def _verified_runtime_evidence(
     return verification
 
 
-def _validate_memex_supply(
+def _rehydrate_memex_supply(
     memex_supply: Mapping[str, Any],
     determination: Mapping[str, Any],
+    authority_profile: Mapping[str, Any],
+    current_holoindex_receipt: Any,
+    now_iso: str,
     reasons: list[str],
-) -> Mapping[str, Any]:
+) -> OperationalMemexSupplyReceipt | None:
     if not isinstance(memex_supply, Mapping) or not memex_supply:
         reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_MISSING)
-        return {}
-    if memex_supply.get("schema_version") != "reddog_operational_memex_snapshot_supply_receipt.v1":
+        return None
+    try:
+        proposal = _mapping(determination.get("proposal_admission"))
+        return rehydrate_operational_memex_supply_receipt(
+            memex_supply,
+            expected_foundup_id=str(authority_profile.get("foundup_id") or ""),
+            expected_principal_id=str(authority_profile.get("principal_id") or ""),
+            expected_snapshot_receipt_id=str(
+                determination.get("snapshot_receipt_id") or ""
+            ),
+            expected_snapshot_content_digest=str(
+                determination.get("snapshot_content_digest") or ""
+            ),
+            expected_holoindex_generation_id=str(
+                getattr(current_holoindex_receipt, "generation_id", "") or ""
+            ),
+            expected_source_revision=str(
+                proposal.get("work_state_revision") or ""
+            ),
+            now_iso=now_iso,
+        )
+    except (TypeError, ValueError):
         reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
-    receipt_id = str(memex_supply.get("receipt_id") or "")
-    if not receipt_id.startswith("sha256:"):
-        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
-    snapshot_receipt_id = str(memex_supply.get("snapshot_receipt_id") or "")
-    if snapshot_receipt_id != str(determination.get("snapshot_receipt_id") or ""):
-        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
-    if memex_supply.get("no_holoindex_reindex_performed") is not True:
-        reasons.append(ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID)
-    return {"receipt_id": receipt_id, "snapshot_receipt_id": snapshot_receipt_id}
-
-
+        return None
 def _validate_authority_profile(profile: Mapping[str, Any]) -> list[str]:
     if not isinstance(profile, Mapping) or not profile:
         return [ArchitectFixPromotionReason.AUTHORITY_PROFILE_MISSING]

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_authenticity.py
@@ -26,13 +26,20 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
 from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
     SignatureVerifier,
 )
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    OperationalMemexSupplyReceipt,
+    canonical_operational_memex_supply_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_proposal_binding import (
+    verify_memex_supply_for_architect_proposal,
+)
 
 
 PROPOSAL_AUTHENTICITY_SCHEMA_VERSION = (
-    "reddog_architect_proposal_authenticity_attestation.v1"
+    "reddog_architect_proposal_authenticity_attestation.v2"
 )
 PROPOSAL_AUTHENTICITY_SIGNING_OPERATION = "attest_architect_proposal"
-PROPOSAL_AUTHENTICITY_SIGNING_PREFIX = "reddog-architect-proposal.v1."
+PROPOSAL_AUTHENTICITY_SIGNING_PREFIX = "reddog-architect-proposal.v2."
 PROPOSAL_AUTHENTICITY_SIGNER_ROLE = "reddog_architect"
 PROPOSAL_POLICY_AUTHORIZATION_SCHEMA_VERSION = (
     "reddog_architect_proposal_policy_authorization.v1"
@@ -68,6 +75,8 @@ class ArchitectProposalAuthenticityPayload:
     required_tests_digest: str
     required_policy_gates_digest: str
     target_effect_plane: str
+    memex_supply_receipt_id: str
+    memex_supply_digest: str
     requester_principal_id: str
     reddog_id: str
     signer_public_key: str
@@ -200,6 +209,7 @@ def build_architect_proposal_authenticity_payload(
     proposal_admission: Mapping[str, Any],
     determination: Mapping[str, Any],
     queue_candidate: Mapping[str, Any],
+    memex_supply_receipt: OperationalMemexSupplyReceipt,
     requester_principal_id: str,
     reddog_id: str,
     signer_public_key: str,
@@ -214,9 +224,20 @@ def build_architect_proposal_authenticity_payload(
 
     proposal = _mapping(proposal_admission)
     candidate = _mapping(queue_candidate)
+    memex_supply_receipt = verify_memex_supply_for_architect_proposal(
+        memex_supply_receipt,
+        proposal_admission=proposal,
+        requester_principal_id=requester_principal_id,
+        proposal_issued_at=issued_at,
+    )
     values = {
         "schema_version": PROPOSAL_AUTHENTICITY_SCHEMA_VERSION,
-        **_proposal_binding_values(proposal, determination, candidate),
+        **_proposal_binding_values(
+            proposal,
+            determination,
+            candidate,
+            memex_supply_receipt,
+        ),
         **_proposal_identity_values(
             requester_principal_id=requester_principal_id,
             reddog_id=reddog_id,
@@ -245,6 +266,7 @@ def _proposal_binding_values(
     proposal: Mapping[str, Any],
     determination: Mapping[str, Any],
     candidate: Mapping[str, Any],
+    memex_supply_receipt: OperationalMemexSupplyReceipt,
 ) -> dict[str, Any]:
     determination_body = {
         key: value
@@ -285,6 +307,10 @@ def _proposal_binding_values(
             proposal.get("required_policy_gates")
         ),
         "target_effect_plane": _text(proposal.get("target_effect_plane")),
+        "memex_supply_receipt_id": memex_supply_receipt.receipt_id,
+        "memex_supply_digest": canonical_operational_memex_supply_digest(
+            memex_supply_receipt.to_dict()
+        ),
     }
 
 
@@ -879,6 +905,7 @@ def _proposal_digests_valid(payload: Mapping[str, Any]) -> bool:
             "denied_paths_digest",
             "required_tests_digest",
             "required_policy_gates_digest",
+            "memex_supply_digest",
             "consensus_receipt_digest",
             "authority_profile_source_receipt_id",
         )

--- a/modules/communication/moltbot_bridge/src/reddog_architect_proposal_verified_authority.py
+++ b/modules/communication/moltbot_bridge/src/reddog_architect_proposal_verified_authority.py
@@ -32,10 +32,13 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runti
 from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
     PrincipalKeyResolver,
 )
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    OperationalMemexSupplyReceipt,
+)
 
 
 VERIFIED_ARCHITECT_PROPOSAL_AUTHORITY_SCHEMA_VERSION = (
-    "verified_reddog_architect_proposal_promotion_authority.v2"
+    "verified_reddog_architect_proposal_promotion_authority.v3"
 )
 
 
@@ -58,6 +61,8 @@ class ArchitectProposalAuthorityBinding:
     replay_store_binding_digest: str
     security_context_digest: str
     signer_runtime_context_digest: str
+    memex_supply_receipt_id: str
+    memex_supply_digest: str
 
 
 def verify_architect_proposal_promotion_authority(
@@ -66,6 +71,7 @@ def verify_architect_proposal_promotion_authority(
     proposal_admission: Mapping[str, Any],
     determination: Mapping[str, Any],
     queue_candidate: Mapping[str, Any],
+    memex_supply_receipt: OperationalMemexSupplyReceipt,
     authority_profile: Mapping[str, Any],
     signer_runtime_config: SignerSocketServiceRuntimeWiringConfig,
     principal_key_resolver: PrincipalKeyResolver,
@@ -79,6 +85,7 @@ def verify_architect_proposal_promotion_authority(
         proposal_admission=proposal_admission,
         determination=determination,
         queue_candidate=queue_candidate,
+        memex_supply_receipt=memex_supply_receipt,
         authority_profile=authority_profile,
         signer_runtime_config=signer_runtime_config,
         principal_key_resolver=principal_key_resolver,
@@ -119,6 +126,8 @@ def _authority_binding(
         signer_runtime_context_digest=_runtime_context_digest(
             authorization, signer_runtime_config
         ),
+        memex_supply_receipt_id=verified_attestation.payload.memex_supply_receipt_id,
+        memex_supply_digest=verified_attestation.payload.memex_supply_digest,
     )
 
 
@@ -128,6 +137,7 @@ def _verification_inputs(
     proposal_admission: Mapping[str, Any],
     determination: Mapping[str, Any],
     queue_candidate: Mapping[str, Any],
+    memex_supply_receipt: OperationalMemexSupplyReceipt,
     authority_profile: Mapping[str, Any],
     signer_runtime_config: SignerSocketServiceRuntimeWiringConfig,
     principal_key_resolver: PrincipalKeyResolver,
@@ -146,6 +156,7 @@ def _verification_inputs(
         proposal_admission=proposal_admission,
         determination=determination,
         queue_candidate=queue_candidate,
+        memex_supply_receipt=memex_supply_receipt,
         authority_profile=profile,
     )
     policy, authorization = verify_architect_proposal_runtime_authorization(
@@ -248,6 +259,7 @@ def _rebuild_payload(
     proposal_admission: Mapping[str, Any],
     determination: Mapping[str, Any],
     queue_candidate: Mapping[str, Any],
+    memex_supply_receipt: OperationalMemexSupplyReceipt,
     authority_profile: Mapping[str, Any],
 ) -> ArchitectProposalAuthenticityPayload:
     profile = _mapping(authority_profile)
@@ -255,6 +267,7 @@ def _rebuild_payload(
         proposal_admission=_mapping(proposal_admission),
         determination=_mapping(determination),
         queue_candidate=_mapping(queue_candidate),
+        memex_supply_receipt=memex_supply_receipt,
         requester_principal_id=_required_text(profile, "principal_id"),
         reddog_id=_required_text(profile, "reddog_id"),
         signer_public_key=_required_text(profile, "reddog_public_key"),

--- a/modules/communication/moltbot_bridge/src/reddog_authority_profile_seed_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authority_profile_seed_supply.py
@@ -21,6 +21,7 @@ import json
 import os
 import tempfile
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
@@ -28,6 +29,9 @@ from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_
     HIGH_AUTHORITY_OPERATIONS,
     HIGH_AUTHORITY_VALVE_STATES,
     PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    rehydrate_operational_memex_supply_receipt,
 )
 from modules.communication.moltbot_bridge.src.reddog_work_order_signature_verifier import (
     PermissionSnapshot,
@@ -163,7 +167,6 @@ def run_reddog_authority_profile_seed_supply(
     else:
         reasons.append(AuthorityProfileSeedSupplyReason.WSP15_ALLOCATION_INVALID)
     reasons.extend(_model_selection_reasons(model_selection))
-    reasons.extend(_memex_supply_reasons(memex_supply, determination))
     if principal is None:
         reasons.append(AuthorityProfileSeedSupplyReason.PRINCIPAL_INVALID)
     if snapshot is None:
@@ -181,6 +184,15 @@ def run_reddog_authority_profile_seed_supply(
     fid = _selected_foundup_id(foundup_id, principal)
     if not fid:
         reasons.append(AuthorityProfileSeedSupplyReason.FOUNDUP_SCOPE_INVALID)
+    reasons.extend(
+        _memex_supply_reasons(
+            memex_supply,
+            determination,
+            principal_id=(principal.principal_id if principal else ""),
+            foundup_id=fid or "",
+            now_epoch=now_epoch,
+        )
+    )
     repo_full_name = _selected_repo_full_name(snapshot, principal)
     if not repo_full_name:
         reasons.append(AuthorityProfileSeedSupplyReason.REPO_SCOPE_INVALID)
@@ -308,16 +320,30 @@ def _model_selection_reasons(model_selection: Mapping[str, Any]) -> list[str]:
     return []
 
 
-def _memex_supply_reasons(memex_supply: Mapping[str, Any], determination: Mapping[str, Any]) -> list[str]:
+def _memex_supply_reasons(
+    memex_supply: Mapping[str, Any],
+    determination: Mapping[str, Any],
+    *,
+    principal_id: str,
+    foundup_id: str,
+    now_epoch: int,
+) -> list[str]:
     if not memex_supply:
         return [AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID]
-    if memex_supply.get("schema_version") != "reddog_operational_memex_snapshot_supply_receipt.v1":
-        return [AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID]
-    if not str(memex_supply.get("receipt_id") or "").startswith("sha256:"):
-        return [AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID]
-    if str(memex_supply.get("snapshot_receipt_id") or "") != str(determination.get("snapshot_receipt_id") or ""):
-        return [AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID]
-    if memex_supply.get("no_holoindex_reindex_performed") is not True:
+    proposal = _mapping(determination.get("proposal_admission"))
+    try:
+        now_iso = datetime.fromtimestamp(now_epoch, timezone.utc).isoformat()
+        rehydrate_operational_memex_supply_receipt(
+            memex_supply,
+            expected_foundup_id=foundup_id,
+            expected_principal_id=principal_id,
+            expected_snapshot_receipt_id=str(determination.get("snapshot_receipt_id") or ""),
+            expected_snapshot_content_digest=str(determination.get("snapshot_content_digest") or ""),
+            expected_holoindex_generation_id=str(proposal.get("holoindex_generation_id") or ""),
+            expected_source_revision=str(proposal.get("work_state_revision") or ""),
+            now_iso=now_iso,
+        )
+    except (OSError, OverflowError, TypeError, ValueError):
         return [AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID]
     return []
 

--- a/modules/communication/moltbot_bridge/src/reddog_main_fix_promotion_claim_handoff.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_fix_promotion_claim_handoff.py
@@ -100,6 +100,7 @@ def _materialize_claim(
                 claim.wsp15_allocation_receipt_id or ""
             ),
         },
+        now_iso=(now.isoformat() if now is not None else None),
     )
     if not handoff.accepted:
         store.release(claim, now=now)

--- a/modules/communication/moltbot_bridge/src/reddog_operational_memex_supply_freshness.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_memex_supply_freshness.py
@@ -1,0 +1,57 @@
+"""Bounded freshness policy for operational Memex supply receipts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+
+DEFAULT_MAX_AGE_SECONDS = 300
+DEFAULT_MAX_TTL_SECONDS = 600
+
+
+class MemexSupplyPolicyWindow(Protocol):
+    policy_issued_at: str
+    policy_expires_at: str
+
+
+def validate_operational_memex_supply_freshness(
+    receipt: MemexSupplyPolicyWindow,
+    *,
+    now_iso: str,
+    max_age_seconds: int,
+    max_ttl_seconds: int,
+) -> None:
+    """Reject stale, overlong, timezone-ambiguous policy windows."""
+
+    if type(max_age_seconds) is not int or max_age_seconds <= 0:
+        raise ValueError("memex_supply_receipt_max_age_invalid")
+    if type(max_ttl_seconds) is not int or max_ttl_seconds <= 0:
+        raise ValueError("memex_supply_receipt_max_ttl_invalid")
+    try:
+        issued = _parse(receipt.policy_issued_at)
+        expires = _parse(receipt.policy_expires_at)
+        now = _parse(now_iso)
+    except (TypeError, ValueError):
+        raise ValueError("memex_supply_receipt_time_invalid") from None
+    if issued > now or expires <= now or expires <= issued:
+        raise ValueError("memex_supply_receipt_expired")
+    if (now - issued).total_seconds() > max_age_seconds:
+        raise ValueError("memex_supply_receipt_too_old")
+    if (expires - issued).total_seconds() > max_ttl_seconds:
+        raise ValueError("memex_supply_receipt_ttl_exceeded")
+
+
+def _parse(value: str) -> datetime:
+    parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if parsed.utcoffset() is None:
+        raise ValueError("memex_supply_receipt_time_timezone_missing")
+    return parsed
+
+
+__all__ = [
+    "DEFAULT_MAX_AGE_SECONDS",
+    "DEFAULT_MAX_TTL_SECONDS",
+    "MemexSupplyPolicyWindow",
+    "validate_operational_memex_supply_freshness",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_operational_memex_supply_proposal_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_memex_supply_proposal_binding.py
@@ -1,0 +1,49 @@
+"""Revalidate typed Memex supply before architect-proposal signing."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    OperationalMemexSupplyReceipt,
+    rehydrate_operational_memex_supply_receipt,
+)
+
+
+def verify_memex_supply_for_architect_proposal(
+    receipt: OperationalMemexSupplyReceipt,
+    *,
+    proposal_admission: Mapping[str, Any],
+    requester_principal_id: str,
+    proposal_issued_at: int,
+) -> OperationalMemexSupplyReceipt:
+    """Reject manually constructed or proposal-mismatched typed receipts."""
+
+    if not isinstance(receipt, OperationalMemexSupplyReceipt):
+        raise ValueError("architect_proposal_memex_supply_not_verified")
+    proposal = dict(proposal_admission)
+    return rehydrate_operational_memex_supply_receipt(
+        receipt.to_dict(),
+        expected_foundup_id=receipt.foundup_id,
+        expected_principal_id=requester_principal_id,
+        expected_snapshot_receipt_id=str(
+            proposal.get("snapshot_receipt_id") or ""
+        ),
+        expected_snapshot_content_digest=str(
+            proposal.get("snapshot_content_digest") or ""
+        ),
+        expected_holoindex_generation_id=str(
+            proposal.get("holoindex_generation_id") or ""
+        ),
+        expected_source_revision=str(
+            proposal.get("work_state_revision") or ""
+        ),
+        now_iso=datetime.fromtimestamp(
+            int(proposal_issued_at),
+            timezone.utc,
+        ).isoformat(),
+    )
+
+
+__all__ = ["verify_memex_supply_for_architect_proposal"]

--- a/modules/communication/moltbot_bridge/src/reddog_operational_memex_supply_receipt.py
+++ b/modules/communication/moltbot_bridge/src/reddog_operational_memex_supply_receipt.py
@@ -1,0 +1,200 @@
+"""Canonical rehydration for resident RedDog Memex supply receipts.
+
+This module proves structural integrity only. Producer authenticity is supplied
+by the existing signed architect-proposal attestation, which binds the complete
+canonical receipt digest before promotion can mutate authoritative state.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_freshness import (
+    DEFAULT_MAX_AGE_SECONDS,
+    DEFAULT_MAX_TTL_SECONDS,
+    validate_operational_memex_supply_freshness,
+)
+
+
+SCHEMA_VERSION = "reddog_operational_memex_snapshot_supply_receipt.v1"
+_SEQUENCE_FIELDS = (
+    "assignment_ids",
+    "lane_ids",
+    "task_ids",
+    "assignment_receipt_ids",
+)
+_INTEGER_FIELDS = ("assignment_count", "max_records")
+_BOOLEAN_FIELDS = (
+    "no_memex_write_performed",
+    "no_holoindex_reindex_performed",
+    "no_repo_mutation_performed",
+)
+
+
+@dataclass(frozen=True)
+class OperationalMemexSupplyReceipt:
+    schema_version: str
+    foundup_id: str
+    principal_id: str
+    snapshot_receipt_id: str
+    snapshot_content_digest: str
+    memex_view_id: str
+    holoindex_generation_id: str
+    source_revision: str
+    policy_issued_at: str
+    policy_expires_at: str
+    assignment_count: int
+    assignment_ids: tuple[str, ...]
+    lane_ids: tuple[str, ...]
+    task_ids: tuple[str, ...]
+    assignment_receipt_ids: tuple[str, ...]
+    max_records: int
+    no_memex_write_performed: bool
+    no_holoindex_reindex_performed: bool
+    no_repo_mutation_performed: bool
+    receipt_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def canonical_operational_memex_supply_digest(value: Mapping[str, Any]) -> str:
+    """Digest the complete serialized receipt for signed authority binding."""
+
+    return _digest(dict(value))
+
+
+def operational_memex_supply_receipt_id(value: Mapping[str, Any]) -> str:
+    """Compute the self-integrity ID over the exact receipt body."""
+
+    return _digest({key: item for key, item in value.items() if key != "receipt_id"})
+
+
+def rehydrate_operational_memex_supply_receipt(
+    value: Mapping[str, Any],
+    *,
+    expected_foundup_id: str,
+    expected_principal_id: str,
+    expected_snapshot_receipt_id: str,
+    expected_snapshot_content_digest: str,
+    expected_holoindex_generation_id: str,
+    expected_source_revision: str,
+    now_iso: str,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    max_ttl_seconds: int = DEFAULT_MAX_TTL_SECONDS,
+) -> OperationalMemexSupplyReceipt:
+    """Return an exact typed receipt or fail closed on any mismatch."""
+
+    if not isinstance(value, Mapping):
+        raise ValueError("memex_supply_receipt_not_mapping")
+    raw = dict(value)
+    expected_fields = set(OperationalMemexSupplyReceipt.__dataclass_fields__)
+    if set(raw) != expected_fields:
+        raise ValueError("memex_supply_receipt_fields_invalid")
+    if raw.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("memex_supply_receipt_schema_invalid")
+    normalized = _normalize(raw)
+    receipt = OperationalMemexSupplyReceipt(**normalized)
+    _validate_integrity(receipt)
+    _validate_bindings(
+        receipt,
+        expected_foundup_id=expected_foundup_id,
+        expected_principal_id=expected_principal_id,
+        expected_snapshot_receipt_id=expected_snapshot_receipt_id,
+        expected_snapshot_content_digest=expected_snapshot_content_digest,
+        expected_holoindex_generation_id=expected_holoindex_generation_id,
+        expected_source_revision=expected_source_revision,
+    )
+    validate_operational_memex_supply_freshness(
+        receipt,
+        now_iso=now_iso,
+        max_age_seconds=max_age_seconds,
+        max_ttl_seconds=max_ttl_seconds,
+    )
+    return receipt
+
+
+def _normalize(raw: Mapping[str, Any]) -> dict[str, Any]:
+    values = dict(raw)
+    special_fields = set(_SEQUENCE_FIELDS + _INTEGER_FIELDS + _BOOLEAN_FIELDS)
+    for field in set(values) - special_fields:
+        if not isinstance(values[field], str) or not values[field].strip():
+            raise ValueError(f"memex_supply_receipt_{field}_invalid")
+        values[field] = values[field].strip()
+    for field in _SEQUENCE_FIELDS:
+        items = values.get(field)
+        if not isinstance(items, (list, tuple)):
+            raise ValueError(f"memex_supply_receipt_{field}_invalid")
+        if any(not isinstance(item, str) or not item.strip() for item in items):
+            raise ValueError(f"memex_supply_receipt_{field}_invalid")
+        values[field] = tuple(item.strip() for item in items)
+    for field in _INTEGER_FIELDS:
+        if isinstance(values.get(field), bool) or not isinstance(values.get(field), int):
+            raise ValueError(f"memex_supply_receipt_{field}_invalid")
+    for field in _BOOLEAN_FIELDS:
+        if not isinstance(values.get(field), bool):
+            raise ValueError(f"memex_supply_receipt_{field}_invalid")
+    return values
+
+
+def _validate_integrity(receipt: OperationalMemexSupplyReceipt) -> None:
+    payload = receipt.to_dict()
+    if receipt.receipt_id != operational_memex_supply_receipt_id(payload):
+        raise ValueError("memex_supply_receipt_id_mismatch")
+    if receipt.assignment_count <= 0 or receipt.max_records <= 0:
+        raise ValueError("memex_supply_receipt_count_invalid")
+    sequences = (
+        receipt.assignment_ids,
+        receipt.lane_ids,
+        receipt.task_ids,
+        receipt.assignment_receipt_ids,
+    )
+    if any(len(items) != receipt.assignment_count for items in sequences):
+        raise ValueError("memex_supply_receipt_assignment_count_mismatch")
+    if any(not item for items in sequences for item in items):
+        raise ValueError("memex_supply_receipt_assignment_value_missing")
+    if any(len(set(items)) != len(items) for items in sequences):
+        raise ValueError("memex_supply_receipt_assignment_duplicate")
+    if not all((
+        receipt.no_memex_write_performed,
+        receipt.no_holoindex_reindex_performed,
+        receipt.no_repo_mutation_performed,
+    )):
+        raise ValueError("memex_supply_receipt_boundary_invalid")
+
+
+def _validate_bindings(receipt: OperationalMemexSupplyReceipt, **expected: str) -> None:
+    observed = {
+        "expected_foundup_id": receipt.foundup_id,
+        "expected_principal_id": receipt.principal_id,
+        "expected_snapshot_receipt_id": receipt.snapshot_receipt_id,
+        "expected_snapshot_content_digest": receipt.snapshot_content_digest,
+        "expected_holoindex_generation_id": receipt.holoindex_generation_id,
+        "expected_source_revision": receipt.source_revision,
+    }
+    if any(not value or observed[key] != str(value).strip() for key, value in expected.items()):
+        raise ValueError("memex_supply_receipt_authority_binding_mismatch")
+
+
+def _digest(value: Any) -> str:
+    raw = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+__all__ = [
+    "OperationalMemexSupplyReceipt",
+    "SCHEMA_VERSION",
+    "DEFAULT_MAX_AGE_SECONDS",
+    "DEFAULT_MAX_TTL_SECONDS",
+    "canonical_operational_memex_supply_digest",
+    "operational_memex_supply_receipt_id",
+    "rehydrate_operational_memex_supply_receipt",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_resident_fix_promotion_artifact_handoff.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_fix_promotion_artifact_handoff.py
@@ -20,8 +20,9 @@ import json
 import os
 import tempfile
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping
 
 from modules.communication.moltbot_bridge.src.reddog_agentdb_architect_determination_reader import (
     load_agentdb_architect_determination,
@@ -29,13 +30,13 @@ from modules.communication.moltbot_bridge.src.reddog_agentdb_architect_determina
 from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
     ACTION_FIX,
     ARCHITECT_DETERMINATION_ACCEPT,
-    AgentDbArchitectDeterminationStore,
-    ArchitectDeterminationStore,
 )
 from modules.communication.moltbot_bridge.src.reddog_resident_architect_durable_agentdb_cycle import (
     AgentDbResidentArchitectCycleStore,
-    ResidentArchitectCycleStore,
     STATUS_DETERMINED,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    rehydrate_operational_memex_supply_receipt,
 )
 
 
@@ -91,33 +92,27 @@ def run_reddog_resident_fix_promotion_artifact_handoff(
     intent_id: str,
     architect_determination_output_path: Path | str | None,
     memex_supply_receipt_output_path: Path | str | None,
-    cycle_store: ResidentArchitectCycleStore | None = None,
-    architect_store: ArchitectDeterminationStore | None = None,
     expected_claim_binding: Mapping[str, str] | None = None,
+    now_iso: str | None = None,
 ) -> ResidentFixPromotionArtifactHandoffResult:
     """Materialize promotion input artifacts from one determined resident cycle."""
 
-    root = Path(repo_root).resolve()
-    cleaned_intent = _clean(intent_id)
+    root, cleaned_intent = Path(repo_root).resolve(), _clean(intent_id)
     if not cleaned_intent:
         return _reject(cleaned_intent, None, None, (ResidentFixHandoffReason.MISSING_INTENT_ID,))
 
-    cycle_reader = cycle_store or AgentDbResidentArchitectCycleStore()
-    architect_reader = architect_store or AgentDbArchitectDeterminationStore()
+    cycle_reader = AgentDbResidentArchitectCycleStore()
     cycle = cycle_reader.load_cycle_by_intent(cleaned_intent)
     if not isinstance(cycle, Mapping) or not cycle:
         return _reject(cleaned_intent, None, None, (ResidentFixHandoffReason.CYCLE_NOT_FOUND,))
 
     cycle_id = _clean(cycle.get("cycle_id"))
     architect_id = _clean(cycle.get("architect_determination_id"))
-    reasons = _validate_cycle(cycle, require_store_integrity=cycle_store is None)
+    reasons = _validate_cycle(cycle)
     if cycle_id and architect_id and not reasons:
         determination_payload, determination_reasons = _load_determination(
             cycle,
-            cycle_id=cycle_id,
             architect_id=architect_id,
-            architect_reader=architect_reader,
-            direct_agentdb_read=architect_store is None,
             expected_claim_binding=expected_claim_binding,
         )
         reasons.extend(determination_reasons)
@@ -126,7 +121,7 @@ def run_reddog_resident_fix_promotion_artifact_handoff(
         reasons.append(ResidentFixHandoffReason.DETERMINATION_NOT_FOUND)
 
     memex_supply = _memex_supply_receipt(cycle)
-    reasons.extend(_validate_memex_supply(memex_supply, determination_payload))
+    reasons.extend(_validate_memex_supply(memex_supply, determination_payload, cycle=cycle, now_iso=_now_iso(now_iso)))
     determination_path, memex_path, path_reasons = _resolve_output_paths(
         architect_determination_output_path,
         memex_supply_receipt_output_path,
@@ -166,11 +161,9 @@ def run_reddog_resident_fix_promotion_artifact_handoff(
 
 def _validate_cycle(
     cycle: Mapping[str, Any],
-    *,
-    require_store_integrity: bool = False,
 ) -> list[str]:
     reasons: list[str] = []
-    if require_store_integrity and cycle.get("_store_integrity_valid") is not True:
+    if cycle.get("_store_integrity_valid") is not True:
         reasons.append("resident_cycle_integrity_invalid")
     if _clean(cycle.get("status")) != STATUS_DETERMINED:
         reasons.append(ResidentFixHandoffReason.CYCLE_NOT_DETERMINED)
@@ -184,18 +177,10 @@ def _validate_cycle(
 def _load_determination(
     cycle: Mapping[str, Any],
     *,
-    cycle_id: str,
     architect_id: str,
-    architect_reader: ArchitectDeterminationStore,
-    direct_agentdb_read: bool,
     expected_claim_binding: Mapping[str, str] | None,
 ) -> tuple[Mapping[str, Any] | None, list[str]]:
-    if direct_agentdb_read:
-        record = load_agentdb_architect_determination(architect_id)
-    else:
-        record = architect_reader.load_architect_determination_by_cycle(
-            cycle_id
-        )
+    record = load_agentdb_architect_determination(architect_id)
     payload = _mapping(record, "determination")
     if payload is None and isinstance(record, Mapping):
         payload = record
@@ -216,7 +201,7 @@ def _validate_expected_claim_binding(
     expected: Mapping[str, str] | None,
 ) -> list[str]:
     if expected is None:
-        return []
+        return ["fix_claim_binding_missing"]
     candidate = (
         determination.get("queue_candidate")
         if isinstance(determination, Mapping)
@@ -277,31 +262,64 @@ def _memex_supply_receipt(cycle: Mapping[str, Any]) -> Mapping[str, Any] | None:
 def _validate_memex_supply(
     receipt: Mapping[str, Any] | None,
     determination: Mapping[str, Any] | None,
+    *,
+    cycle: Mapping[str, Any],
+    now_iso: str,
 ) -> list[str]:
     if not isinstance(receipt, Mapping) or not receipt:
         return [ResidentFixHandoffReason.MISSING_MEMEX_SUPPLY_RECEIPT]
-    reasons: list[str] = []
-    required = (
-        "schema_version",
-        "receipt_id",
-        "snapshot_receipt_id",
-        "snapshot_content_digest",
-        "memex_view_id",
-        "holoindex_generation_id",
-        "source_revision",
-        "no_holoindex_reindex_performed",
+    if not isinstance(determination, Mapping) or not determination:
+        return [ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID]
+    proposal = determination.get("proposal_admission")
+    intent = cycle.get("intent")
+    expected_view_id = _memex_supply_view_id(cycle)
+    if not isinstance(proposal, Mapping) or not isinstance(intent, Mapping):
+        return [ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID]
+    expected_foundup = _clean(intent.get("foundup_id"))
+    expected_principal = _clean(
+        intent.get("principal_id")
+        or intent.get("principal_ref")
+        or intent.get("origin_principal")
     )
-    missing = [field for field in required if receipt.get(field) in (None, "", ())]
-    if missing or receipt.get("schema_version") != "reddog_operational_memex_snapshot_supply_receipt.v1":
-        reasons.append(ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID)
-    if receipt.get("no_holoindex_reindex_performed") is not True:
-        reasons.append(ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID)
-    if isinstance(determination, Mapping) and determination:
-        if _clean(receipt.get("snapshot_receipt_id")) != _clean(determination.get("snapshot_receipt_id")):
-            reasons.append(ResidentFixHandoffReason.MEMEX_SNAPSHOT_MISMATCH)
-        if _clean(receipt.get("snapshot_content_digest")) != _clean(determination.get("snapshot_content_digest")):
-            reasons.append(ResidentFixHandoffReason.MEMEX_SNAPSHOT_MISMATCH)
-    return reasons
+    if not expected_foundup or not expected_principal or not expected_view_id:
+        return [ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID]
+    if _clean(receipt.get("memex_view_id")) != expected_view_id:
+        return [ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID]
+    if (
+        _clean(receipt.get("snapshot_receipt_id"))
+        != _clean(determination.get("snapshot_receipt_id"))
+        or _clean(receipt.get("snapshot_content_digest"))
+        != _clean(determination.get("snapshot_content_digest"))
+    ):
+        return [ResidentFixHandoffReason.MEMEX_SNAPSHOT_MISMATCH]
+    try:
+        rehydrate_operational_memex_supply_receipt(
+            receipt,
+            expected_foundup_id=expected_foundup,
+            expected_principal_id=expected_principal,
+            expected_snapshot_receipt_id=_clean(determination.get("snapshot_receipt_id")),
+            expected_snapshot_content_digest=_clean(determination.get("snapshot_content_digest")),
+            expected_holoindex_generation_id=_clean(proposal.get("holoindex_generation_id")),
+            expected_source_revision=_clean(proposal.get("work_state_revision")),
+            now_iso=now_iso,
+        )
+    except (TypeError, ValueError):
+        return [ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID]
+    return []
+
+
+def _memex_supply_view_id(cycle: Mapping[str, Any]) -> str:
+    for key in ("initial_bootstrap", "final_bootstrap"):
+        bootstrap = cycle.get(key)
+        if isinstance(bootstrap, Mapping):
+            value = _clean(bootstrap.get("memex_snapshot_supply_view_id"))
+            if value:
+                return value
+    return ""
+
+
+def _now_iso(value: str | None) -> str:
+    return value or datetime.now(timezone.utc).isoformat()
 
 
 def _runtime_output_path(

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,14 @@
+## 2026-08-04: Memex supply authenticity regressions
+
+- Added exact receipt round-trip, unknown-field/type, lineage, scope, expiry,
+  timezone, maximum-age, maximum-lifetime, and boundary tests.
+- Added promotion-level proofs that fabricated `sha256:` IDs and
+  attacker-rehashed Memex substitutions cannot mutate authoritative work state,
+  while valid promotion binds the complete canonical Memex receipt digest.
+- Added proposal-builder, resident-handoff, and authority-seed regressions that
+  reject malformed public dataclass instances and forged serialized receipts
+  before signer, artifact, or profile effects.
+
 ## 2026-08-03: Upstream Hermes complete-event-history confinement
 
 - Added regressions proving a completed poll result cannot hide an earlier

--- a/modules/communication/moltbot_bridge/tests/architect_proposal_promotion_test_helpers.py
+++ b/modules/communication/moltbot_bridge/tests/architect_proposal_promotion_test_helpers.py
@@ -7,7 +7,7 @@ import json
 import tempfile
 import uuid
 from dataclasses import replace
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping
 from unittest.mock import patch
@@ -32,6 +32,9 @@ from modules.communication.moltbot_bridge.src.reddog_signer_socket_service_runti
 )
 from modules.communication.moltbot_bridge.src.reddog_main_architect_fix_promotion_bootstrap import (
     run_reddog_main_architect_fix_promotion_bootstrap as _run_bootstrap,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    rehydrate_operational_memex_supply_receipt,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_architect_proposal_signer_policy_runtime import (
     _policy_authorization,
@@ -101,6 +104,7 @@ def seal_authority_profile(
 def build_proposal_runtime_inputs(
     determination: Mapping[str, Any],
     authority_profile: Mapping[str, Any],
+    memex_supply_receipt: Mapping[str, Any],
     *,
     now_epoch: int,
     nonce: str | None = None,
@@ -109,10 +113,18 @@ def build_proposal_runtime_inputs(
         "proposal-promotion-nonce-"
         f"{next(_NONCE_COUNTER)}-{uuid.uuid4().hex}"
     )
+    proposal = dict(determination["proposal_admission"])
+    verified_memex = verified_memex_supply_for_test(
+        determination,
+        authority_profile,
+        memex_supply_receipt,
+        now_epoch=now_epoch,
+    )
     payload = build_architect_proposal_authenticity_payload(
-        proposal_admission=dict(determination["proposal_admission"]),
+        proposal_admission=proposal,
         determination=determination,
         queue_candidate=dict(determination["queue_candidate"]),
+        memex_supply_receipt=verified_memex,
         requester_principal_id=str(authority_profile["principal_id"]),
         reddog_id=str(authority_profile["reddog_id"]),
         signer_public_key=str(authority_profile["reddog_public_key"]),
@@ -135,6 +147,30 @@ def build_proposal_runtime_inputs(
             now_epoch=now_epoch,
         ),
         StaticPrincipalKeyResolver(),
+    )
+
+
+def verified_memex_supply_for_test(
+    determination: Mapping[str, Any],
+    authority_profile: Mapping[str, Any],
+    memex_supply_receipt: Mapping[str, Any],
+    *,
+    now_epoch: int,
+):
+    proposal = dict(determination["proposal_admission"])
+    return rehydrate_operational_memex_supply_receipt(
+        memex_supply_receipt,
+        expected_foundup_id=str(authority_profile["foundup_id"]),
+        expected_principal_id=str(authority_profile["principal_id"]),
+        expected_snapshot_receipt_id=str(determination["snapshot_receipt_id"]),
+        expected_snapshot_content_digest=str(
+            determination["snapshot_content_digest"]
+        ),
+        expected_holoindex_generation_id=str(
+            proposal["holoindex_generation_id"]
+        ),
+        expected_source_revision=str(proposal["work_state_revision"]),
+        now_iso=datetime.fromtimestamp(now_epoch, timezone.utc).isoformat(),
     )
 
 
@@ -211,12 +247,18 @@ def run_bootstrap_with_test_authority(runner: Any, **kwargs: Any) -> Any:
                     encoding="utf-8"
                 )
             )
+            memex_supply = json.loads(
+                Path(kwargs["memex_supply_receipt_path"]).read_text(
+                    encoding="utf-8"
+                )
+            )
             now_epoch = int(
                 datetime.fromisoformat(str(kwargs["now_iso"])).timestamp()
             )
             attestation, config, resolver = build_proposal_runtime_inputs(
                 determination,
                 authority_profile,
+                memex_supply,
                 now_epoch=now_epoch,
             )
             kwargs["proposal_authenticity_attestation"] = attestation
@@ -245,6 +287,7 @@ def invoke_promotion_with_test_authority(
     values = dict(args)
     default_determination = values["architect_determination"]
     default_authority_profile = values["authority_profile"]
+    default_memex_supply = values["memex_supply_receipt"]
     values.update(overrides)
     if "proposal_authenticity_attestation" not in values:
         determination = values["architect_determination"]
@@ -266,9 +309,20 @@ def invoke_promotion_with_test_authority(
         )
         if not all(profile.get(field) for field in required):
             profile = default_authority_profile
+        memex_supply = values["memex_supply_receipt"]
+        try:
+            verified_memex_supply_for_test(
+                determination,
+                profile,
+                memex_supply,
+                now_epoch=now_epoch,
+            )
+        except (TypeError, ValueError):
+            memex_supply = default_memex_supply
         attestation, runtime_config, resolver = build_proposal_runtime_inputs(
             determination,
             profile,
+            memex_supply,
             now_epoch=now_epoch,
         )
         values.update(
@@ -296,4 +350,5 @@ __all__ = [
     "run_main_bootstrap_with_test_authority",
     "run_bootstrap_with_test_authority",
     "seal_authority_profile",
+    "verified_memex_supply_for_test",
 ]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_agentdb_fix_promotion_claim.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_agentdb_fix_promotion_claim.py
@@ -110,16 +110,29 @@ def _seed_fix_cycle(*, include_memex: bool = True):
     )
     assert result.accepted is True
     assert result.receipt is not None
+    assert result.receipt.proposal_admission is not None
+    proposal = result.receipt.proposal_admission
+    intent = _bound_intent()
+    memex = _memex_supply(
+        foundup_id=str(intent["foundup_id"]),
+        principal_id=str(intent["principal_ref"]),
+        snapshot_receipt_id=result.receipt.snapshot_receipt_id,
+        snapshot_content_digest=result.receipt.snapshot_content_digest,
+        policy_issued_at=NOW.isoformat(),
+        policy_expires_at=(NOW + timedelta(seconds=600)).isoformat(),
+        holoindex_generation_id=proposal.holoindex_generation_id,
+        source_revision=proposal.work_state_revision,
+    )
     cycle_store = AgentDbResidentArchitectCycleStore()
     record = cycle_runtime._new_record(_bound_intent(), retry_count=0)
     assert cycle_store.create_cycle(record)["ok"]
-    enqueued = cycle_store.transition_cycle(
+    cycle_store.transition_cycle(
         str(record["intent_id"]),
         expected_revision=0,
         expected_statuses=("SUBMITTED",),
         updates={"status": "ENQUEUED"},
     )["record"]
-    running = cycle_store.transition_cycle(
+    cycle_store.transition_cycle(
         str(record["intent_id"]),
         expected_revision=1,
         expected_statuses=("ENQUEUED",),
@@ -137,10 +150,8 @@ def _seed_fix_cycle(*, include_memex: bool = True):
             "queue_candidate_count": 1,
             "initial_bootstrap": (
                 {
-                    "memex_snapshot_supply_receipt": _memex_supply(
-                        snapshot_receipt_id=result.receipt.snapshot_receipt_id,
-                        snapshot_content_digest=result.receipt.snapshot_content_digest,
-                    )
+                    "memex_snapshot_supply_view_id": memex["memex_view_id"],
+                    "memex_snapshot_supply_receipt": memex,
                 }
                 if include_memex
                 else {}
@@ -650,6 +661,7 @@ def test_materialization_rejects_determination_changed_after_claim(
             "queue_candidate_id": claim.queue_candidate_id,
             "wsp15_allocation_receipt_id": claim.wsp15_allocation_receipt_id,
         },
+        now_iso=NOW.isoformat(),
     )
 
     assert result.accepted is False
@@ -662,6 +674,7 @@ def test_artifact_pair_failure_restores_previous_pair(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cycle = _seed_fix_cycle()
+    claim = claim_next_reddog_fix_promotion(worker_id="main", now=NOW)
     determination_path = tmp_path / "determination.json"
     memex_path = tmp_path / "memex.json"
     determination_path.write_bytes(b"old-determination")
@@ -682,6 +695,14 @@ def test_artifact_pair_failure_restores_previous_pair(
         intent_id=cycle.intent_id,
         architect_determination_output_path=determination_path,
         memex_supply_receipt_output_path=memex_path,
+        expected_claim_binding={
+            "cycle_id": claim.cycle_id,
+            "snapshot_id": claim.snapshot_id,
+            "determination_id": claim.determination_id,
+            "queue_candidate_id": claim.queue_candidate_id,
+            "wsp15_allocation_receipt_id": claim.wsp15_allocation_receipt_id,
+        },
+        now_iso=NOW.isoformat(),
     )
 
     assert result.accepted is False

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_fix_signed_wsp15_work_order_promotion.py
@@ -79,6 +79,10 @@ from modules.communication.moltbot_bridge.src.reddog_wsp15_allocation_receipt im
     allocate_reddog_wsp15_receipt,
     canonical_reddog_wsp15_allocation_digest,
 )
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    canonical_operational_memex_supply_digest,
+    operational_memex_supply_receipt_id,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -383,18 +387,25 @@ def _memex_supply(**overrides: Any) -> dict[str, Any]:
         "snapshot_receipt_id": SNAPSHOT_ID,
         "snapshot_content_digest": "sha256:" + ("b" * 64),
         "memex_view_id": "memex-view-1",
-        "holoindex_generation_id": "sha256:holo-generation",
-        "source_revision": "sha256:memex-source",
-        "policy_issued_at": NOW,
-        "policy_expires_at": "2026-07-16T01:00:00+00:00",
-        "assignment_id": "assignment-1",
-        "lane_id": "repo_code_audit",
-        "receipt_id": "sha256:memex-supply",
+        "holoindex_generation_id": _holo_receipt().generation_id,
+        "source_revision": _work_state()["revision"],
+        "policy_issued_at": "2026-07-15T23:59:50+00:00",
+        "policy_expires_at": "2026-07-16T00:09:50+00:00",
+        "assignment_count": 1,
+        "assignment_ids": ["assignment-1"],
+        "lane_ids": ["repo_code_audit"],
+        "task_ids": ["task-1"],
+        "assignment_receipt_ids": ["sha256:assignment-receipt-1"],
+        "max_records": 32,
         "no_memex_write_performed": True,
         "no_holoindex_reindex_performed": True,
         "no_repo_mutation_performed": True,
     }
+    supplied_receipt_id = overrides.pop("receipt_id", None)
     payload.update(overrides)
+    payload["receipt_id"] = supplied_receipt_id or operational_memex_supply_receipt_id(
+        payload
+    )
     return payload
 
 
@@ -601,7 +612,7 @@ def test_promotes_fix_determination_to_queue_item_and_authority_profile() -> Non
     assert result.status == promotion.ARCHITECT_FIX_WSP15_PROMOTION_ACCEPT
     assert result.receipt is not None
     assert result.receipt.model_selection_receipt_id.startswith("model_selection_receipt:")
-    assert result.receipt.memex_supply_receipt_id == "sha256:memex-supply"
+    assert result.receipt.memex_supply_receipt_id == _memex_supply()["receipt_id"]
     assert result.authority_profile is not None
     assert result.authority_profile["wsp15_allocation_receipt"]["receipt_id"] == _allocation()["receipt_id"]
     assert result.authority_profile["model_selection_receipt"]["receipt_id"] == (
@@ -748,6 +759,85 @@ def test_rejects_missing_memex_supply_receipt() -> None:
     assert promotion.ArchitectFixPromotionReason.MEMEX_SUPPLY_MISSING in result.rejection_reasons
 
 
+def _signed_inputs_for_memex(receipt: Mapping[str, Any]):
+    determination = _determination()
+    profile = _authority_profile()
+    attestation, runtime_config, resolver = build_proposal_runtime_inputs(
+        determination,
+        profile,
+        receipt,
+        now_epoch=NOW_EPOCH,
+    )
+    return determination, profile, attestation, runtime_config, resolver
+
+
+def test_fabricated_sha256_memex_id_rejects_before_state_mutation() -> None:
+    original = _memex_supply()
+    determination, profile, attestation, runtime_config, resolver = (
+        _signed_inputs_for_memex(original)
+    )
+    forged = {**original, "receipt_id": "sha256:" + ("a" * 64)}
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+    before = store.load()
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=determination,
+        authority_profile=profile,
+        memex_supply_receipt=forged,
+        proposal_authenticity_attestation=attestation,
+        signer_runtime_config=runtime_config,
+        principal_key_resolver=resolver,
+    )
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.MEMEX_SUPPLY_INVALID in (
+        result.rejection_reasons
+    )
+    assert store.load() == before
+
+
+def test_self_rehashed_memex_substitution_rejects_signed_digest_mismatch() -> None:
+    original = _memex_supply()
+    determination, profile, attestation, runtime_config, resolver = (
+        _signed_inputs_for_memex(original)
+    )
+    substituted = _memex_supply(memex_view_id="attacker-selected-view")
+    store = InMemoryAuthoritativeWorkStateStore(_work_state())
+    before = store.load()
+
+    result, _ = _promote(
+        store=store,
+        architect_determination=determination,
+        authority_profile=profile,
+        memex_supply_receipt=substituted,
+        proposal_authenticity_attestation=attestation,
+        signer_runtime_config=runtime_config,
+        principal_key_resolver=resolver,
+    )
+
+    assert result.accepted is False
+    assert promotion.ArchitectFixPromotionReason.PROPOSAL_AUTHENTICITY_INVALID in (
+        result.rejection_reasons
+    )
+    assert store.load() == before
+
+
+def test_promotion_binds_complete_memex_receipt_digest() -> None:
+    memex = _memex_supply()
+    result, store = _promote(memex_supply_receipt=memex)
+    expected = canonical_operational_memex_supply_digest(memex)
+
+    assert result.accepted is True
+    assert result.receipt is not None
+    assert result.receipt.memex_supply_digest == expected
+    assert store.load()["wre_queue_items"][0]["memex_supply_digest"] == expected
+    assert result.authority_profile is not None
+    assert result.authority_profile["operational_context_binding"][
+        "memex_supply_digest"
+    ] == expected
+
+
 def test_rejects_duplicate_active_queue_item_for_same_determination() -> None:
     first, store = _promote()
     assert first.accepted is True
@@ -792,6 +882,7 @@ def test_blocked_candidate_with_forged_authenticity_still_rejects() -> None:
     attestation, runtime_config, resolver = build_proposal_runtime_inputs(
         determination,
         profile,
+        _memex_supply(),
         now_epoch=NOW_EPOCH,
     )
     forged = dict(attestation)

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_authenticity.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_authenticity.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -35,6 +37,10 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signer_backend impo
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
     SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    OperationalMemexSupplyReceipt,
+    operational_memex_supply_receipt_id,
 )
 from modules.communication.moltbot_bridge.src.reddog_signer_delegated_authority_runtime import (
     SigningRequest,
@@ -139,6 +145,33 @@ def _determination(candidate: dict | None = None) -> dict:
     }
 
 
+def _memex_receipt() -> OperationalMemexSupplyReceipt:
+    issued = datetime.fromtimestamp(NOW - 10, timezone.utc)
+    values = {
+        "schema_version": "reddog_operational_memex_snapshot_supply_receipt.v1",
+        "foundup_id": "foundups-agent",
+        "principal_id": "github:012",
+        "snapshot_receipt_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:" + "2" * 64,
+        "memex_view_id": "memex-view-1",
+        "holoindex_generation_id": "generation-1",
+        "source_revision": "revision-1",
+        "policy_issued_at": issued.isoformat(),
+        "policy_expires_at": (issued + timedelta(seconds=600)).isoformat(),
+        "assignment_count": 1,
+        "assignment_ids": ("assignment-1",),
+        "lane_ids": ("lane-1",),
+        "task_ids": ("task-1",),
+        "assignment_receipt_ids": ("assignment-receipt-1",),
+        "max_records": 32,
+        "no_memex_write_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+    values["receipt_id"] = operational_memex_supply_receipt_id(values)
+    return OperationalMemexSupplyReceipt(**values)
+
+
 def _payload(public_key: str, *, nonce: str = "proposal-nonce-1"):
     candidate = _candidate()
     determination = _determination(candidate)
@@ -146,6 +179,7 @@ def _payload(public_key: str, *, nonce: str = "proposal-nonce-1"):
         proposal_admission=_proposal(),
         determination=determination,
         queue_candidate=candidate,
+        memex_supply_receipt=_memex_receipt(),
         requester_principal_id="github:012",
         reddog_id="reddog-0102",
         signer_public_key=public_key,
@@ -402,6 +436,8 @@ def test_signer_rolls_back_nonce_reservation_when_audit_mac_fails() -> None:
         ("repo_head_sha", "b" * 40),
         ("wsp15_allocation_digest", "sha256:" + "b" * 64),
         ("holoindex_generation_id", "generation-2"),
+        ("memex_supply_receipt_id", "sha256:" + "c" * 64),
+        ("memex_supply_digest", "sha256:" + "d" * 64),
         ("key_epoch", "epoch-2"),
         ("requester_principal_id", "github:attacker"),
     ],
@@ -431,6 +467,51 @@ def test_verifier_rejects_non_typed_integrity_context() -> None:
         )
 
 
+def test_payload_builder_rejects_unverified_memex_mapping() -> None:
+    private_key = _private_key()
+
+    with pytest.raises(ValueError, match="memex_supply_not_verified"):
+        build_architect_proposal_authenticity_payload(
+            proposal_admission=_proposal(),
+            determination=_determination(),
+            queue_candidate=_candidate(),
+            memex_supply_receipt={"receipt_id": "sha256:" + "a" * 64},
+            requester_principal_id="github:012",
+            reddog_id="reddog-0102",
+            signer_public_key=_public_text(private_key),
+            key_epoch="epoch-1",
+            consensus_receipt_digest="sha256:" + "8" * 64,
+            authority_profile_source_receipt_id="sha256:" + "9" * 64,
+            nonce="unverified-memex",
+            issued_at=NOW - 5,
+            expires_at=NOW + 120,
+        )
+
+
+def test_payload_builder_rehydrates_typed_memex_before_signing() -> None:
+    private_key = _private_key()
+
+    with pytest.raises(ValueError, match="receipt_id_mismatch"):
+        build_architect_proposal_authenticity_payload(
+            proposal_admission=_proposal(),
+            determination=_determination(),
+            queue_candidate=_candidate(),
+            memex_supply_receipt=replace(
+                _memex_receipt(),
+                receipt_id="sha256:" + "a" * 64,
+            ),
+            requester_principal_id="github:012",
+            reddog_id="reddog-0102",
+            signer_public_key=_public_text(private_key),
+            key_epoch="epoch-1",
+            consensus_receipt_digest="sha256:" + "8" * 64,
+            authority_profile_source_receipt_id="sha256:" + "9" * 64,
+            nonce="malformed-typed-memex",
+            issued_at=NOW - 5,
+            expires_at=NOW + 120,
+        )
+
+
 def test_expiry_and_revocation_fail_closed() -> None:
     attestation, _, _ = _attestation()
     with pytest.raises(ValueError):
@@ -446,6 +527,7 @@ def test_verifier_rejects_ttl_above_policy_maximum() -> None:
         proposal_admission=_proposal(),
         determination=_determination(),
         queue_candidate=_candidate(),
+        memex_supply_receipt=_memex_receipt(),
         requester_principal_id="github:012",
         reddog_id="reddog-0102",
         signer_public_key=payload.signer_public_key,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_signer_policy_runtime.py
@@ -15,6 +15,7 @@ import tempfile
 import threading
 import time
 from concurrent.futures import ProcessPoolExecutor
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -42,6 +43,10 @@ from modules.communication.moltbot_bridge.src.reddog_ed25519_signature_verifier_
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_protocol import (
     SignerPeerAttestation,
+)
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    OperationalMemexSupplyReceipt,
+    operational_memex_supply_receipt_id,
 )
 from modules.communication.moltbot_bridge.src.reddog_isolated_signer_socket_resident_service import (
     SIGNER_SOCKET_RESIDENT_SERVICE_SERVED,
@@ -307,6 +312,7 @@ def _payload(public_key: str, **overrides: object):
         "proposal_admission": proposal,
         "determination": determination,
         "queue_candidate": candidate,
+        "memex_supply_receipt": _memex_receipt(now),
         "requester_principal_id": "github:mjtrout",
         "reddog_id": "reddog:foundups-agent",
         "signer_public_key": public_key,
@@ -318,7 +324,43 @@ def _payload(public_key: str, **overrides: object):
         "expires_at": now + 120,
     }
     values.update(overrides)
+    if "requester_principal_id" in overrides:
+        values["memex_supply_receipt"] = _memex_receipt(
+            now,
+            principal_id=str(values["requester_principal_id"]),
+        )
     return build_architect_proposal_authenticity_payload(**values)
+
+
+def _memex_receipt(
+    now: int,
+    *,
+    principal_id: str = "github:mjtrout",
+) -> OperationalMemexSupplyReceipt:
+    issued = datetime.fromtimestamp(now - 10, timezone.utc)
+    values = {
+        "schema_version": "reddog_operational_memex_snapshot_supply_receipt.v1",
+        "foundup_id": "foundups-agent",
+        "principal_id": principal_id,
+        "snapshot_receipt_id": "snapshot-1",
+        "snapshot_content_digest": "sha256:" + "2" * 64,
+        "memex_view_id": "memex-view-1",
+        "holoindex_generation_id": "generation-1",
+        "source_revision": "revision-1",
+        "policy_issued_at": issued.isoformat(),
+        "policy_expires_at": (issued + timedelta(seconds=600)).isoformat(),
+        "assignment_count": 1,
+        "assignment_ids": ("assignment-1",),
+        "lane_ids": ("lane-1",),
+        "task_ids": ("task-1",),
+        "assignment_receipt_ids": ("assignment-receipt-1",),
+        "max_records": 32,
+        "no_memex_write_performed": True,
+        "no_holoindex_reindex_performed": True,
+        "no_repo_mutation_performed": True,
+    }
+    values["receipt_id"] = operational_memex_supply_receipt_id(values)
+    return OperationalMemexSupplyReceipt(**values)
 
 
 def _profile(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_verified_authority.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_architect_proposal_verified_authority.py
@@ -28,11 +28,13 @@ from modules.communication.moltbot_bridge.tests.architect_proposal_promotion_tes
     StaticPrincipalKeyResolver,
     build_proposal_runtime_inputs,
     seal_authority_profile,
+    verified_memex_supply_for_test,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
     NOW_EPOCH,
     _authority_profile,
     _determination,
+    _memex_supply,
     _promote,
     _work_state,
 )
@@ -63,18 +65,26 @@ def _inputs():
     attestation, runtime_config, resolver = build_proposal_runtime_inputs(
         determination,
         profile,
+        _memex_supply(),
         now_epoch=NOW_EPOCH,
     )
-    return determination, profile, attestation, runtime_config, resolver
+    memex = verified_memex_supply_for_test(
+        determination,
+        profile,
+        _memex_supply(),
+        now_epoch=NOW_EPOCH,
+    )
+    return determination, profile, memex, attestation, runtime_config, resolver
 
 
 def _verify(**overrides: Any):
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, memex, attestation, runtime_config, resolver = _inputs()
     values = {
         "attestation": attestation,
         "proposal_admission": determination["proposal_admission"],
         "determination": determination,
         "queue_candidate": determination["queue_candidate"],
+        "memex_supply_receipt": memex,
         "authority_profile": profile,
         "signer_runtime_config": runtime_config,
         "principal_key_resolver": resolver,
@@ -94,7 +104,7 @@ def test_untrusted_principal_cannot_self_mint_authority() -> None:
 
 
 def test_tampered_attestation_and_runtime_authorization_fail() -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     changed_attestation = dict(attestation)
     signature = str(changed_attestation["signature"])
     midpoint = len(signature) // 2
@@ -123,7 +133,7 @@ def test_tampered_attestation_and_runtime_authorization_fail() -> None:
 
 
 def test_tautological_signer_context_is_rejected() -> None:
-    _, _, _, runtime_config, _ = _inputs()
+    _, _, _, _, runtime_config, _ = _inputs()
     authorization = runtime_config.proposal_policy_authorization.to_dict()
     authorization["signer_instance_id"] = "attacker-selected-instance"
     changed = dataclasses.replace(
@@ -135,7 +145,7 @@ def test_tautological_signer_context_is_rejected() -> None:
 
 
 def test_current_determination_profile_and_revocation_are_rechecked() -> None:
-    determination, _, attestation, runtime_config, resolver = _inputs()
+    determination, _, _, attestation, runtime_config, resolver = _inputs()
     changed_determination = json.loads(json.dumps(determination))
     changed_determination["next_slice_name"] = "REDDOG_CHANGED_PHASE1"
     changed_determination["queue_candidate"]["slice_id"] = (
@@ -189,7 +199,7 @@ def test_caller_profile_cannot_substitute_signed_authority_fields(
     changed: Any,
     receipt_mode: str,
 ) -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     changed_profile = {**profile, field: changed}
     if receipt_mode == "recomputed":
         changed_profile = seal_authority_profile(changed_profile)
@@ -206,7 +216,7 @@ def test_caller_profile_cannot_substitute_signed_authority_fields(
 
 
 def test_caller_cannot_substitute_authority_profile_source_receipt() -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     result, store = _promote(
         architect_determination=determination,
         authority_profile={
@@ -238,7 +248,7 @@ def test_missing_runtime_trust_cannot_enter_promotion() -> None:
 
 
 def test_failed_profile_write_allows_verified_retry() -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     common = {
         "architect_determination": determination,
         "authority_profile": profile,
@@ -258,7 +268,7 @@ def test_failed_profile_write_allows_verified_retry() -> None:
 
 
 def test_failed_store_write_allows_verified_retry() -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     store = InMemoryAuthoritativeWorkStateStore(
         _work_state(), fail_commit=True
     )
@@ -281,7 +291,7 @@ def test_failed_store_write_allows_verified_retry() -> None:
 
 
 def test_success_persists_replay_guard_in_authoritative_store() -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     first, store = _promote(
         architect_determination=determination,
         authority_profile=profile,
@@ -306,7 +316,7 @@ def test_success_persists_replay_guard_in_authoritative_store() -> None:
 def test_replay_guard_survives_authoritative_store_restart(
     tmp_path: Path,
 ) -> None:
-    determination, profile, attestation, runtime_config, resolver = _inputs()
+    determination, profile, _, attestation, runtime_config, resolver = _inputs()
     store_path = tmp_path / "runtime" / "work-state.json"
     store_path.parent.mkdir()
     store_path.write_text(

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_seed_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_seed_supply.py
@@ -38,7 +38,7 @@ MODULE_PATH = (
     / "src"
     / "reddog_authority_profile_seed_supply.py"
 )
-NOW = 1_800_000_000
+NOW = 1_784_160_000
 
 
 def _supply(tmp_path: Path, **overrides):
@@ -170,6 +170,32 @@ def test_seed_supply_rejects_memex_foundup_mismatch(tmp_path: Path) -> None:
 
     assert result.accepted is False
     assert AuthorityProfileSeedSupplyReason.FOUNDUP_SCOPE_INVALID in result.rejection_reasons
+
+
+def test_seed_supply_rejects_fabricated_memex_receipt_without_writes(tmp_path: Path) -> None:
+    output = tmp_path / "runtime" / "authority_profile_seed.json"
+    result = _supply(
+        tmp_path,
+        output_path=output,
+        memex_supply_receipt=_memex_supply(receipt_id="sha256:" + ("f" * 64)),
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID in result.rejection_reasons
+    assert not output.exists()
+
+
+def test_seed_supply_rejects_rehashed_memex_lineage_without_writes(tmp_path: Path) -> None:
+    output = tmp_path / "runtime" / "authority_profile_seed.json"
+    result = _supply(
+        tmp_path,
+        output_path=output,
+        memex_supply_receipt=_memex_supply(source_revision="sha256:attacker-revision"),
+    )
+
+    assert result.accepted is False
+    assert AuthorityProfileSeedSupplyReason.MEMEX_SUPPLY_INVALID in result.rejection_reasons
+    assert not output.exists()
 
 
 def test_seed_supply_rejects_output_inside_repo(tmp_path: Path) -> None:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_seed_supply_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authority_profile_seed_supply_bootstrap.py
@@ -33,7 +33,7 @@ MODULE_PATH = (
     / "src"
     / "reddog_authority_profile_seed_supply_bootstrap.py"
 )
-NOW = 1_800_000_000
+NOW = 1_784_160_000
 
 
 def _write_json(root: Path, name: str, payload: object) -> Path:

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_model_runtime_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_model_runtime_bootstrap.py
@@ -52,9 +52,11 @@ def test_bootstrap_forwards_runtime_binding_receipt_into_promotion(tmp_path: Pat
     capability = model_runtime_binding_test_capability(selection, binding)
     determination = json.loads(files["determination"].read_text(encoding="utf-8"))
     authority_profile = json.loads(files["authority_profile_source"].read_text(encoding="utf-8"))
+    memex_supply = json.loads(files["memex_supply"].read_text(encoding="utf-8"))
     attestation, signer_config, key_resolver = build_proposal_runtime_inputs(
         determination,
         authority_profile,
+        memex_supply,
         now_epoch=int(datetime.fromisoformat(NOW).timestamp()),
     )
     with (

--- a/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_main_architect_fix_promotion_bootstrap.py
@@ -239,6 +239,7 @@ def test_bootstrap_exact_retry_reconstructs_committed_promotion(
     attestation, config, resolver = build_proposal_runtime_inputs(
         determination,
         profile,
+        json.loads(files["memex_supply"].read_text(encoding="utf-8")),
         now_epoch=now_epoch,
         nonce="proposal-promotion-retry-0001",
     )
@@ -400,6 +401,7 @@ def test_crash_after_publication_reclaims_and_reconstructs_exact_promotion(
     attestation, config, resolver = build_proposal_runtime_inputs(
         determination,
         profile,
+        json.loads(files["memex_supply"].read_text(encoding="utf-8")),
         now_epoch=int(datetime.fromisoformat(NOW).timestamp()),
         nonce="proposal-promotion-crash-reclaim-0001",
     )

--- a/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_supply_receipt.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_operational_memex_supply_receipt.py
@@ -1,0 +1,180 @@
+"""Security tests for operational Memex supply receipt rehydration."""
+
+from __future__ import annotations
+
+import ast
+import copy
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_operational_memex_supply_receipt import (
+    canonical_operational_memex_supply_digest,
+    operational_memex_supply_receipt_id,
+    rehydrate_operational_memex_supply_receipt,
+)
+from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    NOW,
+    _authority_profile,
+    _determination,
+    _holo_receipt,
+    _memex_supply,
+)
+
+
+MODULE_PATHS = tuple(
+    Path(__file__).resolve().parents[1] / "src" / name
+    for name in (
+        "reddog_operational_memex_supply_freshness.py",
+        "reddog_operational_memex_supply_proposal_binding.py",
+        "reddog_operational_memex_supply_receipt.py",
+    )
+)
+
+
+def _rehydrate(receipt=None, **overrides):
+    determination = _determination()
+    profile = _authority_profile()
+    values = {
+        "expected_foundup_id": profile["foundup_id"],
+        "expected_principal_id": profile["principal_id"],
+        "expected_snapshot_receipt_id": determination["snapshot_receipt_id"],
+        "expected_snapshot_content_digest": determination[
+            "snapshot_content_digest"
+        ],
+        "expected_holoindex_generation_id": _holo_receipt().generation_id,
+        "expected_source_revision": determination["proposal_admission"][
+            "work_state_revision"
+        ],
+        "now_iso": NOW,
+    }
+    values.update(overrides)
+    return rehydrate_operational_memex_supply_receipt(
+        receipt or _memex_supply(),
+        **values,
+    )
+
+
+def test_valid_serialized_receipt_rehydrates_and_binds_full_digest() -> None:
+    source = _memex_supply()
+    receipt = _rehydrate(source)
+
+    assert receipt.receipt_id == source["receipt_id"]
+    assert canonical_operational_memex_supply_digest(receipt.to_dict()) == (
+        canonical_operational_memex_supply_digest(source)
+    )
+
+
+def test_fabricated_sha256_looking_receipt_id_is_rejected() -> None:
+    forged = {**_memex_supply(), "receipt_id": "sha256:" + ("a" * 64)}
+
+    with pytest.raises(ValueError, match="receipt_id_mismatch"):
+        _rehydrate(forged)
+
+
+def test_changed_content_with_old_receipt_id_is_rejected() -> None:
+    forged = {**_memex_supply(), "memex_view_id": "attacker-view"}
+
+    with pytest.raises(ValueError, match="receipt_id_mismatch"):
+        _rehydrate(forged)
+
+
+def test_self_rehashed_content_cannot_satisfy_expected_bindings() -> None:
+    forged = {**_memex_supply(), "foundup_id": "attacker_foundup"}
+    forged["receipt_id"] = operational_memex_supply_receipt_id(forged)
+
+    with pytest.raises(ValueError, match="authority_binding_mismatch"):
+        _rehydrate(forged)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("snapshot_receipt_id", "sha256:attacker-snapshot"),
+        ("snapshot_content_digest", "sha256:" + ("0" * 64)),
+        ("holoindex_generation_id", "sha256:" + ("1" * 64)),
+        ("source_revision", "sha256:attacker-revision"),
+    ),
+)
+def test_self_rehashed_lineage_mismatch_is_rejected(field: str, value: str) -> None:
+    forged = {**_memex_supply(), field: value}
+    forged["receipt_id"] = operational_memex_supply_receipt_id(forged)
+
+    with pytest.raises(ValueError, match="authority_binding_mismatch"):
+        _rehydrate(forged)
+
+
+def test_unknown_field_is_rejected() -> None:
+    forged = {**_memex_supply(), "accepted": True}
+    forged["receipt_id"] = operational_memex_supply_receipt_id(forged)
+
+    with pytest.raises(ValueError, match="fields_invalid"):
+        _rehydrate(forged)
+
+
+def test_expired_or_timezone_ambiguous_policy_is_rejected() -> None:
+    expired = _memex_supply(policy_expires_at=NOW)
+    naive = _memex_supply(
+        policy_issued_at="2026-07-15T23:00:00",
+        policy_expires_at="2026-07-16T01:00:00",
+    )
+
+    with pytest.raises(ValueError, match="expired"):
+        _rehydrate(expired)
+    with pytest.raises(ValueError, match="time_invalid"):
+        _rehydrate(naive)
+
+
+def test_overage_and_overlong_policy_windows_are_rejected() -> None:
+    old = _memex_supply(
+        policy_issued_at="2026-07-15T23:54:59+00:00",
+        policy_expires_at="2026-07-16T00:04:59+00:00",
+    )
+    overlong = _memex_supply(
+        policy_expires_at="2026-07-16T00:10:01+00:00"
+    )
+
+    with pytest.raises(ValueError, match="too_old"):
+        _rehydrate(old)
+    with pytest.raises(ValueError, match="ttl_exceeded"):
+        _rehydrate(overlong)
+
+
+def test_freshness_policy_accepts_exact_age_and_ttl_boundaries() -> None:
+    boundary = _memex_supply(
+        policy_issued_at="2026-07-15T23:55:00+00:00",
+        policy_expires_at="2026-07-16T00:05:00+00:00",
+    )
+
+    assert _rehydrate(boundary).receipt_id == boundary["receipt_id"]
+
+
+def test_type_coercion_and_false_boundary_flags_are_rejected() -> None:
+    scalar = copy.deepcopy(_memex_supply())
+    scalar["assignment_ids"] = [1]
+    scalar["receipt_id"] = operational_memex_supply_receipt_id(scalar)
+    boundary = _memex_supply(no_repo_mutation_performed=False)
+
+    with pytest.raises(ValueError, match="assignment_ids_invalid"):
+        _rehydrate(scalar)
+    with pytest.raises(ValueError, match="boundary_invalid"):
+        _rehydrate(boundary)
+
+
+def test_receipt_gate_is_bounded_and_has_no_effect_surface() -> None:
+    banned_roots = {"os", "pathlib", "socket", "subprocess", "urllib"}
+
+    for path in MODULE_PATHS:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        assert len(source.splitlines()) <= 200
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                assert node.end_lineno - node.lineno + 1 <= 50
+            if isinstance(node, ast.Import):
+                assert all(
+                    alias.name.split(".", 1)[0] not in banned_roots
+                    for alias in node.names
+                )
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert node.module.split(".", 1)[0] not in banned_roots

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_fix_promotion_artifact_handoff.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import ast
+import inspect
 import json
 from pathlib import Path
 from typing import Any, Mapping, Optional
+from unittest.mock import patch
 
+import pytest
+
+import modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_artifact_handoff as handoff_module
 from modules.communication.moltbot_bridge.src.reddog_backend_architect_determination_runtime import (
     ACTION_RESEARCH_MORE,
     InMemoryArchitectDeterminationStore,
@@ -18,9 +23,10 @@ from modules.communication.moltbot_bridge.src.reddog_resident_fix_promotion_arti
     RESIDENT_FIX_HANDOFF_APPLIED,
     RESIDENT_FIX_HANDOFF_NOT_READY,
     ResidentFixHandoffReason,
-    run_reddog_resident_fix_promotion_artifact_handoff,
+    run_reddog_resident_fix_promotion_artifact_handoff as _run_handoff,
 )
 from modules.communication.moltbot_bridge.tests.test_reddog_architect_fix_signed_wsp15_work_order_promotion import (
+    NOW,
     _determination,
     _memex_supply,
 )
@@ -64,15 +70,23 @@ class _CycleStore:
 
 def _cycle(**overrides: Any) -> dict[str, Any]:
     determination_id = _determination()["determination_receipt_id"]
+    memex = _memex_supply()
     record = {
-        "schema_version": "reddog_resident_architect_cycle.v1",
+        "schema_version": "reddog_resident_architect_cycle.v2",
         "intent_id": INTENT_ID,
+        "intent": {
+            "foundup_id": memex["foundup_id"],
+            "principal_id": memex["principal_id"],
+        },
         "cycle_id": CYCLE_ID,
+        "snapshot_id": _determination()["snapshot_receipt_id"],
         "status": STATUS_DETERMINED,
         "architect_action": "FIX",
         "architect_determination_id": determination_id,
+        "_store_integrity_valid": True,
         "initial_bootstrap": {
-            "memex_snapshot_supply_receipt": _memex_supply(),
+            "memex_snapshot_supply_view_id": memex["memex_view_id"],
+            "memex_snapshot_supply_receipt": memex,
         },
     }
     record.update(overrides)
@@ -91,16 +105,51 @@ def _architect_store(determination: Mapping[str, Any] | None = None) -> InMemory
     )
 
 
+def _claim_binding(cycle: Mapping[str, Any]) -> dict[str, str]:
+    determination = _determination()
+    candidate = determination["queue_candidate"]
+    allocation = candidate["wsp15_allocation_receipt"]
+    return {
+        "cycle_id": str(cycle.get("cycle_id") or ""),
+        "snapshot_id": str(cycle.get("snapshot_id") or ""),
+        "determination_id": str(determination["determination_receipt_id"]),
+        "queue_candidate_id": str(candidate["queue_candidate_id"]),
+        "wsp15_allocation_receipt_id": str(allocation["receipt_id"]),
+    }
+
+
+def _handoff(*, cycle_store=None, architect_store=None, **kwargs):
+    cycle_store = cycle_store or _CycleStore(_cycle())
+    architect_store = architect_store or _architect_store()
+    kwargs.setdefault("expected_claim_binding", _claim_binding(cycle_store.record))
+    with (
+        patch.object(
+            handoff_module,
+            "AgentDbResidentArchitectCycleStore",
+            return_value=cycle_store,
+        ),
+        patch.object(
+            handoff_module,
+            "load_agentdb_architect_determination",
+            side_effect=lambda _determination_id: (
+                architect_store.load_architect_determination_by_cycle(CYCLE_ID)
+            ),
+        ),
+    ):
+        return _run_handoff(**kwargs)
+
+
 def test_handoff_writes_determination_and_memex_artifacts_outside_repo(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
 
-    result = run_reddog_resident_fix_promotion_artifact_handoff(
+    result = _handoff(
         repo_root=REPO_ROOT,
         intent_id=INTENT_ID,
         architect_determination_output_path=runtime / "architect_determination.json",
         memex_supply_receipt_output_path=runtime / "memex_supply_receipt.json",
         cycle_store=_CycleStore(_cycle()),
         architect_store=_architect_store(),
+        now_iso=NOW,
     )
 
     assert result.accepted is True
@@ -113,7 +162,7 @@ def test_handoff_writes_determination_and_memex_artifacts_outside_repo(tmp_path:
         "determination_receipt_id"
     ]
     assert memex["schema_version"] == "reddog_operational_memex_snapshot_supply_receipt.v1"
-    assert memex["receipt_id"] == "sha256:memex-supply"
+    assert memex["receipt_id"] == _memex_supply()["receipt_id"]
     assert result.no_signing_performed is True
     assert result.no_openclaw_enqueue_performed is True
     assert result.no_holoindex_reindex_performed is True
@@ -121,13 +170,14 @@ def test_handoff_writes_determination_and_memex_artifacts_outside_repo(tmp_path:
 
 
 def test_handoff_rejects_non_fix_cycle_without_writes(tmp_path: Path) -> None:
-    result = run_reddog_resident_fix_promotion_artifact_handoff(
+    result = _handoff(
         repo_root=REPO_ROOT,
         intent_id=INTENT_ID,
         architect_determination_output_path=tmp_path / "runtime" / "architect.json",
         memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
         cycle_store=_CycleStore(_cycle(architect_action=ACTION_RESEARCH_MORE)),
         architect_store=_architect_store(),
+        now_iso=NOW,
     )
 
     assert result.accepted is False
@@ -139,13 +189,14 @@ def test_handoff_rejects_non_fix_cycle_without_writes(tmp_path: Path) -> None:
 def test_handoff_rejects_missing_memex_supply_receipt(tmp_path: Path) -> None:
     cycle = _cycle(initial_bootstrap={})
 
-    result = run_reddog_resident_fix_promotion_artifact_handoff(
+    result = _handoff(
         repo_root=REPO_ROOT,
         intent_id=INTENT_ID,
         architect_determination_output_path=tmp_path / "runtime" / "architect.json",
         memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
         cycle_store=_CycleStore(cycle),
         architect_store=_architect_store(),
+        now_iso=NOW,
     )
 
     assert result.accepted is False
@@ -156,13 +207,21 @@ def test_handoff_rejects_missing_memex_supply_receipt(tmp_path: Path) -> None:
 def test_handoff_rejects_memex_snapshot_mismatch(tmp_path: Path) -> None:
     memex = _memex_supply(snapshot_receipt_id="sha256:other-snapshot")
 
-    result = run_reddog_resident_fix_promotion_artifact_handoff(
+    result = _handoff(
         repo_root=REPO_ROOT,
         intent_id=INTENT_ID,
         architect_determination_output_path=tmp_path / "runtime" / "architect.json",
         memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
-        cycle_store=_CycleStore(_cycle(initial_bootstrap={"memex_snapshot_supply_receipt": memex})),
+        cycle_store=_CycleStore(
+            _cycle(
+                initial_bootstrap={
+                    "memex_snapshot_supply_view_id": memex["memex_view_id"],
+                    "memex_snapshot_supply_receipt": memex,
+                }
+            )
+        ),
         architect_store=_architect_store(),
+        now_iso=NOW,
     )
 
     assert result.accepted is False
@@ -170,13 +229,14 @@ def test_handoff_rejects_memex_snapshot_mismatch(tmp_path: Path) -> None:
 
 
 def test_handoff_rejects_outputs_inside_repo(tmp_path: Path) -> None:
-    result = run_reddog_resident_fix_promotion_artifact_handoff(
+    result = _handoff(
         repo_root=REPO_ROOT,
         intent_id=INTENT_ID,
         architect_determination_output_path=REPO_ROOT / "runtime" / "architect.json",
         memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
         cycle_store=_CycleStore(_cycle()),
         architect_store=_architect_store(),
+        now_iso=NOW,
     )
 
     assert result.accepted is False
@@ -189,14 +249,16 @@ def test_handoff_rejects_aliased_output_paths_before_writing(tmp_path: Path) -> 
     original = b"existing-artifact\n"
     output_path.write_bytes(original)
 
-    result = run_reddog_resident_fix_promotion_artifact_handoff(
+    result = _handoff(
         repo_root=REPO_ROOT,
         intent_id=INTENT_ID,
         architect_determination_output_path=output_path,
         memex_supply_receipt_output_path=output_path.parent / "." / output_path.name,
         cycle_store=_CycleStore(_cycle()),
         architect_store=_architect_store(),
+        now_iso=NOW,
     )
+
 
     assert result.accepted is False
     assert result.status == RESIDENT_FIX_HANDOFF_NOT_READY
@@ -205,6 +267,87 @@ def test_handoff_rejects_aliased_output_paths_before_writing(tmp_path: Path) -> 
     assert result.memex_supply_receipt_path is None
     assert output_path.read_bytes() == original
     assert tuple(output_path.parent.iterdir()) == (output_path,)
+
+
+def test_handoff_rejects_fabricated_memex_receipt_before_writes(tmp_path: Path) -> None:
+    memex = _memex_supply(receipt_id="sha256:" + ("f" * 64))
+
+    result = _handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=tmp_path / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        cycle_store=_CycleStore(
+            _cycle(initial_bootstrap={"memex_snapshot_supply_receipt": memex})
+        ),
+        architect_store=_architect_store(),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID in result.rejection_reasons
+    assert not (tmp_path / "runtime" / "architect.json").exists()
+    assert not (tmp_path / "runtime" / "memex.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        ("foundup_id", "attacker_foundup"),
+        ("principal_id", "github:attacker"),
+        ("memex_view_id", "attacker-view"),
+    ),
+)
+def test_handoff_rejects_self_rehashed_authority_substitution(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    memex = _memex_supply(**{field: value})
+    cycle = _cycle()
+    cycle["initial_bootstrap"] = {
+        "memex_snapshot_supply_view_id": _memex_supply()["memex_view_id"],
+        "memex_snapshot_supply_receipt": memex,
+    }
+
+    result = _handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=tmp_path / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        cycle_store=_CycleStore(cycle),
+        architect_store=_architect_store(),
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert ResidentFixHandoffReason.MEMEX_SUPPLY_INVALID in result.rejection_reasons
+    assert not (tmp_path / "runtime" / "architect.json").exists()
+    assert not (tmp_path / "runtime" / "memex.json").exists()
+
+
+def test_handoff_rejects_missing_durable_claim_binding(tmp_path: Path) -> None:
+    result = _handoff(
+        repo_root=REPO_ROOT,
+        intent_id=INTENT_ID,
+        architect_determination_output_path=tmp_path / "runtime" / "architect.json",
+        memex_supply_receipt_output_path=tmp_path / "runtime" / "memex.json",
+        expected_claim_binding=None,
+        now_iso=NOW,
+    )
+
+    assert result.accepted is False
+    assert "fix_claim_binding_missing" in result.rejection_reasons
+    assert not (tmp_path / "runtime" / "architect.json").exists()
+    assert not (tmp_path / "runtime" / "memex.json").exists()
+
+
+def test_public_handoff_has_no_store_injection_surface() -> None:
+    parameters = inspect.signature(_run_handoff).parameters
+
+    assert "cycle_store" not in parameters
+    assert "architect_store" not in parameters
+    assert "expected_claim_binding" in parameters
 
 
 def test_handoff_module_has_no_execution_network_or_reindex_imports() -> None:

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -36,7 +36,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1394
+    threshold_override: 1409
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -418,7 +418,7 @@ exemptions:
     reason: >-
       Legacy module WSP_22 reverse-chronological journal. This slice adds one
       bounded boundary record and preserves the historical audit sequence.
-    threshold_override: 9407
+    threshold_override: 9420
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"
@@ -430,7 +430,7 @@ exemptions:
     reason: >-
       Legacy WSP_22 test journal. Current entries record focused validation;
       historical test evidence is not split during a runtime-security slice.
-    threshold_override: 1890
+    threshold_override: 1901
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"


### PR DESCRIPTION
## Summary
- replace prefix-only operational Memex supply checks with exact typed rehydration and canonical digest verification
- bind principal, FoundUp, snapshot, Memex view, HoloIndex generation, and source revision to independent durable runtime truth
- enforce a 300-second maximum receipt age and 600-second maximum policy lifetime
- bind the complete canonical Memex receipt digest into architect proposal attestation v2 before signing
- remove resident handoff store injection and require exact durable FIX-claim binding before artifact writes

## Security evidence
- fabricated `sha256:` IDs reject
- attacker-rehashed FoundUp, principal, view, snapshot, generation, and source-revision substitutions reject
- manually constructed malformed typed receipts reject before signer effects
- invalid receipts produce no handoff artifact, profile seed, queue, signer, or authoritative-state effects
- independent adversarial review: GO, zero blocker/major/minor

## Validation
- affected authority/promotion/valve matrix: 396 passed, 1 skipped
- main startup/promotion compatibility: 69 passed
- focused handoff/claim matrix: 38 passed
- ruff: pass
- WSP 62/static gates: pass
- backend manifest check: pass (`runtime_files=1128`)
- `git diff --check`: pass

## Truth boundary
This slice authenticates the complete operational Memex supply through the existing signed architect-proposal authority chain. It does not add learning candidates, default resident Memex supply, HoloIndex maintenance/re-indexing, worker execution, repository mutation, or autonomous merge.