### PR TITLE
fix(reddog): enforce conversation history policy

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -1,5 +1,12 @@
 # RedDog Interface
 
+Version 0.4.57 separates sanitized packet continuation from raw model history.
+`Use last RedDog packet` remains an advisory-summary opt-in. The extension sends
+zero prior raw turns to Fusion, discards provider-returned history, and reports
+the exact zero-admission policy in Run Trace and Copy MD. Authenticated scoped
+turn admission is deferred to the conversational-scope slice; history never
+supplies work authority.
+
 Version 0.4.54 keeps the single Fusion adversarial retry but deterministically
 prefers a critic with a usable initial response over a route that blocked or
 abstained. Quorum still requires a material framing/evidence/WSP_15 challenge;

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -1,5 +1,18 @@
 # RedDog ModLog
 
+## 2026-08-06 - Conversation history policy enforcement (0.4.57)
+
+- Separated the sanitized last-packet continuation summary from raw provider
+  conversation history.
+- Added a zero-admission policy until authenticated FoundUp-scoped conversation
+  state exists; prior raw turns cannot reach Fusion or persist back into editor
+  state.
+- Added truthful Run Trace/Copy MD telemetry for requested inclusion, stored and
+  admitted counts, admitted turn IDs, rejection reason, setting-sensitive prompt
+  policy key, and discarded provider history.
+- Preserved the existing no-authority boundary and deferred persistent scope and
+  work promotion to later slices (WSP 00, 15, 22, 50, 62, 97).
+
 ## 2026-08-05 - Current-generation trust binding manifest pin (0.4.56)
 
 - Pinned the regenerated backend manifest containing the signer

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,6 +1,13 @@
 # RedDog
 
-Version: 0.4.56
+Version: 0.4.57
+
+Version 0.4.57 makes the continuation/model-history boundary truthful. The
+existing `Use last RedDog packet` control may append only the sanitized advisory
+summary. Raw provider history is admitted as zero turns until authenticated,
+FoundUp-scoped conversation state exists. Run Trace telemetry reports the
+request, rejection reason, admitted turn IDs, and discarded provider-history
+count. Conversation history grants no work authority.
 
 Version 0.4.56 pins the resident live-canary current-generation trust binding
 and the verified-outcome runtime-binding foundation in the
@@ -406,6 +413,6 @@ vsce package --no-dependencies
 From Cursor:
 
 1. Open Command Palette.
