### PR TITLE
feat(digital-twin): add readonly principal memex projection

### DIFF
--- a/WSP_framework/docs/annexes/WSP_60_FOUNDUP_MEMEX_ADDENDUM.md
+++ b/WSP_framework/docs/annexes/WSP_60_FOUNDUP_MEMEX_ADDENDUM.md
@@ -23,7 +23,17 @@ Breadcrumbs
 
 RedDog
 = orchestrator that launches, builds, runs, audits, and improves FoundUps
+
+012 Principal Memex
+= persistent cognition substrate for the 012/0102 relationship
+
+0102 Digital Twin
+= active reasoning and orchestration agent hosted by RedDog
 ```
+
+The Principal Memex is not a FoundUp Memex, conversation log, AgentDB work
+state, or authority source. RedDog hosts the Digital Twin; RedDog is not the
+Digital Twin's memory.
 
 ## WSP_60 relationship
 
@@ -37,6 +47,30 @@ WSP_60 already defines:
 - verified operational outcome writeback.
 
 The FoundUp Memex composes those existing surfaces for one `foundup_id`. It does not replace them and does not introduce a parallel general-purpose memory database.
+
+## Principal vs FoundUp cognition
+
+The 012 Principal Memex contains principal-scoped goals, stable preferences,
+architectural principles, accepted terminology, decision history,
+communication preferences, and long-term unresolved questions. It may inform
+0102 interpretation across FoundUps, but it cannot establish repository truth,
+FoundUp scope, or work authority.
+
+The first implemented Principal Memex layer is:
+
+```text
+REDDOG_012_PRINCIPAL_MEMEX_READONLY_PROJECTION_PHASE1
+```
+
+It is a structural, in-memory projection owned by
+`modules/ai_intelligence/digital_twin`. It is not runtime-admissible and
+performs no persistence, model-context admission, FoundUp projection,
+HoloIndex write, or work authorization. Authenticated source admission is a
+separate required slice.
+
+Information crosses between Principal and FoundUp Memex only through a future
+explicit, provenance-preserving projection. Neither side silently copies or
+promotes the other's cognition.
 
 ## Required Memex sources
 
@@ -85,7 +119,9 @@ The following remain specified but not implemented:
 - CABR-weighted contribution credibility;
 - stakeholder and revocable delegate authority;
 - governance thresholds and Sybil resistance;
-- personal 012/0102 Memex application.
+- authenticated resident Principal Memex admission;
+- governed Principal Memex source issuance and retention;
+- explicit Principal-to-FoundUp and FoundUp-to-Principal projection.
 
 These require separate WSP_97 analysis and tested contracts before runtime authority is granted.
 
@@ -106,6 +142,7 @@ These require separate WSP_97 analysis and tested contracts before runtime autho
 - `docs/adr/ADR_REDDOG_FOUNDUPS_SECOND_BRAIN_BOUNDARY.md`
 - `docs/architecture/architecture_registry.yaml`
 - `modules/communication/moltbot_bridge/src/foundup_memex_current_state.py`
+- `modules/ai_intelligence/digital_twin/src/principal_memex_projection.py`
 - `modules/communication/moltbot_bridge/ROADMAP.md`
 
 ## Framework and knowledge synchronization

--- a/WSP_knowledge/docs/annexes/WSP_60_FOUNDUP_MEMEX_ADDENDUM.md
+++ b/WSP_knowledge/docs/annexes/WSP_60_FOUNDUP_MEMEX_ADDENDUM.md
@@ -23,7 +23,17 @@ Breadcrumbs
 
 RedDog
 = orchestrator that launches, builds, runs, audits, and improves FoundUps
+
+012 Principal Memex
+= persistent cognition substrate for the 012/0102 relationship
+
+0102 Digital Twin
+= active reasoning and orchestration agent hosted by RedDog
 ```
+
+The Principal Memex is not a FoundUp Memex, conversation log, AgentDB work
+state, or authority source. RedDog hosts the Digital Twin; RedDog is not the
+Digital Twin's memory.
 
 ## WSP_60 relationship
 
@@ -37,6 +47,30 @@ WSP_60 already defines:
 - verified operational outcome writeback.
 
 The FoundUp Memex composes those existing surfaces for one `foundup_id`. It does not replace them and does not introduce a parallel general-purpose memory database.
+
+## Principal vs FoundUp cognition
+
+The 012 Principal Memex contains principal-scoped goals, stable preferences,
+architectural principles, accepted terminology, decision history,
+communication preferences, and long-term unresolved questions. It may inform
+0102 interpretation across FoundUps, but it cannot establish repository truth,
+FoundUp scope, or work authority.
+
+The first implemented Principal Memex layer is:
+
+```text
+REDDOG_012_PRINCIPAL_MEMEX_READONLY_PROJECTION_PHASE1
+```
+
+It is a structural, in-memory projection owned by
+`modules/ai_intelligence/digital_twin`. It is not runtime-admissible and
+performs no persistence, model-context admission, FoundUp projection,
+HoloIndex write, or work authorization. Authenticated source admission is a
+separate required slice.
+
+Information crosses between Principal and FoundUp Memex only through a future
+explicit, provenance-preserving projection. Neither side silently copies or
+promotes the other's cognition.
 
 ## Required Memex sources
 
@@ -85,7 +119,9 @@ The following remain specified but not implemented:
 - CABR-weighted contribution credibility;
 - stakeholder and revocable delegate authority;
 - governance thresholds and Sybil resistance;
-- personal 012/0102 Memex application.
+- authenticated resident Principal Memex admission;
+- governed Principal Memex source issuance and retention;
+- explicit Principal-to-FoundUp and FoundUp-to-Principal projection.
 
 These require separate WSP_97 analysis and tested contracts before runtime authority is granted.
 
@@ -106,6 +142,7 @@ These require separate WSP_97 analysis and tested contracts before runtime autho
 - `docs/adr/ADR_REDDOG_FOUNDUPS_SECOND_BRAIN_BOUNDARY.md`
 - `docs/architecture/architecture_registry.yaml`
 - `modules/communication/moltbot_bridge/src/foundup_memex_current_state.py`
+- `modules/ai_intelligence/digital_twin/src/principal_memex_projection.py`
 - `modules/communication/moltbot_bridge/ROADMAP.md`
 
 ## Framework and knowledge synchronization

--- a/docs/adr/ADR_REDDOG_FOUNDUPS_SECOND_BRAIN_BOUNDARY.md
+++ b/docs/adr/ADR_REDDOG_FOUNDUPS_SECOND_BRAIN_BOUNDARY.md
@@ -16,8 +16,22 @@ The earlier Second Brain framing mixed a long-term personal digital-twin vision 
 3. **Breadcrumbs** remain episodic continuity inside the Memex.
 4. **RedDog** orchestrates FoundUps through exact `foundup_id` and `snapshot_id` bindings.
 5. **Foundups Agent** is the first POC entity.
-6. Personal 012/0102 Memex work is deferred.
+6. The 012 Principal Memex is a separate cognition substrate for 0102, not a
+   FoundUp Memex or authority source. Its structural read-only projection is
+   implemented; authenticated resident admission remains deferred.
 7. Multi-RedDog governance, CABR weighting, stakeholders, and delegates are deferred research, not active runtime authority.
