### PR TITLE
feat(reddog): authenticated conversational scope state

### DIFF
--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -1,5 +1,39 @@
 # OpenClaw Bridge Interface
 
+## Authenticated RedDog conversation scope
+
+`authenticate_conversation_scope()` verifies an existing `sess.v1` token and
+derives the principal exclusively from its signed subject. It resolves the
+current `PrincipalAuthorityRecord` and returns an opaque, one-use process-local
+capability. The capability cannot be constructed, copied, pickled, or
+serialized, and no session secret or derived record-MAC key is returned.
+
+`create_authenticated_conversation_scope()`,
+`resume_authenticated_conversation_scope()`, and
+`advance_authenticated_conversation_scope()` persist a bounded scope in the
+existing AgentDB. The record binds principal, transport/session, one active
+FoundUp, discussion FoundUps, typed decisions/questions, repository evidence
+references, operational snapshot, repository HEAD, HoloIndex generation and
+freshness receipt, turn lineage, expiry, and a revision receipt chain. Create
+is insert-only; updates use revision compare-and-swap.
+
+Persisted evidence references must already occur in the verified grounding
+receipt. This state layer does not upgrade a model-supplied path or claim into
+repository evidence.
+
+Every create/resume/update consumes fresh authentication, resolves current
+principal scope, checks the current grounding and registered FoundUp receipt,
+and authenticates the stored record with a derived HMAC. Recomputed local
+hashes cannot replace that authentication. Key rotation accepts the configured
+previous secret only for verification; the next accepted revision is signed
+with the current secret.
+
+The returned projection omits principal identity, token material, public-key
+material, MACs, and raw conversation. It grants no work, worker, repository,
+HoloIndex, proposal, signing, or dispatch authority. The editor is not wired to
+this API until a production-authenticated session source is available;
+`REDDOG_AUTHENTICATED_PRINCIPAL_ID` remains configuration, not authentication.
+
 ## Public API
 ### Architect proposal validity and execution readiness
 

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,25 @@
 # ModLog - moltbot_bridge
 
+## 2026-08-06: Authenticated conversational scope state
+- Added a real AgentDB-backed RedDog conversation-scope runtime using
+  create-if-absent, revision CAS, expiry, strict schemas, turn/revision lineage,
+  and current operational-snapshot, repository-HEAD, HoloIndex-generation, and
+  registered-FoundUp grounding bindings.
+- Reused the existing signed `sess.v1` verifier and current
+  `PrincipalAuthorityResolver`. The verified subject, never caller text or an
+  environment principal, selects the record. Authentication is represented by
+  opaque one-use process-local capabilities; session secrets and derived record
+  MAC keys never enter records or projections.
+- Added authenticated record MACs with current/previous secret rotation,
+  exact-field parsing, recomputed-hash tamper rejection, restart recovery,
+  principal/key/transport/session revalidation, stale-grounding rejection, and
+  bounded non-authoritative projections. Typed repository facts may retain
+  only evidence references already admitted by the verified grounding receipt.
+- Kept proposal creation, principal policy authorization, worker dispatch,
+  repository mutation, HoloIndex maintenance, and editor runtime consumption
+  outside this slice. Production editor binding remains blocked on a genuine
+  authenticated-session source (WSP 00/15/22/50/62/97).
+
 ## 2026-08-05: Resident live-canary current-generation trust concatenation
 - Extended the canonical use-time authority resolver to consume the existing
   root-owned system-service manifest selection after signed work-authority

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -1,5 +1,19 @@
 # OpenClaw Bridge = 012's Digital Twin
 
+## RedDog conversational state boundary
+
+RedDog now has an AgentDB-backed authenticated conversation-scope runtime. It
+stores only typed, bounded continuity state and current evidence bindings; raw
+provider history is never stored by this runtime. A fresh signed session proof
+and current principal/FoundUp resolution are required for create, resume, and
+CAS update. Stale HEAD, HoloIndex generation, operational snapshot, expiry,
+principal key, transport/session, or turn lineage fails closed.
+
+This state helps RedDog interpret follow-up requests. It is not work authority.
+Proposal creation, principal authorization, WRE/OpenClaw/Hermes dispatch,
+repository mutation, and merge remain downstream gates. The extension does not
+consume this state until a production authenticated-session source is bound.
+
 ## Upstream Agent Execution Boundary
 
 RedDog's bounded author stage can use the installed upstream agent runtimes,

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -1,5 +1,20 @@
 # moltbot_bridge Roadmap
 
+## RedDog conversational work promotion
+
+- COMPLETE: raw provider history is denied by default and continuation
+  telemetry reflects the actual admitted context.
+- COMPLETE: AgentDB-backed authenticated conversation scope with insert-only
+  creation, CAS revisions, expiry, FoundUp and session scope, typed continuity,
+  current grounding, snapshot/HEAD/Holo bindings, opaque one-use session
+  capabilities, authenticated records, and bounded projections.
+- BLOCKED: editor consumption until a production signed-session issuer/source
+  is available. Environment principal/FoundUp values are not authentication.
+- NEXT: bind one immutable pending architect proposal to the exact conversation
+  revision and use the existing principal-signed proposal policy authorization.
+- HELD: OpenClaw/Hermes dispatch until exact proposal authorization and all
+  existing WRE work-order gates pass.
+
 ## Stable External Signer Lifecycle
 
 - COMPLETE: current authenticated signer generation selection.

