### PR TITLE
fix(reddog): classify upstream agent runtime provenance

### DIFF
--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,22 @@
 # ModLog - moltbot_bridge
 
+## 2026-08-05: Upstream agent runtime truth registry
+- Upgraded the existing OpenClaw integration manifest to a static provenance
+  v2 ledger with stable integration IDs, exact checked-in implementation and
+  test evidence paths, and explicit upstream CLI/API versus Foundups-local
+  classifications.
+- Bound the only two accepted upstream artifact providers to the canonical
+  `openclaw_gateway` and `hermes_api` runtime modes while recording that both
+  remain default-off, fail-closed, text-only, and tool-free. No upstream hook
+  is currently claimed.
+- Split the previous aggregate Hermes label into the WRE dry-run executor,
+  FoundUp builder, and resident transport surfaces so each records its actual
+  owner, controls, consumers, and capability boundary. The structured registry
+  remains readable and below the WSP 62 configuration threshold.
+- The ledger is explicitly non-authoritative: it does not prove installation,
+  health, version freshness, live execution, or grant any worker authority
+  (WSP 00/15/22/50/62/97). WSP 15 classified the correction P1 at 14/20.
+
 ## 2026-08-04: Memex supply authenticity gate
 - Replaced the promotion path's `sha256:` prefix check with exact typed Memex
   supply receipt rehydration, canonical digest verification, scope/lineage and