+
+## Digital Twin and Principal Memex boundary
+
+RedDog is the application/runtime shell. 0102 is the active Digital Twin hosted
+by RedDog. The Principal Memex informs 0102 with bounded principal cognition.
+It does not grant FoundUp scope, repository truth, execution, or merge
+authority. The existing Digital Twin voice-memory POC remains an application
+and is not relabeled as the canonical Principal Memex.
+
+Principal-to-FoundUp transfer requires a future explicit projection with
+source and destination scope, provenance, classification, timestamp, and
+supersession state. No automatic copying is allowed.
 
 ## Existing boundary preserved
 

--- a/docs/architecture/REDDOG_FOUNDUPS_SECOND_BRAIN_ARCHITECTURE.md
+++ b/docs/architecture/REDDOG_FOUNDUPS_SECOND_BRAIN_ARCHITECTURE.md
@@ -21,9 +21,34 @@ Breadcrumbs
 
 RedDog
 = the orchestrator that launches, builds, runs, audits, and improves FoundUps
+
+012 Principal Memex
+= persistent principal cognition that informs 0102 across FoundUps
+
+0102 Digital Twin
+= active reasoning/orchestration agent hosted by RedDog
 ```
 
-"Second Brain" and personal digital-twin language describe possible later applications. They are not the implementation center of the current lane.
+The FoundUp Memex remains the implementation center of FoundUp cognition. The
+Principal Memex is a separate Digital Twin substrate, not a global FoundUp
+store, conversation transcript, AgentDB queue, or authority source.
+
+## Principal Memex and RedDog
+
+```text
+012 -> Principal Memex -> 0102 Digital Twin -> RedDog interface/runtime
+```
+
+RedDog hosts 0102. The Principal Memex helps 0102 interpret stable 012 goals,
+preferences, terminology, decision history, and cross-FoundUp strategy.
+Current repository evidence remains authoritative for code truth, and signed
+authorization remains authoritative for work.
+
+The structural read-only projection is implemented in
+`modules/ai_intelligence/digital_twin/src/principal_memex_projection.py`. It is
+not resident-admissible and cannot persist, enter model context, project into a
+FoundUp, mutate HoloIndex, or grant authority. Conversation learning and
+cross-Memex transfer remain explicit governed lifecycles.
 
 ## WSP alignment
 
@@ -132,4 +157,6 @@ docs/architecture/FOUNDUPS_MEMEX_DEFERRED_GOVERNANCE_NOTES.md
 7. FOUNDUP_MEMEX_MULTI_REDDOG_COLLABORATION_PROTOTYPE_PHASE1
 ```
 
-Personal 012/0102 Memex work and collective ecosystem memory remain deferred until the FoundUp-centric contracts are proven.
+Authenticated Principal Memex admission, governed retention, explicit
+cross-Memex projection, and collective ecosystem memory remain deferred until
+their independent trust contracts are proven.

--- a/docs/architecture/architecture_registry.yaml
+++ b/docs/architecture/architecture_registry.yaml
@@ -29,7 +29,9 @@ architectures:
     primary_poc_entity: foundups_agent
     primary_runtime_slice: FOUNDUP_MEMEX_CURRENT_STATE_ASSEMBLY_PHASE1
     compatibility_runtime_slice: FOUNDUP_BRAIN_CURRENT_STATE_ASSEMBLY_PHASE1
-    deferred_application: REDDOG_012_PERSONAL_MEMEX_PHASE1
+    principal_memex_owner: modules/ai_intelligence/digital_twin
+    principal_memex_runtime_slice: REDDOG_012_PRINCIPAL_MEMEX_READONLY_PROJECTION_PHASE1
+    principal_memex_status: structural_readonly_projection
     domains:
       - foundup_dae
       - memex
@@ -50,6 +52,7 @@ architectures:
       - research_receipts
       - 0102_public_key_identity
       - reddog_operational_state
+      - principal_memex_readonly_projection
     invariants:
       - foundup_first_implementation
       - brain_is_a_memex_component
@@ -68,6 +71,8 @@ architectures:
       - roadmaps_change_only_through_governed_deltas
       - verified_outcomes_only_for_durable_learning
       - runtime_reddog_does_not_reindex_holoindex
+      - principal_memex_does_not_grant_foundup_or_work_authority
+      - principal_foundup_memex_transfer_is_explicit
       - cabr_influences_policy_but_does_not_directly_grant_access
       - foundup_cabr_and_0102_contribution_profile_are_not_conflated
       - cabr_and_delegate_runtime_authority_remain_deferred
@@ -86,7 +91,8 @@ architectures:
       - FOUNDUP_MEMEX_CABR_CAPABILITY_POLICY_CONTRACT_PHASE1
       - CABR_0102_CONTRIBUTION_PROFILE_CONTRACT_PHASE1
       - FOUNDUPS_COLLECTIVE_MEMEX_EXCHANGE_PHASE1
-      - REDDOG_012_PERSONAL_MEMEX_PHASE1
+      - REDDOG_012_PRINCIPAL_MEMEX_READONLY_PROJECTION_PHASE1
+      - REDDOG_PRINCIPAL_MEMEX_AUTHENTICATED_RESIDENT_ADMISSION_PHASE1
     search_terms:
       - FoundUps Memex
       - FoundUp Memex
@@ -112,3 +118,6 @@ architectures:
       - adaptive roadmap delta
       - verified outcome
       - HoloIndex canonical repo truth
+      - 012 Principal Memex
+      - 0102 Digital Twin cognition
+      - RedDog hosts 0102

--- a/modules/ai_intelligence/digital_twin/INTERFACE.md
+++ b/modules/ai_intelligence/digital_twin/INTERFACE.md
@@ -4,6 +4,32 @@
 
 ---
 
+## Principal Memex read-only projection
+
+```python
+from modules.ai_intelligence.digital_twin.src.principal_memex_projection import (
+    build_principal_memex_item,
+    project_principal_memex_readonly,
+    rehydrate_principal_memex_projection,
+)
+```
+
+The builder creates structurally verified Principal Memex items from explicit
+provenance. The projector rejects mixed principals, duplicate items,
+inconsistent self-digests, incoherent supersession, unknown schemas,
+secret-shaped serialized text, and malformed provenance identifiers.
+Rehydration recomputes the complete projection. Public digest recomputation is
+structural integrity, not source authenticity.
+
+This interface grants no trust or authority. Its output remains
+`runtime_admissible=false` until a separate authenticated resident admission
+layer verifies each source receipt and binds the exact principal conversation.
+It never projects data to a FoundUp automatically. This structural API is
+intentionally not exported by `src.__init__` or included in RedDog's sealed
+resident dependency closure until that admission slice is implemented.
+
+---
+
 ## boot_digital_twin (V0.5.0)
 
 ### Purpose