-2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.56.vsix` (or current package version).
+2. Run `Extensions: Install from VSIX...` and select the generated `reddog-0.4.57.vsix` (or current package version).
 3. Do not use workspace-extension install for normal operation; install the VSIX and reload the window.
 4. Run `RedDog: Open` from Command Palette or the three-dot command list.

--- a/extensions/reddog/conversation_history_policy.js
+++ b/extensions/reddog/conversation_history_policy.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const SCHEMA_VERSION = 'reddog_conversation_history_policy.v1';
+const MODE = 'raw_history_disabled_until_authenticated_scope';
+
+function boundedCount(value) {
+  return Array.isArray(value) ? Math.min(value.length, 1000) : 0;
+}
+
+function promptAssemblyKey(requested) {
+  return SCHEMA_VERSION + ':' + (requested ? 'requested' : 'disabled') + ':admitted=0';
+}
+
+function enforceHistoryPolicy(options) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const requested = opts.inclusionRequested === true;
+  const storedCount = boundedCount(opts.storedHistory);
+  return {
+    admittedHistory: [],
+    telemetry: {
+      schema_version: SCHEMA_VERSION,
+      policy_mode: MODE,
+      history_inclusion_requested: requested,
+      stored_history_turn_count: storedCount,
+      admitted_turn_count: 0,
+      admitted_turn_ids: [],
+      model_history_attached: false,
+      scoped_history_authority_available: false,
+      history_policy_reason: requested
+        ? 'authenticated_scoped_history_unavailable'
+        : 'disabled_by_operator',
+      prompt_assembly_policy_key: promptAssemblyKey(requested),
+      provider_history_discarded_count: 0,
+      no_work_authority_from_history: true
+    }
+  };
+}
+
+function prepareHistoryAdmission(state, inclusionRequested) {
+  const mutableState = state && typeof state === 'object' ? state : {};
+  const admission = enforceHistoryPolicy({
+    inclusionRequested,
+    storedHistory: mutableState.history
+  });
+  mutableState.history = [];
+  return admission;
+}
+
+function withProviderHistoryDiscarded(telemetry, providerHistory) {
+  return Object.assign({}, normalizeTelemetry(telemetry), {
+    provider_history_discarded_count: boundedCount(providerHistory),
+    model_history_attached: false,
+    admitted_turn_count: 0,
+    admitted_turn_ids: []
+  });
+}
+
+function discardProviderHistory(admission, result, promptConstruction) {
+  const context = admission && typeof admission === 'object' ? admission : {};
+  const updated = withProviderHistoryDiscarded(context.telemetry, result && result.history);
+  context.telemetry = updated;
+  if (result && typeof result === 'object') {
+    delete result.history;
+    result.conversation_history_policy = updated;
+  }
+  if (promptConstruction && typeof promptConstruction === 'object') {
+    promptConstruction.conversation_history_policy = updated;
+  }
+  return updated;
+}
+
+function normalizeTelemetry(value) {
+  const incoming = value && typeof value === 'object' ? value : {};
+  const requested = incoming.history_inclusion_requested === true;
+  return {
+    schema_version: SCHEMA_VERSION,
+    policy_mode: MODE,
+    history_inclusion_requested: requested,
+    stored_history_turn_count: Number.isInteger(incoming.stored_history_turn_count)
+      ? Math.max(0, incoming.stored_history_turn_count)
+      : 0,
+    admitted_turn_count: 0,
+    admitted_turn_ids: [],
+    model_history_attached: false,
+    scoped_history_authority_available: false,
+    history_policy_reason: requested
+      ? 'authenticated_scoped_history_unavailable'
+      : 'disabled_by_operator',
+    prompt_assembly_policy_key: promptAssemblyKey(requested),
+    provider_history_discarded_count: Number.isInteger(incoming.provider_history_discarded_count)
+      ? Math.max(0, incoming.provider_history_discarded_count)
+      : 0,
+    no_work_authority_from_history: true
+  };
+}
+
+function formatTelemetryLines(value) {
+  const telemetry = normalizeTelemetry(value);
+  return [
+    '- conversation_history_policy: ' + telemetry.policy_mode,
+    '- history_inclusion_requested: ' + (telemetry.history_inclusion_requested ? 'true' : 'false'),
+    '- stored_history_turn_count: ' + telemetry.stored_history_turn_count,
+    '- admitted_turn_count: 0',
+    '- admitted_turn_ids: []',
+    '- model_history_attached: false',
+    '- scoped_history_authority_available: false',
+    '- history_policy_reason: ' + telemetry.history_policy_reason,
+    '- prompt_assembly_policy_key: ' + telemetry.prompt_assembly_policy_key,
+    '- provider_history_discarded_count: ' + telemetry.provider_history_discarded_count,
+    '- no_work_authority_from_history: true'
+  ];
+}
+
+function buildTelemetrySection(value) {
+  return ['## Conversation History Policy'].concat(formatTelemetryLines(value)).join('\n');
+}
+
+module.exports = {
+  MODE,
+  SCHEMA_VERSION,
+  buildTelemetrySection,
+  discardProviderHistory,
+  enforceHistoryPolicy,
+  formatTelemetryLines,
+  normalizeTelemetry,
+  prepareHistoryAdmission,
+  withProviderHistoryDiscarded
+};

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -17,6 +17,7 @@ const backendCompatibility = require('./backend_compatibility_preflight');
 const backendCompatibilityAsync = require('./backend_compatibility_async');
 const backendCompatibilityRender = require('./backend_compatibility_render');
 const continuationPrompt = require('./continuation_prompt');
+const conversationHistoryPolicy = require('./conversation_history_policy');
 const authoritativeWorkStateQuery = require('./authoritative_work_state_query');
 const conversationalDraftPolicy = require('./conversational_draft_policy');
 const modelRuntimeBindingQuery = require('./model_runtime_binding_query');
@@ -27,7 +28,7 @@ const repoDeepDiveFocusPolicy = require('./repo_deep_dive_focus_policy');
 const repoAuditGrounding = require('./repo_audit_grounding');
 const localDiagnosticRouter = require('./local_diagnostic_router');
 const foundupWorkRuntime = require('./foundup_work_runtime_binding');
-const EXTENSION_VERSION = '0.4.56';
+const EXTENSION_VERSION = '0.4.57';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -2449,6 +2450,9 @@ function buildRunTraceSection(result, workerType, contextSummary, holoScorecard,
     }
   }
   lines.push.apply(lines, formatContinuationTelemetryLines(rp.continuation_telemetry || (result && result.continuation_telemetry)));
+  lines.push.apply(lines, conversationHistoryPolicy.formatTelemetryLines(
+    rp.conversation_history_policy || (result && result.conversation_history_policy)
+  ));
   lines.push('- output_validation: ' + formatOutputValidationStatus(rp.output_validation));
   lines.push.apply(lines, formatJudgmentVerificationLines(rp.output_validation));
   if (rp.runtime_consumption_gate && typeof rp.runtime_consumption_gate === 'object') {
@@ -3955,6 +3959,9 @@ function buildCopyMarkdown(result, workerType, contextSummary, workTrail, holoSc
     }
   }
   sections.push(buildContinuationTelemetrySection(ctx.continuationTelemetry || packet.continuation_telemetry));
+  sections.push(conversationHistoryPolicy.buildTelemetrySection(
+    ctx.conversationHistoryPolicy || packet.conversation_history_policy
+  ));
   // Gate Copy MD continuation inclusion on the toggle (continuationEnabled), not merely on summary existence.
   if (ctx.continuationEnabled && ctx.continuationSummary) {
     sections.push(buildContinuationSummaryCopySection(ctx.continuationSummary));
@@ -5254,6 +5261,7 @@ function attachOrchestratorMetadata(reviewPacket, classification, resolvedEffort
     provider_reasoning_requested: providerReport.provider_reasoning_requested,
     provider_reasoning_applied: providerReport.provider_reasoning_applied,
     provider_reasoning_note: providerReport.provider_reasoning_note,
+    conversation_history_policy: construction.conversation_history_policy,
     unicode_normalization_applied: unicode.unicode_normalization_applied === true,
     unicode_replacements_count: typeof unicode.unicode_replacements_count === 'number' ? unicode.unicode_replacements_count : 0,
     unicode_normalization_sources: typeof unicode.unicode_normalization_sources === 'string' ? unicode.unicode_normalization_sources : '',
@@ -5458,6 +5466,7 @@ function wireFusionWebview(context, webview, worker, state) {
     );
     const wspTaskPrompt = continuation.prompt;
     const continuationTelemetry = continuation.telemetry;
+    const historyAdmission = conversationHistoryPolicy.prepareHistoryAdmission(state, continuationEnabled);
     const promptConstruction = {
       work_focus_digest: redactedDigest(workFocus, 180),
       wsp_prompt_digest: redactedDigest(wspTaskPrompt, 320),
@@ -5576,8 +5585,9 @@ function wireFusionWebview(context, webview, worker, state) {
       postStatusAndProgress(webview, null, 'Grounding preflight blocked Fusion: ' + groundingPreflight.rejection_reasons.join(', '));
       result = buildGroundingPreflightBlockedResult(groundingPreflight);
     } else {
-      result = await callFusion(context, worker, wspTaskPrompt, contextPacket.text, systemPrompt, state.history, mode, onBridgeProgress, state, promptConstruction);
+      result = await callFusion(context, worker, wspTaskPrompt, contextPacket.text, systemPrompt, historyAdmission.admittedHistory, mode, onBridgeProgress, state, promptConstruction);
     }
+    conversationHistoryPolicy.discardProviderHistory(historyAdmission, result, promptConstruction);
     fusionProgress.capture(result);
     if (holoScorecard) {
       holoScorecard.audit_context_applied = result && result.audit_context_applied === true;
@@ -5932,9 +5942,6 @@ function wireFusionWebview(context, webview, worker, state) {
           mojibake_markers: mojibake.markers
         });
       }
-    }
-    if (result.ok && Array.isArray(result.history)) {
-      state.history = result.history;
     }
     result = enrichRedactionBlockResult(result);
     if (result.review_packet) {
@@ -8336,6 +8343,10 @@ module.exports = {
   buildContinuationTelemetrySection,
   formatContinuationTelemetryLines,
   normalizeContinuationTelemetry,
+  buildConversationHistoryPolicyTelemetrySection: conversationHistoryPolicy.buildTelemetrySection,
+  enforceConversationHistoryPolicy: conversationHistoryPolicy.enforceHistoryPolicy,
+  formatConversationHistoryPolicyTelemetryLines: conversationHistoryPolicy.formatTelemetryLines,
+  normalizeConversationHistoryPolicyTelemetry: conversationHistoryPolicy.normalizeTelemetry,
   sanitizeContinuationField,
   redactedDigest,
   resolvePythonInterpreter,

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.56",
+  "version": "0.4.57",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/tests/README.md
+++ b/extensions/reddog/tests/README.md
@@ -19,6 +19,7 @@ node extensions/reddog/tests/verify_repo_audit_grounding.js
 node extensions/reddog/tests/verify_extension_contract.js
 node extensions/reddog/tests/test_start_operations_control.js
 node extensions/reddog/tests/test_holoindex_incident_repair.js
+node extensions/reddog/tests/test_conversation_history_policy.js
 git diff --check -- extensions/reddog
 ```
 
