### PR TITLE
fix(holoindex): isolate test write probe

### DIFF
--- a/holo_index/ModLog.md
+++ b/holo_index/ModLog.md
@@ -1,5 +1,11 @@
 # HoloIndex Package ModLog
 
+## [2026-08-04] Test write isolation
+
+- Removed a legacy HoloIndex test's import-time write into the repository root.
+- The write probe now uses pytest's per-test temporary directory, preserving a
+  clean checkout for exact-HEAD HoloIndex query admission and WSP 85.
+
 ## [2026-08-03] Windows device-entry repository discovery guard
 
 - Repository-audit discovery now rejects entries whose path cannot be

--- a/holo_index/tests/TESTModLog.md
+++ b/holo_index/tests/TESTModLog.md
@@ -1,5 +1,12 @@
 ﻿# HoloIndex Test Suite TESTModLog
 
+## [2026-08-04] Sandboxed write-probe regression
+
+- Replaced the import-time, checkout-specific `test_write.txt` write with a
+  pytest `tmp_path` probe.
+- Added source-level regression coverage preventing module-import filesystem
+  effects and a return of any absolute Windows checkout target.
+
 ## [2026-08-02] Persisted vector-segment cold-start gate
 
 - Proved exact persisted collection snapshots are insufficient to certify

--- a/holo_index/tests/test_write_simple.py
+++ b/holo_index/tests/test_write_simple.py
@@ -1,4 +1,50 @@
+"""Regression coverage for sandboxed filesystem write probes."""
 
-with open("O:\\Foundups-Agent\\test_write.txt", "w") as f:
-    f.write("WRITE SUCCESS")
-print("PRINT SUCCESS")
+from __future__ import annotations
+
+import ast
+from pathlib import Path, PureWindowsPath
+
+
+def test_write_probe_uses_pytest_sandbox(tmp_path: Path) -> None:
+    target = tmp_path / "test_write.txt"
+
+    target.write_text("WRITE SUCCESS", encoding="ascii")
+
+    assert target.read_text(encoding="ascii") == "WRITE SUCCESS"
+    assert target.parent == tmp_path
+
+
+def test_write_probe_has_no_import_time_effect_or_checkout_path() -> None:
+    source_path = Path(__file__)
+    source = source_path.read_text(encoding="utf-8")
+    module = ast.parse(source)
+    imports = [node for node in module.body if isinstance(node, ast.Import)]
+    import_from = [node for node in module.body if isinstance(node, ast.ImportFrom)]
+    functions = [node for node in module.body if isinstance(node, ast.FunctionDef)]
+    docstrings = [
+        node
+        for node in module.body
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    ]
+    allowed_nodes = [*imports, *import_from, *functions, *docstrings]
+
+    assert len(allowed_nodes) == len(module.body)
+    assert [[alias.name for alias in node.names] for node in imports] == [["ast"]]
+    assert [(node.module, [alias.name for alias in node.names]) for node in import_from] == [
+        ("__future__", ["annotations"]),
+        ("pathlib", ["Path", "PureWindowsPath"]),
+    ]
+    for function in functions:
+        assert function.decorator_list == []
+        assert function.args.defaults == []
+        assert all(value is None for value in function.args.kw_defaults)
+        assert not any(isinstance(node, ast.Call) for node in ast.walk(function.returns))
+    path_literals = [
+        node.value
+        for node in ast.walk(module)
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    ]
+    assert not any(PureWindowsPath(value).is_absolute() for value in path_literals)


### PR DESCRIPTION
## WSP 97 finding

HoloIndex semantic maintenance succeeded at current `origin/main`, but workspace query admission still failed because `holo_index/tests/test_write_simple.py` wrote `test_write.txt` into `O:\Foundups-Agent` at pytest import/collection time.

## Change

- replace the checkout-specific import-time write with a real `tmp_path` pytest
- assert the sandboxed write/read behavior
- reject any future top-level executable statement except the module docstring
- reject restoration of the absolute checkout target
- document WSP 85 test isolation

## Validation

- `11 passed` for the write probe plus repository-state freshness tests
- repair worktree remains clean and creates no root artifact
- `git diff --check` passes
- HoloIndex canonical authority was separately refreshed to current `origin/main`; this PR does not mutate or re-index HoloIndex

## Boundary

No query admission, freshness, indexing, runtime, RedDog, or Memex behavior changes. This is test-hygiene only.