--- a/modules/ai_intelligence/digital_twin/ModLog.md
+++ b/modules/ai_intelligence/digital_twin/ModLog.md
@@ -2,6 +2,24 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## 2026-08-06 - 012 Principal Memex read-only projection
+
+- Added typed Principal Memex items and a deterministic read-only projection
+  for the 0102 Digital Twin.
+- Added structural rehydration, exact digest and native JSON type checks,
+  principal isolation, provenance/sensitivity/supersession policy, and
+  secret-material rejection.
+- Hardened all serialized text, bounded container admission before traversal,
+  enforced multi-generation supersession relationships, and guarded typed
+  projection/result construction with process-local factories and exact native
+  boolean checks.
+- Kept the result non-persistent and ineligible for model context, FoundUp
+  projection, HoloIndex writes, or work authority.
+- Kept the structural API outside the package export and sealed RedDog runtime
+  closure; authenticated resident admission owns that later integration.
+- Clarified that RedDog hosts 0102; the Principal Memex informs the Digital
+  Twin but is not itself the agent.
+
 ## V0.5.0 - WSP_00 Boot Integration (2026-03-23)
 
 ### Added

--- a/modules/ai_intelligence/digital_twin/README.md
+++ b/modules/ai_intelligence/digital_twin/README.md
@@ -1,5 +1,22 @@
 # Digital Twin Module
 
+## Product boundary
+
+RedDog is the application/runtime shell. 0102 is the Digital Twin hosted by
+RedDog. The Principal Memex is the bounded cognition substrate that may help
+0102 understand 012; it is neither the Digital Twin nor operational authority.
+
+`principal_memex_projection.py` implements the first structural, read-only
+Principal Memex projection. It validates provenance identifiers, canonical
+content/item/projection digests, principal isolation, sensitivity, and
+projection-level supersession relationships. Public digest recomputation does
+not authenticate a source. The projection is explicitly `STRUCTURAL_ONLY` and
+`runtime_admissible=false`: it performs no persistence, model-context
+admission, FoundUp projection, HoloIndex write, or work authorization.
+
+The existing social comment/voice pipeline below remains a Digital Twin
+application. Its voice memory is not the canonical Principal Memex.
+
 **WSP Compliance**: WSP 49 (Module Structure), WSP 77 (Agent Coordination)
 
 ## Purpose

--- a/modules/ai_intelligence/digital_twin/ROADMAP.md
+++ b/modules/ai_intelligence/digital_twin/ROADMAP.md
@@ -6,11 +6,23 @@
 
 ## Vision
 
-Train 012's Digital Twin (0102) to autonomously engage across social platforms with 012's authentic voice, using 20 years of 012 video corpus to drive comment drafting, decisioning, and scheduling. Current POC focus: LinkedIn comment processing and scheduling with 012 studio comment style.
+Host 0102 as 012's Digital Twin across FoundUps and bounded applications.
+Social engagement remains one application. Principal cognition is supplied by
+a separate Principal Memex rather than being conflated with voice memory,
+conversation state, AgentDB, or any FoundUp Memex.
+
+## Principal Memex lane
+
+- Complete: structural read-only item and projection contract.
+- Complete: canonical digest, principal isolation, provenance-shape,
+  sensitivity, supersession, and no-authority invariants.
+- Next: authenticated resident admission for `principal` conversation scope.
+- Deferred: durable governed source issuance, explicit learning admission, and
+  explicit Principal-to-FoundUp projection.
 
 ---
 
-## Current State (V0.5.2) - Audited 2026-01-21
+## Current State (V0.6.0) - Audited 2026-08-06
 
 ### Phase 0b: Vision System ✅ COMPLETE
 