--- a/modules/communication/moltbot_bridge/src/reddog_authenticated_conversation_scope_state.py
+++ b/modules/communication/moltbot_bridge/src/reddog_authenticated_conversation_scope_state.py
@@ -1,0 +1,183 @@
+"""Authenticated create, resume, and CAS-update operations for RedDog scope."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_capability import (
+    AuthenticatedConversationScopeCapability,
+    consume_conversation_scope_capability,
+    conversation_scope_authority_view,
+    sign_record_with_scope_authority,
+    verify_record_with_scope_authority,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_advance import (
+    advance_authenticated_conversation_scope,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    SCHEMA_VERSION,
+    canonical_digest,
+    sanitized_text,
+    with_record_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_record import (
+    AuthenticatedConversationScopeResult,
+    accepted,
+    authority_matches,
+    grounding_evidence_refs,
+    rejected,
+    revision_receipt,
+    state_values,
+    stored_result,
+    verified_grounding,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_store import (
+    AgentDbConversationScopeStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_request import (
+    ConversationScopeCreateRequest,
+)
+
+
+MAX_SCOPE_TTL_SECONDS = 86400
+
+
+def create_authenticated_conversation_scope(
+    *,
+    store: AgentDbConversationScopeStore,
+    capability: AuthenticatedConversationScopeCapability,
+    repo_root: Any,
+    request: ConversationScopeCreateRequest,
+    now_epoch: int,
+) -> AuthenticatedConversationScopeResult:
+    grounded, reason = verified_grounding(
+        repo_root, request.work_focus, request.grounding_receipt
+    )
+    if reason:
+        return rejected(reason)
+    foundup_id = str(grounded.get("foundup_id") or "")
+    discussions = tuple(
+        dict.fromkeys(str(item) for item in request.discussion_foundup_ids if str(item))
+    )
+    authority = consume_conversation_scope_capability(
+        capability,
+        active_foundup_id=foundup_id,
+        discussion_foundup_ids=discussions,
+        now_epoch=now_epoch,
+    )
+    authority_view = conversation_scope_authority_view(authority)
+    if authority is None or authority_view is None:
+        return rejected("conversation_scope_access_denied")
+    try:
+        record = _new_scope_record(
+            request, grounded, authority_view, discussions, now_epoch
+        )
+    except (TypeError, ValueError):
+        return rejected("conversation_scope_input_invalid")
+    record["revision_receipts"] = [revision_receipt(record, previous="", revision=0)]
+    record["record_auth_mac"] = sign_record_with_scope_authority(authority, record)
+    return stored_result(store.create(with_record_digest(record)))
+
+
+def _new_scope_record(
+    request: ConversationScopeCreateRequest, grounded: Mapping[str, Any], authority_view: Mapping[str, Any],
+    discussions: tuple[str, ...], now_epoch: int,
+) -> dict[str, Any]:
+    state = state_values(
+        turn_id=request.turn_id, parent_turn_id="", discussions=discussions,
+        active_topic=request.active_topic, current_objective=request.current_objective,
+        accepted_decisions=request.accepted_decisions,
+        rejected_options=request.rejected_options, open_questions=request.open_questions,
+        repository_evidence_refs=request.repository_evidence_refs,
+        allowed_evidence_refs=grounding_evidence_refs(grounded),
+    )
+    ttl = int(request.ttl_seconds)
+    nonce = sanitized_text(request.conversation_nonce, limit=160)
+    if ttl <= 0 or ttl > MAX_SCOPE_TTL_SECONDS or not nonce:
+        raise ValueError("conversation_scope_ttl_or_nonce_invalid")
+    foundup_id = str(grounded.get("foundup_id") or "")
+    conversation_id = _conversation_id(authority_view, foundup_id, nonce)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "conversation_id": conversation_id,
+        **{key: authority_view[key] for key in (
+            "principal_id", "principal_provider", "verified_subject_digest",
+            "principal_record_digest", "principal_key_fingerprint", "transport",
+            "session_binding_digest",
+        )},
+        "authorized_foundup_id": foundup_id,
+        "conversation_revision": 0,
+        **state,
+        "source_snapshot_id": str(request.source_snapshot_id or ""),
+        "source_snapshot_digest": str(request.source_snapshot_digest or ""),
+        "last_grounded_head_sha": str(grounded["holoindex_repo_head_sha"]),
+        "holoindex_generation_id": str(grounded.get("holoindex_generation_id") or ""),
+        "holoindex_freshness_receipt_id": str(grounded.get("holoindex_freshness_receipt_digest") or ""),
+        "grounding_receipt_id": str(grounded["receipt_id"]),
+        "pending_work_proposal_id": "",
+        "pending_work_proposal_digest": "",
+        "created_at": int(now_epoch),
+        "updated_at": int(now_epoch),
+        "expires_at": int(now_epoch) + ttl,
+        "revision_receipts": [],
+        "record_auth_mac": "",
+        "record_digest": "",
+    }
+
+
+def _conversation_id(authority: Mapping[str, Any], foundup_id: str, nonce: str) -> str:
+    return canonical_digest(
+        {
+            "principal_id": authority["principal_id"],
+            "foundup_id": foundup_id,
+            "session_binding_digest": authority["session_binding_digest"],
+            "conversation_nonce": nonce,
+        }
+    )
+
+
+def resume_authenticated_conversation_scope(
+    *,
+    store: AgentDbConversationScopeStore,
+    capability: AuthenticatedConversationScopeCapability,
+    conversation_id: str,
+    expected_head_sha: str,
+    expected_holoindex_generation_id: str,
+    expected_source_snapshot_id: str,
+    expected_source_snapshot_digest: str,
+    now_epoch: int,
+) -> AuthenticatedConversationScopeResult:
+    loaded = store.load(conversation_id)
+    record = loaded.get("record") if loaded.get("ok") else None
+    if not isinstance(record, Mapping):
+        return rejected("conversation_scope_access_denied")
+    authority = consume_conversation_scope_capability(
+        capability,
+        active_foundup_id=str(record["authorized_foundup_id"]),
+        discussion_foundup_ids=tuple(str(item) for item in record["discussion_foundup_ids"]),
+        now_epoch=now_epoch,
+    )
+    authority_view = conversation_scope_authority_view(authority)
+    if (
+        authority is None
+        or authority_view is None
+        or not authority_matches(record, authority_view)
+        or not verify_record_with_scope_authority(authority, record)
+    ):
+        return rejected("conversation_scope_access_denied")
+    if int(now_epoch) >= int(record["expires_at"]):
+        return rejected("conversation_scope_expired")
+    if (
+        str(record["last_grounded_head_sha"]) != str(expected_head_sha)
+        or str(record["holoindex_generation_id"]) != str(expected_holoindex_generation_id)
+        or str(record["source_snapshot_id"]) != str(expected_source_snapshot_id)
+        or str(record["source_snapshot_digest"]) != str(expected_source_snapshot_digest)
+    ):
+        return rejected("conversation_scope_regrounding_required")
+    return accepted(record)
+
+
+__all__ = [
+    "AuthenticatedConversationScopeResult", "advance_authenticated_conversation_scope",
+    "create_authenticated_conversation_scope", "resume_authenticated_conversation_scope",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_advance.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_advance.py
@@ -1,0 +1,153 @@
+"""CAS update operation for authenticated RedDog conversation scope."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_capability import (
+    AuthenticatedConversationScopeCapability,
+    consume_conversation_scope_capability,
+    conversation_scope_authority_view,
+    sign_record_with_scope_authority,
+    verify_record_with_scope_authority,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    with_record_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_record import (
+    AuthenticatedConversationScopeResult,
+    authority_matches,
+    grounding_evidence_refs,
+    rejected,
+    revision_receipt,
+    state_values,
+    stored_result,
+    verified_grounding,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_request import (
+    ConversationScopeAdvanceRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_store import (
+    AgentDbConversationScopeStore,
+)
+
+
+def advance_authenticated_conversation_scope(
+    *,
+    store: AgentDbConversationScopeStore,
+    capability: AuthenticatedConversationScopeCapability,
+    repo_root: Any,
+    request: ConversationScopeAdvanceRequest,
+    now_epoch: int,
+) -> AuthenticatedConversationScopeResult:
+    current, grounded, authority, reason = _authorized_current(
+        store, capability, repo_root, request, now_epoch
+    )
+    if reason:
+        return rejected(reason)
+    try:
+        updated = _updated_record(current, grounded, request, now_epoch)
+    except (KeyError, TypeError, ValueError):
+        return rejected("conversation_scope_input_invalid")
+    updated["record_auth_mac"] = sign_record_with_scope_authority(authority, updated)
+    return stored_result(
+        store.compare_and_swap(
+            request.conversation_id,
+            expected_revision=int(request.expected_revision),
+            next_record=with_record_digest(updated),
+        )
+    )
+
+
+def _authorized_current(
+    store: AgentDbConversationScopeStore,
+    capability: AuthenticatedConversationScopeCapability,
+    repo_root: Any,
+    request: ConversationScopeAdvanceRequest,
+    now_epoch: int,
+) -> tuple[Mapping[str, Any], Mapping[str, Any], Any, str]:
+    loaded = store.load(request.conversation_id)
+    current = loaded.get("record") if loaded.get("ok") else None
+    if not isinstance(current, Mapping):
+        return {}, {}, None, "conversation_scope_access_denied"
+    grounded, reason = verified_grounding(
+        repo_root, request.work_focus, request.grounding_receipt
+    )
+    discussions = tuple(
+        str(item)
+        for item in request.state_patch.get(
+            "discussion_foundup_ids", current["discussion_foundup_ids"]
+        )
+    )
+    authority = consume_conversation_scope_capability(
+        capability,
+        active_foundup_id=str(grounded.get("foundup_id") or "") if not reason else "",
+        discussion_foundup_ids=discussions,
+        now_epoch=now_epoch,
+    )
+    authority_view = conversation_scope_authority_view(authority)
+    if (
+        reason
+        or str(grounded.get("foundup_id") or "") != str(current["authorized_foundup_id"])
+        or str(current["source_snapshot_id"]) != request.expected_source_snapshot_id
+        or str(current["source_snapshot_digest"]) != request.expected_source_snapshot_digest
+        or authority is None
+        or authority_view is None
+        or not authority_matches(current, authority_view)
+        or not verify_record_with_scope_authority(authority, current)
+    ):
+        return {}, {}, None, reason or "conversation_scope_access_denied"
+    if int(now_epoch) >= int(current["expires_at"]):
+        return {}, {}, None, "conversation_scope_expired"
+    if int(current["conversation_revision"]) != int(request.expected_revision):
+        return {}, {}, None, "conversation_scope_revision_conflict"
+    return current, grounded, authority, ""
+
+
+def _updated_record(
+    current: Mapping[str, Any],
+    grounded: Mapping[str, Any],
+    request: ConversationScopeAdvanceRequest,
+    now_epoch: int,
+) -> dict[str, Any]:
+    if str(request.state_patch["parent_turn_id"]) != str(current["turn_id"]):
+        raise ValueError("conversation_scope_parent_turn_mismatch")
+    state = state_values(
+        turn_id=request.state_patch["turn_id"],
+        parent_turn_id=request.state_patch["parent_turn_id"],
+        discussions=request.state_patch.get("discussion_foundup_ids", current["discussion_foundup_ids"]),
+        active_topic=request.state_patch["active_topic"],
+        current_objective=request.state_patch["current_objective"],
+        accepted_decisions=request.state_patch.get("accepted_decisions", ()),
+        rejected_options=request.state_patch.get("rejected_options", ()),
+        open_questions=request.state_patch.get("open_questions", ()),
+        repository_evidence_refs=request.state_patch.get("repository_evidence_refs", ()),
+        allowed_evidence_refs=grounding_evidence_refs(grounded),
+    )
+    updated = dict(current)
+    updated.update(state)
+    updated.update(
+        {
+            "conversation_revision": int(request.expected_revision) + 1,
+            "last_grounded_head_sha": str(grounded["holoindex_repo_head_sha"]),
+            "holoindex_generation_id": str(grounded.get("holoindex_generation_id") or ""),
+            "holoindex_freshness_receipt_id": str(
+                grounded.get("holoindex_freshness_receipt_digest") or ""
+            ),
+            "grounding_receipt_id": str(grounded["receipt_id"]),
+            "pending_work_proposal_id": "",
+            "pending_work_proposal_digest": "",
+            "updated_at": int(now_epoch),
+        }
+    )
+    previous = str(current["revision_receipts"][-1]["receipt_id"])
+    updated["revision_receipts"] = [
+        *current["revision_receipts"],
+        revision_receipt(
+            updated, previous=previous, revision=int(request.expected_revision) + 1
+        ),
+    ]
+    return updated
+
+
+__all__ = ["advance_authenticated_conversation_scope"]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_authentication.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_authentication.py
@@ -1,0 +1,128 @@
+"""Authenticate RedDog conversation scope against signed session identity."""
+
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+from modules.ai_intelligence.ai_overseer.src.foundup_genesis.intake_auth_provider import (
+    build_intake_context,
+    default_secret_provider,
+)
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
+    PrincipalAuthorityRecord,
+    PrincipalAuthorityResolver,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_capability import (
+    AuthenticatedConversationScopeCapability,
+    _ConversationScopeAuthoritySeal,
+    _issue_conversation_scope_capability,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    canonical_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_mac import (
+    derive_conversation_scope_mac_key,
+)
+
+
+CAPABILITY_TTL_SECONDS = 60
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def authenticate_conversation_scope(
+    *,
+    session_token: str,
+    principal_provider: str,
+    transport: str,
+    session_binding: str,
+    principal_resolver: PrincipalAuthorityResolver,
+    now_epoch: int,
+    secret_provider: Callable[[], tuple[str | None, str | None]] | None = None,
+) -> AuthenticatedConversationScopeCapability | None:
+    """Verify token subject and resolve its current principal authority record."""
+
+    if not all(
+        isinstance(value, str) and value.strip()
+        for value in (session_token, principal_provider, transport, session_binding)
+    ):
+        return None
+    try:
+        current, previous = (secret_provider or default_secret_provider)()
+    except Exception:
+        return None
+    if not current:
+        return None
+    secrets = tuple(
+        dict.fromkeys(str(value).encode("utf-8") for value in (current, previous) if value)
+    )
+    context = build_intake_context(
+        session_token,
+        None,
+        now=now_epoch,
+        secret_provider=lambda: (current, previous),
+    )
+    principal_id = str(context.requester_handle or "")
+    if context.authenticated is not True or not principal_id:
+        return None
+    try:
+        record = principal_resolver.resolve(principal_id, principal_provider)
+    except Exception:
+        return None
+    if not _valid_principal(record, principal_id, principal_provider):
+        return None
+    assert record is not None
+    return _issue_conversation_scope_capability(
+        _authority_seal(record, secrets, principal_provider, principal_id, transport, session_binding, now_epoch)
+    )
+
+
+def _authority_seal(
+    record: PrincipalAuthorityRecord,
+    secrets: tuple[bytes, ...],
+    principal_provider: str,
+    principal_id: str,
+    transport: str,
+    session_binding: str,
+    now_epoch: int,
+) -> _ConversationScopeAuthoritySeal:
+    return _ConversationScopeAuthoritySeal(
+        principal_id=record.principal_id,
+        principal_provider=record.principal_provider,
+        verified_subject_digest=record.verified_subject_digest,
+        principal_record_digest=canonical_digest(record.to_dict()),
+        principal_key_fingerprint=canonical_digest(
+            {"principal_public_key": record.principal_public_key}
+        ),
+        foundup_scope=tuple(dict.fromkeys(record.foundup_scope)),
+        transport=transport.strip(),
+        session_binding_digest=canonical_digest(
+            {"transport": transport.strip(), "session_binding": session_binding.strip()}
+        ),
+        expires_at=int(now_epoch) + CAPABILITY_TTL_SECONDS,
+        record_sign_key=derive_conversation_scope_mac_key(
+            secrets[0], principal_provider, principal_id
+        ),
+        record_verify_keys=tuple(
+            derive_conversation_scope_mac_key(secret, principal_provider, principal_id)
+            for secret in secrets
+        ),
+    )
+
+
+def _valid_principal(
+    record: PrincipalAuthorityRecord | None,
+    principal_id: str,
+    principal_provider: str,
+) -> bool:
+    return bool(
+        type(record) is PrincipalAuthorityRecord
+        and record.principal_id == principal_id
+        and record.principal_provider == principal_provider
+        and record.principal_public_key
+        and SHA256_RE.fullmatch(record.verified_subject_digest)
+        and record.foundup_scope
+    )
+
+
+__all__ = ["AuthenticatedConversationScopeCapability", "authenticate_conversation_scope"]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_capability.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_capability.py
@@ -1,0 +1,147 @@
+"""Opaque one-use capabilities for authenticated RedDog conversation scope."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Mapping
+from weakref import WeakKeyDictionary
+
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_mac import (
+    sign_conversation_scope_record,
+    verify_conversation_scope_record,
+)
+
+
+class _OpaqueCapability:
+    __slots__ = ("__weakref__",)
+
+    def __new__(cls, *_args: Any, **_kwargs: Any) -> "_OpaqueCapability":
+        raise TypeError("conversation_scope_capability_direct_construction_forbidden")
+
+    def __setattr__(self, _name: str, _value: Any) -> None:
+        raise TypeError("conversation_scope_capability_is_immutable")
+
+    def __copy__(self) -> Any:
+        raise TypeError("conversation_scope_capability_copy_forbidden")
+
+    def __deepcopy__(self, _memo: Any) -> Any:
+        raise TypeError("conversation_scope_capability_copy_forbidden")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("conversation_scope_capability_pickle_forbidden")
+
+
+class AuthenticatedConversationScopeCapability(_OpaqueCapability):
+    """One-use authenticated session and principal proof."""
+
+
+class VerifiedConversationScopeAuthority(_OpaqueCapability):
+    """Consumed operation-local authority that never exposes MAC keys."""
+
+
+@dataclass(frozen=True)
+class _ConversationScopeAuthoritySeal:
+    principal_id: str
+    principal_provider: str
+    verified_subject_digest: str
+    principal_record_digest: str
+    principal_key_fingerprint: str
+    foundup_scope: tuple[str, ...]
+    transport: str
+    session_binding_digest: str
+    expires_at: int
+    record_sign_key: bytes
+    record_verify_keys: tuple[bytes, ...]
+
+
+_LOCK = threading.Lock()
+_CAPABILITIES: WeakKeyDictionary[AuthenticatedConversationScopeCapability, _ConversationScopeAuthoritySeal] = WeakKeyDictionary()
+_AUTHORITIES: WeakKeyDictionary[VerifiedConversationScopeAuthority, _ConversationScopeAuthoritySeal] = WeakKeyDictionary()
+
+
+def _issue_conversation_scope_capability(
+    seal: _ConversationScopeAuthoritySeal,
+) -> AuthenticatedConversationScopeCapability:
+    capability = object.__new__(AuthenticatedConversationScopeCapability)
+    with _LOCK:
+        _CAPABILITIES[capability] = seal
+    return capability
+
+
+def consume_conversation_scope_capability(
+    capability: Any,
+    *,
+    active_foundup_id: str,
+    discussion_foundup_ids: tuple[str, ...],
+    now_epoch: int,
+) -> VerifiedConversationScopeAuthority | None:
+    if type(capability) is not AuthenticatedConversationScopeCapability:
+        return None
+    with _LOCK:
+        seal = _CAPABILITIES.pop(capability, None)
+    allowed = set(seal.foundup_scope) if seal is not None else set()
+    requested = set(discussion_foundup_ids)
+    if (
+        seal is None or int(now_epoch) >= seal.expires_at or not active_foundup_id
+        or active_foundup_id not in requested or not requested
+        or not requested.issubset(allowed)
+    ):
+        return None
+    authority = object.__new__(VerifiedConversationScopeAuthority)
+    with _LOCK:
+        _AUTHORITIES[authority] = seal
+    return authority
+
+
+def conversation_scope_authority_view(authority: Any) -> Mapping[str, Any] | None:
+    seal = _authority_seal(authority)
+    if seal is None:
+        return None
+    return {
+        "principal_id": seal.principal_id,
+        "principal_provider": seal.principal_provider,
+        "verified_subject_digest": seal.verified_subject_digest,
+        "principal_record_digest": seal.principal_record_digest,
+        "principal_key_fingerprint": seal.principal_key_fingerprint,
+        "foundup_scope": tuple(seal.foundup_scope),
+        "transport": seal.transport,
+        "session_binding_digest": seal.session_binding_digest,
+    }
+
+
+def sign_record_with_scope_authority(
+    authority: Any, record: Mapping[str, Any]
+) -> str:
+    seal = _authority_seal(authority)
+    return sign_conversation_scope_record(record, seal.record_sign_key) if seal else ""
+
+
+def verify_record_with_scope_authority(
+    authority: Any, record: Mapping[str, Any]
+) -> bool:
+    seal = _authority_seal(authority)
+    return bool(seal) and verify_conversation_scope_record(record, seal.record_verify_keys)
+
+
+def discard_conversation_scope_capability(capability: Any) -> None:
+    with _LOCK:
+        if type(capability) is AuthenticatedConversationScopeCapability:
+            _CAPABILITIES.pop(capability, None)
+        elif type(capability) is VerifiedConversationScopeAuthority:
+            _AUTHORITIES.pop(capability, None)
+
+
+def _authority_seal(authority: Any) -> _ConversationScopeAuthoritySeal | None:
+    if type(authority) is not VerifiedConversationScopeAuthority:
+        return None
+    with _LOCK:
+        return _AUTHORITIES.get(authority)
+
+
+__all__ = [
+    "AuthenticatedConversationScopeCapability", "VerifiedConversationScopeAuthority",
+    "consume_conversation_scope_capability",
+    "conversation_scope_authority_view", "discard_conversation_scope_capability",
+    "sign_record_with_scope_authority", "verify_record_with_scope_authority",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_contract.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_contract.py
@@ -1,0 +1,197 @@
+"""Typed contract for authenticated, FoundUp-scoped RedDog conversation state."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+from modules.foundups.agent.src.kanban_plugin_contract import redact_sensitive
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_digest import (
+    canonical_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_revision import (
+    REVISION_RECEIPT_FIELDS,
+    REVISION_RECEIPT_SCHEMA,
+    valid_revision_receipts,
+)
+
+
+SCHEMA_VERSION = "reddog_authenticated_conversation_scope.v1"
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HEAD_RE = re.compile(r"^[0-9a-f]{7,64}$")
+MAX_TEXT = 720
+MAX_ITEMS = 32
+MAX_EVIDENCE_REFS = 64
+ITEM_KINDS = frozenset(
+    {"operator_statement", "repository_fact", "model_inference", "unresolved"}
+)
+IMMUTABLE_FIELDS = frozenset(
+    {
+        "schema_version", "conversation_id", "principal_id", "principal_provider",
+        "verified_subject_digest", "principal_record_digest", "principal_key_fingerprint",
+        "transport", "session_binding_digest", "authorized_foundup_id", "created_at",
+    }
+)
+MUTABLE_FIELDS = frozenset(
+    {
+        "conversation_revision", "turn_id", "parent_turn_id", "discussion_foundup_ids",
+        "active_topic", "current_objective", "accepted_decisions", "rejected_options",
+        "open_questions", "repository_evidence_refs", "source_snapshot_id",
+        "source_snapshot_digest", "last_grounded_head_sha", "holoindex_generation_id",
+        "holoindex_freshness_receipt_id", "grounding_receipt_id", "pending_work_proposal_id",
+        "pending_work_proposal_digest", "updated_at", "expires_at", "revision_receipts",
+        "record_auth_mac", "record_digest",
+    }
+)
+RECORD_FIELDS = IMMUTABLE_FIELDS | MUTABLE_FIELDS
+
+
+def sanitized_text(value: Any, *, limit: int = MAX_TEXT) -> str:
+    text = redact_sensitive(str(value or "")).strip()
+    if "\x00" in text or any(ord(char) < 32 and char not in "\n\r\t" for char in text):
+        raise ValueError("conversation_scope_text_invalid")
+    return text[:limit]
+
+
+def typed_items(values: Any) -> list[dict[str, Any]]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise ValueError("conversation_scope_items_invalid")
+    if len(values) > MAX_ITEMS:
+        raise ValueError("conversation_scope_items_limit")
+    items: list[dict[str, Any]] = []
+    for raw in values:
+        if not isinstance(raw, Mapping) or set(raw) != {"item_id", "kind", "summary", "evidence_refs"}:
+            raise ValueError("conversation_scope_item_shape_invalid")
+        kind = str(raw["kind"])
+        refs = string_list(raw["evidence_refs"], maximum=MAX_EVIDENCE_REFS)
+        item = {
+            "item_id": str(raw["item_id"]),
+            "kind": kind,
+            "summary": sanitized_text(raw["summary"]),
+            "evidence_refs": refs,
+        }
+        if not SHA256_RE.fullmatch(item["item_id"]) or kind not in ITEM_KINDS or not item["summary"]:
+            raise ValueError("conversation_scope_item_invalid")
+        if kind == "repository_fact" and not refs:
+            raise ValueError("conversation_scope_repository_fact_unreferenced")
+        items.append(item)
+    if len({item["item_id"] for item in items}) != len(items):
+        raise ValueError("conversation_scope_item_duplicate")
+    return items
+
+
+def string_list(values: Any, *, maximum: int) -> list[str]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)) or len(values) > maximum:
+        raise ValueError("conversation_scope_list_invalid")
+    result = [sanitized_text(item, limit=320) for item in values]
+    if any(not item for item in result) or len(set(result)) != len(result):
+        raise ValueError("conversation_scope_list_invalid")
+    return result
+
+
+def validate_record(record: Mapping[str, Any]) -> tuple[str, ...]:
+    if set(record) != RECORD_FIELDS or record.get("schema_version") != SCHEMA_VERSION:
+        return ("conversation_scope_record_shape_invalid",)
+    reasons = [*_binding_reasons(record), *_state_reasons(record)]
+    return tuple(dict.fromkeys(reasons))
+
+
+def _binding_reasons(record: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    digest_payload = dict(record)
+    supplied_digest = str(digest_payload.pop("record_digest", ""))
+    if not SHA256_RE.fullmatch(supplied_digest) or supplied_digest != canonical_digest(digest_payload):
+        reasons.append("conversation_scope_record_digest_invalid")
+    required_digests = (
+        "verified_subject_digest", "principal_record_digest", "principal_key_fingerprint",
+        "session_binding_digest", "grounding_receipt_id",
+    )
+    if any(not SHA256_RE.fullmatch(str(record.get(field) or "")) for field in required_digests):
+        reasons.append("conversation_scope_binding_digest_invalid")
+    if not SHA256_RE.fullmatch(str(record.get("conversation_id") or "")):
+        reasons.append("conversation_scope_id_invalid")
+    if not re.fullmatch(r"hmac-sha256:[0-9a-f]{64}", str(record.get("record_auth_mac") or "")):
+        reasons.append("conversation_scope_record_auth_mac_invalid")
+    if not HEAD_RE.fullmatch(str(record.get("last_grounded_head_sha") or "")):
+        reasons.append("conversation_scope_head_invalid")
+    if not _valid_optional_digest_pair(record, "pending_work_proposal_id", "pending_work_proposal_digest"):
+        reasons.append("conversation_scope_pending_proposal_invalid")
+    if not _valid_optional_digest_pair(record, "source_snapshot_id", "source_snapshot_digest"):
+        reasons.append("conversation_scope_snapshot_binding_invalid")
+    if not _valid_optional_digest_pair(
+        record, "holoindex_generation_id", "holoindex_freshness_receipt_id"
+    ):
+        reasons.append("conversation_scope_holoindex_binding_invalid")
+    return reasons
+
+
+def _state_reasons(record: Mapping[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if any(not str(record.get(field) or "") for field in (
+        "principal_id", "principal_provider", "transport", "authorized_foundup_id",
+        "turn_id", "active_topic", "current_objective", "created_at", "updated_at",
+    )):
+        reasons.append("conversation_scope_required_value_missing")
+    if not SHA256_RE.fullmatch(str(record.get("turn_id") or "")):
+        reasons.append("conversation_scope_turn_id_invalid")
+    parent_turn_id = str(record.get("parent_turn_id") or "")
+    revision_value = _integer(record.get("conversation_revision"), default=-1)
+    if (
+        (revision_value == 0 and parent_turn_id)
+        or (revision_value > 0 and not SHA256_RE.fullmatch(parent_turn_id))
+    ):
+        reasons.append("conversation_scope_parent_turn_invalid")
+    discussions = record.get("discussion_foundup_ids")
+    try:
+        normalized_discussions = string_list(discussions, maximum=16)
+    except (TypeError, ValueError):
+        normalized_discussions = []
+    if record.get("authorized_foundup_id") not in normalized_discussions:
+        reasons.append("conversation_scope_foundup_set_invalid")
+    created_at = _integer(record.get("created_at"), default=-1)
+    updated_at = _integer(record.get("updated_at"), default=-1)
+    expires_at = _integer(record.get("expires_at"), default=-1)
+    if (
+        revision_value < 0 or created_at < 0 or updated_at < created_at
+        or expires_at <= updated_at
+    ):
+        reasons.append("conversation_scope_revision_or_expiry_invalid")
+    for field in ("accepted_decisions", "rejected_options", "open_questions"):
+        try:
+            typed_items(record.get(field))
+        except (TypeError, ValueError):
+            reasons.append(f"conversation_scope_{field}_invalid")
+    try:
+        string_list(record.get("repository_evidence_refs"), maximum=MAX_EVIDENCE_REFS)
+    except (TypeError, ValueError):
+        reasons.append("conversation_scope_evidence_refs_invalid")
+    if not valid_revision_receipts(record):
+        reasons.append("conversation_scope_revision_receipts_invalid")
+    return reasons
+
+
+def with_record_digest(record: Mapping[str, Any]) -> dict[str, Any]:
+    value = dict(record)
+    value.pop("record_digest", None)
+    value["record_digest"] = canonical_digest(value)
+    return value
+
+
+def _valid_optional_digest_pair(record: Mapping[str, Any], left: str, right: str) -> bool:
+    values = (str(record.get(left) or ""), str(record.get(right) or ""))
+    return values == ("", "") or all(SHA256_RE.fullmatch(value) for value in values)
+
+
+def _integer(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "IMMUTABLE_FIELDS", "ITEM_KINDS", "MUTABLE_FIELDS", "RECORD_FIELDS",
+    "REVISION_RECEIPT_FIELDS", "REVISION_RECEIPT_SCHEMA", "SCHEMA_VERSION",
+    "canonical_digest", "sanitized_text",
+    "string_list", "typed_items", "validate_record", "with_record_digest",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_digest.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_digest.py
@@ -1,0 +1,18 @@
+"""Canonical digest primitive shared by RedDog conversation-scope records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+
+def canonical_digest(payload: Any) -> str:
+    raw = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+__all__ = ["canonical_digest"]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_mac.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_mac.py
@@ -1,0 +1,44 @@
+"""Derived MAC helpers for authenticated RedDog conversation records."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any, Mapping
+
+
+def derive_conversation_scope_mac_key(
+    secret: bytes, principal_provider: str, principal_id: str
+) -> bytes:
+    context = (
+        f"reddog-conversation-scope-state.v1|{principal_provider}|{principal_id}"
+    ).encode("utf-8")
+    return hmac.new(secret, context, hashlib.sha256).digest()
+
+
+def sign_conversation_scope_record(record: Mapping[str, Any], key: bytes) -> str:
+    payload = dict(record)
+    payload.pop("record_auth_mac", None)
+    payload.pop("record_digest", None)
+    raw = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return "hmac-sha256:" + hmac.new(key, raw, hashlib.sha256).hexdigest()
+
+
+def verify_conversation_scope_record(
+    record: Mapping[str, Any], keys: tuple[bytes, ...]
+) -> bool:
+    supplied = str(record.get("record_auth_mac") or "")
+    return bool(keys) and any(
+        hmac.compare_digest(supplied, sign_conversation_scope_record(record, key))
+        for key in keys
+    )
+
+
+__all__ = [
+    "derive_conversation_scope_mac_key",
+    "sign_conversation_scope_record",
+    "verify_conversation_scope_record",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_record.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_record.py
@@ -1,0 +1,198 @@
+"""Grounded record helpers for RedDog authenticated conversation scope."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    REVISION_RECEIPT_SCHEMA,
+    SHA256_RE,
+    canonical_digest,
+    sanitized_text,
+    string_list,
+    typed_items,
+)
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    validate_grounded_target_receipt,
+)
+from modules.communication.moltbot_bridge.src.reddog_registered_foundup_target_verifier import (
+    verify_registered_foundup_target,
+)
+
+
+@dataclass(frozen=True)
+class AuthenticatedConversationScopeResult:
+    accepted: bool
+    status: str
+    conversation_id: str = ""
+    conversation_revision: int = -1
+    revision_receipt_id: str = ""
+    projection: Mapping[str, Any] | None = None
+    rejection_reasons: tuple[str, ...] = ()
+    no_work_authority_granted: bool = True
+    no_worker_dispatch_performed: bool = True
+    no_repo_mutation_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+
+def verified_grounding(
+    repo_root: Any, work_focus: str, receipt: Mapping[str, Any]
+) -> tuple[Mapping[str, Any], str]:
+    result = validate_grounded_target_receipt(
+        receipt, work_focus=work_focus, expected_source_surface="editor_thin_client"
+    )
+    if not result.accepted or result.verified is None:
+        return {}, (result.rejection_reasons or ("conversation_scope_grounding_invalid",))[0]
+    value = result.verified.to_dict()
+    target = value.get("registered_foundup_target")
+    selection = {
+        "foundup_id": value.get("foundup_id"),
+        "registered_foundup_target_receipt_id": value.get("registered_foundup_target_receipt_id"),
+    }
+    reasons = verify_registered_foundup_target(
+        repo_root, target, selection_receipt=selection
+    )
+    if reasons or not str(value.get("foundup_id") or ""):
+        return {}, reasons[0] if reasons else "conversation_scope_foundup_missing"
+    return value, ""
+
+
+def state_values(**values: Any) -> dict[str, Any]:
+    turn_id = sanitized_text(values["turn_id"], limit=160)
+    parent_turn_id = sanitized_text(values["parent_turn_id"], limit=160)
+    if not SHA256_RE.fullmatch(turn_id) or (
+        parent_turn_id and not SHA256_RE.fullmatch(parent_turn_id)
+    ):
+        raise ValueError("conversation_scope_turn_lineage_invalid")
+    state = {
+        "turn_id": turn_id,
+        "parent_turn_id": parent_turn_id,
+        "discussion_foundup_ids": string_list(values["discussions"], maximum=16),
+        "active_topic": sanitized_text(values["active_topic"]),
+        "current_objective": sanitized_text(values["current_objective"]),
+        "accepted_decisions": typed_items(values["accepted_decisions"]),
+        "rejected_options": typed_items(values["rejected_options"]),
+        "open_questions": typed_items(values["open_questions"]),
+        "repository_evidence_refs": string_list(
+            values["repository_evidence_refs"], maximum=64
+        ),
+    }
+    if not _evidence_is_grounded(state, values["allowed_evidence_refs"]):
+        raise ValueError("conversation_scope_evidence_not_grounded")
+    return state
+
+
+def grounding_evidence_refs(grounded: Mapping[str, Any]) -> tuple[str, ...]:
+    refs: list[str] = []
+    for item in grounded.get("semantic_target_coverage", ()):
+        if isinstance(item, Mapping):
+            refs.extend(str(ref) for ref in item.get("evidence_refs", ()))
+    refs.extend(str(path) for path in grounded.get("direct_read_paths", ()))
+    target = grounded.get("registered_foundup_target")
+    if isinstance(target, Mapping):
+        refs.extend(
+            str(item.get("path") or "")
+            for item in target.get("evidence_digests", ())
+            if isinstance(item, Mapping)
+        )
+    return tuple(dict.fromkeys(ref for ref in refs if ref))
+
+
+def _evidence_is_grounded(state: Mapping[str, Any], allowed: Any) -> bool:
+    approved = set(str(item) for item in allowed)
+    supplied = set(str(item) for item in state["repository_evidence_refs"])
+    for field in ("accepted_decisions", "rejected_options", "open_questions"):
+        for item in state[field]:
+            supplied.update(str(ref) for ref in item["evidence_refs"])
+    return all(ref in approved or _evidence_anchor(ref) in approved for ref in supplied)
+
+
+def _evidence_anchor(reference: str) -> str:
+    base, separator, suffix = reference.rpartition(":")
+    return base if separator and suffix.isdigit() else reference
+
+
+def revision_receipt(
+    record: Mapping[str, Any], *, previous: str, revision: int
+) -> dict[str, Any]:
+    state = {
+        key: value
+        for key, value in record.items()
+        if key not in {"revision_receipts", "record_auth_mac", "record_digest"}
+    }
+    payload = {
+        "schema_version": REVISION_RECEIPT_SCHEMA,
+        "conversation_id": record["conversation_id"],
+        "revision": revision,
+        "previous_receipt_id": previous,
+        "state_digest": canonical_digest(state),
+        "authority": "authenticated_scope_integrity_not_work_authority",
+    }
+    return {**payload, "receipt_id": canonical_digest(payload)}
+
+
+def authority_matches(
+    record: Mapping[str, Any], authority: Mapping[str, Any]
+) -> bool:
+    return all(
+        record.get(field) == authority.get(field)
+        for field in (
+            "principal_id", "principal_provider", "verified_subject_digest",
+            "principal_record_digest", "principal_key_fingerprint", "transport",
+            "session_binding_digest",
+        )
+    )
+
+
+def stored_result(result: Mapping[str, Any]) -> AuthenticatedConversationScopeResult:
+    record = result.get("record")
+    if not result.get("ok") or not isinstance(record, Mapping):
+        return rejected(str(result.get("reason") or "conversation_scope_store_rejected"))
+    return accepted(record)
+
+
+def accepted(record: Mapping[str, Any]) -> AuthenticatedConversationScopeResult:
+    receipt = record["revision_receipts"][-1]
+    projection = {
+        key: record[key]
+        for key in (
+            "conversation_id", "conversation_revision", "turn_id", "parent_turn_id",
+            "authorized_foundup_id", "discussion_foundup_ids", "active_topic",
+            "current_objective", "accepted_decisions", "rejected_options", "open_questions",
+            "repository_evidence_refs", "last_grounded_head_sha", "holoindex_generation_id",
+            "holoindex_freshness_receipt_id", "grounding_receipt_id",
+            "source_snapshot_id", "source_snapshot_digest",
+            "pending_work_proposal_id", "pending_work_proposal_digest", "updated_at",
+            "expires_at", "record_digest",
+        )
+    }
+    projection.update(
+        {
+            "schema_version": "reddog_authenticated_conversation_projection.v1",
+            "authority_effect": "none",
+            "revision_receipt_id": receipt["receipt_id"],
+        }
+    )
+    return AuthenticatedConversationScopeResult(
+        True,
+        "CONVERSATION_SCOPE_ACCEPT",
+        str(record["conversation_id"]),
+        int(record["conversation_revision"]),
+        str(receipt["receipt_id"]),
+        projection,
+        (),
+    )
+
+
+def rejected(reason: str) -> AuthenticatedConversationScopeResult:
+    return AuthenticatedConversationScopeResult(
+        False, "CONVERSATION_SCOPE_REJECT", rejection_reasons=(reason,)
+    )
+
+
+__all__ = [
+    "AuthenticatedConversationScopeResult", "accepted", "authority_matches", "rejected",
+    "grounding_evidence_refs", "revision_receipt", "state_values", "stored_result",
+    "verified_grounding",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_request.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_request.py
@@ -1,0 +1,38 @@
+"""Typed request inputs for RedDog authenticated conversation scope."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class ConversationScopeCreateRequest:
+    work_focus: str
+    grounding_receipt: Mapping[str, Any]
+    discussion_foundup_ids: tuple[str, ...]
+    conversation_nonce: str
+    turn_id: str
+    active_topic: str
+    current_objective: str
+    accepted_decisions: tuple[Mapping[str, Any], ...] = ()
+    rejected_options: tuple[Mapping[str, Any], ...] = ()
+    open_questions: tuple[Mapping[str, Any], ...] = ()
+    repository_evidence_refs: tuple[str, ...] = ()
+    source_snapshot_id: str = ""
+    source_snapshot_digest: str = ""
+    ttl_seconds: int = 3600
+
+
+@dataclass(frozen=True)
+class ConversationScopeAdvanceRequest:
+    conversation_id: str
+    expected_revision: int
+    work_focus: str
+    grounding_receipt: Mapping[str, Any]
+    state_patch: Mapping[str, Any]
+    expected_source_snapshot_id: str
+    expected_source_snapshot_digest: str
+
+
+__all__ = ["ConversationScopeAdvanceRequest", "ConversationScopeCreateRequest"]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_revision.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_revision.py
@@ -1,0 +1,65 @@
+"""Revision-chain validation for authenticated RedDog conversation scope."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_digest import (
+    canonical_digest,
+)
+
+
+REVISION_RECEIPT_SCHEMA = "reddog_conversation_scope_revision.v1"
+REVISION_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version", "conversation_id", "revision", "previous_receipt_id",
+        "state_digest", "authority", "receipt_id",
+    }
+)
+SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def valid_revision_receipts(record: Mapping[str, Any]) -> bool:
+    receipts = record.get("revision_receipts")
+    revision_value = _integer(record.get("conversation_revision"), default=-1)
+    if not isinstance(receipts, list) or len(receipts) != revision_value + 1:
+        return False
+    previous = ""
+    for revision, raw in enumerate(receipts):
+        if (
+            not isinstance(raw, Mapping)
+            or set(raw) != REVISION_RECEIPT_FIELDS
+            or raw.get("schema_version") != REVISION_RECEIPT_SCHEMA
+        ):
+            return False
+        receipt = dict(raw)
+        receipt_id = str(receipt.pop("receipt_id", ""))
+        if (
+            receipt.get("conversation_id") != record.get("conversation_id")
+            or receipt.get("revision") != revision
+            or receipt.get("previous_receipt_id") != previous
+            or receipt.get("authority") != "authenticated_scope_integrity_not_work_authority"
+            or not SHA256_RE.fullmatch(str(receipt.get("state_digest") or ""))
+            or receipt_id != canonical_digest(receipt)
+        ):
+            return False
+        previous = receipt_id
+    state = {
+        key: value
+        for key, value in record.items()
+        if key not in {"revision_receipts", "record_auth_mac", "record_digest"}
+    }
+    return bool(receipts) and receipts[-1].get("state_digest") == canonical_digest(state)
+
+
+def _integer(value: Any, *, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "REVISION_RECEIPT_FIELDS", "REVISION_RECEIPT_SCHEMA", "valid_revision_receipts",
+]

--- a/modules/communication/moltbot_bridge/src/reddog_conversation_scope_store.py
+++ b/modules/communication/moltbot_bridge/src/reddog_conversation_scope_store.py
@@ -1,0 +1,180 @@
+"""AgentDB CAS storage for authenticated RedDog conversation scopes."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any, Callable, Mapping, Optional
+
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    IMMUTABLE_FIELDS,
+    MUTABLE_FIELDS,
+    validate_record,
+    with_record_digest,
+)
+
+
+class AgentDbConversationScopeStore:
+    """Store conversation state in AgentDB without adding a second database."""
+
+    def __init__(self, agent_db_factory: Optional[Callable[[], Any]] = None) -> None:
+        self._agent_db_factory = agent_db_factory
+
+    def create(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        value = with_record_digest(record)
+        if validate_record(value):
+            return _result(False, "conversation_scope_record_invalid")
+        try:
+            db = self._agent_db()
+            self._ensure_table(db)
+            with db.db.get_connection() as conn:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO reddog_conversation_scopes
+                    (conversation_id, principal_id, foundup_id, revision, scope_json, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(conversation_id) DO NOTHING
+                    """,
+                    (
+                        value["conversation_id"], value["principal_id"],
+                        value["authorized_foundup_id"], value["conversation_revision"],
+                        _json(value), _now_iso(),
+                    ),
+                )
+        except Exception:
+            return _result(False, "conversation_scope_store_unavailable")
+        return _result(cursor.rowcount == 1, "" if cursor.rowcount == 1 else "conversation_scope_exists", value)
+
+    def load(self, conversation_id: str) -> Mapping[str, Any]:
+        try:
+            db = self._agent_db()
+            self._ensure_table(db)
+            rows = db.db.execute_query(
+                "SELECT revision, scope_json FROM reddog_conversation_scopes WHERE conversation_id = ?",
+                (conversation_id,),
+            )
+        except Exception:
+            return _result(False, "conversation_scope_store_unavailable")
+        if not rows:
+            return _result(False, "conversation_scope_missing")
+        row = rows[0]
+        try:
+            revision = int(row["revision"] if isinstance(row, Mapping) else row[0])
+            raw = row["scope_json"] if isinstance(row, Mapping) else row[1]
+            record = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError, KeyError, IndexError):
+            return _result(False, "conversation_scope_store_invalid")
+        if (
+            not isinstance(record, Mapping)
+            or int(record.get("conversation_revision", -1)) != revision
+            or validate_record(record)
+        ):
+            return _result(False, "conversation_scope_store_invalid")
+        return _result(True, "", dict(record))
+
+    def compare_and_swap(
+        self,
+        conversation_id: str,
+        *,
+        expected_revision: int,
+        next_record: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        value = with_record_digest(next_record)
+        if validate_record(value):
+            return _result(False, "conversation_scope_record_invalid")
+        try:
+            return self._compare_and_swap(conversation_id, expected_revision, value)
+        except Exception:
+            return _result(False, "conversation_scope_store_unavailable")
+
+    def _compare_and_swap(
+        self, conversation_id: str, expected_revision: int, value: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        db = self._agent_db()
+        self._ensure_table(db)
+        with db.db.get_connection() as conn:
+            row = conn.execute(
+                "SELECT revision, scope_json FROM reddog_conversation_scopes WHERE conversation_id = ?",
+                (conversation_id,),
+            ).fetchone()
+            if row is None:
+                return _result(False, "conversation_scope_missing")
+            current_revision = int(row["revision"] if isinstance(row, Mapping) else row[0])
+            current = json.loads(row["scope_json"] if isinstance(row, Mapping) else row[1])
+            reason = _cas_reason(current, value, current_revision, expected_revision)
+            if reason:
+                return _result(False, reason)
+            cursor = conn.execute(
+                """
+                UPDATE reddog_conversation_scopes
+                SET principal_id = ?, foundup_id = ?, revision = ?, scope_json = ?, updated_at = ?
+                WHERE conversation_id = ? AND revision = ?
+                """,
+                (
+                    value["principal_id"], value["authorized_foundup_id"],
+                    value["conversation_revision"], _json(value), _now_iso(),
+                    conversation_id, expected_revision,
+                ),
+            )
+        return _result(cursor.rowcount == 1, "" if cursor.rowcount == 1 else "conversation_scope_revision_conflict", value)
+
+    def _agent_db(self) -> Any:
+        factory = self._agent_db_factory
+        if factory is None:
+            from modules.infrastructure.database.src.agent_db import AgentDB
+
+            factory = AgentDB
+        return factory()
+
+    @staticmethod
+    def _ensure_table(db: Any) -> None:
+        with db.db.get_connection() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reddog_conversation_scopes (
+                    conversation_id TEXT PRIMARY KEY,
+                    principal_id TEXT NOT NULL,
+                    foundup_id TEXT NOT NULL,
+                    revision INTEGER NOT NULL,
+                    scope_json TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_reddog_conversation_scope_owner
+                ON reddog_conversation_scopes(principal_id, foundup_id, updated_at)
+                """
+            )
+
+
+def _result(ok: bool, reason: str, record: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
+    return {"ok": ok, "reason": reason, "record": dict(record) if record is not None else None}
+
+
+def _cas_reason(
+    current: Any, value: Mapping[str, Any], current_revision: int, expected_revision: int
+) -> str:
+    if not isinstance(current, Mapping) or validate_record(current):
+        return "conversation_scope_store_invalid"
+    if current_revision != expected_revision:
+        return "conversation_scope_revision_conflict"
+    if any(value.get(field) != current.get(field) for field in IMMUTABLE_FIELDS):
+        return "conversation_scope_immutable_binding_changed"
+    if set(value) != IMMUTABLE_FIELDS | MUTABLE_FIELDS:
+        return "conversation_scope_record_invalid"
+    if int(value["conversation_revision"]) != current_revision + 1:
+        return "conversation_scope_revision_invalid"
+    return ""
+
+
+def _json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+__all__ = ["AgentDbConversationScopeStore"]

--- a/modules/communication/moltbot_bridge/tests/README.md
+++ b/modules/communication/moltbot_bridge/tests/README.md
@@ -28,6 +28,18 @@ Optional custom args:
 .\modules\communication\moltbot_bridge\tests\run_tests.ps1 -PytestArgs @("-q", "-k", "skill_safety")
 ```
 
+Focused authenticated conversation-scope runtime:
+```powershell
+python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_authentication.py modules/communication/moltbot_bridge/tests/test_reddog_authenticated_conversation_scope_state.py modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_tamper_and_rotation.py -q
+```
+
+This suite uses a temporary SQLite AgentDB-shaped store plus current-checkout
+FoundUp and grounding receipts. It covers restart recovery, one-use opaque
+authentication, HMAC rotation, recomputed-hash tampering, cross-principal,
+cross-session and cross-FoundUp rejection, stale grounding, expiry, CAS and
+concurrent updates. It performs no provider call, dispatch, repository write,
+HoloIndex reindex, signing operation, PR, or merge.
+
 Focused owner-controlled signer E0 admission:
 ```powershell
 python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_controlled_e0_admission.py modules/communication/moltbot_bridge/tests/test_reddog_signer_owner_e0_static_contract.py -q

--- a/modules/communication/moltbot_bridge/tests/reddog_conversation_scope_test_support.py
+++ b/modules/communication/moltbot_bridge/tests/reddog_conversation_scope_test_support.py
@@ -1,0 +1,236 @@
+"""Current-checkout fixtures for authenticated RedDog conversation scope tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Mapping
+
+from modules.ai_intelligence.ai_overseer.src.foundup_genesis.intake_auth_provider import (
+    _make_session_token,
+)
+from modules.communication.moltbot_bridge.src.reddog_authority_runtime_store import (
+    PrincipalAuthorityRecord,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_authentication import (
+    authenticate_conversation_scope,
+)
+from modules.communication.moltbot_bridge.src.reddog_grounded_target_assignment_continuity import (
+    canonical_digest,
+)
+
+
+ROOT = Path(__file__).resolve().parents[4]
+NOW = 1_800_000_000
+SECRET = "conversation-scope-test-secret-current"
+PREVIOUS_SECRET = "conversation-scope-test-secret-previous"
+FOCUS = "Assess the TRADE FoundUp runtime using current repository evidence."
+SNAPSHOT_ID = "sha256:" + "8" * 64
+SNAPSHOT_DIGEST = "sha256:" + "9" * 64
+HOLO_GENERATION = "sha256:" + "a" * 64
+
+
+def digest(value: Any) -> str:
+    raw = value if isinstance(value, bytes) else json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+class SqliteLayer:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    @contextmanager
+    def get_connection(self):
+        connection = sqlite3.connect(self.path, timeout=5, check_same_thread=False)
+        connection.row_factory = sqlite3.Row
+        try:
+            yield connection
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def execute_query(self, query: str, params: tuple[Any, ...] = ()) -> list[Any]:
+        with self.get_connection() as connection:
+            return list(connection.execute(query, params).fetchall())
+
+
+class TestAgentDb:
+    __test__ = False
+
+    def __init__(self, path: Path) -> None:
+        self.db = SqliteLayer(path)
+
+
+class Resolver:
+    def __init__(
+        self,
+        principal_id: str = "principal_012",
+        *,
+        public_key: str = "ed25519:principal-public-key",
+        foundup_scope: tuple[str, ...] = ("trade",),
+    ) -> None:
+        self.record = PrincipalAuthorityRecord(
+            principal_id=principal_id,
+            principal_provider="test-provider",
+            principal_public_key=public_key,
+            repo_scope=("FOUNDUPS/Foundups-Agent",),
+            foundup_scope=foundup_scope,
+            verified_subject_digest=digest({"subject": principal_id}),
+        )
+
+    def resolve(self, principal_id: str, principal_provider: str):
+        if (
+            principal_id == self.record.principal_id
+            and principal_provider == self.record.principal_provider
+        ):
+            return self.record
+        return None
+
+
+def session_token(
+    principal_id: str = "principal_012", *, secret: str = SECRET
+) -> str:
+    return _make_session_token(secret, principal_id, NOW - 10, NOW + 1800)
+
+
+def capability(
+    *,
+    resolver: Resolver | None = None,
+    principal_id: str = "principal_012",
+    secret: str = SECRET,
+    previous_secret: str | None = None,
+    transport: str = "editor",
+    session_binding: str = "window:one",
+    now_epoch: int = NOW,
+):
+    return authenticate_conversation_scope(
+        session_token=session_token(principal_id, secret=secret),
+        principal_provider="test-provider",
+        transport=transport,
+        session_binding=session_binding,
+        principal_resolver=resolver or Resolver(principal_id),
+        now_epoch=now_epoch,
+        secret_provider=lambda: (secret, previous_secret),
+    )
+
+
+def target_receipt(foundup_id: str = "trade") -> dict[str, Any]:
+    registry_path = ROOT / "modules/foundups/foundup_registry.json"
+    schema_path = ROOT / "modules/foundups/foundup_registry.schema.json"
+    registry_bytes, schema_bytes = registry_path.read_bytes(), schema_path.read_bytes()
+    registry = json.loads(registry_bytes)
+    entity = next(item for item in registry["entities"] if item["foundup_id"] == foundup_id)
+    manifest_path = ROOT / entity["manifest_path"]
+    manifest_bytes = manifest_path.read_bytes()
+    manifest = json.loads(manifest_bytes)
+    evidence = [
+        {"path": "modules/foundups/foundup_registry.json", "content_digest": digest(registry_bytes)},
+        {"path": "modules/foundups/foundup_registry.schema.json", "content_digest": digest(schema_bytes)},
+        {"path": entity["manifest_path"], "content_digest": digest(manifest_bytes)},
+    ]
+    payload = {
+        "schema_version": "registered_foundup_target_receipt.v1",
+        "applied": True,
+        "passed": True,
+        "rejection_reasons": [],
+        "foundup_id": foundup_id,
+        "registry_digest": digest(registry_bytes),
+        "registry_schema_digest": digest(schema_bytes),
+        "registry_entity_digest": digest(entity),
+        "manifest_path": entity["manifest_path"],
+        "evidence_digests": evidence,
+        "safe_mutation_surfaces": manifest["build_contract"]["safe_mutation_surface"],
+        "repo_root_digest": digest(str(ROOT.resolve())),
+        "repo_head_sha": subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+        ).strip(),
+        "grants_authority": False,
+    }
+    return {**payload, "receipt_id": digest(payload)}
+
+
+def grounding_receipt(foundup_id: str = "trade", *, focus: str = FOCUS) -> dict[str, Any]:
+    target = target_receipt(foundup_id)
+    coverage = [
+        {"target": focus, "verdict": "SUFFICIENT", "evidence_refs": ["code:trade"]}
+    ]
+    typed = {
+        "repo_file_targets": [],
+        "semantic_targets": [focus],
+        "external_research_targets": [],
+        "quoted_reference_blocks_count": 0,
+        "quoted_reference_blocks_digest": canonical_digest([]),
+    }
+    payload = {
+        "schema_version": "reddog_grounded_target_receipt.v1",
+        "source_surface": "editor_thin_client",
+        "work_focus_digest": canonical_digest({"work_focus": focus}),
+        "typed_targets": typed,
+        "typed_targets_digest": canonical_digest(typed),
+        "grounding_preflight_applied": True,
+        "grounding_preflight_passed": True,
+        "grounding_preflight_rejection_reasons": [],
+        "grounding_target_universe_required": True,
+        "repo_file_targets_count": 0,
+        "semantic_targets_count": 1,
+        "external_research_targets_count": 0,
+        "quoted_reference_blocks_count": 0,
+        "semantic_target_coverage": coverage,
+        "semantic_target_coverage_digest": canonical_digest(
+            {"semantic_target_coverage": coverage}
+        ),
+        "target_recall_ok": None,
+        "required_targets_missing": [],
+        "direct_read_paths": [],
+        "holoindex_owner_query_ok": True,
+        "holoindex_freshness": "CURRENT",
+        "holoindex_generation_id": HOLO_GENERATION,
+        "holoindex_freshness_receipt_digest": "sha256:" + "b" * 64,
+        "holoindex_repo_head_sha": target["repo_head_sha"],
+        "holoindex_query_receipt_id": "sha256:" + "c" * 64,
+        "holoindex_index_gap_detected": False,
+        "no_holoindex_reindex_performed": True,
+        "foundup_id": foundup_id,
+        "registered_foundup_target_receipt_id": target["receipt_id"],
+        "registered_foundup_target": target,
+    }
+    return {**payload, "receipt_id": canonical_digest(payload)}
+
+
+def item(label: str, kind: str = "operator_statement") -> dict[str, Any]:
+    return {
+        "item_id": digest({"label": label}),
+        "kind": kind,
+        "summary": label,
+        "evidence_refs": ["code:trade"] if kind == "repository_fact" else [],
+    }
+
+
+def state_patch(parent_turn_id: str) -> Mapping[str, Any]:
+    return {
+        "turn_id": digest({"turn": "second"}),
+        "parent_turn_id": parent_turn_id,
+        "discussion_foundup_ids": ["trade"],
+        "active_topic": "TRADE runtime",
+        "current_objective": "Identify the next grounded implementation slice.",
+        "accepted_decisions": [item("Use current repository evidence.", "repository_fact")],
+        "rejected_options": [],
+        "open_questions": [item("Which bounded slice is highest priority?", "unresolved")],
+        "repository_evidence_refs": ["code:trade"],
+    }
+
+
+__all__ = [
+    "FOCUS", "HOLO_GENERATION", "NOW", "PREVIOUS_SECRET", "ROOT", "SECRET",
+    "SNAPSHOT_DIGEST", "SNAPSHOT_ID", "Resolver", "TestAgentDb", "capability",
+    "digest", "grounding_receipt", "item", "session_token", "state_patch",
+]

--- a/modules/communication/moltbot_bridge/tests/test_reddog_authenticated_conversation_scope_state.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_authenticated_conversation_scope_state.py
@@ -1,0 +1,253 @@
+"""AgentDB lifecycle tests for authenticated RedDog conversation scope."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_authenticated_conversation_scope_state import (
+    advance_authenticated_conversation_scope,
+    create_authenticated_conversation_scope,
+    resume_authenticated_conversation_scope,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_store import (
+    AgentDbConversationScopeStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_request import (
+    ConversationScopeAdvanceRequest,
+    ConversationScopeCreateRequest,
+)
+from modules.communication.moltbot_bridge.tests.reddog_conversation_scope_test_support import (
+    FOCUS,
+    HOLO_GENERATION,
+    NOW,
+    SNAPSHOT_DIGEST,
+    SNAPSHOT_ID,
+    TestAgentDb,
+    Resolver,
+    capability,
+    digest,
+    grounding_receipt,
+    item,
+    state_patch,
+)
+
+
+def _store(path: Path) -> AgentDbConversationScopeStore:
+    return AgentDbConversationScopeStore(lambda: TestAgentDb(path))
+
+
+def _create(path: Path, **overrides):
+    values = {
+        "work_focus": FOCUS,
+        "grounding_receipt": grounding_receipt(),
+        "discussion_foundup_ids": ("trade",),
+        "conversation_nonce": "conversation-one",
+        "turn_id": digest({"turn": "first"}),
+        "active_topic": "TRADE runtime",
+        "current_objective": "Identify the next grounded implementation slice.",
+        "accepted_decisions": (item("Use current repository evidence.", "repository_fact"),),
+        "rejected_options": (),
+        "open_questions": (item("What is the next bounded slice?", "unresolved"),),
+        "repository_evidence_refs": ("code:trade",),
+        "source_snapshot_id": SNAPSHOT_ID,
+        "source_snapshot_digest": SNAPSHOT_DIGEST,
+    }
+    values.update(overrides)
+    return create_authenticated_conversation_scope(
+        store=_store(path), capability=capability(),
+        repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeCreateRequest(**values), now_epoch=NOW,
+    )
+
+
+def _resume(path: Path, conversation_id: str, **overrides):
+    values = {
+        "store": _store(path),
+        "capability": capability(),
+        "conversation_id": conversation_id,
+        "expected_head_sha": grounding_receipt()["holoindex_repo_head_sha"],
+        "expected_holoindex_generation_id": HOLO_GENERATION,
+        "expected_source_snapshot_id": SNAPSHOT_ID,
+        "expected_source_snapshot_digest": SNAPSHOT_DIGEST,
+        "now_epoch": NOW + 1,
+    }
+    values.update(overrides)
+    return resume_authenticated_conversation_scope(**values)
+
+
+def test_create_restart_resume_and_projection_are_bounded(tmp_path: Path) -> None:
+    result = _create(tmp_path / "scope.sqlite")
+    assert result.accepted is True
+    resumed = _resume(tmp_path / "scope.sqlite", result.conversation_id)
+    assert resumed.accepted is True
+    assert resumed.projection["authority_effect"] == "none"
+    assert resumed.projection["source_snapshot_id"] == SNAPSHOT_ID
+    assert "principal_id" not in resumed.projection
+    assert resumed.no_work_authority_granted is True
+    assert resumed.no_worker_dispatch_performed is True
+
+
+def test_duplicate_conversation_and_raw_secret_material_do_not_persist(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    first = _create(path)
+    second = _create(path)
+    assert first.accepted is True
+    assert second.accepted is False
+    row = TestAgentDb(path).db.execute_query(
+        "SELECT scope_json FROM reddog_conversation_scopes"
+    )[0]["scope_json"]
+    assert "sess.v1" not in row
+    assert "conversation-scope-test-secret" not in row
+    assert "principal-public-key" not in row
+
+
+def test_advance_uses_revision_cas_and_clears_pending_proposal(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    current = _store(path).load(created.conversation_id)["record"]
+    result = advance_authenticated_conversation_scope(
+        store=_store(path),
+        capability=capability(),
+        repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeAdvanceRequest(
+            conversation_id=created.conversation_id, expected_revision=0,
+            work_focus=FOCUS, grounding_receipt=grounding_receipt(),
+            state_patch=state_patch(current["turn_id"]),
+            expected_source_snapshot_id=SNAPSHOT_ID,
+            expected_source_snapshot_digest=SNAPSHOT_DIGEST,
+        ),
+        now_epoch=NOW + 2,
+    )
+    assert result.accepted is True
+    assert result.conversation_revision == 1
+    advanced = _store(path).load(created.conversation_id)["record"]
+    stale = advance_authenticated_conversation_scope(
+        store=_store(path),
+        capability=capability(),
+        repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeAdvanceRequest(
+            conversation_id=created.conversation_id, expected_revision=0,
+            work_focus=FOCUS, grounding_receipt=grounding_receipt(),
+            state_patch=state_patch(advanced["turn_id"]),
+            expected_source_snapshot_id=SNAPSHOT_ID,
+            expected_source_snapshot_digest=SNAPSHOT_DIGEST,
+        ),
+        now_epoch=NOW + 3,
+    )
+    assert stale.accepted is False
+    assert "conversation_scope_revision_conflict" in stale.rejection_reasons
+
+
+def test_parent_turn_mismatch_and_cross_foundup_grounding_reject(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    bad_parent = dict(state_patch(digest({"turn": "wrong"})))
+    rejected = advance_authenticated_conversation_scope(
+        store=_store(path), capability=capability(),
+        repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeAdvanceRequest(
+            conversation_id=created.conversation_id, expected_revision=0,
+            work_focus=FOCUS, grounding_receipt=grounding_receipt(),
+            state_patch=bad_parent, expected_source_snapshot_id=SNAPSHOT_ID,
+            expected_source_snapshot_digest=SNAPSHOT_DIGEST,
+        ), now_epoch=NOW + 2,
+    )
+    assert rejected.accepted is False
+    other_focus = "Assess the GotJunk FoundUp runtime using current repository evidence."
+    rejected = advance_authenticated_conversation_scope(
+        store=_store(path),
+        capability=capability(resolver=Resolver(foundup_scope=("trade", "gotjunk_001"))),
+        repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeAdvanceRequest(
+            conversation_id=created.conversation_id, expected_revision=0,
+            work_focus=other_focus,
+            grounding_receipt=grounding_receipt("gotjunk_001", focus=other_focus),
+            state_patch=state_patch(digest({"turn": "first"})),
+            expected_source_snapshot_id=SNAPSHOT_ID,
+            expected_source_snapshot_digest=SNAPSHOT_DIGEST,
+        ),
+        now_epoch=NOW + 2,
+    )
+    assert rejected.accepted is False
+
+
+def test_stale_head_holo_snapshot_and_expiry_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path, ttl_seconds=10)
+    for override in (
+        {"expected_head_sha": "0" * 40},
+        {"expected_holoindex_generation_id": "sha256:" + "0" * 64},
+        {"expected_source_snapshot_digest": "sha256:" + "0" * 64},
+        {"now_epoch": NOW + 10},
+    ):
+        assert _resume(path, created.conversation_id, **override).accepted is False
+
+
+def test_wrong_principal_transport_and_key_rotation_reject(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    assert _resume(path, created.conversation_id, capability=capability(principal_id="other-principal")).accepted is False
+    assert _resume(path, created.conversation_id, capability=capability(transport="api")).accepted is False
+    assert _resume(
+        path,
+        created.conversation_id,
+        capability=capability(resolver=Resolver(public_key="ed25519:rotated-key")),
+    ).accepted is False
+
+
+def test_concurrent_updates_commit_exactly_one_revision(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    current = _store(path).load(created.conversation_id)["record"]
+    grounding = grounding_receipt()
+
+    def update(label: str):
+        patch = dict(state_patch(current["turn_id"]))
+        patch["turn_id"] = digest({"turn": label})
+        return advance_authenticated_conversation_scope(
+            store=_store(path), capability=capability(),
+            repo_root=Path(__file__).resolve().parents[4],
+            request=ConversationScopeAdvanceRequest(
+                conversation_id=created.conversation_id, expected_revision=0,
+                work_focus=FOCUS, grounding_receipt=grounding, state_patch=patch,
+                expected_source_snapshot_id=SNAPSHOT_ID,
+                expected_source_snapshot_digest=SNAPSHOT_DIGEST,
+            ), now_epoch=NOW + 2,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(update, ("concurrent-a", "concurrent-b")))
+    assert sum(result.accepted for result in results) == 1
+    assert _store(path).load(created.conversation_id)["record"]["conversation_revision"] == 1
+
+
+def test_database_unavailability_fails_closed() -> None:
+    class BrokenAgentDb:
+        @property
+        def db(self):
+            raise RuntimeError("database unavailable")
+
+    result = create_authenticated_conversation_scope(
+        store=AgentDbConversationScopeStore(BrokenAgentDb),
+        capability=capability(), repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeCreateRequest(
+            work_focus=FOCUS, grounding_receipt=grounding_receipt(),
+            discussion_foundup_ids=("trade",), conversation_nonce="database-failure",
+            turn_id=digest({"turn": "db-failure"}), active_topic="TRADE runtime",
+            current_objective="Remain fail closed.",
+        ), now_epoch=NOW,
+    )
+    assert result.accepted is False
+    assert "conversation_scope_store_unavailable" in result.rejection_reasons
+
+
+def test_invented_repository_evidence_cannot_enter_scope(tmp_path: Path) -> None:
+    result = _create(
+        tmp_path / "scope.sqlite",
+        accepted_decisions=(item("Unsupported claim.", "repository_fact"),),
+        repository_evidence_refs=("invented/path.py:999",),
+    )
+    assert result.accepted is False
+    assert "conversation_scope_input_invalid" in result.rejection_reasons

--- a/modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_authentication.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_authentication.py
@@ -1,0 +1,114 @@
+"""Authentication and opaque-capability regressions for RedDog conversation scope."""
+
+from __future__ import annotations
+
+import copy
+import pickle
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import reddog_conversation_scope_capability as capability_module
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_authentication import (
+    AuthenticatedConversationScopeCapability,
+    authenticate_conversation_scope,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_capability import (
+    consume_conversation_scope_capability,
+    conversation_scope_authority_view,
+)
+from modules.communication.moltbot_bridge.tests.reddog_conversation_scope_test_support import (
+    NOW,
+    SECRET,
+    Resolver,
+    capability,
+    session_token,
+)
+
+
+def test_signed_session_subject_resolves_current_principal_scope() -> None:
+    proof = capability()
+    authority = consume_conversation_scope_capability(
+        proof,
+        active_foundup_id="trade",
+        discussion_foundup_ids=("trade",),
+        now_epoch=NOW,
+    )
+    view = conversation_scope_authority_view(authority)
+    assert view is not None
+    assert view["principal_id"] == "principal_012"
+    assert view["foundup_scope"] == ("trade",)
+    assert not any("key" in name and name != "principal_key_fingerprint" for name in view)
+
+
+def test_session_token_tamper_and_unresolved_subject_fail_closed() -> None:
+    token = session_token()
+    assert authenticate_conversation_scope(
+        session_token=token[:-1] + ("a" if token[-1] != "a" else "b"),
+        principal_provider="test-provider",
+        transport="editor",
+        session_binding="window:one",
+        principal_resolver=Resolver(),
+        now_epoch=NOW,
+        secret_provider=lambda: (SECRET, None),
+    ) is None
+    assert authenticate_conversation_scope(
+        session_token=session_token("other-principal"),
+        principal_provider="test-provider",
+        transport="editor",
+        session_binding="window:one",
+        principal_resolver=Resolver(),
+        now_epoch=NOW,
+        secret_provider=lambda: (SECRET, None),
+    ) is None
+
+
+def test_capability_is_one_use_and_foundup_scope_is_enforced() -> None:
+    proof = capability()
+    assert consume_conversation_scope_capability(
+        proof,
+        active_foundup_id="other",
+        discussion_foundup_ids=("other",),
+        now_epoch=NOW,
+    ) is None
+    assert consume_conversation_scope_capability(
+        proof,
+        active_foundup_id="trade",
+        discussion_foundup_ids=("trade",),
+        now_epoch=NOW,
+    ) is None
+
+
+def test_expired_capability_fails_closed() -> None:
+    proof = capability()
+    assert consume_conversation_scope_capability(
+        proof,
+        active_foundup_id="trade",
+        discussion_foundup_ids=("trade",),
+        now_epoch=NOW + 60,
+    ) is None
+
+
+def test_capability_cannot_be_constructed_copied_or_pickled() -> None:
+    with pytest.raises(TypeError):
+        AuthenticatedConversationScopeCapability()
+    proof = capability()
+    assert proof is not None
+    with pytest.raises(TypeError):
+        copy.copy(proof)
+    with pytest.raises(TypeError):
+        copy.deepcopy(proof)
+    with pytest.raises(TypeError):
+        pickle.dumps(proof)
+
+
+def test_principal_record_requires_exact_subject_digest() -> None:
+    resolver = Resolver()
+    resolver.record = resolver.record.__class__(
+        **{**resolver.record.to_dict(), "verified_subject_digest": "sha256:not-a-digest"}
+    )
+    assert capability(resolver=resolver) is None
+
+
+def test_secret_bearing_issuer_is_not_a_public_api() -> None:
+    assert "_ConversationScopeAuthoritySeal" not in capability_module.__all__
+    assert "_issue_conversation_scope_capability" not in capability_module.__all__

--- a/modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_tamper_and_rotation.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_tamper_and_rotation.py
@@ -1,0 +1,175 @@
+"""Tamper, rotation, and static boundary tests for conversation scope."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+from pathlib import Path
+
+from modules.communication.moltbot_bridge.src.reddog_authenticated_conversation_scope_state import (
+    advance_authenticated_conversation_scope,
+    create_authenticated_conversation_scope,
+    resume_authenticated_conversation_scope,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    canonical_digest,
+    with_record_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_store import (
+    AgentDbConversationScopeStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_request import (
+    ConversationScopeAdvanceRequest,
+    ConversationScopeCreateRequest,
+)
+from modules.communication.moltbot_bridge.tests.reddog_conversation_scope_test_support import (
+    FOCUS,
+    HOLO_GENERATION,
+    NOW,
+    PREVIOUS_SECRET,
+    ROOT,
+    SECRET,
+    SNAPSHOT_DIGEST,
+    SNAPSHOT_ID,
+    TestAgentDb,
+    capability,
+    digest,
+    grounding_receipt,
+    state_patch,
+)
+
+
+def _store(path: Path) -> AgentDbConversationScopeStore:
+    return AgentDbConversationScopeStore(lambda: TestAgentDb(path))
+
+
+def _create(path: Path):
+    return create_authenticated_conversation_scope(
+        store=_store(path), capability=capability(), repo_root=ROOT,
+        request=ConversationScopeCreateRequest(
+            work_focus=FOCUS, grounding_receipt=grounding_receipt(),
+            discussion_foundup_ids=("trade",), conversation_nonce="tamper-test",
+            turn_id=digest({"turn": "first"}), active_topic="TRADE runtime",
+            current_objective="Ground the next slice.", source_snapshot_id=SNAPSHOT_ID,
+            source_snapshot_digest=SNAPSHOT_DIGEST,
+        ), now_epoch=NOW,
+    )
+
+
+def _resume(path: Path, conversation_id: str, proof):
+    return resume_authenticated_conversation_scope(
+        store=_store(path), capability=proof, conversation_id=conversation_id,
+        expected_head_sha=grounding_receipt()["holoindex_repo_head_sha"],
+        expected_holoindex_generation_id=HOLO_GENERATION,
+        expected_source_snapshot_id=SNAPSHOT_ID,
+        expected_source_snapshot_digest=SNAPSHOT_DIGEST, now_epoch=NOW + 3,
+    )
+
+
+def test_attacker_rehashing_record_and_revision_cannot_forge_mac(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    record = _store(path).load(created.conversation_id)["record"]
+    forged = copy.deepcopy(record)
+    forged["active_topic"] = "attacker-selected topic"
+    state = {
+        key: value for key, value in forged.items()
+        if key not in {"revision_receipts", "record_auth_mac", "record_digest"}
+    }
+    receipt = dict(forged["revision_receipts"][-1])
+    receipt["state_digest"] = canonical_digest(state)
+    receipt.pop("receipt_id")
+    receipt["receipt_id"] = canonical_digest(receipt)
+    forged["revision_receipts"][-1] = receipt
+    forged = with_record_digest(forged)
+    with TestAgentDb(path).db.get_connection() as connection:
+        connection.execute(
+            "UPDATE reddog_conversation_scopes SET scope_json = ? WHERE conversation_id = ?",
+            (json.dumps(forged, sort_keys=True, separators=(",", ":")), created.conversation_id),
+        )
+    assert _resume(path, created.conversation_id, capability()).accepted is False
+
+
+def test_secret_rotation_reauthenticates_state_then_retires_old_key(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    current = _store(path).load(created.conversation_id)["record"]
+    rotated = advance_authenticated_conversation_scope(
+        store=_store(path),
+        capability=capability(secret=PREVIOUS_SECRET, previous_secret=SECRET),
+        repo_root=ROOT,
+        request=ConversationScopeAdvanceRequest(
+            conversation_id=created.conversation_id, expected_revision=0,
+            work_focus=FOCUS, grounding_receipt=grounding_receipt(),
+            state_patch=state_patch(current["turn_id"]),
+            expected_source_snapshot_id=SNAPSHOT_ID,
+            expected_source_snapshot_digest=SNAPSHOT_DIGEST,
+        ), now_epoch=NOW + 2,
+    )
+    assert rotated.accepted is True
+    assert _resume(
+        path, created.conversation_id, capability(secret=PREVIOUS_SECRET)
+    ).accepted is True
+    assert _resume(path, created.conversation_id, capability(secret=SECRET)).accepted is False
+
+
+def test_unknown_record_or_revision_fields_fail_before_disclosure(tmp_path: Path) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    record = _store(path).load(created.conversation_id)["record"]
+    for mutation in ("record", "revision"):
+        forged = copy.deepcopy(record)
+        if mutation == "record":
+            forged["attacker_field"] = "ignored-by-lenient-parser"
+        else:
+            forged["revision_receipts"][-1]["attacker_field"] = "ignored"
+        forged = with_record_digest(forged)
+        with TestAgentDb(path).db.get_connection() as connection:
+            connection.execute(
+                "UPDATE reddog_conversation_scopes SET scope_json = ? WHERE conversation_id = ?",
+                (json.dumps(forged, sort_keys=True, separators=(",", ":")), created.conversation_id),
+            )
+        assert _resume(path, created.conversation_id, capability()).accepted is False
+        with TestAgentDb(path).db.get_connection() as connection:
+            connection.execute(
+                "UPDATE reddog_conversation_scopes SET scope_json = ? WHERE conversation_id = ?",
+                (json.dumps(record, sort_keys=True, separators=(",", ":")), created.conversation_id),
+            )
+
+
+def test_production_modules_have_no_effect_or_raw_history_surfaces() -> None:
+    module_paths = list(
+        (ROOT / "modules/communication/moltbot_bridge/src").glob(
+            "reddog_conversation_scope_*.py"
+        )
+    ) + [
+        ROOT / "modules/communication/moltbot_bridge/src/reddog_authenticated_conversation_scope_state.py"
+    ]
+    forbidden_imports = {"subprocess", "requests", "httpx", "socket"}
+    for path in module_paths:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported = {
+            node.names[0].name.split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+        } | {
+            str(node.module or "").split(".")[0]
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+        }
+        assert not imported.intersection(forbidden_imports)
+        assert "state.history" not in source
+        assert "commit_all" not in source
+        assert "enqueue" not in source
+        calls = {
+            str(node.func.attr).lower()
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        } | {
+            str(node.func.id).lower()
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert not calls.intersection({"reindex", "index_all", "refresh_index"})


### PR DESCRIPTION
## Summary
- add authenticated, principal-bound, FoundUp-scoped conversation state in the existing AgentDB
- enforce insert-only creation, revision CAS, expiry, turn lineage, current grounding, operational snapshot, repository HEAD, and HoloIndex generation/freshness bindings
- reuse the existing signed `sess.v1` verifier and `PrincipalAuthorityResolver` through opaque one-use process-local capabilities
- authenticate durable records with rotated HMACs and expose only bounded, non-authoritative projections
- restrict persisted repository evidence references to the verified grounding receipt

## Truth boundary
- no raw provider history is persisted
- no work proposal, worker dispatch, queue mutation, repository write, signer operation, HoloIndex reindex, PR, or merge authority is added
- the editor is not wired to this API until a production-authenticated session source exists; environment principal values are not authentication
- P2 proposal promotion remains blocked on the existing principal-signed policy authorization path

## Validation
- 20 focused conversation-scope tests passed
- 97 related auth/grounding/runtime tests passed; 50 platform-conditioned skips
- 42 WRE red-team tests passed
- RedDog conversation-history policy checks passed
- RedDog extension contract checks passed
- all changed Python functions <= 50 lines and classes <= 200 lines
- staged diff check clean; added bytes ASCII-clean with zero NUL

## HoloIndex
- pre-slice generation-bound owner query was CURRENT at base `1b70aec97`
- no query-time reindex was performed
- post-merge owner refresh remains a WRE/CI maintenance action