### PR TITLE
test(reddog): remove calendar-bound compatibility fixture

### DIFF
--- a/modules/infrastructure/dependency_launcher/ModLog.md
+++ b/modules/infrastructure/dependency_launcher/ModLog.md
@@ -7,6 +7,15 @@
 
 ## Change Log
 
+### 2026-08-05: Runtime compatibility test clock consistency
+
+- Removed a calendar-bound fixture failure by composing publication evidence at
+  the test's current instant.
+- Preserved the wall-clock production API and all integrity-only, nonblocking,
+  no-update authority boundaries. (WSP 15/22/50/97)
+
+---
+
 ### 2026-08-02: Trusted WSL resolver exported for upstream agent dispatch
 
 - Exported the existing System32-only WSL executable resolver for reuse by the

--- a/modules/infrastructure/dependency_launcher/tests/test_runtime_compatibility_evidence_supplier.py
+++ b/modules/infrastructure/dependency_launcher/tests/test_runtime_compatibility_evidence_supplier.py
@@ -157,8 +157,9 @@ def test_atomic_publish_is_off_repo_and_preserves_old_file_on_invalid(tmp_path: 
     repo.mkdir()
     runtime.mkdir()
     output = runtime / "compatibility.json"
+    current = datetime.now(timezone.utc)
     evidence = compose_runtime_compatibility_evidence(
-        _supply(), upstream_releases=_releases(), now=NOW
+        _supply(now=current), upstream_releases=_releases(), now=current
     )
     publish_runtime_compatibility_evidence(
         evidence, repo_root=repo, runtime_root=runtime, output_path=output


### PR DESCRIPTION
## Summary
- build runtime compatibility publication evidence at the test's current UTC instant
- preserve the production wall-clock freshness boundary unchanged
- document the focused regression repair

## Verification
- 36 focused dependency-launcher compatibility tests pass
- git diff --check passes
- production source files unchanged

## Truth Boundary
TEST_ONLY / NO_RUNTIME_AUTHORITY / NO_UPDATE / NO_INSTALL / NO_ROUTE_CHANGE / NO_HOLOINDEX_MUTATION