--- a/modules/ai_intelligence/digital_twin/src/principal_memex_contract.py
+++ b/modules/ai_intelligence/digital_twin/src/principal_memex_contract.py
@@ -1,0 +1,340 @@
+"""Typed read-only contract for 012 Principal Memex projections."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import InitVar, asdict, dataclass
+from datetime import datetime
+from typing import Any
+
+from holo_index.query_receipt import digest_json
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    redact_runtime_text,
+)
+
+
+ITEM_SCHEMA_VERSION = "principal_memex_item.v1"
+PROJECTION_SCHEMA_VERSION = "principal_memex_projection.v1"
+SOURCE_CLASS_PRINCIPAL_MEMEX = "principal_memex"
+PROJECTION_READY = "PRINCIPAL_MEMEX_PROJECTION_READY"
+PROJECTION_REJECTED = "PRINCIPAL_MEMEX_PROJECTION_REJECTED"
+STRUCTURAL_VERIFICATION = "STRUCTURAL_ONLY"
+_CONSTRUCTION_TOKEN = object()
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+MAX_ITEMS = 128
+MAX_STATEMENT_CHARS = 4096
+MAX_PRINCIPAL_ID_CHARS = 160
+MAX_SOURCE_REVISION_CHARS = 256
+
+ITEM_CATEGORIES = frozenset(
+    {
+        "accepted_terminology",
+        "architectural_principle",
+        "communication_preference",
+        "decision_history",
+        "identity_statement",
+        "long_term_objective",
+        "rejected_strategy",
+        "stable_preference",
+        "unresolved_hypothesis",
+    }
+)
+SOURCE_KINDS = frozenset(
+    {
+        "accepted_decision",
+        "governed_import",
+        "principal_statement",
+        "verified_observation",
+    }
+)
+RETENTION_STATES = frozenset({"active", "superseded"})
+SENSITIVITY_CLASSES = frozenset({"private", "public", "restricted"})
+
+
+@dataclass(frozen=True)
+class PrincipalMemexItem:
+    schema_version: str
+    item_id: str
+    principal_id: str
+    category: str
+    statement: str
+    source_kind: str
+    source_receipt_id: str
+    source_revision: str
+    created_at: str
+    retention_state: str
+    sensitivity: str
+    supersedes_item_id: str
+    content_digest: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class PrincipalMemexProjection:
+    schema_version: str
+    source_class: str
+    principal_id: str
+    created_at: str
+    item_ids: tuple[str, ...]
+    source_receipt_ids: tuple[str, ...]
+    manifest_digest: str
+    verification: str
+    runtime_admissible: bool
+    no_persistence_performed: bool
+    no_model_context_admission_performed: bool
+    no_foundup_projection_performed: bool
+    no_holoindex_write_performed: bool
+    no_work_authority_granted: bool
+    projection_id: str
+    items: tuple[PrincipalMemexItem, ...]
+    _construction_token: InitVar[object] = None
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if (
+            _construction_token is not _CONSTRUCTION_TOKEN
+            or type(self.schema_version) is not str
+            or type(self.source_class) is not str
+            or type(self.verification) is not str
+            or self.schema_version != PROJECTION_SCHEMA_VERSION
+            or self.source_class != SOURCE_CLASS_PRINCIPAL_MEMEX
+            or self.verification != STRUCTURAL_VERIFICATION
+            or type(self.runtime_admissible) is not bool
+            or self.runtime_admissible is not False
+            or not _projection_binding_valid(self)
+            or any(
+                type(value) is not bool or value is not True
+                for value in (
+                    self.no_persistence_performed,
+                    self.no_model_context_admission_performed,
+                    self.no_foundup_projection_performed,
+                    self.no_holoindex_write_performed,
+                    self.no_work_authority_granted,
+                )
+            )
+        ):
+            raise ValueError("principal_memex_projection_boundary_invalid")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["item_ids"] = list(self.item_ids)
+        payload["source_receipt_ids"] = list(self.source_receipt_ids)
+        payload["items"] = [item.to_dict() for item in self.items]
+        return payload
+
+
+@dataclass(frozen=True)
+class PrincipalMemexProjectionResult:
+    accepted: bool
+    status: str
+    projection: PrincipalMemexProjection | None
+    rejection_reasons: tuple[str, ...]
+    _construction_token: InitVar[object] = None
+
+    def __post_init__(self, _construction_token: object) -> None:
+        if (
+            _construction_token is not _CONSTRUCTION_TOKEN
+            or type(self.accepted) is not bool
+            or type(self.status) is not str
+            or type(self.rejection_reasons) is not tuple
+            or any(type(reason) is not str for reason in self.rejection_reasons)
+        ):
+            raise ValueError("principal_memex_projection_result_invalid")
+        accepted_valid = (
+            self.accepted is True
+            and self.status == PROJECTION_READY
+            and type(self.projection) is PrincipalMemexProjection
+            and not self.rejection_reasons
+        )
+        rejected_valid = (
+            self.accepted is False
+            and self.status == PROJECTION_REJECTED
+            and self.projection is None
+            and bool(self.rejection_reasons)
+        )
+        if not accepted_valid and not rejected_valid:
+            raise ValueError("principal_memex_projection_result_invalid")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "accepted": self.accepted,
+            "status": self.status,
+            "projection": self.projection.to_dict() if self.projection else None,
+            "rejection_reasons": list(self.rejection_reasons),
+        }
+
+
+def _projection_binding_valid(projection: PrincipalMemexProjection) -> bool:
+    if (
+        type(projection.principal_id) is not str
+        or type(projection.created_at) is not str
+        or not _principal_memex_valid_time(projection.created_at)
+        or type(projection.item_ids) is not tuple
+        or type(projection.source_receipt_ids) is not tuple
+        or type(projection.manifest_digest) is not str
+        or type(projection.projection_id) is not str
+        or type(projection.items) is not tuple
+        or not 0 < len(projection.items) <= MAX_ITEMS
+        or len(projection.item_ids) != len(projection.items)
+        or len(projection.source_receipt_ids) > len(projection.items)
+        or any(type(item) is not PrincipalMemexItem for item in projection.items)
+        or any(_principal_memex_item_reasons(item) for item in projection.items)
+        or _principal_memex_supersession_reasons(projection.items)
+    ):
+        return False
+    expected_item_ids = tuple(item.item_id for item in projection.items)
+    if (
+        projection.items != tuple(sorted(projection.items, key=lambda item: item.item_id))
+        or projection.item_ids != expected_item_ids
+        or len(expected_item_ids) != len(set(expected_item_ids))
+    ):
+        return False
+    expected_sources = tuple(sorted({item.source_receipt_id for item in projection.items}))
+    if projection.source_receipt_ids != expected_sources:
+        return False
+    if any(item.principal_id != projection.principal_id for item in projection.items):
+        return False
+    expected_manifest = digest_json(
+        [
+            {"item_id": item.item_id, "content_digest": item.content_digest}
+            for item in projection.items
+        ]
+    )
+    return (
+        projection.manifest_digest == expected_manifest
+        and projection.projection_id == digest_json(_projection_id_payload(projection))
+    )
+
+
+def _principal_memex_item_reasons(item: PrincipalMemexItem) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if any(type(value) is not str for value in item.to_dict().values()):
+        return ("principal_memex_item_type_invalid",)
+    if item.schema_version != ITEM_SCHEMA_VERSION:
+        reasons.append("principal_memex_item_schema_invalid")
+    for value, allowed, reason in (
+        (item.category, ITEM_CATEGORIES, "principal_memex_category_invalid"),
+        (item.source_kind, SOURCE_KINDS, "principal_memex_source_kind_invalid"),
+        (item.retention_state, RETENTION_STATES, "principal_memex_retention_invalid"),
+        (item.sensitivity, SENSITIVITY_CLASSES, "principal_memex_sensitivity_invalid"),
+    ):
+        if value not in allowed:
+            reasons.append(reason)
+    reasons.extend(_principal_memex_item_value_reasons(item))
+    expected_content = digest_json({"statement": item.statement})
+    payload = item.to_dict()
+    payload.pop("item_id")
+    payload["content_digest"] = expected_content
+    if item.content_digest != expected_content or item.item_id != digest_json(payload):
+        reasons.append("principal_memex_item_digest_mismatch")
+    return tuple(reasons)
+
+
+def _principal_memex_item_value_reasons(item: PrincipalMemexItem) -> list[str]:
+    reasons: list[str] = []
+    if not item.principal_id or not item.statement.strip() or not item.source_revision:
+        reasons.append("principal_memex_required_value_missing")
+    for value, limit, field in (
+        (item.principal_id, MAX_PRINCIPAL_ID_CHARS, "principal_id"),
+        (item.source_revision, MAX_SOURCE_REVISION_CHARS, "source_revision"),
+        (item.statement, MAX_STATEMENT_CHARS, "statement"),
+    ):
+        reasons.extend(_principal_memex_text_reasons(value, limit, field))
+    if not _principal_memex_valid_time(item.created_at):
+        reasons.append("principal_memex_created_at_invalid")
+    if not _SHA256_RE.fullmatch(item.source_receipt_id):
+        reasons.append("principal_memex_source_receipt_id_invalid")
+    if item.supersedes_item_id and not _SHA256_RE.fullmatch(item.supersedes_item_id):
+        reasons.append("principal_memex_supersedes_item_id_invalid")
+    return reasons
+
+
+def _principal_memex_text_reasons(value: str, limit: int, field: str) -> list[str]:
+    redaction = redact_runtime_text(value, max_chars=limit)
+    reasons: list[str] = []
+    if redaction.replacements:
+        reasons.append("principal_memex_secret_material_forbidden")
+    if redaction.truncated:
+        reasons.append(f"principal_memex_{field}_too_long")
+    if not redaction.replacements and redaction.text != value:
+        reasons.append(f"principal_memex_{field}_not_canonical")
+    return reasons
+
+
+def _principal_memex_valid_time(value: str) -> bool:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return False
+    return bool(value and parsed.tzinfo is not None and parsed.utcoffset() is not None)
+
+
+def _principal_memex_supersession_reasons(
+    items: tuple[PrincipalMemexItem, ...] | list[PrincipalMemexItem],
+) -> tuple[str, ...]:
+    by_id = {item.item_id: item for item in items}
+    target_counts: dict[str, int] = {}
+    reasons: list[str] = []
+    for item in items:
+        if not item.supersedes_item_id:
+            continue
+        target = by_id.get(item.supersedes_item_id)
+        if target is None:
+            reasons.append("principal_memex_supersession_target_missing")
+            continue
+        if target.retention_state != "superseded":
+            reasons.append("principal_memex_supersession_target_state_invalid")
+        target_counts[target.item_id] = target_counts.get(target.item_id, 0) + 1
+    for item in items:
+        expected = 1 if item.retention_state == "superseded" else 0
+        if target_counts.get(item.item_id, 0) != expected:
+            reasons.append("principal_memex_supersession_target_count_invalid")
+    return tuple(reasons)
+
+
+def _projection_id_payload(projection: PrincipalMemexProjection) -> dict[str, Any]:
+    payload = projection.to_dict()
+    payload.pop("projection_id")
+    payload.pop("items")
+    payload["item_ids"] = projection.item_ids
+    payload["source_receipt_ids"] = projection.source_receipt_ids
+    return payload
+
+
+def _create_principal_memex_projection(
+    **values: Any,
+) -> PrincipalMemexProjection:
+    return PrincipalMemexProjection(**values, _construction_token=_CONSTRUCTION_TOKEN)
+
+
+def _create_principal_memex_projection_result(
+    accepted: bool,
+    status: str,
+    projection: PrincipalMemexProjection | None,
+    rejection_reasons: tuple[str, ...],
+) -> PrincipalMemexProjectionResult:
+    return PrincipalMemexProjectionResult(
+        accepted,
+        status,
+        projection,
+        rejection_reasons,
+        _construction_token=_CONSTRUCTION_TOKEN,
+    )
+
+
+__all__ = [
+    "ITEM_CATEGORIES",
+    "ITEM_SCHEMA_VERSION",
+    "PROJECTION_READY",
+    "PROJECTION_REJECTED",
+    "PROJECTION_SCHEMA_VERSION",
+    "RETENTION_STATES",
+    "SENSITIVITY_CLASSES",
+    "SOURCE_CLASS_PRINCIPAL_MEMEX",
+    "SOURCE_KINDS",
+    "STRUCTURAL_VERIFICATION",
+    "PrincipalMemexItem",
+    "PrincipalMemexProjection",
+    "PrincipalMemexProjectionResult",
+]

--- a/modules/ai_intelligence/digital_twin/src/principal_memex_projection.py
+++ b/modules/ai_intelligence/digital_twin/src/principal_memex_projection.py
@@ -1,0 +1,246 @@
+"""Build and rehydrate structural 012 Principal Memex projections.
+
+The projection is cognition data for the 0102 Digital Twin. It is not an
+authenticated capability and is deliberately ineligible for resident model
+context until a later authority-bound admission layer verifies every source.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any, Mapping, Sequence
+
+from holo_index.query_receipt import digest_json
+from modules.ai_intelligence.digital_twin.src.principal_memex_contract import (
+    ITEM_SCHEMA_VERSION,
+    MAX_ITEMS,
+    PROJECTION_READY,
+    PROJECTION_REJECTED,
+    PROJECTION_SCHEMA_VERSION,
+    SOURCE_CLASS_PRINCIPAL_MEMEX,
+    STRUCTURAL_VERIFICATION,
+    PrincipalMemexItem,
+    PrincipalMemexProjection,
+    PrincipalMemexProjectionResult,
+    _create_principal_memex_projection,
+    _create_principal_memex_projection_result,
+    _principal_memex_item_reasons,
+    _principal_memex_supersession_reasons,
+    _principal_memex_valid_time,
+)
+
+
+_ITEM_FIELDS = frozenset(field.name for field in fields(PrincipalMemexItem))
+_PROJECTION_FIELDS = frozenset(field.name for field in fields(PrincipalMemexProjection))
+_PROJECTION_BOOLEAN_FIELDS = frozenset(
+    {
+        "runtime_admissible",
+        "no_persistence_performed",
+        "no_model_context_admission_performed",
+        "no_foundup_projection_performed",
+        "no_holoindex_write_performed",
+        "no_work_authority_granted",
+    }
+)
+
+
+def build_principal_memex_item(
+    *, principal_id: str, category: str, statement: str, source_kind: str,
+    source_receipt_id: str, source_revision: str, created_at: str,
+    retention_state: str = "active", sensitivity: str = "private",
+    supersedes_item_id: str = "",
+) -> PrincipalMemexItem:
+    values = (
+        principal_id, category, statement, source_kind, source_receipt_id,
+        source_revision, created_at, retention_state, sensitivity,
+        supersedes_item_id,
+    )
+    if any(type(value) is not str for value in values):
+        raise ValueError("principal_memex_item_type_invalid")
+    payload = {
+        "schema_version": ITEM_SCHEMA_VERSION,
+        "principal_id": principal_id,
+        "category": category,
+        "statement": statement,
+        "source_kind": source_kind,
+        "source_receipt_id": source_receipt_id,
+        "source_revision": source_revision,
+        "created_at": created_at,
+        "retention_state": retention_state,
+        "sensitivity": sensitivity,
+        "supersedes_item_id": supersedes_item_id,
+        "content_digest": digest_json({"statement": statement}),
+    }
+    item = PrincipalMemexItem(item_id=digest_json(payload), **payload)
+    reasons = _principal_memex_item_reasons(item)
+    if reasons:
+        raise ValueError(",".join(reasons))
+    return item
+
+
+def project_principal_memex_readonly(
+    *, principal_id: str, items: Sequence[PrincipalMemexItem | Mapping[str, Any]],
+    created_at: str,
+) -> PrincipalMemexProjectionResult:
+    reasons = _projection_input_reasons(principal_id, created_at, items)
+    if (
+        type(items) not in (list, tuple)
+        or not items
+        or len(items) > MAX_ITEMS
+    ):
+        return _rejected(*reasons)
+    normalized: list[PrincipalMemexItem] = []
+    for raw in items:
+        item, item_reasons = _rehydrate_item(raw)
+        reasons.extend(item_reasons)
+        if item is not None:
+            normalized.append(item)
+    if normalized and any(item.principal_id != principal_id for item in normalized):
+        reasons.append("principal_memex_cross_principal_item")
+    reasons.extend(_principal_memex_supersession_reasons(normalized))
+    item_ids = [item.item_id for item in normalized]
+    if len(item_ids) != len(set(item_ids)):
+        reasons.append("principal_memex_duplicate_item")
+    if reasons:
+        return _rejected(*reasons)
+    projection = _build_projection(principal_id, normalized, created_at)
+    return _create_principal_memex_projection_result(
+        True, PROJECTION_READY, projection, ()
+    )
+
+
+def rehydrate_principal_memex_projection(
+    raw: Mapping[str, Any] | PrincipalMemexProjection,
+) -> PrincipalMemexProjectionResult:
+    payload = raw.to_dict() if isinstance(raw, PrincipalMemexProjection) else raw
+    if (
+        type(payload) is not dict
+        or len(payload) != len(_PROJECTION_FIELDS)
+        or set(payload) != _PROJECTION_FIELDS
+    ):
+        return _rejected("principal_memex_projection_schema_fields_invalid")
+    if not _serialized_projection_types_valid(payload):
+        return _rejected("principal_memex_projection_type_invalid")
+    item_result = project_principal_memex_readonly(
+        principal_id=_strict_string(payload.get("principal_id")),
+        items=_strict_sequence(payload.get("items")),
+        created_at=_strict_string(payload.get("created_at")),
+    )
+    if not item_result.accepted or item_result.projection is None:
+        return item_result
+    expected = item_result.projection.to_dict()
+    if any(payload.get(name) != expected[name] for name in _PROJECTION_FIELDS):
+        return _rejected("principal_memex_projection_digest_or_boundary_mismatch")
+    return item_result
+
+
+def _build_projection(
+    principal_id: str, items: Sequence[PrincipalMemexItem], created_at: str,
+) -> PrincipalMemexProjection:
+    ordered = tuple(sorted(items, key=lambda item: item.item_id))
+    item_ids = tuple(item.item_id for item in ordered)
+    source_ids = tuple(sorted({item.source_receipt_id for item in ordered}))
+    manifest = digest_json(
+        [{"item_id": item.item_id, "content_digest": item.content_digest} for item in ordered]
+    )
+    payload = {
+        "schema_version": PROJECTION_SCHEMA_VERSION,
+        "source_class": SOURCE_CLASS_PRINCIPAL_MEMEX,
+        "principal_id": principal_id,
+        "created_at": created_at,
+        "item_ids": item_ids,
+        "source_receipt_ids": source_ids,
+        "manifest_digest": manifest,
+        "verification": STRUCTURAL_VERIFICATION,
+        "runtime_admissible": False,
+        "no_persistence_performed": True,
+        "no_model_context_admission_performed": True,
+        "no_foundup_projection_performed": True,
+        "no_holoindex_write_performed": True,
+        "no_work_authority_granted": True,
+    }
+    return _create_principal_memex_projection(
+        **payload, projection_id=digest_json(payload), items=ordered
+    )
+
+
+def _rehydrate_item(
+    raw: PrincipalMemexItem | Mapping[str, Any],
+) -> tuple[PrincipalMemexItem | None, list[str]]:
+    payload = raw.to_dict() if isinstance(raw, PrincipalMemexItem) else raw
+    if (
+        type(payload) is not dict
+        or len(payload) != len(_ITEM_FIELDS)
+        or set(payload) != _ITEM_FIELDS
+    ):
+        return None, ["principal_memex_item_schema_fields_invalid"]
+    if any(type(payload.get(name)) is not str for name in _ITEM_FIELDS):
+        return None, ["principal_memex_item_type_invalid"]
+    item = PrincipalMemexItem(**{name: payload[name] for name in _ITEM_FIELDS})
+    return item, list(_principal_memex_item_reasons(item))
+
+
+def _projection_input_reasons(
+    principal_id: object, created_at: object, items: object,
+) -> list[str]:
+    reasons: list[str] = []
+    if type(principal_id) is not str or not principal_id:
+        reasons.append("principal_memex_principal_id_invalid")
+    if type(created_at) is not str or not _principal_memex_valid_time(created_at):
+        reasons.append("principal_memex_projection_created_at_invalid")
+    if type(items) not in (list, tuple) or not items:
+        reasons.append("principal_memex_items_missing")
+    elif len(items) > MAX_ITEMS:
+        reasons.append("principal_memex_item_limit_exceeded")
+    return reasons
+
+
+def _serialized_projection_types_valid(payload: Mapping[str, Any]) -> bool:
+    string_fields = _PROJECTION_FIELDS - _PROJECTION_BOOLEAN_FIELDS - {
+        "item_ids",
+        "source_receipt_ids",
+        "items",
+    }
+    if any(type(payload.get(name)) is not str for name in string_fields):
+        return False
+    if any(type(payload.get(name)) is not bool for name in _PROJECTION_BOOLEAN_FIELDS):
+        return False
+    for name in ("item_ids", "source_receipt_ids", "items"):
+        if type(payload.get(name)) is not list:
+            return False
+    if (
+        not 0 < len(payload["items"]) <= MAX_ITEMS
+        or len(payload["item_ids"]) != len(payload["items"])
+        or len(payload["source_receipt_ids"]) > MAX_ITEMS
+    ):
+        return False
+    if any(
+        type(item) is not str
+        for name in ("item_ids", "source_receipt_ids")
+        for item in payload[name]
+    ):
+        return False
+    if any(type(item) is not dict for item in payload["items"]):
+        return False
+    return True
+
+
+def _strict_string(value: object) -> str:
+    return value if type(value) is str else ""
+
+
+def _strict_sequence(value: object) -> Sequence[Any]:
+    return value if type(value) is list else ()
+
+
+def _rejected(*reasons: str) -> PrincipalMemexProjectionResult:
+    return _create_principal_memex_projection_result(
+        False, PROJECTION_REJECTED, None, tuple(dict.fromkeys(reasons))
+    )
+
+
+__all__ = [
+    "build_principal_memex_item",
+    "project_principal_memex_readonly",
+    "rehydrate_principal_memex_projection",
+]