--- a/modules/communication/moltbot_bridge/config/openclaw_integration_manifest.json
+++ b/modules/communication/moltbot_bridge/config/openclaw_integration_manifest.json
@@ -1,216 +1,192 @@
 {
-  "$schema": "openclaw_integration_manifest/v1",
-  "description": "Machine-readable ledger of all OpenClaw integration points. Source of truth: docs/audits/openclaw_plugins/OPENCLAW_PLUGIN_LEDGER_AUDIT.md",
-  "generated": "2026-04-05",
-  "maintenance": "When adding a new OPENCLAW_*/IRONCLAW_*/OPENROUTER_* env key to main.py or wre_defaults.env, add it to the owning integration entry here. Run: pytest modules/communication/moltbot_bridge/tests/test_openclaw_integration_manifest.py",
+  "$schema": "openclaw_integration_manifest/v2",
+  "description": "Static, non-authoritative provenance inventory for upstream OpenClaw/Hermes runtimes and Foundups-local integrations that expose related names or controls.",
+  "coverage_scope": "Runtime entrypoints and control-plane integrations. Runtime names and this ledger never prove live upstream execution or grant authority.",
+  "truth_scope": "STATIC_IMPLEMENTATION_PROVENANCE_ONLY",
+  "generated": "2026-08-05",
+  "runtime_origin_values": ["UPSTREAM_CLI","UPSTREAM_API","UPSTREAM_HOOK","FOUNDUPS_LOCAL","LEGACY_ALIAS"],
+  "runtime_origin_definitions": {
+    "UPSTREAM_CLI": "Foundups directly invokes an installed upstream executable.",
+    "UPSTREAM_API": "Foundups directly invokes an installed upstream service API.",
+    "UPSTREAM_HOOK": "Checked-in upstream hook configuration proves upstream dispatch into Foundups.",
+    "FOUNDUPS_LOCAL": "The implementation is owned by this repository, even when it calls an external model or service.",
+    "LEGACY_ALIAS": "A deprecated or compatibility identifier with a required canonical alias_of target; it never proves upstream execution."
+  },
+  "upstream_hook_status": "NO_PROVEN_UPSTREAM_HOOK",
+  "maintenance": "When adding an OpenClaw/Hermes runtime entrypoint or related environment control, classify runtime_origin, bind checked-in implementation_paths, and add upstream_identity only for a directly invoked upstream runtime. Run: pytest modules/communication/moltbot_bridge/tests/test_openclaw_integration_manifest.py",
   "integrations": [
     {
-      "name": "IronClaw Gateway",
-      "type": "conversation_provider",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "off",
-      "env_keys": [
-        "OPENCLAW_CONVERSATION_BACKEND",
-        "OPENCLAW_IRONCLAW_STRICT",
-        "OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK",
-        "OPENCLAW_IRONCLAW_AUTOSTART",
-        "IRONCLAW_BASE_URL",
-        "IRONCLAW_MODEL"
+      "integration_id": "ironclaw_gateway", "name": "IronClaw Gateway", "type": "conversation_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_conversation_adapter",
+      "implementation_paths": ["modules/communication/moltbot_bridge/src/ironclaw_gateway_client.py","modules/communication/moltbot_bridge/src/openclaw_provider_chain.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": ["OPENCLAW_CONVERSATION_BACKEND","OPENCLAW_IRONCLAW_STRICT","OPENCLAW_IRONCLAW_ALLOW_LOCAL_FALLBACK","OPENCLAW_IRONCLAW_AUTOSTART","IRONCLAW_BASE_URL","IRONCLAW_MODEL"], "secret_keys": ["IRONCLAW_AUTH_TOKEN"],
+      "external_service": "local_service", "fail_mode": "fail_closed_strict_or_fail_open_fallback", "consumers": ["openclaw_provider_chain","main.py"]
+    },
+    {
+      "integration_id": "local_ollama_qwen", "name": "Local Ollama / Qwen", "type": "conversation_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_local_model_adapter",
+      "implementation_paths": ["modules/communication/moltbot_bridge/src/openclaw_bootstrap_config.py","modules/communication/moltbot_bridge/src/openclaw_provider_chain.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_OLLAMA_MODEL"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_closed", "consumers": ["openclaw_bootstrap_config","openclaw_provider_chain"]
+    },
+    {
+      "integration_id": "openclaw_gateway_artifact_provider", "name": "OpenClaw Gateway Artifact Provider", "type": "artifact_generation_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "UPSTREAM_CLI", "capability_boundary": "text_artifact_only_no_tools", "provider_runtime": "openclaw_gateway", "upstream_invocation_surface": "openclaw agent via the version-matched loopback Gateway",
+      "implementation_paths": [
+        "modules/communication/moltbot_bridge/src/reddog_artifact_generation_provider_bootstrap.py",
+        "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_artifact_provider.py",
+        "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_command_runner.py",
+        "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_confinement.py"
       ],
-      "secret_keys": ["IRONCLAW_AUTH_TOKEN"],
-      "external_service": "local_service",
-      "fail_mode": "fail_closed_strict_or_fail_open_fallback",
-      "consumers": ["openclaw_provider_chain", "main.py"]
+      "evidence_paths": ["modules/communication/moltbot_bridge/tests/test_reddog_openclaw_gateway_artifact_provider.py","modules/communication/moltbot_bridge/tests/test_reddog_upstream_artifact_provider_bootstrap.py"], "upstream_identity": {"project":"openclaw/openclaw","runtime_interface":"CLI","runtime_entrypoint":"/usr/local/bin/openclaw","runtime_operation":"agent","canonical_provider_path":"modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_artifact_provider.py","confinement_path":"modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_confinement.py"},
+      "status": "landed", "default": "off", "env_keys": ["REDDOG_ARTIFACT_GENERATOR_MODE"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_closed", "consumers": ["reddog_artifact_generation_provider_bootstrap"]
     },
     {
-      "name": "Local Ollama / Qwen",
-      "type": "conversation_provider",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "on",
-      "env_keys": ["OPENCLAW_OLLAMA_MODEL"],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_closed",
-      "consumers": ["openclaw_bootstrap_config", "openclaw_provider_chain"]
-    },
-    {
-      "name": "AI Gateway - OpenAI",
-      "type": "ai_gateway_provider",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "off",
-      "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"],
-      "secret_keys": ["OPENAI_API_KEY"],
-      "external_service": "external_service",
-      "fail_mode": "fail_open",
-      "consumers": ["ai_gateway"]
-    },
-    {
-      "name": "AI Gateway - Anthropic",
-      "type": "ai_gateway_provider",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "off",
-      "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"],
-      "secret_keys": ["ANTHROPIC_API_KEY"],
-      "external_service": "external_service",
-      "fail_mode": "fail_open",
-      "consumers": ["ai_gateway"]
-    },
-    {
-      "name": "AI Gateway - Grok/XAI",
-      "type": "ai_gateway_provider",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "off",
-      "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"],
-      "secret_keys": ["GROK_API_KEY", "XAI_API_KEY"],
-      "external_service": "external_service",
-      "fail_mode": "fail_open",
-      "consumers": ["ai_gateway"]
-    },
-    {
-      "name": "AI Gateway - Google Gemini",
-      "type": "ai_gateway_provider",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "off",
-      "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"],
-      "secret_keys": ["GEMINI_API_KEY"],
-      "external_service": "external_service",
-      "fail_mode": "fail_open",
-      "consumers": ["ai_gateway"]
-    },
-    {
-      "name": "OpenRouter",
-      "type": "standalone_llm_router",
-      "owner_module": "modules/infrastructure/openrouter_client",
-      "status": "parked",
-      "notes": "contract_pending / BLOCKED_PENDING_REDACTION_GATE. Live OpenRouter client is dormant: modules/infrastructure/openrouter_client is an empty/reverted shell. The FusionAdapter contract lives at modules/communication/moltbot_bridge/src/fusion_adapter.py (mock/dry-run only). Status 'parked' is the manifest-schema honest value (enum: landed/planned/parked/removed); it is NOT 'landed'. See docs/audits/architecture/OPENROUTER_FUSION_FOUNDUPS_INTEGRATION_AUDIT_PHASE1.md.",
-      "default": "off",
-      "env_keys": [
-        "OPENROUTER_BASE_URL",
-        "OPENROUTER_DEFAULT_MODEL",
-        "OPENROUTER_PRESET",
-        "OPENROUTER_FALLBACK_ENABLED",
-        "OPENROUTER_WEB_SEARCH",
-        "OPENROUTER_TIMEOUT_SEC"
+      "integration_id": "hermes_api_artifact_provider", "name": "Hermes API Artifact Provider", "type": "artifact_generation_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "UPSTREAM_API", "capability_boundary": "text_artifact_only_no_tools", "provider_runtime": "hermes_api", "upstream_invocation_surface": "authenticated loopback POST /v1/runs",
+      "implementation_paths": [
+        "modules/communication/moltbot_bridge/src/reddog_artifact_generation_provider_bootstrap.py",
+        "modules/communication/moltbot_bridge/src/reddog_hermes_api_artifact_provider.py",
+        "modules/communication/moltbot_bridge/src/reddog_hermes_api_transport.py",
+        "modules/communication/moltbot_bridge/src/reddog_hermes_api_confinement.py",
+        "modules/communication/moltbot_bridge/src/reddog_hermes_api_run_lifecycle.py",
+        "modules/communication/moltbot_bridge/src/reddog_hermes_api_event_log.py"
       ],
-      "secret_keys": ["OPENROUTER_API_KEY"],
-      "external_service": "external_service",
-      "fail_mode": "fail_open",
-      "consumers": ["holo_index/skillz/consciousness_migration/executor.py"]
+      "evidence_paths": ["modules/communication/moltbot_bridge/tests/test_reddog_hermes_api_artifact_provider.py","modules/communication/moltbot_bridge/tests/test_reddog_upstream_artifact_provider_bootstrap.py"], "upstream_identity": {"project":"NousResearch/hermes-agent","runtime_interface":"API","runtime_entrypoint":"http://127.0.0.1:8642/v1/runs","runtime_operation":"POST /v1/runs","canonical_provider_path":"modules/communication/moltbot_bridge/src/reddog_hermes_api_artifact_provider.py","confinement_path":"modules/communication/moltbot_bridge/src/reddog_hermes_api_confinement.py"},
+      "status": "landed", "default": "off", "env_keys": ["REDDOG_ARTIFACT_GENERATOR_MODE"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_closed", "consumers": ["reddog_artifact_generation_provider_bootstrap"]
     },
     {
-      "name": "Resident OpenClaw",
-      "type": "service_daemon",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "on",
-      "env_keys": ["OPENCLAW_RESIDENT_ENABLED", "OPENCLAW_RESIDENT_AUTOSTART"],
-      "secret_keys": ["FOUNDUPS_WEBHOOK_TOKEN"],
-      "external_service": "local_service",
-      "fail_mode": "fail_open",
-      "consumers": ["main.py"]
+      "integration_id": "ai_gateway_openai", "name": "AI Gateway - OpenAI", "type": "ai_gateway_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_model_provider_adapter",
+      "implementation_paths": ["modules/ai_intelligence/ai_gateway/src/ai_gateway.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"], "secret_keys": ["OPENAI_API_KEY"],
+      "external_service": "external_service", "fail_mode": "fail_open", "consumers": ["ai_gateway"]
     },
     {
-      "name": "Supervisor",
-      "type": "service_daemon",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "on",
-      "env_keys": ["OPENCLAW_SUPERVISOR_ENABLED"],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_open",
-      "consumers": ["main.py"]
+      "integration_id": "ai_gateway_anthropic", "name": "AI Gateway - Anthropic", "type": "ai_gateway_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_model_provider_adapter",
+      "implementation_paths": ["modules/ai_intelligence/ai_gateway/src/ai_gateway.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"], "secret_keys": ["ANTHROPIC_API_KEY"],
+      "external_service": "external_service", "fail_mode": "fail_open", "consumers": ["ai_gateway"]
     },
     {
-      "name": "WRE Orchestrator",
-      "type": "service_daemon",
-      "owner_module": "modules/infrastructure/wre_core",
-      "status": "landed",
-      "default": "on",
-      "env_keys": [],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_open",
-      "consumers": ["main.py", "openclaw_dae"]
+      "integration_id": "ai_gateway_grok_xai", "name": "AI Gateway - Grok/XAI", "type": "ai_gateway_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_model_provider_adapter",
+      "implementation_paths": ["modules/ai_intelligence/ai_gateway/src/ai_gateway.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"], "secret_keys": ["GROK_API_KEY","XAI_API_KEY"],
+      "external_service": "external_service", "fail_mode": "fail_open", "consumers": ["ai_gateway"]
     },
     {
-      "name": "Skill Safety Gate",
-      "type": "security_gate",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "on",
-      "env_keys": [
-        "OPENCLAW_SKILL_SCAN_REQUIRED",
-        "OPENCLAW_SKILL_SCAN_ENFORCED",
-        "OPENCLAW_SKILL_MANIFEST_REQUIRED",
-        "OPENCLAW_SKILL_MANIFEST_ENFORCED"
-      ],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_closed",
-      "consumers": ["wre_core", "openclaw_dae"]
+      "integration_id": "ai_gateway_google_gemini", "name": "AI Gateway - Google Gemini", "type": "ai_gateway_provider",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_model_provider_adapter",
+      "implementation_paths": ["modules/ai_intelligence/ai_gateway/src/ai_gateway.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": ["OPENCLAW_ALLOW_EXTERNAL_LLM"], "secret_keys": ["GEMINI_API_KEY"],
+      "external_service": "external_service", "fail_mode": "fail_open", "consumers": ["ai_gateway"]
     },
     {
-      "name": "Permission Manager",
-      "type": "security_gate",
-      "owner_module": "modules/ai_intelligence/agent_permissions",
-      "status": "landed",
-      "default": "on",
-      "env_keys": [],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_closed",
-      "consumers": ["openclaw_dae"]
+      "integration_id": "openrouter", "name": "OpenRouter", "type": "standalone_llm_router",
+      "owner_module": "modules/infrastructure/openrouter_client", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_router_contract",
+      "implementation_paths": ["modules/communication/moltbot_bridge/src/fusion_adapter.py"],
+      "upstream_identity": null,
+      "status": "parked", "default": "off", "env_keys": ["OPENROUTER_BASE_URL","OPENROUTER_DEFAULT_MODEL","OPENROUTER_PRESET","OPENROUTER_FALLBACK_ENABLED","OPENROUTER_WEB_SEARCH","OPENROUTER_TIMEOUT_SEC"], "secret_keys": ["OPENROUTER_API_KEY"],
+      "external_service": "external_service", "fail_mode": "fail_open", "consumers": ["holo_index/skillz/consciousness_migration/executor.py"],
+      "notes": "contract_pending / BLOCKED_PENDING_REDACTION_GATE. Live OpenRouter client is dormant: modules/infrastructure/openrouter_client is an empty/reverted shell. The FusionAdapter contract lives at modules/communication/moltbot_bridge/src/fusion_adapter.py (mock/dry-run only). Status 'parked' is the manifest-schema honest value (enum: landed/planned/parked/removed); it is NOT 'landed'. See docs/audits/architecture/OPENROUTER_FUSION_FOUNDUPS_INTEGRATION_AUDIT_PHASE1.md."
     },
     {
-      "name": "Key Isolation",
-      "type": "security_gate",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "on",
-      "env_keys": ["OPENCLAW_NO_API_KEYS", "IRONCLAW_NO_API_KEYS"],
-      "secret_keys": [],
-      "external_service": null,
-      "fail_mode": "fail_closed",
-      "consumers": ["main.py", "openclaw_bootstrap_config"]
+      "integration_id": "resident_openclaw", "name": "Resident OpenClaw", "type": "service_daemon",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_control_plane_dae",
+      "implementation_paths": ["main.py","modules/communication/moltbot_bridge/src/openclaw_dae.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_RESIDENT_ENABLED","OPENCLAW_RESIDENT_AUTOSTART"], "secret_keys": ["FOUNDUPS_WEBHOOK_TOKEN"],
+      "external_service": "local_service", "fail_mode": "fail_open", "consumers": ["main.py"]
     },
     {
-      "name": "Dep Security Preflight",
-      "type": "security_gate",
-      "owner_module": "modules/communication/moltbot_bridge",
-      "status": "landed",
-      "default": "on",
-      "env_keys": [
-        "OPENCLAW_DEP_SECURITY_PREFLIGHT",
-        "OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED"
-      ],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_open",
-      "consumers": ["main.py"]
+      "integration_id": "openclaw_supervisor", "name": "Supervisor", "type": "service_daemon",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_resident_supervisor",
+      "implementation_paths": ["modules/communication/moltbot_bridge/src/openclaw_supervisor.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_SUPERVISOR_ENABLED"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_open", "consumers": ["main.py"]
     },
     {
-      "name": "Self-Audit Loop",
-      "type": "security_gate",
-      "owner_module": "modules/infrastructure/wre_core",
-      "status": "landed",
-      "default": "on",
-      "env_keys": [
-        "OPENCLAW_SELF_AUDIT_ENABLED",
-        "OPENCLAW_SELF_AUDIT_AUTO_FIX",
-        "OPENCLAW_SELF_AUDIT_INTERVAL_SEC",
-        "OPENCLAW_SELF_AUDIT_RUNTIME_ROOT"
-      ],
-      "secret_keys": [],
-      "external_service": "local_service",
-      "fail_mode": "fail_open",
-      "consumers": ["main.py", "wre_core"]
+      "integration_id": "wre_orchestrator", "name": "WRE Orchestrator", "type": "service_daemon",
+      "owner_module": "modules/infrastructure/wre_core", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_governed_execution_orchestrator",
+      "implementation_paths": ["modules/infrastructure/wre_core/wre_master_orchestrator/src/wre_master_orchestrator.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": [], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_open", "consumers": ["main.py","openclaw_dae"]
+    },
+    {
+      "integration_id": "skill_safety_gate", "name": "Skill Safety Gate", "type": "security_gate",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_skill_admission_gate",
+      "implementation_paths": ["modules/communication/moltbot_bridge/src/skill_safety_guard.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_SKILL_SCAN_REQUIRED","OPENCLAW_SKILL_SCAN_ENFORCED","OPENCLAW_SKILL_MANIFEST_REQUIRED","OPENCLAW_SKILL_MANIFEST_ENFORCED"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_closed", "consumers": ["wre_core","openclaw_dae"]
+    },
+    {
+      "integration_id": "permission_manager", "name": "Permission Manager", "type": "security_gate",
+      "owner_module": "modules/ai_intelligence/agent_permissions", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_permission_gate",
+      "implementation_paths": ["modules/ai_intelligence/agent_permissions/src/agent_permission_manager.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": [], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_closed", "consumers": ["openclaw_dae"]
+    },
+    {
+      "integration_id": "key_isolation", "name": "Key Isolation", "type": "security_gate",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_secret_isolation_policy",
+      "implementation_paths": ["modules/communication/moltbot_bridge/src/openclaw_bootstrap_config.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_NO_API_KEYS","IRONCLAW_NO_API_KEYS"], "secret_keys": [],
+      "external_service": null, "fail_mode": "fail_closed", "consumers": ["main.py","openclaw_bootstrap_config"]
+    },
+    {
+      "integration_id": "dependency_security_preflight", "name": "Dep Security Preflight", "type": "security_gate",
+      "owner_module": "modules/communication/moltbot_bridge", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_dependency_preflight",
+      "implementation_paths": ["modules/infrastructure/wre_core/src/dependency_security_preflight.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_DEP_SECURITY_PREFLIGHT","OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_open", "consumers": ["main.py"]
+    },
+    {
+      "integration_id": "self_audit_loop", "name": "Self-Audit Loop", "type": "security_gate",
+      "owner_module": "modules/infrastructure/wre_core", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_readonly_self_audit",
+      "implementation_paths": ["modules/infrastructure/wre_core/src/daemon_self_audit_loop.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["OPENCLAW_SELF_AUDIT_ENABLED","OPENCLAW_SELF_AUDIT_AUTO_FIX","OPENCLAW_SELF_AUDIT_INTERVAL_SEC","OPENCLAW_SELF_AUDIT_RUNTIME_ROOT"], "secret_keys": [],
+      "external_service": "local_service", "fail_mode": "fail_open", "consumers": ["main.py","wre_core"]
+    },
+    {
+      "integration_id": "foundups_hermes_wre_job_executor", "name": "Foundups Hermes WRE Job Executor", "type": "dryrun_worker_adapter",
+      "owner_module": "modules/infrastructure/wre_core", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_local_dryrun_delegation_seam",
+      "implementation_paths": ["modules/infrastructure/wre_core/src/hermes_job_executor.py","modules/infrastructure/wre_core/src/foundup_job_consumer.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": ["HERMES_DELEGATE_ENABLED"], "secret_keys": [],
+      "external_service": null, "fail_mode": "fail_closed", "consumers": ["foundup_job_consumer"]
+    },
+    {
+      "integration_id": "foundups_hermes_foundup_builder", "name": "Foundups Hermes FoundUp Builder", "type": "bounded_foundup_builder_adapter",
+      "owner_module": "modules/foundups/agent", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_local_foundup_builder_dryrun_default_double_opt_in_writes",
+      "implementation_paths": ["modules/foundups/agent/src/hermes_adapter.py","modules/foundups/agent/src/hermes_foundup_job_executor.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "on", "env_keys": ["HERMES_BUILDER_ENABLED","HERMES_BUILDER_ALLOW_REAL_WRITES","HERMES_BUILDER_DRY_RUN","HERMES_BUILDER_SECURITY_GATE"], "secret_keys": [],
+      "external_service": null, "fail_mode": "fail_closed", "consumers": ["hermes_foundup_job_executor"]
+    },
+    {
+      "integration_id": "foundups_hermes_resident_client_transport", "name": "Foundups Hermes Resident Client Transport", "type": "resident_client_transport",
+      "owner_module": "modules/foundups/agent", "runtime_origin": "FOUNDUPS_LOCAL", "capability_boundary": "foundups_transport_only_no_model_no_execution",
+      "implementation_paths": ["modules/foundups/agent/src/hermes_reddog_resident_client_adapter.py","scripts/hermes_reddog_resident_client_once.py"],
+      "upstream_identity": null,
+      "status": "landed", "default": "off", "env_keys": [], "secret_keys": [],
+      "external_service": null, "fail_mode": "fail_closed", "consumers": ["hermes_reddog_resident_client_once"]
     }
   ]
 }

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,18 @@
+## 2026-08-05: Upstream agent runtime provenance regressions
+
+- Added a strict v2 schema and independent integration-ID allowlist for the
+  OpenClaw Gateway and Hermes API upstream claims.
+- Added regressions for local-name relabeling, fabricated upstream providers,
+  provider substitution, unknown fields, documentation-only evidence,
+  absolute/traversal/missing paths, and source-marker drift.
+- Proved every existing manifest entry resolves to a checked-in regular file,
+  no current upstream hook is claimed, no production source consumes the
+  static ledger as authority, and local adapters cannot satisfy an upstream
+  runtime requirement. Source invocation checks use AST rather than comments.
+- Added exact owner and runtime-origin definition checks, distinct Hermes-local
+  control contracts, bounded common-field validation, and a repository-wide
+  executable-source scan proving the static ledger has no runtime consumer.
+
 ## 2026-08-04: Memex supply authenticity regressions
 
 - Added exact receipt round-trip, unknown-field/type, lineage, scope, expiry,

--- a/modules/communication/moltbot_bridge/tests/test_openclaw_integration_manifest.py
+++ b/modules/communication/moltbot_bridge/tests/test_openclaw_integration_manifest.py
@@ -8,15 +8,39 @@ env surfaces documented in main.py and wre_defaults.env.
 Slice: OPENCLAW_INTEGRATION_MANIFEST_LINT_PHASE1
 """
 
+import ast
 import json
+import re
+import subprocess
+from copy import deepcopy
 from pathlib import Path
+from pathlib import PurePosixPath
 
 import pytest
+
+from modules.communication.moltbot_bridge.src.reddog_artifact_generation_provider_modes import (
+    RUNTIME_MODE_HERMES_API,
+    RUNTIME_MODE_OPENCLAW_GATEWAY,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 MANIFEST_PATH = REPO_ROOT / "modules" / "communication" / "moltbot_bridge" / "config" / "openclaw_integration_manifest.json"
 MAIN_PY = REPO_ROOT / "main.py"
 WRE_DEFAULTS = REPO_ROOT / "modules" / "infrastructure" / "wre_core" / "config" / "wre_defaults.env"
+
+
+def _tracked_repo_paths():
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        shell=False,
+    )
+    return frozenset(result.stdout.decode("utf-8").split("\0")) - {""}
+
+
+TRACKED_PATHS = _tracked_repo_paths()
 
 
 @pytest.fixture(scope="module")
@@ -64,7 +88,162 @@ class TestManifestSchema:
 # -- 2. Entry completeness --
 
 
-REQUIRED_FIELDS = {"name", "type", "owner_module", "status", "default", "env_keys", "secret_keys", "fail_mode"}
+REQUIRED_FIELDS = {
+    "integration_id",
+    "name",
+    "type",
+    "owner_module",
+    "runtime_origin",
+    "implementation_paths",
+    "capability_boundary",
+    "upstream_identity",
+    "status",
+    "default",
+    "env_keys",
+    "secret_keys",
+    "external_service",
+    "fail_mode",
+    "consumers",
+}
+TOP_LEVEL_FIELDS = {
+    "$schema",
+    "description",
+    "coverage_scope",
+    "truth_scope",
+    "generated",
+    "runtime_origin_values",
+    "runtime_origin_definitions",
+    "upstream_hook_status",
+    "maintenance",
+    "integrations",
+}
+ENTRY_FIELDS = REQUIRED_FIELDS | {
+    "notes",
+    "provider_runtime",
+    "upstream_invocation_surface",
+    "evidence_paths",
+    "alias_of",
+}
+RUNTIME_ORIGINS = frozenset(
+    {"UPSTREAM_CLI", "UPSTREAM_API", "UPSTREAM_HOOK", "FOUNDUPS_LOCAL", "LEGACY_ALIAS"}
+)
+RUNTIME_ORIGIN_DEFINITIONS = {
+    "UPSTREAM_CLI": "Foundups directly invokes an installed upstream executable.",
+    "UPSTREAM_API": "Foundups directly invokes an installed upstream service API.",
+    "UPSTREAM_HOOK": "Checked-in upstream hook configuration proves upstream dispatch into Foundups.",
+    "FOUNDUPS_LOCAL": "The implementation is owned by this repository, even when it calls an external model or service.",
+    "LEGACY_ALIAS": "A deprecated or compatibility identifier with a required canonical alias_of target; it never proves upstream execution.",
+}
+UPSTREAM_ORIGINS = frozenset({"UPSTREAM_CLI", "UPSTREAM_API", "UPSTREAM_HOOK"})
+EXPECTED_ORIGINS = {
+    "ironclaw_gateway": "FOUNDUPS_LOCAL",
+    "local_ollama_qwen": "FOUNDUPS_LOCAL",
+    "openclaw_gateway_artifact_provider": "UPSTREAM_CLI",
+    "hermes_api_artifact_provider": "UPSTREAM_API",
+    "ai_gateway_openai": "FOUNDUPS_LOCAL",
+    "ai_gateway_anthropic": "FOUNDUPS_LOCAL",
+    "ai_gateway_grok_xai": "FOUNDUPS_LOCAL",
+    "ai_gateway_google_gemini": "FOUNDUPS_LOCAL",
+    "openrouter": "FOUNDUPS_LOCAL",
+    "resident_openclaw": "FOUNDUPS_LOCAL",
+    "openclaw_supervisor": "FOUNDUPS_LOCAL",
+    "wre_orchestrator": "FOUNDUPS_LOCAL",
+    "skill_safety_gate": "FOUNDUPS_LOCAL",
+    "permission_manager": "FOUNDUPS_LOCAL",
+    "key_isolation": "FOUNDUPS_LOCAL",
+    "dependency_security_preflight": "FOUNDUPS_LOCAL",
+    "self_audit_loop": "FOUNDUPS_LOCAL",
+    "foundups_hermes_wre_job_executor": "FOUNDUPS_LOCAL",
+    "foundups_hermes_foundup_builder": "FOUNDUPS_LOCAL",
+    "foundups_hermes_resident_client_transport": "FOUNDUPS_LOCAL",
+}
+EXPECTED_OWNERS = {
+    "ironclaw_gateway": "modules/communication/moltbot_bridge",
+    "local_ollama_qwen": "modules/communication/moltbot_bridge",
+    "openclaw_gateway_artifact_provider": "modules/communication/moltbot_bridge",
+    "hermes_api_artifact_provider": "modules/communication/moltbot_bridge",
+    "ai_gateway_openai": "modules/communication/moltbot_bridge",
+    "ai_gateway_anthropic": "modules/communication/moltbot_bridge",
+    "ai_gateway_grok_xai": "modules/communication/moltbot_bridge",
+    "ai_gateway_google_gemini": "modules/communication/moltbot_bridge",
+    "openrouter": "modules/infrastructure/openrouter_client",
+    "resident_openclaw": "modules/communication/moltbot_bridge",
+    "openclaw_supervisor": "modules/communication/moltbot_bridge",
+    "wre_orchestrator": "modules/infrastructure/wre_core",
+    "skill_safety_gate": "modules/communication/moltbot_bridge",
+    "permission_manager": "modules/ai_intelligence/agent_permissions",
+    "key_isolation": "modules/communication/moltbot_bridge",
+    "dependency_security_preflight": "modules/communication/moltbot_bridge",
+    "self_audit_loop": "modules/infrastructure/wre_core",
+    "foundups_hermes_wre_job_executor": "modules/infrastructure/wre_core",
+    "foundups_hermes_foundup_builder": "modules/foundups/agent",
+    "foundups_hermes_resident_client_transport": "modules/foundups/agent",
+}
+ALLOWED_DEFAULTS = frozenset({"on", "off"})
+ALLOWED_FAIL_MODES = frozenset(
+    {"fail_closed", "fail_open", "fail_closed_strict_or_fail_open_fallback"}
+)
+ALLOWED_EXTERNAL_SERVICES = frozenset({None, "local_service", "external_service"})
+EXECUTABLE_SUFFIXES = frozenset({".py", ".js", ".ts", ".mjs", ".cjs", ".rs", ".ps1", ".sh"})
+EXPECTED_LOCAL_HERMES = {
+    "foundups_hermes_wre_job_executor": ("dryrun_worker_adapter", "foundups_local_dryrun_delegation_seam", "off", ("HERMES_DELEGATE_ENABLED",), ("foundup_job_consumer",), ("modules/infrastructure/wre_core/src/hermes_job_executor.py", "modules/infrastructure/wre_core/src/foundup_job_consumer.py")),
+    "foundups_hermes_foundup_builder": ("bounded_foundup_builder_adapter", "foundups_local_foundup_builder_dryrun_default_double_opt_in_writes", "on", ("HERMES_BUILDER_ENABLED", "HERMES_BUILDER_ALLOW_REAL_WRITES", "HERMES_BUILDER_DRY_RUN", "HERMES_BUILDER_SECURITY_GATE"), ("hermes_foundup_job_executor",), ("modules/foundups/agent/src/hermes_adapter.py", "modules/foundups/agent/src/hermes_foundup_job_executor.py")),
+    "foundups_hermes_resident_client_transport": ("resident_client_transport", "foundups_transport_only_no_model_no_execution", "off", (), ("hermes_reddog_resident_client_once",), ("modules/foundups/agent/src/hermes_reddog_resident_client_adapter.py", "scripts/hermes_reddog_resident_client_once.py")),
+}
+EXPECTED_UPSTREAM = {
+    "openclaw_gateway_artifact_provider": {
+        "name": "OpenClaw Gateway Artifact Provider",
+        "type": "artifact_generation_provider",
+        "owner_module": "modules/communication/moltbot_bridge",
+        "origin": "UPSTREAM_CLI",
+        "provider_runtime": RUNTIME_MODE_OPENCLAW_GATEWAY,
+        "implementation_paths": [
+            "modules/communication/moltbot_bridge/src/reddog_artifact_generation_provider_bootstrap.py",
+            "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_artifact_provider.py",
+            "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_command_runner.py",
+            "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_confinement.py",
+        ],
+        "evidence_paths": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_openclaw_gateway_artifact_provider.py",
+            "modules/communication/moltbot_bridge/tests/test_reddog_upstream_artifact_provider_bootstrap.py",
+        ],
+        "invocation_surface": "openclaw agent via the version-matched loopback Gateway",
+        "project": "openclaw/openclaw",
+        "runtime_interface": "CLI",
+        "entrypoint": "/usr/local/bin/openclaw",
+        "runtime_operation": "agent",
+        "provider_path": "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_artifact_provider.py",
+        "confinement_path": "modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_confinement.py",
+        "consumers": ["reddog_artifact_generation_provider_bootstrap"],
+    },
+    "hermes_api_artifact_provider": {
+        "name": "Hermes API Artifact Provider",
+        "type": "artifact_generation_provider",
+        "owner_module": "modules/communication/moltbot_bridge",
+        "origin": "UPSTREAM_API",
+        "provider_runtime": RUNTIME_MODE_HERMES_API,
+        "implementation_paths": [
+            "modules/communication/moltbot_bridge/src/reddog_artifact_generation_provider_bootstrap.py",
+            "modules/communication/moltbot_bridge/src/reddog_hermes_api_artifact_provider.py",
+            "modules/communication/moltbot_bridge/src/reddog_hermes_api_transport.py",
+            "modules/communication/moltbot_bridge/src/reddog_hermes_api_confinement.py",
+            "modules/communication/moltbot_bridge/src/reddog_hermes_api_run_lifecycle.py",
+            "modules/communication/moltbot_bridge/src/reddog_hermes_api_event_log.py",
+        ],
+        "evidence_paths": [
+            "modules/communication/moltbot_bridge/tests/test_reddog_hermes_api_artifact_provider.py",
+            "modules/communication/moltbot_bridge/tests/test_reddog_upstream_artifact_provider_bootstrap.py",
+        ],
+        "invocation_surface": "authenticated loopback POST /v1/runs",
+        "project": "NousResearch/hermes-agent",
+        "runtime_interface": "API",
+        "entrypoint": "http://127.0.0.1:8642/v1/runs",
+        "runtime_operation": "POST /v1/runs",
+        "provider_path": "modules/communication/moltbot_bridge/src/reddog_hermes_api_artifact_provider.py",
+        "confinement_path": "modules/communication/moltbot_bridge/src/reddog_hermes_api_confinement.py",
+        "consumers": ["reddog_artifact_generation_provider_bootstrap"],
+    },
+}
 
 
 class TestEntryCompleteness:
@@ -79,6 +258,11 @@ class TestEntryCompleteness:
         for entry in integrations:
             assert isinstance(entry["name"], str) and len(entry["name"]) > 0
 
+    def test_all_entries_have_stable_ids(self, integrations):
+        ids = [entry["integration_id"] for entry in integrations]
+        assert len(ids) == len(set(ids))
+        assert all(re.fullmatch(r"[a-z][a-z0-9_]{2,63}", value) for value in ids)
+
     def test_env_keys_are_lists(self, integrations):
         for entry in integrations:
             assert isinstance(entry["env_keys"], list), f"{entry['name']}: env_keys not a list"
@@ -90,11 +274,311 @@ class TestEntryCompleteness:
             assert entry["status"] in allowed, f"{entry['name']}: unknown status '{entry['status']}'"
 
 
-# -- 3. Critical env key coverage --
+# -- 3. Runtime provenance truth --
+
+
+def _repo_file_error(value, tracked_paths=TRACKED_PATHS):
+    if not isinstance(value, str) or not value or "\\" in value:
+        return "path_not_normalized"
+    if re.match(r"^[A-Za-z]:/", value) or value.startswith("//"):
+        return "path_not_confined"
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or path.as_posix() != value:
+        return "path_not_confined"
+    candidate = REPO_ROOT.joinpath(*path.parts)
+    try:
+        candidate.resolve().relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        return "path_escapes_repo"
+    if not candidate.is_file() or candidate.is_symlink():
+        return "path_not_checked_in_file"
+    if value not in tracked_paths:
+        return "path_not_tracked"
+    return ""
+
+
+def _upstream_semantic_errors(entry, expected):
+    exact = {
+        "name": expected["name"],
+        "type": expected["type"],
+        "owner_module": expected["owner_module"],
+        "status": "landed",
+        "default": "off",
+        "fail_mode": "fail_closed",
+        "capability_boundary": "text_artifact_only_no_tools",
+        "provider_runtime": expected["provider_runtime"],
+        "upstream_invocation_surface": expected["invocation_surface"],
+        "env_keys": ["REDDOG_ARTIFACT_GENERATOR_MODE"],
+        "secret_keys": [],
+        "external_service": "local_service",
+        "consumers": expected["consumers"],
+    }
+    return [
+        f"upstream_semantic_mismatch:{key}"
+        for key, value in exact.items()
+        if entry.get(key) != value
+    ]
+
+
+def _upstream_errors(entry, expected, paths):
+    errors = []
+    if expected is None:
+        errors.append("upstream_entry_not_allowlisted")
+    identity = entry.get("upstream_identity")
+    evidence = entry.get("evidence_paths")
+    if not isinstance(identity, dict) or not isinstance(evidence, list) or not evidence:
+        errors.append("upstream_evidence_invalid")
+    else:
+        errors.extend(filter(None, (_repo_file_error(value) for value in evidence)))
+        if any("/tests/" not in value or not value.endswith(".py") for value in evidence):
+            errors.append("upstream_evidence_not_test")
+    if expected is not None and isinstance(identity, dict):
+        if paths != expected["implementation_paths"]:
+            errors.append("upstream_implementation_paths_mismatch")
+        if evidence != expected["evidence_paths"]:
+            errors.append("upstream_evidence_paths_mismatch")
+        exact = {
+            "project": expected["project"],
+            "runtime_interface": expected["runtime_interface"],
+            "runtime_entrypoint": expected["entrypoint"],
+            "runtime_operation": expected["runtime_operation"],
+            "canonical_provider_path": expected["provider_path"],
+            "confinement_path": expected["confinement_path"],
+        }
+        if identity != exact:
+            errors.append("upstream_identity_mismatch")
+        errors.extend(_upstream_semantic_errors(entry, expected))
+    return errors
+
+
+def _common_entry_errors(entry):
+    errors = []
+    string_fields = ("integration_id", "name", "type", "owner_module", "capability_boundary")
+    list_fields = ("implementation_paths", "env_keys", "secret_keys", "consumers")
+    for key in string_fields:
+        if not isinstance(entry.get(key), str) or not entry[key]:
+            errors.append(f"entry_string_invalid:{key}")
+    for key in list_fields:
+        value = entry.get(key)
+        if not isinstance(value, list) or len(value) != len(set(value)):
+            errors.append(f"entry_list_invalid:{key}")
+        elif any(not isinstance(item, str) or not item for item in value):
+            errors.append(f"entry_list_item_invalid:{key}")
+    if EXPECTED_OWNERS.get(entry.get("integration_id")) != entry.get("owner_module"):
+        errors.append("owner_module_mismatch")
+    if entry.get("default") not in ALLOWED_DEFAULTS:
+        errors.append("default_invalid")
+    if entry.get("fail_mode") not in ALLOWED_FAIL_MODES:
+        errors.append("fail_mode_invalid")
+    if entry.get("external_service") not in ALLOWED_EXTERNAL_SERVICES:
+        errors.append("external_service_invalid")
+    return errors
+
+
+def _provenance_errors(entry):
+    errors = _common_entry_errors(entry)
+    integration_id = entry.get("integration_id")
+    origin = entry.get("runtime_origin")
+    if set(entry) - ENTRY_FIELDS:
+        errors.append("entry_fields_invalid")
+    if origin not in RUNTIME_ORIGINS:
+        errors.append("runtime_origin_invalid")
+    if EXPECTED_ORIGINS.get(integration_id) != origin:
+        errors.append("runtime_origin_mismatch")
+    paths = entry.get("implementation_paths")
+    if not isinstance(paths, list) or not paths or len(paths) != len(set(paths)):
+        errors.append("implementation_paths_invalid")
+    else:
+        errors.extend(filter(None, (_repo_file_error(value) for value in paths)))
+    if not isinstance(entry.get("capability_boundary"), str) or not entry["capability_boundary"]:
+        errors.append("capability_boundary_invalid")
+    if origin in UPSTREAM_ORIGINS:
+        errors.extend(_upstream_errors(entry, EXPECTED_UPSTREAM.get(integration_id), paths))
+    elif any(key in entry for key in ("provider_runtime", "evidence_paths", "upstream_invocation_surface")) or entry.get("upstream_identity") is not None:
+        errors.append("local_entry_claims_upstream_identity")
+    if origin != "LEGACY_ALIAS" and "alias_of" in entry:
+        errors.append("alias_not_allowed")
+    if origin == "LEGACY_ALIAS" and entry.get("alias_of") not in set(EXPECTED_ORIGINS) - {integration_id}:
+        errors.append("legacy_alias_target_invalid")
+    return errors
+
+
+def _source_tree(relative_path):
+    return ast.parse((REPO_ROOT / relative_path).read_text(encoding="utf-8"))
+
+
+def _has_literal_sequence(tree, expected):
+    for node in ast.walk(tree):
+        values = node.elts if isinstance(node, (ast.Tuple, ast.List)) else ()
+        literals = tuple(item.value for item in values if isinstance(item, ast.Constant))
+        if literals[: len(expected)] == expected:
+            return True
+    return False
+
+
+def _has_call_prefix(tree, expected):
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        values = tuple(item.value for item in node.args if isinstance(item, ast.Constant))
+        if values[: len(expected)] == expected:
+            return True
+    return False
+
+
+def _has_named_constant(tree, name, expected):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = (node.target,)
+        else:
+            continue
+        if any(isinstance(item, ast.Name) and item.id == name for item in targets):
+            if isinstance(node.value, ast.Constant) and node.value.value == expected:
+                return True
+    return False
+
+
+class TestRuntimeProvenance:
+    def test_schema_v2_and_origin_contract(self, manifest):
+        assert set(manifest) == TOP_LEVEL_FIELDS
+        assert manifest["$schema"] == "openclaw_integration_manifest/v2"
+        assert manifest["truth_scope"] == "STATIC_IMPLEMENTATION_PROVENANCE_ONLY"
+        assert set(manifest["runtime_origin_values"]) == RUNTIME_ORIGINS
+        assert manifest["runtime_origin_definitions"] == RUNTIME_ORIGIN_DEFINITIONS
+        assert manifest["upstream_hook_status"] == "NO_PROVEN_UPSTREAM_HOOK"
+
+    def test_every_entry_has_exact_expected_classification(self, integrations):
+        assert {entry["integration_id"] for entry in integrations} == set(EXPECTED_ORIGINS)
+        for entry in integrations:
+            assert not _provenance_errors(entry), entry["integration_id"]
+
+    def test_local_hermes_surfaces_keep_distinct_controls(self, integrations):
+        by_id = {entry["integration_id"]: entry for entry in integrations}
+        for key, expected in EXPECTED_LOCAL_HERMES.items():
+            entry = by_id[key]
+            actual = (entry["type"], entry["capability_boundary"], entry["default"], tuple(entry["env_keys"]), tuple(entry["consumers"]), tuple(entry["implementation_paths"]))
+            assert actual == expected
+    def test_exact_upstream_provider_set_and_runtime_values(self, integrations):
+        upstream = [entry for entry in integrations if entry["runtime_origin"] in UPSTREAM_ORIGINS]
+        assert {entry["integration_id"] for entry in upstream} == set(EXPECTED_UPSTREAM)
+        assert {entry["provider_runtime"] for entry in upstream} == {
+            RUNTIME_MODE_OPENCLAW_GATEWAY,
+            RUNTIME_MODE_HERMES_API,
+        }
+        assert not any(entry["runtime_origin"] == "UPSTREAM_HOOK" for entry in integrations)
+
+    def test_runtime_mode_vocabulary_and_default_remain_code_owned(self):
+        assert RUNTIME_MODE_OPENCLAW_GATEWAY == "openclaw_gateway"
+        assert RUNTIME_MODE_HERMES_API == "hermes_api"
+        profile = (
+            REPO_ROOT
+            / "modules/communication/moltbot_bridge/src/reddog_resident_queue_binding_profile.py"
+        ).read_text(encoding="utf-8")
+        assert 'return "foundups_fusion"' in profile
+
+    @pytest.mark.parametrize(
+        ("mutation", "reason"),
+        [
+            ({"runtime_origin": "UNKNOWN"}, "runtime_origin_invalid"),
+            ({"runtime_origin": "UPSTREAM_CLI"}, "runtime_origin_mismatch"),
+            ({"implementation_paths": ["../escape.py"]}, "path_not_confined"),
+            ({"implementation_paths": ["C:/private/runtime.py"]}, "path_not_confined"),
+            ({"implementation_paths": ["modules/not-present.py"]}, "path_not_checked_in_file"),
+            ({"owner_module": "modules/untrusted"}, "owner_module_mismatch"),
+            ({"fail_mode": "allow_all"}, "fail_mode_invalid"),
+            ({"consumers": "shell"}, "entry_list_invalid:consumers"),
+            ({"external_service": "untrusted_service"}, "external_service_invalid"),
+        ],
+    )
+    def test_local_entry_cannot_be_relabelled_or_supply_bad_paths(self, integrations, mutation, reason):
+        entry = deepcopy(next(item for item in integrations if item["integration_id"] == "openclaw_supervisor"))
+        entry.update(mutation)
+        assert reason in _provenance_errors(entry)
+
+    def test_fabricated_or_substituted_upstream_claim_rejects(self, integrations):
+        source = deepcopy(next(item for item in integrations if item["integration_id"] == "openclaw_gateway_artifact_provider"))
+        fabricated = {**source, "integration_id": "fabricated_upstream"}
+        substituted = {**source, "provider_runtime": RUNTIME_MODE_HERMES_API}
+        assert "upstream_entry_not_allowlisted" in _provenance_errors(fabricated)
+        assert "upstream_semantic_mismatch:provider_runtime" in _provenance_errors(substituted)
+
+    def test_upstream_evidence_and_implementation_substitution_rejects(self, integrations):
+        source = deepcopy(next(item for item in integrations if item["integration_id"] == "openclaw_gateway_artifact_provider"))
+        unrelated = {**source, "evidence_paths": ["modules/communication/moltbot_bridge/tests/test_openclaw_dae.py"]}
+        incomplete = {**source, "implementation_paths": source["implementation_paths"][1:]}
+        assert "upstream_evidence_paths_mismatch" in _provenance_errors(unrelated)
+        assert "upstream_implementation_paths_mismatch" in _provenance_errors(incomplete)
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("upstream_invocation_surface", "shell tools subagents merge"),
+            ("type", "security_gate"),
+            ("owner_module", "modules/untrusted"),
+            ("status", "removed"),
+            ("consumers", ["shell", "merge"]),
+            ("alias_of", "hermes_api_artifact_provider"),
+        ],
+    )
+    def test_upstream_security_semantics_are_exact(self, integrations, field, value):
+        source = deepcopy(next(item for item in integrations if item["integration_id"] == "openclaw_gateway_artifact_provider"))
+        source[field] = value
+        assert _provenance_errors(source)
+
+    def test_unknown_fields_and_documentation_only_evidence_reject(self, integrations):
+        source = deepcopy(next(item for item in integrations if item["integration_id"] == "hermes_api_artifact_provider"))
+        unknown = {**source, "unreviewed_claim": True}
+        docs_only = {**source, "evidence_paths": ["modules/communication/moltbot_bridge/README.md"]}
+        assert "entry_fields_invalid" in _provenance_errors(unknown)
+        assert "upstream_evidence_not_test" in _provenance_errors(docs_only)
+
+    def test_untracked_file_cannot_support_provenance(self):
+        path = "modules/communication/moltbot_bridge/src/openclaw_supervisor.py"
+        assert _repo_file_error(path, frozenset()) == "path_not_tracked"
+
+    def test_static_manifest_has_no_runtime_authority_consumer(self):
+        consumers = []
+        for value in TRACKED_PATHS:
+            if PurePosixPath(value).suffix.lower() not in EXECUTABLE_SUFFIXES:
+                continue
+            if "/tests/" in value or value.startswith("tests/"):
+                continue
+            if b"openclaw_integration_manifest.json" in (REPO_ROOT / value).read_bytes():
+                consumers.append(value)
+        assert not consumers, f"runtime sources consume static manifest: {consumers}"
+
+    def test_provenance_lint_stays_wsp62_bounded(self):
+        source = Path(__file__).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        assert len(source.splitlines()) <= 675
+        manifest_text = MANIFEST_PATH.read_text(encoding="utf-8")
+        assert len(manifest_text) <= 18_000
+        assert len(manifest_text.splitlines()) <= 200 and max(map(len, manifest_text.splitlines())) <= 600
+        oversized = [
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and (node.end_lineno or node.lineno) - node.lineno + 1 > 50
+        ]
+        assert not oversized
+
+    def test_upstream_source_markers_match_registered_invocation(self):
+        openclaw_provider = _source_tree(EXPECTED_UPSTREAM["openclaw_gateway_artifact_provider"]["provider_path"])
+        openclaw_runner = _source_tree("modules/communication/moltbot_bridge/src/reddog_openclaw_gateway_command_runner.py")
+        hermes_lifecycle = _source_tree("modules/communication/moltbot_bridge/src/reddog_hermes_api_run_lifecycle.py")
+        hermes_transport = _source_tree("modules/communication/moltbot_bridge/src/reddog_hermes_api_transport.py")
+        assert _has_literal_sequence(openclaw_provider, ("openclaw", "agent"))
+        assert _has_named_constant(openclaw_runner, "executable", "/usr/local/bin/openclaw")
+        assert _has_call_prefix(hermes_lifecycle, ("POST", "/v1/runs"))
+        assert _has_named_constant(hermes_transport, "HERMES_API_HOST", "127.0.0.1")
+
+
+# -- 4. Critical env key coverage --
 #    These keys are read by main.py at startup via os.getenv().
 #    If they exist in main.py, they must appear in the manifest
 #    so operators know which integration owns them.
-
 
 CRITICAL_MAIN_PY_KEYS = {
     "OPENCLAW_CONVERSATION_BACKEND",
@@ -108,7 +592,6 @@ CRITICAL_MAIN_PY_KEYS = {
     "OPENCLAW_SELF_AUDIT_INTERVAL_SEC",
 }
 
-
 class TestCriticalEnvCoverage:
     """Critical env keys from main.py appear in the manifest."""
 
@@ -120,7 +603,7 @@ class TestCriticalEnvCoverage:
         )
 
 
-# -- 4. WRE defaults coverage --
+# -- 5. WRE defaults coverage --
 #    Keys in wre_defaults.env that start with OPENCLAW_ should
 #    have a corresponding manifest entry.
 
@@ -159,7 +642,7 @@ class TestWreDefaultsCoverage:
         assert not missing, f"wre_defaults.env keys not in manifest: {missing}"
 
 
-# -- 5. OpenRouter module coverage --
+# -- 6. OpenRouter module coverage --
 
 
 class TestOpenRouterCoverage:
@@ -181,7 +664,7 @@ class TestOpenRouterCoverage:
         assert "OPENROUTER_API_KEY" in entry["secret_keys"]
 
 
-# -- 6. No duplicate integration names --
+# -- 7. No duplicate integration names --
 
 
 class TestNoDuplicates:


### PR DESCRIPTION
## Summary

- upgrades the existing OpenClaw integration manifest to a v2 static provenance ledger
- distinguishes direct upstream OpenClaw CLI and Hermes API providers from Foundups-local adapters and legacy naming
- splits the three local Hermes surfaces by owner, control flags, consumers, and capability boundary
- binds every provenance claim to tracked implementation and test evidence paths

## Truth boundary

This ledger is static and non-authoritative. It does not prove installation, health, freshness, or live execution, and it grants no signer, queue, shell, worktree, repository, PR, or merge authority.

## Validation

- 143 focused manifest/provider/Fusion tests passed
- Ruff passed
- git diff --check passed
- WSP 62: manifest 17,851 chars / 192 lines / max line 592; test file 675 lines, functions <= 50
- ASCII/NUL and secret-addition scans passed
- two independent exact-SHA reviews returned GO with zero findings

## WSP_97 truth

- OBSERVED: current RedDog directly invokes upstream OpenClaw through the canonical Gateway CLI provider and upstream Hermes through the authenticated loopback API provider.
- OBSERVED: Foundups-local Hermes WRE, builder, and resident transport surfaces remain separate control planes.
- SPECIFIED_NOT_IMPLEMENTED: runtime compatibility/freshness admission and broader upstream tool/subagent authority remain separate slices.

## Checklist

- [x] WSP_00 / WSP_15 / WSP_50 / WSP_62 / WSP_97 applied
- [x] no runtime behavior change
- [x] no authority expansion
- [x] no HoloIndex mutation or reindex
- [x] no VSIX change
