### PR TITLE
docs(holoindex): use governed owner query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,9 +128,18 @@ RIGHT: Simplest layer → Test → Feedback → Course correct → Next layer �
 - The Cube forms through validated layers, not through top-down design.
 
 ### Step 2: HoloIndex Search
-```bash
-python holo_index.py --search "[task]"
+```powershell
+$main = Split-Path (git rev-parse --path-format=absolute --git-common-dir) -Parent
+'{"query":"[task]","limit":5}' | python "$main/scripts/reddog_holoindex_owner_query_once.py"
 ```
+- Derive the canonical main checkout from Git's common directory so the same
+  command works from main and linked worker worktrees. Accept its
+  generation-bound evidence only when `ok=true`, `freshness=CURRENT`, and
+  `index_gap_detected=false`.
+- Do not run raw `holo_index.py --search` from a shared or dirty checkout. Its
+  root-bound freshness proof correctly rejects a different authority root.
+- A query path is read-only. On failure, preserve the exact error and route the
+  existing governed WRE/CI maintenance path; never reindex inside the query.
 - Find existing implementations FIRST
 - Examples: "test orchestration" -> autonomous_refactoring.py
 - NEVER vibecode - always search first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,18 @@ RIGHT: Simplest layer → Test → Feedback → Course correct → Next layer �
 - The Cube forms through validated layers, not through top-down design.
 
 ### Step 2: HoloIndex Search
-```bash
-python holo_index.py --search "[task]"
+```powershell
+$main = Split-Path (git rev-parse --path-format=absolute --git-common-dir) -Parent
+'{"query":"[task]","limit":5}' | python "$main/scripts/reddog_holoindex_owner_query_once.py"
 ```
+- Derive the canonical main checkout from Git's common directory so the same
+  command works from main and linked worker worktrees. Accept its
+  generation-bound evidence only when `ok=true`, `freshness=CURRENT`, and
+  `index_gap_detected=false`.
+- Do not run raw `holo_index.py --search` from a shared or dirty checkout. Its
+  root-bound freshness proof correctly rejects a different authority root.
+- A query path is read-only. On failure, preserve the exact error and route the
+  existing governed WRE/CI maintenance path; never reindex inside the query.
 - Find existing implementations FIRST
 - Examples: "test orchestration" -> autonomous_refactoring.py
 - NEVER vibecode - always search first


### PR DESCRIPTION
## Summary

- replace the stale raw HoloIndex CLI instruction with the governed generation-bound owner query
- derive canonical main through Git's common directory so the command works from main and linked worker worktrees
- require `CURRENT` freshness and no index gap before accepting retrieval evidence
- preserve the read-only query boundary and route failures to existing WRE/CI maintenance

## Validation

- live command from an isolated worktree: `ok=true`, `freshness=CURRENT`, `index_gap_detected=false`
- `generate_codex_tooling_projection.py --check` passed
- 16 projection tests passed, 1 platform skip
- `git diff --check` passed

## Boundary

No HoloIndex mutation, reindex, authority widening, runtime code, extension code, or model behavior changes.