--- a/modules/ai_intelligence/digital_twin/tests/TestModLog.md
+++ b/modules/ai_intelligence/digital_twin/tests/TestModLog.md
@@ -14,6 +14,13 @@
 - evidence location (log file, screenshot)
 
 ## Entries
+- 2026-08-06
+  - Command: `pytest -q modules/ai_intelligence/digital_twin/tests/test_principal_memex_projection.py`
+  - Result: PASS (32/32)
+  - Coverage: round-trip rehydration, digest tamper, cross-principal and
+    duplicate rejection, exact JSON type policy, secret material,
+    pre-traversal mapping bounds, factory-bound typed results,
+    multi-generation supersession, and no-authority fields.
 - 2026-02-04
   - Command: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest modules/ai_intelligence/digital_twin/tests`
   - Result: PASS (17/17)

--- a/modules/ai_intelligence/digital_twin/tests/test_principal_memex_projection.py
+++ b/modules/ai_intelligence/digital_twin/tests/test_principal_memex_projection.py
@@ -1,0 +1,420 @@
+"""Read-only 012 Principal Memex projection contract tests."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+
+import pytest
+
+from holo_index.query_receipt import digest_json
+from modules.ai_intelligence.digital_twin.src.principal_memex_projection import (
+    build_principal_memex_item,
+    project_principal_memex_readonly,
+    rehydrate_principal_memex_projection,
+)
+from modules.ai_intelligence.digital_twin.src.principal_memex_contract import (
+    PROJECTION_READY,
+    PrincipalMemexProjection,
+    PrincipalMemexProjectionResult,
+    _create_principal_memex_projection,
+)
+
+
+NOW = "2026-08-06T12:00:00+00:00"
+RECEIPT = "sha256:" + "1" * 64
+
+
+def _item(**overrides: object):
+    values = {
+        "principal_id": "012",
+        "category": "architectural_principle",
+        "statement": "Audit before implementation.",
+        "source_kind": "principal_statement",
+        "source_receipt_id": RECEIPT,
+        "source_revision": "conversation:42",
+        "created_at": NOW,
+        "sensitivity": "private",
+    }
+    values.update(overrides)
+    return build_principal_memex_item(**values)
+
+
+def _private_factory_values(projection, items, *, created_at: str = NOW):
+    values = {
+        key: value
+        for key, value in projection.to_dict().items()
+        if key not in {"projection_id", "items"}
+    }
+    values["created_at"] = created_at
+    values["item_ids"] = tuple(item.item_id for item in items)
+    values["source_receipt_ids"] = tuple(
+        sorted({item.source_receipt_id for item in items})
+    )
+    values["manifest_digest"] = digest_json(
+        [
+            {"item_id": item.item_id, "content_digest": item.content_digest}
+            for item in items
+        ]
+    )
+    return values
+
+
+def _construct_with_private_factory(projection, items, *, created_at: str = NOW):
+    values = _private_factory_values(projection, items, created_at=created_at)
+    return _create_principal_memex_projection(
+        **values,
+        projection_id=digest_json(values),
+        items=items,
+    )
+
+
+def test_valid_projection_is_structural_readonly_and_round_trips() -> None:
+    result = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    )
+
+    assert result.accepted is True
+    projection = result.projection
+    assert projection is not None
+    assert projection.source_class == "principal_memex"
+    assert projection.verification == "STRUCTURAL_ONLY"
+    assert projection.runtime_admissible is False
+    assert projection.no_persistence_performed is True
+    assert projection.no_model_context_admission_performed is True
+    assert projection.no_foundup_projection_performed is True
+    assert projection.no_holoindex_write_performed is True
+    assert projection.no_work_authority_granted is True
+    assert rehydrate_principal_memex_projection(projection.to_dict()).accepted is True
+
+
+@pytest.mark.parametrize(
+    "field,value,reason",
+    [
+        ("category", "foundup_work", "principal_memex_category_invalid"),
+        ("source_kind", "model_claim", "principal_memex_source_kind_invalid"),
+        ("retention_state", "approved", "principal_memex_retention_invalid"),
+        ("sensitivity", "worker", "principal_memex_sensitivity_invalid"),
+        ("created_at", "now", "principal_memex_created_at_invalid"),
+        ("source_receipt_id", "sha256:claim", "principal_memex_source_receipt_id_invalid"),
+    ],
+)
+def test_item_policy_rejects_invalid_values(field: str, value: str, reason: str) -> None:
+    item = _item()
+    forged = replace(item, **{field: value})
+    result = project_principal_memex_readonly(
+        principal_id="012", items=[forged], created_at=NOW
+    )
+    assert result.accepted is False
+    assert reason in result.rejection_reasons
+
+
+def test_cross_principal_and_duplicate_items_fail_closed() -> None:
+    item = _item()
+    cross = _item(principal_id="999")
+    cross_result = project_principal_memex_readonly(
+        principal_id="012", items=[item, cross], created_at=NOW
+    )
+    duplicate_result = project_principal_memex_readonly(
+        principal_id="012", items=[item, item], created_at=NOW
+    )
+    assert "principal_memex_cross_principal_item" in cross_result.rejection_reasons
+    assert "principal_memex_duplicate_item" in duplicate_result.rejection_reasons
+
+
+def test_tampered_item_and_projection_digests_fail_closed() -> None:
+    item = _item()
+    tampered_item = replace(item, statement="Skip the audit.")
+    item_result = project_principal_memex_readonly(
+        principal_id="012", items=[tampered_item], created_at=NOW
+    )
+    valid = project_principal_memex_readonly(
+        principal_id="012", items=[item], created_at=NOW
+    ).projection
+    assert valid is not None
+    tampered_projection = valid.to_dict()
+    tampered_projection["manifest_digest"] = "sha256:" + "2" * 64
+    projection_result = rehydrate_principal_memex_projection(tampered_projection)
+    assert "principal_memex_item_digest_mismatch" in item_result.rejection_reasons
+    assert projection_result.rejection_reasons == (
+        "principal_memex_projection_digest_or_boundary_mismatch",
+    )
+
+
+def test_serialized_acceptance_claim_and_unknown_fields_are_not_trusted() -> None:
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    ).projection
+    assert projection is not None
+    forged = projection.to_dict()
+    forged["accepted"] = True
+    result = rehydrate_principal_memex_projection(forged)
+    assert result.accepted is False
+    assert result.rejection_reasons == (
+        "principal_memex_projection_schema_fields_invalid",
+    )
+
+
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "api_key=not-allowed",
+        "password=not-allowed",
+        "private_key=material",
+        "Bearer abc.def.ghi",
+        "sk-forbiddenvalue",
+    ],
+)
+def test_secret_shaped_material_is_rejected(statement: str) -> None:
+    with pytest.raises(ValueError, match="principal_memex_secret_material_forbidden"):
+        _item(statement=statement)
+
+
+@pytest.mark.parametrize("field", ["principal_id", "source_revision"])
+def test_secret_shaped_provenance_is_rejected(field: str) -> None:
+    with pytest.raises(ValueError, match="principal_memex_secret_material_forbidden"):
+        _item(**{field: "api_key=not-allowed"})
+
+
+def test_no_foundup_or_authority_fields_exist_in_contract() -> None:
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    ).projection
+    assert projection is not None
+    serialized = projection.to_dict()
+    forbidden = {
+        "foundup_id",
+        "repository_id",
+        "work_order_id",
+        "allowed_paths",
+        "worker_id",
+        "merge_authority",
+    }
+    assert forbidden.isdisjoint(serialized)
+    assert forbidden.isdisjoint(serialized["items"][0])
+
+
+def test_naive_time_integer_boolean_and_oversized_projection_fail_closed() -> None:
+    item = _item()
+    naive = replace(item, created_at="2026-08-06T12:00:00")
+    naive_result = project_principal_memex_readonly(
+        principal_id="012", items=[naive], created_at=NOW
+    )
+    assert "principal_memex_created_at_invalid" in naive_result.rejection_reasons
+
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[item], created_at=NOW
+    ).projection
+    assert projection is not None
+    forged = projection.to_dict()
+    forged["no_work_authority_granted"] = 1
+    assert rehydrate_principal_memex_projection(forged).rejection_reasons == (
+        "principal_memex_projection_type_invalid",
+    )
+
+    oversized = project_principal_memex_readonly(
+        principal_id="012", items=[item] * 129, created_at=NOW
+    )
+    assert "principal_memex_item_limit_exceeded" in oversized.rejection_reasons
+
+
+@pytest.mark.parametrize("field", ["principal_id", "statement", "created_at"])
+def test_item_builder_rejects_non_string_values(field: str) -> None:
+    with pytest.raises(ValueError, match="principal_memex_item_type_invalid"):
+        _item(**{field: None})
+
+
+def test_serialized_projection_requires_exact_json_container_types() -> None:
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    ).projection
+    assert projection is not None
+
+    tuple_ids = projection.to_dict()
+    tuple_ids["item_ids"] = tuple(tuple_ids["item_ids"])
+    assert rehydrate_principal_memex_projection(tuple_ids).rejection_reasons == (
+        "principal_memex_projection_type_invalid",
+    )
+
+    numeric_source = projection.to_dict()
+    numeric_source["source_receipt_ids"] = [1]
+    assert rehydrate_principal_memex_projection(numeric_source).rejection_reasons == (
+        "principal_memex_projection_type_invalid",
+    )
+
+
+@pytest.mark.parametrize("items", [None, "not-an-item-list", []])
+def test_projection_rejects_malformed_item_containers(items: object) -> None:
+    result = project_principal_memex_readonly(
+        principal_id="012", items=items, created_at=NOW
+    )
+    assert result.accepted is False
+    assert result.rejection_reasons == ("principal_memex_items_missing",)
+
+
+def test_projection_rejects_hostile_and_oversized_containers_before_traversal() -> None:
+    class HostileSequence(Sequence):
+        def __getitem__(self, _index: int):
+            raise AssertionError("hostile sequence traversed")
+
+        def __len__(self) -> int:
+            raise AssertionError("hostile sequence measured")
+
+    hostile = project_principal_memex_readonly(
+        principal_id="012", items=HostileSequence(), created_at=NOW
+    )
+    assert hostile.rejection_reasons == ("principal_memex_items_missing",)
+
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    ).projection
+    assert projection is not None
+    oversized = projection.to_dict()
+    oversized["items"] = [oversized["items"][0]] * 129
+    oversized["item_ids"] = [projection.item_ids[0]] * 129
+    assert rehydrate_principal_memex_projection(oversized).rejection_reasons == (
+        "principal_memex_projection_type_invalid",
+    )
+
+    oversized_projection_mapping = {f"extra_{index}": index for index in range(50_000)}
+    oversized_projection_mapping.update(projection.to_dict())
+    assert rehydrate_principal_memex_projection(
+        oversized_projection_mapping
+    ).rejection_reasons == ("principal_memex_projection_schema_fields_invalid",)
+
+    oversized_item_mapping = {f"extra_{index}": index for index in range(50_000)}
+    oversized_item_mapping.update(_item().to_dict())
+    bounded = project_principal_memex_readonly(
+        principal_id="012", items=[oversized_item_mapping], created_at=NOW
+    )
+    assert bounded.rejection_reasons == (
+        "principal_memex_item_schema_fields_invalid",
+    )
+
+
+def test_supersession_relationships_are_projection_coherent() -> None:
+    old = _item(statement="Use one implementation pass.", retention_state="superseded")
+    current = _item(
+        statement="Audit before implementation.",
+        source_revision="conversation:43",
+        supersedes_item_id=old.item_id,
+    )
+    assert project_principal_memex_readonly(
+        principal_id="012", items=[old, current], created_at=NOW
+    ).accepted is True
+
+    orphan = project_principal_memex_readonly(
+        principal_id="012", items=[old], created_at=NOW
+    )
+    assert "principal_memex_supersession_target_count_invalid" in orphan.rejection_reasons
+
+    missing_target = _item(supersedes_item_id="sha256:" + "9" * 64)
+    missing = project_principal_memex_readonly(
+        principal_id="012", items=[missing_target], created_at=NOW
+    )
+    assert "principal_memex_supersession_target_missing" in missing.rejection_reasons
+
+    first = _item(statement="Implement before auditing.", retention_state="superseded")
+    second = _item(
+        statement="Audit and then implement.",
+        source_revision="conversation:44",
+        retention_state="superseded",
+        supersedes_item_id=first.item_id,
+    )
+    third = _item(
+        statement="Audit, refute-test, then implement.",
+        source_revision="conversation:45",
+        supersedes_item_id=second.item_id,
+    )
+    assert project_principal_memex_readonly(
+        principal_id="012", items=[first, second, third], created_at=NOW
+    ).accepted is True
+
+
+def test_typed_projection_objects_enforce_boundary_invariants() -> None:
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    ).projection
+    assert projection is not None
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        replace(projection, runtime_admissible=True)
+    with pytest.raises(ValueError, match="principal_memex_projection_result_invalid"):
+        PrincipalMemexProjectionResult(True, PROJECTION_READY, None, ())
+
+    forged_values = projection.to_dict()
+    forged_values["items"] = tuple(projection.items)
+    forged_values["item_ids"] = tuple(projection.item_ids)
+    forged_values["source_receipt_ids"] = tuple(projection.source_receipt_ids)
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        PrincipalMemexProjection(**forged_values)
+
+    class StatefulBool:
+        def __bool__(self) -> bool:
+            return False
+
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        replace(projection, runtime_admissible=StatefulBool())
+    with pytest.raises(ValueError, match="principal_memex_projection_result_invalid"):
+        PrincipalMemexProjectionResult(1, PROJECTION_READY, projection, ())
+
+
+def test_private_factory_rejects_policy_invalid_projection_shapes() -> None:
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[_item()], created_at=NOW
+    ).projection
+    assert projection is not None
+
+    orphan = _item(retention_state="superseded")
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        _construct_with_private_factory(projection, (orphan,))
+
+    second_item = _item(statement="Keep scopes isolated.", source_revision="conversation:46")
+    ordered = project_principal_memex_readonly(
+        principal_id="012", items=[_item(), second_item], created_at=NOW
+    ).projection
+    assert ordered is not None
+    reversed_items = tuple(reversed(ordered.items))
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        _construct_with_private_factory(ordered, reversed_items)
+
+
+def test_private_factory_rejects_duplicates_and_invalid_timestamp() -> None:
+    item = _item()
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[item], created_at=NOW
+    ).projection
+    assert projection is not None
+
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        _construct_with_private_factory(projection, (item, item))
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        _construct_with_private_factory(
+            projection, (item,), created_at="not-a-time"
+        )
+
+
+def test_private_factory_bounds_identifier_tuples_before_traversal() -> None:
+    item = _item()
+    projection = project_principal_memex_readonly(
+        principal_id="012", items=[item], created_at=NOW
+    ).projection
+    assert projection is not None
+    values = _private_factory_values(projection, (item,))
+    values["item_ids"] = tuple("sha256:" + "a" * 64 for _ in range(50_000))
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        _create_principal_memex_projection(
+            **values,
+            projection_id="sha256:" + "b" * 64,
+            items=(item,),
+        )
+
+    values = _private_factory_values(projection, (item,))
+    values["source_receipt_ids"] = tuple(
+        "sha256:" + "c" * 64 for _ in range(50_000)
+    )
+    with pytest.raises(ValueError, match="principal_memex_projection_boundary_invalid"):
+        _create_principal_memex_projection(
+            **values,
+            projection_id="sha256:" + "d" * 64,
+            items=(item,),
+        )


### PR DESCRIPTION
## Summary
- add the first typed, deterministic 012 Principal Memex projection owned by the Digital Twin module
- define the RedDog host / 0102 Digital Twin / Principal Memex / FoundUp Memex boundary in WSP 60, ADR, and architecture registry
- fail closed on malformed, secret-shaped, cross-principal, duplicate, inconsistent supersession, and tampered structural projections

## Truth boundary
- structural projection only: `STRUCTURAL_ONLY`, `runtime_admissible=false`
- no persistence, resident model-context admission, FoundUp projection, HoloIndex write, or work authority
- source authentication and resident admission remain a later slice
- HoloIndex retrieval failed closed with a stale/mismatched generation; no reindex was performed in this worktree

## Validation
- `pytest -q modules/ai_intelligence/digital_twin/tests` -> 49 passed
- focused projection suite -> 32 passed
- compileall, YAML parse, ASCII/NUL, diff check, and WSP 62 checks passed
- WSP framework/knowledge mirrors are byte-identical
- two independent exact-SHA reviews returned GO after adversarial factory/type/bounds/supersession probes

Worker-Lane: digital-twin-principal-memex
Slice: REDDOG_012_PRINCIPAL_MEMEX_READONLY_PROJECTION_PHASE1