@@ -42,6 +43,7 @@ python -m pytest holo_index/tests/test_repo_audit_discovery.py scripts/tests/tes
 | `scripts/tests/test_generate_reddog_backend_manifest.py` | Package-initializer resolution, executable roots, dynamic-load sentinels, and checked-in generator parity |
 | `test_start_operations_control.js` | Cross-language receipt parity, request replay, cumulative output, environment allowlist, and durable intent controls |
 | `test_holoindex_incident_repair.js` | Exhausted-owner admission, bounded bridge execution, WRE repair telemetry, version wiring, and no direct model binding |
+| `test_conversation_history_policy.js` | Raw-history denial, setting-sensitive prompt policy keys, provider-history discard, non-authority telemetry, and extension wiring |
 | `verify_extension_contract.js` | Single contract runner; ADDENDUM E ~line 518+, ADDENDUM F gate probe ~line 595+ |
 | `verify_repo_audit_grounding.js` | Focused alias, receipt, protected-context non-vacuity, local block, repair-provenance, and defensive-prompt contracts |
 

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,14 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-08-06 - Conversation history policy enforcement (0.4.57)
+
+- Added focused zero-admission tests for disabled, enabled-without-authenticated-
+  scope, missing input, cross-FoundUp/secret-shaped raw history, setting changes,
+  provider-history discard, and content-free telemetry.
+- Extended the full extension contract to prove Fusion receives only policy-
+  admitted history, editor state does not retain provider history, and Run Trace
+  reports zero admitted turn IDs.
+
 ## 2026-08-05 - Current-generation trust binding manifest (0.4.56)
 
 - Updated the exact generated backend-manifest pin and RedDog build identity

--- a/extensions/reddog/tests/test_conversation_history_policy.js
+++ b/extensions/reddog/tests/test_conversation_history_policy.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const policy = require('../conversation_history_policy');
+
+const extensionRoot = path.resolve(__dirname, '..');
+const extensionSource = fs.readFileSync(path.join(extensionRoot, 'extension.js'), 'utf8');
+
+const hostileHistory = [
+  { role: 'user', content: 'FoundUp A secret context', turn_id: 'turn-a' },
+  { role: 'assistant', content: 'Cross-FoundUp B result', turn_id: 'turn-b' }
+];
+
+const disabled = policy.enforceHistoryPolicy({
+  inclusionRequested: false,
+  storedHistory: hostileHistory
+});
+assert.deepStrictEqual(disabled.admittedHistory, []);
+assert.strictEqual(disabled.telemetry.stored_history_turn_count, 2);
+assert.strictEqual(disabled.telemetry.model_history_attached, false);
+assert.strictEqual(disabled.telemetry.history_policy_reason, 'disabled_by_operator');
+assert.deepStrictEqual(disabled.telemetry.admitted_turn_ids, []);
+
+const requested = policy.enforceHistoryPolicy({
+  inclusionRequested: true,
+  storedHistory: hostileHistory
+});
+assert.deepStrictEqual(requested.admittedHistory, []);
+assert.strictEqual(requested.telemetry.history_inclusion_requested, true);
+assert.strictEqual(
+  requested.telemetry.history_policy_reason,
+  'authenticated_scoped_history_unavailable'
+);
+assert.notStrictEqual(
+  requested.telemetry.prompt_assembly_policy_key,
+  disabled.telemetry.prompt_assembly_policy_key
+);
+
+const missing = policy.enforceHistoryPolicy();
+assert.deepStrictEqual(missing.admittedHistory, []);
+assert.strictEqual(missing.telemetry.history_inclusion_requested, false);
+
+const discarded = policy.withProviderHistoryDiscarded(requested.telemetry, hostileHistory);
+assert.strictEqual(discarded.provider_history_discarded_count, 2);
+assert.strictEqual(discarded.model_history_attached, false);
+assert.deepStrictEqual(discarded.admitted_turn_ids, []);
+
+const rendered = policy.buildTelemetrySection(discarded);
+assert(rendered.includes('## Conversation History Policy'));
+assert(rendered.includes('model_history_attached: false'));
+assert(rendered.includes('admitted_turn_ids: []'));
+assert(!rendered.includes('FoundUp A secret context'));
+assert(!rendered.includes('Cross-FoundUp B result'));
+
+const mutableState = { history: hostileHistory.slice() };
+const prepared = policy.prepareHistoryAdmission(mutableState, true);
+assert.deepStrictEqual(prepared.admittedHistory, []);
+assert.deepStrictEqual(mutableState.history, []);
+
+const providerResult = { history: hostileHistory.slice(), ok: true };
+const promptConstruction = {};
+const finalized = policy.discardProviderHistory(
+  prepared,
+  providerResult,
+  promptConstruction
+);
+assert.strictEqual(Object.prototype.hasOwnProperty.call(providerResult, 'history'), false);
+assert.strictEqual(finalized.provider_history_discarded_count, 2);
+assert.deepStrictEqual(providerResult.conversation_history_policy, finalized);
+assert.deepStrictEqual(promptConstruction.conversation_history_policy, finalized);
+assert.deepStrictEqual(prepared.telemetry, finalized);
+
+assert(extensionSource.includes("require('./conversation_history_policy')"));
+assert(extensionSource.includes('historyAdmission.admittedHistory'));
+assert(extensionSource.includes('conversationHistoryPolicy.prepareHistoryAdmission('));
+assert(extensionSource.includes('conversationHistoryPolicy.discardProviderHistory('));
+assert(!extensionSource.includes('systemPrompt, state.history, mode'));
+assert(
+  extensionSource.indexOf('conversationHistoryPolicy.discardProviderHistory(') < extensionSource.indexOf('fusionProgress.capture(result)'),
+  'provider history must be deleted before progress capture'
+);
+
+console.log('RedDog conversation history policy checks passed.');

--- a/extensions/reddog/tests/test_holoindex_incident_repair.js
+++ b/extensions/reddog/tests/test_holoindex_incident_repair.js
@@ -104,8 +104,8 @@ assert(extensionSource.includes('holoGenerationBoundQuery.isObserved(ownerResult
 assert(extensionSource.includes('holoIncidentRepair.shouldCoordinate(ownerResult, ownerObserved)'));
 assert(extensionSource.includes('coordinateHoloIndexIncident(root, query, ownerResult, ownerObserved)'));
 assert((extensionSource.match(/holoIncidentRepair\.metadata\(incidentRepair\)/g) || []).length >= 4);
-assert.strictEqual(pkg.version, '0.4.56');
-assert(extensionSource.includes("const EXTENSION_VERSION = '0.4.56'"));
+assert.strictEqual(pkg.version, '0.4.57');
+assert(extensionSource.includes("const EXTENSION_VERSION = '0.4.57'"));
 assert(!fs.readFileSync(path.join(extDir, 'holoindex_incident_repair.js'), 'utf8').includes('qwen'));
 
 console.log('RedDog HoloIndex incident repair extension tests passed.');

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -16,6 +16,8 @@ const root = path.resolve(__dirname, '..', '..', '..');
 const extDir = path.join(root, 'extensions', 'reddog');
 const extensionJs = fs.readFileSync(path.join(extDir, 'extension.js'), 'utf8');
 const continuationPromptJs = fs.readFileSync(path.join(extDir, 'continuation_prompt.js'), 'utf8');
+const conversationHistoryPolicyJs = fs.readFileSync(path.join(extDir, 'conversation_history_policy.js'), 'utf8');
+const conversationHistoryPolicy = require(path.join(extDir, 'conversation_history_policy.js'));
 const fusionProgressJs = fs.readFileSync(path.join(extDir, 'fusion_progress_receipt.js'), 'utf8');
 const fusionProgress = require(path.join(extDir, 'fusion_progress_receipt.js'));
 const holoGenerationBoundQueryJs = fs.readFileSync(path.join(extDir, 'holoindex_generation_bound_query.js'), 'utf8');
@@ -222,8 +224,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.56', 'package version must be 0.4.56');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.56'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.57', 'package version must be 0.4.57');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.57'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -366,7 +368,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.56', 'README version mismatch');
+includes(readme, 'Version: 0.4.57', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -2107,7 +2109,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.56', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.57', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [],
@@ -3615,7 +3617,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.56'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.57'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -3629,7 +3631,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.56'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.57'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -3641,7 +3643,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.56'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.57'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -3970,6 +3972,38 @@ const copyManualCheck = orchestrator.buildCopyMarkdown(
 );
 includes(copyManualCheck, 'Continuation from last RedDog packet', 'manual check: Copy MD must still append continuation summary (feature available on opt-in)');
 includes(copyManualCheck, 'continuation_enabled: true', 'manual check: Copy MD telemetry must report enabled=true');
+
+// REDDOG_CONVERSATION_HISTORY_POLICY_ENFORCEMENT_PHASE1 (v0.4.57): the existing
+// continuation toggle controls only the sanitized last-packet summary. Raw provider
+// history remains fail-closed until P1 supplies authenticated FoundUp-scoped turns.
+const deniedRawHistory = conversationHistoryPolicy.enforceHistoryPolicy({
+  inclusionRequested: true,
+  storedHistory: [
+    { role: 'user', content: 'FoundUp A secret', turn_id: 'turn-a' },
+    { role: 'assistant', content: 'FoundUp B result', turn_id: 'turn-b' }
+  ]
+});
+assert.deepStrictEqual(deniedRawHistory.admittedHistory, [], 'raw history must be excluded until authenticated scoped state exists');
+assert.strictEqual(deniedRawHistory.telemetry.model_history_attached, false, 'telemetry must report no raw model history');
+assert.deepStrictEqual(deniedRawHistory.telemetry.admitted_turn_ids, [], 'no unauthenticated turn IDs may be admitted');
+assert.strictEqual(deniedRawHistory.telemetry.history_policy_reason, 'authenticated_scoped_history_unavailable');
+includes(conversationHistoryPolicyJs, 'no_work_authority_from_history: true', 'history non-authority invariant missing');
+includes(extensionJs, 'historyAdmission.admittedHistory', 'Fusion must receive policy-admitted history only');
+includes(extensionJs, 'conversationHistoryPolicy.prepareHistoryAdmission(', 'stored history must clear before Fusion');
+includes(extensionJs, 'conversationHistoryPolicy.discardProviderHistory(', 'provider history discard wiring missing');
+includes(conversationHistoryPolicyJs, 'mutableState.history = []', 'policy must clear stored history');
+includes(conversationHistoryPolicyJs, 'delete result.history', 'provider-returned history must be deleted');
+assert(!extensionJs.includes('systemPrompt, state.history, mode'), 'raw state.history must never reach Fusion');
+assert(
+  extensionJs.indexOf('conversationHistoryPolicy.discardProviderHistory(') < extensionJs.indexOf('fusionProgress.capture(result)'),
+  'provider-returned history must be discarded before progress capture'
+);
+const historyPolicyTrace = orchestrator.buildRunTraceSection(
+  { review_packet: { conversation_history_policy: deniedRawHistory.telemetry } },
+  'reddog_architect', null, null, 'high'
+);
+includes(historyPolicyTrace, 'model_history_attached: false', 'Run Trace must expose actual history attachment state');
+includes(historyPolicyTrace, 'admitted_turn_ids: []', 'Run Trace must expose admitted turn IDs');
 
 // REDDOG_REPAIR_PRESERVES_EVIDENCE_PHASE1: the repair path must protect a primary Determine
 // answer block through the schema-repair pass (reuses the Python guard; no rules duplicated in JS).
@@ -4988,7 +5022,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.56' } }
+      ? { id, packageJSON: { version: '0.4.57' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({


### PR DESCRIPTION
﻿## Summary
- make the existing continuation control truthful by separating sanitized last-packet continuation from raw provider conversation history
- admit zero raw turns until authenticated FoundUp-scoped conversation state exists
- discard provider-returned history before progress capture or webview state persistence
- report requested inclusion, stored/admitted counts, admitted turn IDs, policy reason, setting-sensitive prompt key, and discarded-provider count

## WSP_97 truth boundary
- OBSERVED: previous raw state.history reached the Fusion bridge independently of the continuation toggle
- IMPLEMENTED: raw history is now denied at the extension boundary and provider history is discarded
- SPECIFIED_NOT_IMPLEMENTED: authenticated persistent conversational scope
- SPECIFIED_NOT_IMPLEMENTED: conversation-to-work promotion
- NO new signer, worker dispatch, repository authority, HoloIndex mutation, or reindex

## Validation
- node --check extensions/reddog/extension.js
- node --check extensions/reddog/conversation_history_policy.js
- node extensions/reddog/tests/test_conversation_history_policy.js
- node extensions/reddog/tests/verify_extension_contract.js
- node extensions/reddog/tests/test_backend_compatibility_contract.js
- node extensions/reddog/tests/test_backend_compatibility_preflight.js
- node extensions/reddog/tests/test_backend_compatibility_async.js
- node extensions/reddog/tests/test_start_operations_control.js
- node extensions/reddog/tests/test_holoindex_incident_repair.js
- node extensions/reddog/tests/verify_repo_audit_grounding.js
- python -B -m pytest -q -p no:cacheprovider --tb=short scripts/tests/test_generate_reddog_backend_manifest.py
- git diff --check
- ASCII/NUL byte checks: clean

## Operational note
The governed HoloIndex owner query returned current semantic status but remained pinned to the pre-#1459 HEAD. Direct reads were used for current-main truth; no runtime/query-lane reindex was performed.
