### PR TITLE
fix(startup): harden RedDog queue and dependency preflights

### DIFF
--- a/main.py
+++ b/main.py
@@ -676,17 +676,32 @@ def run_dependency_security_preflight(repo_root: Path) -> bool:
         print(f"[DEP-SECURITY] Preflight warning: {exc}")
         return True
 
-    totals = status.get("totals", {}) if isinstance(status, dict) else {}
+    return _report_dependency_security_status(status, enforced=enforced)
+
+
+def _report_dependency_security_status(
+    status: Mapping[str, Any], *, enforced: bool,
+) -> bool:
+    totals = status.get("totals", {})
     critical = int(totals.get("critical", 0) or 0)
     high = int(totals.get("high", 0) or 0)
     unknown = int(totals.get("unknown", 0) or 0)
     tool_failures = int(status.get("tool_failures", 0) or 0)
+    evidence_failures = int(status.get("evidence_failures", 0) or 0)
     cached = bool(status.get("cached", False))
     passed = bool(status.get("passed", False))
+    degraded = bool(status.get("degraded", False))
     cache_state = "cached" if cached else "fresh"
+    decision = "PASS" if passed else ("WARN" if degraded else "FAIL")
+    findings = (
+        "counts=WITHHELD"
+        if status.get("counts_withheld", False)
+        else f"critical={critical} high={high} unknown={unknown}"
+    )
     print(
-        f"[DEP-SECURITY] preflight={'PASS' if passed else 'FAIL'} ({cache_state}) "
-        f"critical={critical} high={high} unknown={unknown} tool_failures={tool_failures}"
+        f"[DEP-SECURITY] preflight={decision} ({cache_state}) "
+        f"{findings} "
+        f"tool_failures={tool_failures} evidence_failures={evidence_failures}"
     )
 
     if not passed:
@@ -695,18 +710,15 @@ def run_dependency_security_preflight(repo_root: Path) -> bool:
                 on_preflight_fail,
             )
 
-            severity = "critical" if critical > 0 else ("high" if high > 0 else "medium")
+            severity, payload = _dependency_failure_payload(
+                status, critical=critical, high=high, unknown=unknown,
+                tool_failures=tool_failures, evidence_failures=evidence_failures,
+                cache_state=cache_state, enforced=enforced,
+            )
             on_preflight_fail(
                 component="dep_security",
                 severity=severity,
-                payload={
-                    "critical": critical,
-                    "high": high,
-                    "unknown": unknown,
-                    "tool_failures": tool_failures,
-                    "cache_state": cache_state,
-                    "enforced": enforced,
-                },
+                payload=payload,
                 source="main.py:run_dep_security_preflight",
             )
         except Exception as exc:
@@ -716,6 +728,22 @@ def run_dependency_security_preflight(repo_root: Path) -> bool:
         print("[DEP-SECURITY] Startup blocked by OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED=1")
         return False
     return True
+
+
+def _dependency_failure_payload(
+    status: Mapping[str, Any], **values: object,
+) -> tuple[str, dict[str, object]]:
+    payload = dict(values)
+    if bool(status.get("counts_withheld", False)):
+        payload.pop("critical", None)
+        payload.pop("high", None)
+        payload.pop("unknown", None)
+        payload["counts_withheld"] = True
+        payload["cache_authority"] = str(status.get("cache_authority", "ADVISORY_ONLY"))
+        return "medium", payload
+    critical = int(payload.get("critical", 0) or 0)
+    high = int(payload.get("high", 0) or 0)
+    return ("critical" if critical > 0 else "high" if high > 0 else "medium"), payload
 
 
 def run_env_hygiene_preflight(repo_root: Path) -> bool:
@@ -1628,7 +1656,11 @@ def run_reddog_wre_queue_consumer_preflight(repo_root: Path) -> bool:
         print(f"[REDDOG-WRE-QUEUE] preflight=WARN error={type(exc).__name__}")
         return True
 
-    status = "PASS" if result.ready else "WARN"
+    return _report_reddog_wre_queue_consumer_result(result, enforced=enforced)
+
+
+def _report_reddog_wre_queue_consumer_result(result, *, enforced: bool) -> bool:
+    status = "PASS" if result.ready else ("FAIL" if enforced else "WARN")
     reasons = ",".join(result.rejection_reasons) if result.rejection_reasons else "(none)"
     print(
         f"[REDDOG-WRE-QUEUE] preflight={status} status={result.status} "

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,15 @@
 # ModLog - moltbot_bridge
+## 2026-08-08: RedDog startup queue runtime-root contract repair
+- Completed the existing `runtime_allowed_root` startup contract instead of
+  dropping the caller's confinement argument. The WRE queue dry-run now
+  validates an external runtime root and reads work state through the shared
+  descriptor-confined runtime-artifact helper.
+- Added regressions for missing roots, out-of-root work state, and the exact
+  `main.py` root/path forwarding pair. Enforced rejection is now reported as
+  `FAIL`, while non-enforced degraded startup remains `WARN`. No queue
+  mutation, worker dispatch, HoloIndex maintenance, or execution authority was
+  added. (WSP 00/15/22/50/97)
+
 ## 2026-08-06: Principal Memex live resident source supply
 - Bound one pre-issued principal disclosure to the current signed session,
   AgentDB revision, runtime generation, exact architect cycle, and model

--- a/modules/communication/moltbot_bridge/src/reddog_main_wre_queue_consumer_bootstrap.py
+++ b/modules/communication/moltbot_bridge/src/reddog_main_wre_queue_consumer_bootstrap.py
@@ -3,9 +3,16 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Optional
+
+from modules.infrastructure.shared_utilities.runtime_artifact_safety import (
+    secure_read_confined_text,
+    validate_runtime_artifact_path,
+    validate_runtime_root_path,
+)
 
 from modules.communication.moltbot_bridge.src.reddog_wre_queue_consumer_dryrun import (
     WRE_QUEUE_CONSUMER_DRYRUN_READY,
@@ -45,6 +52,7 @@ class RedDogMainWREQueueConsumerBootstrapResult:
 def run_reddog_main_wre_queue_consumer_bootstrap(
     *,
     repo_root: Path | str,
+    runtime_allowed_root: Path | str | None = None,
     work_state_path: Path | str | None,
     now_iso: str | None = None,
     requested_queue_item_id: str | None = None,
@@ -52,19 +60,22 @@ def run_reddog_main_wre_queue_consumer_bootstrap(
     """Load authoritative work state and dry-run consume one WRE queue item."""
 
     root = Path(repo_root).resolve()
-    if not work_state_path:
-        return _not_ready(("missing_authoritative_work_state_path",))
-    path = Path(work_state_path)
-    if not path.is_absolute():
-        path = (root / path).resolve()
-    else:
-        path = path.resolve()
-    if _is_inside(path, root):
-        return _not_ready(("work_state_path_inside_repo",))
-    if not path.exists() or not path.is_file():
-        return _not_ready(("missing_authoritative_work_state",))
+    runtime_root, reasons = _resolve_runtime_root(root, runtime_allowed_root)
+    if reasons:
+        return _not_ready(reasons)
+    assert runtime_root is not None
+    path, reasons = _resolve_work_state_path(
+        root,
+        runtime_root,
+        work_state_path,
+    )
+    if reasons:
+        return _not_ready(reasons)
+    assert path is not None
     try:
-        snapshot = json.loads(path.read_text(encoding="utf-8"))
+        snapshot = json.loads(
+            secure_read_confined_text(path, allowed_root=runtime_root)
+        )
     except Exception:
         return _not_ready(("malformed_authoritative_work_state",))
 
@@ -73,6 +84,10 @@ def run_reddog_main_wre_queue_consumer_bootstrap(
         now_iso=now_iso,
         requested_queue_item_id=requested_queue_item_id,
     )
+    return _bootstrap_result(result)
+
+
+def _bootstrap_result(result: Any) -> RedDogMainWREQueueConsumerBootstrapResult:
     if not result.accepted or result.status != WRE_QUEUE_CONSUMER_DRYRUN_READY:
         return RedDogMainWREQueueConsumerBootstrapResult(
             ready=False,
@@ -94,6 +109,46 @@ def run_reddog_main_wre_queue_consumer_bootstrap(
         rejection_reasons=(),
         receipt_id=receipt_id,
     )
+
+
+def _resolve_runtime_root(
+    repo_root: Path,
+    value: Path | str | None,
+) -> tuple[Optional[Path], tuple[str, ...]]:
+    if value is None or not str(value).strip():
+        return None, ("missing_runtime_artifact_root",)
+    runtime_root = Path(os.path.abspath(Path(value).expanduser()))
+    try:
+        return validate_runtime_root_path(runtime_root, repo_root=repo_root), ()
+    except ValueError:
+        return None, ("invalid_runtime_artifact_root",)
+
+
+def _resolve_work_state_path(
+    repo_root: Path,
+    runtime_root: Path,
+    value: Path | str | None,
+) -> tuple[Optional[Path], tuple[str, ...]]:
+    if not value:
+        return None, ("missing_authoritative_work_state_path",)
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = Path(os.path.abspath(repo_root / path))
+    else:
+        path = Path(os.path.abspath(path))
+    if _is_inside(path, repo_root):
+        return None, ("work_state_path_inside_repo",)
+    try:
+        path = validate_runtime_artifact_path(
+            path,
+            repo_root=repo_root,
+            allowed_root=runtime_root,
+        )
+    except ValueError:
+        return None, ("work_state_path_outside_runtime_root_or_linked",)
+    if not path.exists() or not path.is_file():
+        return None, ("missing_authoritative_work_state",)
+    return path, ()
 
 
 def _not_ready(reasons: tuple[str, ...]) -> RedDogMainWREQueueConsumerBootstrapResult:

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,10 @@
+## 2026-08-08: Startup queue runtime-root regressions
+
+- Proved the WRE queue bootstrap requires a valid runtime root, rejects
+  out-of-root state, and receives the exact root/path pair from `main.py`.
+- Focused queue-consumer and dependency-preflight matrix: 49 passed with two
+  platform symlink skips.
+
 ## 2026-08-06: Principal Memex live resident source regressions
 
 - Proved current-generation session splitting, principal-signed disclosure

--- a/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_consumer_dryrun.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from modules.communication.moltbot_bridge.src import (
     reddog_wre_queue_consumer_dryrun as consumer,
 )
@@ -264,6 +266,7 @@ def test_bootstrap_loads_work_state_outside_repo(tmp_path: Path) -> None:
 
     result = run_reddog_main_wre_queue_consumer_bootstrap(
         repo_root=REPO_ROOT,
+        runtime_allowed_root=tmp_path,
         work_state_path=path,
         now_iso=NOW,
     )
@@ -280,6 +283,7 @@ def test_bootstrap_loads_work_state_outside_repo(tmp_path: Path) -> None:
 def test_bootstrap_rejects_work_state_inside_repo() -> None:
     result = run_reddog_main_wre_queue_consumer_bootstrap(
         repo_root=REPO_ROOT,
+        runtime_allowed_root=REPO_ROOT.parent / "resident-runtime",
         work_state_path=REPO_ROOT / "inside-repo.json",
         now_iso=NOW,
     )
@@ -288,9 +292,103 @@ def test_bootstrap_rejects_work_state_inside_repo() -> None:
     assert "work_state_path_inside_repo" in result.rejection_reasons
 
 
+def test_bootstrap_requires_runtime_artifact_root(tmp_path: Path) -> None:
+    path = tmp_path / "authoritative_work_state.json"
+    path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        work_state_path=path,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert result.rejection_reasons == ("missing_runtime_artifact_root",)
+
+
+def test_bootstrap_rejects_work_state_outside_runtime_root(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    outside = tmp_path / "outside" / "authoritative_work_state.json"
+    outside.parent.mkdir()
+    outside.write_text(json.dumps(_snapshot()), encoding="utf-8")
+
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        runtime_allowed_root=runtime_root,
+        work_state_path=outside,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert result.rejection_reasons == (
+        "work_state_path_outside_runtime_root_or_linked",
+    )
+
+
+def test_bootstrap_rejects_invalid_runtime_root_inside_repo() -> None:
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        runtime_allowed_root=REPO_ROOT / "runtime",
+        work_state_path=REPO_ROOT / "runtime" / "state.json",
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert result.rejection_reasons == ("invalid_runtime_artifact_root",)
+
+
+def test_bootstrap_rejects_linked_work_state_path(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    target = runtime_root / "target.json"
+    target.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    linked = runtime_root / "linked.json"
+    try:
+        linked.symlink_to(target)
+    except OSError as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        runtime_allowed_root=runtime_root,
+        work_state_path=linked,
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert result.rejection_reasons == (
+        "work_state_path_outside_runtime_root_or_linked",
+    )
+
+
+def test_bootstrap_rejects_linked_runtime_root(tmp_path: Path) -> None:
+    target_root = tmp_path / "actual-runtime"
+    target_root.mkdir()
+    path = target_root / "state.json"
+    path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+    linked_root = tmp_path / "linked-runtime"
+    try:
+        linked_root.symlink_to(target_root, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlink unavailable: {exc}")
+
+    result = run_reddog_main_wre_queue_consumer_bootstrap(
+        repo_root=REPO_ROOT,
+        runtime_allowed_root=linked_root,
+        work_state_path=linked_root / "state.json",
+        now_iso=NOW,
+    )
+
+    assert result.ready is False
+    assert result.rejection_reasons == ("invalid_runtime_artifact_root",)
+
+
 def test_main_queue_consumer_preflight_passes_when_bootstrap_ready(tmp_path: Path) -> None:
     import main
 
+    runtime_root = tmp_path / "resident-runtime"
+    work_state_path = runtime_root / "state.json"
     with patch(
         "modules.communication.moltbot_bridge.src.reddog_main_wre_queue_consumer_bootstrap.run_reddog_main_wre_queue_consumer_bootstrap",
         return_value=type(
@@ -313,13 +411,15 @@ def test_main_queue_consumer_preflight_passes_when_bootstrap_ready(tmp_path: Pat
             {
                 "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN": "1",
                 "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED": "0",
-                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(tmp_path / "state.json"),
+                "REDDOG_AUTHORITATIVE_WORK_STATE_PATH": str(work_state_path),
+                "REDDOG_RESIDENT_RUNTIME_ROOT": str(runtime_root),
             },
             clear=False,
         ):
             assert main.run_reddog_wre_queue_consumer_preflight(REPO_ROOT) is True
 
-    assert mocked.call_args.kwargs["work_state_path"] == str(tmp_path / "state.json")
+    assert mocked.call_args.kwargs["work_state_path"] == str(work_state_path)
+    assert mocked.call_args.kwargs["runtime_allowed_root"] == str(runtime_root)
 
 
 def test_main_queue_consumer_preflight_profile_derives_work_state_path(tmp_path: Path) -> None:
@@ -357,7 +457,44 @@ def test_main_queue_consumer_preflight_profile_derives_work_state_path(tmp_path:
     assert mocked.call_args.kwargs["work_state_path"] == str(
         runtime_root / "authoritative_work_state.json"
     )
+    assert mocked.call_args.kwargs["runtime_allowed_root"] == str(runtime_root)
     assert not runtime_root.exists()
+
+
+def test_main_queue_consumer_real_bootstrap_warns_without_runtime_root(capsys) -> None:
+    import main
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN": "1",
+            "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED": "0",
+        },
+        clear=True,
+    ):
+        assert main.run_reddog_wre_queue_consumer_preflight(REPO_ROOT) is True
+
+    output = capsys.readouterr().out
+    assert "preflight=WARN" in output
+    assert "missing_runtime_artifact_root" in output
+
+
+def test_main_queue_consumer_real_bootstrap_blocks_when_enforced(capsys) -> None:
+    import main
+
+    with patch.dict(
+        "os.environ",
+        {
+            "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN": "1",
+            "REDDOG_WRE_QUEUE_CONSUMER_DRYRUN_ENFORCED": "1",
+        },
+        clear=True,
+    ):
+        assert main.run_reddog_wre_queue_consumer_preflight(REPO_ROOT) is False
+
+    output = capsys.readouterr().out
+    assert "preflight=FAIL" in output
+    assert "missing_runtime_artifact_root" in output
 
 
 def test_main_queue_consumer_preflight_blocks_when_enforced() -> None:

--- a/modules/infrastructure/wre_core/ModLog.md
+++ b/modules/infrastructure/wre_core/ModLog.md
@@ -1,5 +1,24 @@
 # WRE Core - ModLog
 ## Chronological Change Log
+### [2026-08-08] - DEPENDENCY PREFLIGHT EVIDENCE INTEGRITY
+
+- Captured scanner output as bytes and required strict UTF-8 JSON evidence,
+  preventing Windows host-codepage reader failures and silent loss of npm
+  findings. Human-readable stderr alone permits replacement decoding.
+- Required the pip, npm, and cargo schema plus allowed exit status before
+  counts are trusted. Invalid encoding, empty/malformed JSON, missing schema,
+  and cargo exit 101 are now evidence failures rather than zero findings.
+- Recovered the live `clerk-nextjs` npm evidence that the former reader lost:
+  2 critical and 7 high findings now reach the startup policy unchanged.
+- Required npm and cargo summary totals to agree with their detailed evidence.
+- Audited every discovered Rust lockfile from its own crate directory so one
+  clean crate cannot hide a vulnerable nested crate.
+- Added evidence-failure telemetry without changing vulnerability thresholds
+  or startup enforcement policy. Cache v3 binds scanner policy, installed
+  Python packages, tool identity, and lockfile content; it is advisory-only,
+  withholds unsigned counts, and enforced startup always performs a live scan.
+  (WSP 00/15/22/50/97)
+
 ### [2026-08-02] - LEGACY SELF-AUDIT PROCESS DISPATCH MASTER GATE
 
 - Added a common fail-closed master gate at both legacy self-audit process

--- a/modules/infrastructure/wre_core/src/dependency_security_preflight.py
+++ b/modules/infrastructure/wre_core/src/dependency_security_preflight.py
@@ -4,14 +4,20 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import math
 import os
 import shutil
 import subprocess
 import sys
 import time
+from importlib import metadata
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List, Optional
+
+
+_CACHE_SCHEMA_VERSION = "dependency_security_preflight.v3"
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -36,27 +42,48 @@ def _run(cmd: List[str], timeout_sec: int = 180, cwd: Path | None = None) -> Dic
         completed = subprocess.run(
             cmd,
             capture_output=True,
-            text=True,
+            text=False,
             timeout=timeout_sec,
             cwd=str(cwd) if cwd else None,
         )
+        stderr = _decode_output(completed.stderr, errors="replace")
+        try:
+            stdout = _decode_output(completed.stdout, errors="strict")
+        except UnicodeDecodeError:
+            return {
+                "ok": False,
+                "failure_kind": "invalid_stdout_encoding",
+                "code": int(completed.returncode),
+                "stdout": "",
+                "stderr": "invalid_utf8_scanner_stdout",
+                "cmd": cmd,
+                "cwd": str(cwd) if cwd else "",
+            }
         return {
             "ok": True,
+            "failure_kind": "",
             "code": int(completed.returncode),
-            "stdout": completed.stdout or "",
-            "stderr": completed.stderr or "",
+            "stdout": stdout,
+            "stderr": stderr,
             "cmd": cmd,
             "cwd": str(cwd) if cwd else "",
         }
     except Exception as exc:
         return {
             "ok": False,
+            "failure_kind": "process_error",
             "code": 127,
             "stdout": "",
             "stderr": str(exc),
             "cmd": cmd,
             "cwd": str(cwd) if cwd else "",
         }
+
+
+def _decode_output(value: object, *, errors: str) -> str:
+    if isinstance(value, str):
+        return value
+    return bytes(value or b"").decode("utf-8", errors=errors)
 
 
 def _resolve_tool(name: str) -> str:
@@ -71,30 +98,49 @@ def _resolve_tool(name: str) -> str:
     return name
 
 
-def _count_pip_audit(stdout: str) -> Dict[str, int]:
-    """Best-effort parse for pip-audit json payload."""
-    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+def _empty_counts() -> Dict[str, int]:
+    return {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+
+
+def _load_scanner_json(stdout: str) -> object:
+    if not str(stdout or "").strip():
+        raise ValueError("empty_scanner_json")
     try:
-        payload = json.loads(stdout or "[]")
-    except Exception:
-        counts["unknown"] = 1
-        return counts
+        return json.loads(stdout)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("malformed_scanner_json") from exc
+
+
+def _count_pip_audit(stdout: str) -> Dict[str, int]:
+    """Parse and validate a pip-audit JSON payload."""
+    counts = _empty_counts()
+    payload = _load_scanner_json(stdout)
 
     # pip-audit historically emitted a list; newer versions emit
     # {"dependencies":[...], "fixes":[...]}.
     deps: List[Dict[str, Any]] = []
     if isinstance(payload, list):
-        deps = [item for item in payload if isinstance(item, dict)]
+        if not all(isinstance(item, dict) for item in payload):
+            raise ValueError("invalid_pip_dependency_entry")
+        deps = list(payload)
     elif isinstance(payload, dict):
-        deps = [item for item in (payload.get("dependencies") or []) if isinstance(item, dict)]
+        raw_deps = payload.get("dependencies")
+        if not isinstance(raw_deps, list) or not all(
+            isinstance(item, dict) for item in raw_deps
+        ):
+            raise ValueError("invalid_pip_dependencies")
+        deps = list(raw_deps)
     else:
-        counts["unknown"] = 1
-        return counts
+        raise ValueError("invalid_pip_payload")
 
     for pkg in deps:
-        vulns = pkg.get("vulns", []) if isinstance(pkg, dict) else []
+        vulns = pkg.get("vulns", [])
+        if not isinstance(vulns, list) or not all(
+            isinstance(vuln, dict) for vuln in vulns
+        ):
+            raise ValueError("invalid_pip_vulnerabilities")
         for vuln in vulns:
-            sev = str((vuln or {}).get("severity", "unknown")).strip().lower()
+            sev = str(vuln.get("severity", "unknown")).strip().lower()
             if sev in counts:
                 counts[sev] += 1
             elif sev == "moderate":
@@ -105,37 +151,79 @@ def _count_pip_audit(stdout: str) -> Dict[str, int]:
 
 
 def _count_npm_audit(stdout: str) -> Dict[str, int]:
-    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
-    try:
-        payload = json.loads(stdout or "{}")
-        vulns = ((payload or {}).get("metadata") or {}).get("vulnerabilities") or {}
-        for key in ("critical", "high", "moderate", "low"):
-            value = int(vulns.get(key, 0) or 0)
-            if key == "moderate":
-                counts["medium"] += value
-            else:
-                counts[key] += value
-    except Exception:
-        counts["unknown"] = 1
+    counts = _empty_counts()
+    payload = _load_scanner_json(stdout)
+    if not isinstance(payload, dict) or not isinstance(payload.get("metadata"), dict):
+        raise ValueError("invalid_npm_metadata")
+    vulns = payload["metadata"].get("vulnerabilities")
+    if not isinstance(vulns, dict):
+        raise ValueError("invalid_npm_vulnerabilities")
+    values = {
+        key: _nonnegative_int(vulns.get(key), field=f"npm_{key}")
+        for key in ("info", "low", "moderate", "high", "critical", "total")
+    }
+    if values["total"] != sum(
+        values[key] for key in ("info", "low", "moderate", "high", "critical")
+    ):
+        raise ValueError("invalid_npm_total")
+    counts["unknown"] = values["info"]
+    for key in ("critical", "high", "moderate", "low"):
+        value = values[key]
+        if key == "moderate":
+            counts["medium"] = value
+        else:
+            counts[key] = value
     return counts
 
 
 def _count_cargo_audit(stdout: str) -> Dict[str, int]:
-    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
-    try:
-        payload = json.loads(stdout or "{}")
-        vulns = ((payload or {}).get("vulnerabilities") or {}).get("list") or []
-        for vuln in vulns:
-            sev = str((vuln or {}).get("severity", "unknown")).strip().lower()
-            if sev in counts:
-                counts[sev] += 1
-            elif sev == "moderate":
-                counts["medium"] += 1
-            else:
-                counts["unknown"] += 1
-    except Exception:
-        counts["unknown"] = 1
+    counts = _empty_counts()
+    payload = _load_scanner_json(stdout)
+    if not isinstance(payload, dict) or not isinstance(payload.get("vulnerabilities"), dict):
+        raise ValueError("invalid_cargo_vulnerabilities")
+    block = payload["vulnerabilities"]
+    found = block.get("found")
+    count = _nonnegative_int(block.get("count"), field="cargo_count")
+    vulns = block.get("list")
+    if not isinstance(vulns, list) or not all(isinstance(item, dict) for item in vulns):
+        raise ValueError("invalid_cargo_vulnerability_list")
+    if not isinstance(found, bool) or count != len(vulns) or found != (count > 0):
+        raise ValueError("invalid_cargo_summary")
+    for vuln in vulns:
+        sev = str(vuln.get("severity", "unknown")).strip().lower()
+        if sev in counts:
+            counts[sev] += 1
+        elif sev == "moderate":
+            counts["medium"] += 1
+        else:
+            counts["unknown"] += 1
     return counts
+
+
+def _nonnegative_int(value: object, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"invalid_{field}")
+    if value < 0:
+        raise ValueError(f"invalid_{field}")
+    return value
+
+
+def _validated_counts(
+    result: Dict[str, Any],
+    parser: Callable[[str], Dict[str, int]],
+    *,
+    allowed_exit_codes: frozenset[int],
+) -> tuple[Optional[Dict[str, int]], str, bool]:
+    if not result.get("ok"):
+        kind = str(result.get("failure_kind") or "process_error")
+        return None, str(result.get("stderr") or kind)[:240], kind != "process_error"
+    code = int(result.get("code", 127))
+    if code not in allowed_exit_codes:
+        return None, f"unexpected_scanner_exit:{code}", True
+    try:
+        return parser(str(result.get("stdout") or "")), f"exit={code}", False
+    except (TypeError, ValueError):
+        return None, "invalid_scanner_json_evidence", True
 
 
 def _merge_counts(dest: Dict[str, int], source: Dict[str, int]) -> None:
@@ -181,16 +269,130 @@ def _cache_path(repo_root: Path) -> Path:
     )
 
 
+def _file_identity(path: Path, repo_root: Path) -> Dict[str, Any]:
+    try:
+        stat = path.stat()
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        try:
+            label = str(path.relative_to(repo_root)).replace("\\", "/")
+        except ValueError:
+            label = str(path)
+        return {"path": label, "size": stat.st_size, "digest": digest}
+    except OSError:
+        return {"path": str(path), "missing": True}
+
+
+def _tool_identity(name: str) -> Dict[str, Any]:
+    resolved = Path(sys.executable) if name == "python" else Path(_resolve_tool(name))
+    if not resolved.is_absolute() or not resolved.exists():
+        return {"name": name, "resolved": str(resolved), "missing": True}
+    stat = resolved.stat()
+    return {
+        "name": name,
+        "resolved": str(resolved),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _python_environment_digest() -> str:
+    packages = sorted(
+        f"{str(dist.metadata.get('Name') or '').lower()}=={dist.version}"
+        for dist in metadata.distributions()
+    )
+    raw = "\n".join(packages).encode("utf-8")
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
+def _cache_context_digest(
+    repo_root: Path,
+    *,
+    config: Dict[str, Any],
+    node_lockfiles: List[Path],
+    cargo_lockfiles: List[Path],
+) -> str:
+    payload = {
+        "config": config,
+        "python_environment_digest": _python_environment_digest(),
+        "tools": [
+            _tool_identity(name) for name in ("python", "npm", "cargo")
+        ],
+        "node_locks": [_file_identity(path, repo_root) for path in node_lockfiles],
+        "cargo_locks": [_file_identity(path, repo_root) for path in cargo_lockfiles],
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
 def _load_cache(path: Path) -> Dict[str, Any] | None:
     try:
         if not path.exists():
             return None
         payload = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(payload, dict):
+        if isinstance(payload, dict) and payload.get("schema_version") == _CACHE_SCHEMA_VERSION:
             return payload
     except Exception:
         return None
     return None
+
+
+def _cached_status(
+    payload: Dict[str, Any] | None, *, config: Dict[str, Any],
+    context_digest: str, now: float, ttl_sec: int,
+) -> Dict[str, Any] | None:
+    if not payload or payload.get("cache_context_digest") != context_digest:
+        return None
+    if payload.get("cache_config") != config:
+        return None
+    for key in (
+        "ttl_sec", "require_tools", "max_critical", "max_high",
+        "max_unknown", "node_lock_scope",
+    ):
+        if payload.get(key) != config.get(key):
+            return None
+    checked_at = payload.get("checked_at")
+    if isinstance(checked_at, bool) or not isinstance(checked_at, (int, float)):
+        return None
+    if not math.isfinite(checked_at):
+        return None
+    if checked_at <= 0 or checked_at > now or now - checked_at >= max(ttl_sec, 0):
+        return None
+    try:
+        totals = _validated_totals(payload.get("totals"))
+        tool_failures = _nonnegative_int(payload.get("tool_failures"), field="tool_failures")
+        evidence_failures = _nonnegative_int(
+            payload.get("evidence_failures"), field="evidence_failures"
+        )
+        expected = _status_passed(totals, config, tool_failures, evidence_failures)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload.get("passed"), bool) or payload["passed"] != expected:
+        return None
+    return _cached_advisory(config, context_digest, checked_at, ttl_sec)
+
+
+def _cached_advisory(
+    config: Dict[str, Any], context_digest: str, checked_at: float, ttl_sec: int,
+) -> Dict[str, Any]:
+    return {
+        "schema_version": _CACHE_SCHEMA_VERSION,
+        "available": False, "passed": False, "degraded": True, "cached": True,
+        "cache_authority": "ADVISORY_ONLY", "counts_withheld": True,
+        "totals": _empty_counts(), "tool_failures": 0, "evidence_failures": 1,
+        "checked_at": checked_at, "ttl_sec": ttl_sec,
+        "cache_context_digest": context_digest, "cache_config": dict(config),
+        "checks": [],
+        "message": "cached evidence is unsigned; scanner counts withheld",
+    }
+
+
+def _validated_totals(value: object) -> Dict[str, int]:
+    if not isinstance(value, dict):
+        raise ValueError("invalid_cached_totals")
+    return {
+        key: _nonnegative_int(value.get(key), field=f"cached_{key}")
+        for key in ("critical", "high", "medium", "low", "unknown")
+    }
 
 
 def _save_cache(path: Path, payload: Dict[str, Any]) -> None:
@@ -201,153 +403,197 @@ def _save_cache(path: Path, payload: Dict[str, Any]) -> None:
         return
 
 
+def _append_scanner_result(
+    *,
+    result: Dict[str, Any],
+    parser: Callable[[str], Dict[str, int]],
+    ecosystem: str,
+    label: str,
+    totals: Dict[str, int],
+    checks: List[Dict[str, Any]],
+    target: str = "",
+) -> tuple[int, int]:
+    counts, message, evidence_failure = _validated_counts(
+        result,
+        parser,
+        allowed_exit_codes=frozenset({0, 1}),
+    )
+    item: Dict[str, Any] = {"ecosystem": ecosystem}
+    if target:
+        item["target"] = target
+    if counts is None:
+        item.update(
+            available=bool(result.get("ok")),
+            passed=False,
+            message=message,
+            counts=_empty_counts(),
+        )
+        checks.append(item)
+        return 1, int(evidence_failure)
+    _merge_counts(totals, counts)
+    item.update(
+        available=True,
+        passed=True,
+        message=f"{label} {message}",
+        counts=counts,
+    )
+    checks.append(item)
+    return 0, 0
+
+
+def _run_security_checks(
+    repo_root: Path,
+    *,
+    check_node: bool,
+    check_rust: bool,
+    node_lockfiles: List[Path],
+    cargo_lockfiles: List[Path],
+) -> tuple[Dict[str, int], List[Dict[str, Any]], int, int, int]:
+    totals = _empty_counts()
+    checks: List[Dict[str, Any]] = []
+    failures = [0, 0]
+    py_cmd = [sys.executable, "-m", "pip_audit", "-f", "json", "--progress-spinner", "off"]
+    result = _append_scanner_result(
+        result=_run(py_cmd, timeout_sec=240), parser=_count_pip_audit,
+        ecosystem="python", label="pip-audit", totals=totals,
+        checks=checks,
+    )
+    failures = [sum(values) for values in zip(failures, result)]
+    if check_node:
+        for lock in node_lockfiles:
+            cmd = [_resolve_tool("npm"), "audit", "--json", "--package-lock-only", "--omit=dev"]
+            result = _append_scanner_result(
+                result=_run(cmd, timeout_sec=300, cwd=lock.parent),
+                parser=_count_npm_audit, ecosystem="node", label="npm audit",
+                totals=totals, checks=checks,
+                target=str(lock.relative_to(repo_root)).replace("\\", "/"),
+            )
+            failures = [sum(values) for values in zip(failures, result)]
+    if check_rust:
+        for lock in cargo_lockfiles:
+            result = _append_scanner_result(
+                result=_run(
+                    [_resolve_tool("cargo"), "audit", "--json"],
+                    timeout_sec=300,
+                    cwd=lock.parent,
+                ),
+                parser=_count_cargo_audit, ecosystem="rust", label="cargo audit",
+                totals=totals, checks=checks,
+                target=str(lock.relative_to(repo_root)).replace("\\", "/"),
+            )
+            failures = [sum(values) for values in zip(failures, result)]
+    return totals, checks, failures[0], failures[1], len(node_lockfiles)
+
+
+def _status_passed(
+    totals: Dict[str, int],
+    policy: Dict[str, Any],
+    tool_failures: int,
+    evidence_failures: int,
+) -> bool:
+    threshold_failure = (
+        totals["critical"] > int(policy["max_critical"])
+        or totals["high"] > int(policy["max_high"])
+        or totals["unknown"] > int(policy["max_unknown"])
+    )
+    return not threshold_failure and tool_failures == 0 and evidence_failures == 0
+
+
+def _build_status(
+    *,
+    totals: Dict[str, int],
+    checks: List[Dict[str, Any]],
+    now: float,
+    ttl_sec: int,
+    require_tools: bool,
+    thresholds: tuple[int, int, int],
+    node_lock_scope: str,
+    node_lock_count: int,
+    cargo_lock_count: int,
+    tool_failures: int,
+    evidence_failures: int,
+    cache_context_digest: str,
+    cache_config: Dict[str, Any],
+) -> Dict[str, Any]:
+    max_critical, max_high, max_unknown = thresholds
+    policy = {"max_critical": max_critical, "max_high": max_high, "max_unknown": max_unknown}
+    passed = _status_passed(totals, policy, tool_failures, evidence_failures)
+    degraded = not passed and evidence_failures == 0 and tool_failures > 0
+    return {
+        "schema_version": _CACHE_SCHEMA_VERSION,
+        "available": tool_failures == 0 and evidence_failures == 0,
+        "passed": passed, "degraded": degraded,
+        "checked_at": now, "cached": False, "cache_authority": "LIVE_SCAN",
+        "cache_context_digest": cache_context_digest,
+        "cache_config": dict(cache_config), "counts_withheld": False,
+        "ttl_sec": ttl_sec, "require_tools": require_tools,
+        "max_critical": max_critical, "max_high": max_high, "max_unknown": max_unknown,
+        "node_lock_scope": node_lock_scope, "node_lock_count": node_lock_count,
+        "cargo_lock_count": cargo_lock_count,
+        "totals": totals, "tool_failures": tool_failures,
+        "evidence_failures": evidence_failures, "checks": checks,
+        "message": (
+            f"critical={totals['critical']} high={totals['high']} "
+            f"unknown={totals['unknown']} tool_failures={tool_failures} "
+            f"evidence_failures={evidence_failures}"
+        ),
+    }
+
+
+def _preflight_config(runtime_24x7: bool) -> Dict[str, Any]:
+    return {
+        "ttl_sec": _env_int("OPENCLAW_DEP_SECURITY_PREFLIGHT_TTL_SEC", 21600),
+        "require_tools": _env_bool("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", runtime_24x7),
+        "max_critical": _env_int("OPENCLAW_DEP_SECURITY_MAX_CRITICAL", 0),
+        "max_high": _env_int("OPENCLAW_DEP_SECURITY_MAX_HIGH", 0),
+        "max_unknown": _env_int("OPENCLAW_DEP_SECURITY_MAX_UNKNOWN", 0),
+        "check_node": _env_bool("OPENCLAW_DEP_SECURITY_CHECK_NODE", True),
+        "check_rust": _env_bool("OPENCLAW_DEP_SECURITY_CHECK_RUST", True),
+        "node_lock_scope": str(os.getenv(
+            "OPENCLAW_DEP_SECURITY_NODE_LOCK_SCOPE", "all"
+        )).strip().lower(),
+    }
+
+
 def run_dependency_security_preflight(repo_root: Path, force: bool = False) -> Dict[str, Any]:
     """Run Python/Node/Rust dependency security checks with TTL cache."""
     repo_root = Path(repo_root).resolve()
     runtime_24x7 = _env_bool("OPENCLAW_24X7", False)
-    ttl_sec = _env_int("OPENCLAW_DEP_SECURITY_PREFLIGHT_TTL_SEC", 21600)
-    require_tools = _env_bool("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", runtime_24x7)
-    max_critical = _env_int("OPENCLAW_DEP_SECURITY_MAX_CRITICAL", 0)
-    max_high = _env_int("OPENCLAW_DEP_SECURITY_MAX_HIGH", 0)
-    max_unknown = _env_int("OPENCLAW_DEP_SECURITY_MAX_UNKNOWN", 0)
-    check_node = _env_bool("OPENCLAW_DEP_SECURITY_CHECK_NODE", True)
-    check_rust = _env_bool("OPENCLAW_DEP_SECURITY_CHECK_RUST", True)
-    node_lock_scope = str(os.getenv("OPENCLAW_DEP_SECURITY_NODE_LOCK_SCOPE", "all")).strip().lower()
-
+    config = _preflight_config(runtime_24x7)
+    thresholds = tuple(config[key] for key in ("max_critical", "max_high", "max_unknown"))
+    node_lockfiles = _iter_node_lockfiles(
+        repo_root, config["node_lock_scope"]
+    ) if config["check_node"] else []
+    cargo_lockfiles = sorted(repo_root.glob("**/Cargo.lock")) if config["check_rust"] else []
+    context_digest = _cache_context_digest(
+        repo_root, config=config, node_lockfiles=node_lockfiles,
+        cargo_lockfiles=cargo_lockfiles,
+    )
     cache = _cache_path(repo_root)
     now = time.time()
-    cached = _load_cache(cache)
-    if cached and not force:
-        checked_at = float(cached.get("checked_at", 0))
-        if checked_at > 0 and (now - checked_at) < max(ttl_sec, 0):
-            cached["cached"] = True
+    enforced = _env_bool("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", runtime_24x7)
+    if not force and not enforced:
+        cached = _cached_status(
+            _load_cache(cache), config=config, context_digest=context_digest,
+            now=now, ttl_sec=config["ttl_sec"],
+        )
+        if cached:
             return cached
 
-    totals = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
-    checks: List[Dict[str, Any]] = []
-    tool_failures = 0
-
-    # Python (always relevant)
-    py_cmd = [sys.executable, "-m", "pip_audit", "-f", "json", "--progress-spinner", "off"]
-    py_run = _run(py_cmd, timeout_sec=240)
-    if not py_run["ok"]:
-        tool_failures += 1
-        checks.append(
-            {
-                "ecosystem": "python",
-                "available": False,
-                "passed": not require_tools,
-                "message": py_run["stderr"][:240],
-                "counts": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
-            }
+    totals, checks, tool_failures, evidence_failures, node_lock_count = (
+        _run_security_checks(
+            repo_root, check_node=config["check_node"], check_rust=config["check_rust"],
+            node_lockfiles=node_lockfiles, cargo_lockfiles=cargo_lockfiles,
         )
-    else:
-        py_counts = _count_pip_audit(py_run.get("stdout", ""))
-        _merge_counts(totals, py_counts)
-        checks.append(
-            {
-                "ecosystem": "python",
-                "available": True,
-                "passed": True,
-                "message": f"pip-audit exit={py_run['code']}",
-                "counts": py_counts,
-            }
-        )
-
-    # Node (scan selected lockfiles using package-lock-only)
-    node_lockfiles = _iter_node_lockfiles(repo_root, node_lock_scope)
-    if check_node and node_lockfiles:
-        npm_bin = _resolve_tool("npm")
-        for node_lock in node_lockfiles:
-            node_run = _run(
-                [npm_bin, "audit", "--json", "--package-lock-only", "--omit=dev"],
-                timeout_sec=300,
-                cwd=node_lock.parent,
-            )
-            rel_lock = str(node_lock.relative_to(repo_root)).replace("\\", "/")
-            if not node_run["ok"]:
-                tool_failures += 1
-                checks.append(
-                    {
-                        "ecosystem": "node",
-                        "target": rel_lock,
-                        "available": False,
-                        "passed": not require_tools,
-                        "message": node_run["stderr"][:240],
-                        "counts": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
-                    }
-                )
-                continue
-            node_counts = _count_npm_audit(node_run.get("stdout", ""))
-            _merge_counts(totals, node_counts)
-            checks.append(
-                {
-                    "ecosystem": "node",
-                    "target": rel_lock,
-                    "available": True,
-                    "passed": True,
-                    "message": f"npm audit exit={node_run['code']}",
-                    "counts": node_counts,
-                }
-            )
-
-    # Rust (only if Cargo.lock exists anywhere)
-    if check_rust:
-        cargo_locks = list(repo_root.glob("**/Cargo.lock"))
-        if cargo_locks:
-            cargo_bin = _resolve_tool("cargo")
-            cargo_run = _run([cargo_bin, "audit", "--json"], timeout_sec=300)
-            if not cargo_run["ok"]:
-                tool_failures += 1
-                checks.append(
-                    {
-                        "ecosystem": "rust",
-                        "available": False,
-                        "passed": not require_tools,
-                        "message": cargo_run["stderr"][:240],
-                        "counts": {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0},
-                    }
-                )
-            else:
-                cargo_counts = _count_cargo_audit(cargo_run.get("stdout", ""))
-                _merge_counts(totals, cargo_counts)
-                checks.append(
-                    {
-                        "ecosystem": "rust",
-                        "available": True,
-                        "passed": True,
-                        "message": f"cargo audit exit={cargo_run['code']}",
-                        "counts": cargo_counts,
-                    }
-                )
-
-    has_threshold_violation = (
-        int(totals.get("critical", 0)) > max_critical
-        or int(totals.get("high", 0)) > max_high
-        or int(totals.get("unknown", 0)) > max_unknown
     )
-    passed = (not has_threshold_violation) and (
-        tool_failures == 0 or not require_tools
+    status = _build_status(
+        totals=totals, checks=checks, now=now, ttl_sec=config["ttl_sec"],
+        require_tools=config["require_tools"], thresholds=thresholds,
+        node_lock_scope=config["node_lock_scope"], node_lock_count=node_lock_count,
+        cargo_lock_count=len(cargo_lockfiles),
+        tool_failures=tool_failures, evidence_failures=evidence_failures,
+        cache_context_digest=context_digest,
+        cache_config=config,
     )
-    status = {
-        "available": True,
-        "passed": passed,
-        "checked_at": now,
-        "cached": False,
-        "ttl_sec": ttl_sec,
-        "require_tools": require_tools,
-        "max_critical": max_critical,
-        "max_high": max_high,
-        "max_unknown": max_unknown,
-        "node_lock_scope": node_lock_scope,
-        "node_lock_count": len(node_lockfiles),
-        "totals": totals,
-        "tool_failures": tool_failures,
-        "checks": checks,
-        "message": (
-            f"critical={totals['critical']} high={totals['high']} unknown={totals['unknown']} "
-            f"tool_failures={tool_failures}"
-        ),
-    }
     _save_cache(cache, status)
     return status

--- a/modules/infrastructure/wre_core/tests/TestModLog.md
+++ b/modules/infrastructure/wre_core/tests/TestModLog.md
@@ -1,4 +1,11 @@
 # TestModLog - wre_core/tests
+## 2026-08-08: Dependency preflight Windows decoding regression
+- Added strict UTF-8 subprocess coverage, npm/cargo schema and exit validation,
+  summary-consistency checks, cache replay/config/input invalidation, a UTF-8
+  advisory fixture, and legacy-cache invalidation; paired focused startup
+  suites pass 49 tests
+  with two platform symlink skips.
+
 ## 2026-08-01: Test impact and differential receipt
 - Proved unchanged and resolved baseline failures accept while new failures,
   errors, skips, removed tests, execution-binding drift, and insufficient full

--- a/modules/infrastructure/wre_core/tests/test_dependency_security_preflight.py
+++ b/modules/infrastructure/wre_core/tests/test_dependency_security_preflight.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 from modules.infrastructure.wre_core.src.dependency_security_preflight import (
+    _run,
     run_dependency_security_preflight,
 )
 
@@ -30,6 +33,195 @@ def test_dependency_preflight_passes_with_clean_results(tmp_path: Path, monkeypa
     assert status["totals"]["high"] == 0
 
 
+def test_dependency_command_rejects_invalid_utf8_scanner_output() -> None:
+    result = _run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write(bytes([0x81]))",
+        ]
+    )
+
+    assert result["ok"] is False
+    assert result["code"] == 0
+    assert result["stdout"] == ""
+    assert result["failure_kind"] == "invalid_stdout_encoding"
+
+
+def test_dependency_command_preserves_valid_utf8_output() -> None:
+    result = _run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write('advisory \\u2014 current'.encode('utf-8'))",
+        ]
+    )
+
+    assert result["ok"] is True
+    assert result["stdout"] == "advisory \u2014 current"
+
+
+def test_dependency_command_captures_bytes_before_strict_decode() -> None:
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight.subprocess.run"
+    ) as mocked:
+        mocked.return_value.returncode = 0
+        mocked.return_value.stdout = b"{}"
+        mocked.return_value.stderr = b""
+
+        result = _run(["scanner", "--json"])
+
+    assert result["ok"] is True
+    assert mocked.call_args.kwargs["text"] is False
+    assert "encoding" not in mocked.call_args.kwargs
+    assert "errors" not in mocked.call_args.kwargs
+
+
+def test_dependency_preflight_rejects_empty_npm_evidence(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", "0")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def _fake_run(cmd, timeout_sec=180, cwd=None):
+        if "pip_audit" in " ".join(cmd):
+            return {"ok": True, "code": 0, "stdout": "[]", "stderr": "", "cmd": cmd}
+        return {"ok": True, "code": 0, "stdout": "", "stderr": "", "cmd": cmd}
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["tool_failures"] == 1
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_rejects_missing_npm_schema(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", "0")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def _fake_run(cmd, timeout_sec=180, cwd=None):
+        stdout = "[]" if "pip_audit" in " ".join(cmd) else "{}"
+        return {"ok": True, "code": 0, "stdout": stdout, "stderr": "", "cmd": cmd}
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_rejects_nonnative_npm_counts(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", "0")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def _fake_run(cmd, timeout_sec=180, cwd=None):
+        if "pip_audit" in " ".join(cmd):
+            stdout = "[]"
+        else:
+            stdout = (
+                '{"metadata":{"vulnerabilities":{"info":0,"critical":"0",'
+                '"high":0,"moderate":0,"low":0,"total":0}}}'
+            )
+        return {"ok": True, "code": 0, "stdout": stdout, "stderr": "", "cmd": cmd}
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_counts_utf8_npm_advisory(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_MAX_CRITICAL", "2")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_MAX_HIGH", "7")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", "1")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def _fake_run(cmd, timeout_sec=180, cwd=None):
+        if "pip_audit" in " ".join(cmd):
+            stdout = "[]"
+        else:
+            stdout = (
+                '{"advisories":{"title":"clerk-nextjs \u2014 current"},'
+                '"metadata":{"vulnerabilities":{"info":0,"critical":2,"high":7,'
+                '"moderate":0,"low":0,"total":9}}}'
+            )
+        return {"ok": True, "code": 1, "stdout": stdout, "stderr": "", "cmd": cmd}
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is True
+    assert status["totals"]["critical"] == 2
+    assert status["totals"]["high"] == 7
+
+
+def test_dependency_preflight_rejects_cargo_exit_101(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_NODE", "0")
+    (tmp_path / "Cargo.lock").write_text("", encoding="utf-8")
+
+    def _fake_run(cmd, timeout_sec=180, cwd=None):
+        if "pip_audit" in " ".join(cmd):
+            return {"ok": True, "code": 0, "stdout": "[]", "stderr": "", "cmd": cmd}
+        return {"ok": True, "code": 101, "stdout": "{}", "stderr": "", "cmd": cmd}
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["tool_failures"] == 1
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_invalidates_legacy_cache(tmp_path: Path, monkeypatch):
+    cache = (
+        tmp_path
+        / "modules"
+        / "infrastructure"
+        / "wre_core"
+        / "reports"
+        / "dependency_security_cache.json"
+    )
+    cache.parent.mkdir(parents=True)
+    cache.write_text(
+        '{"checked_at":99999999999,"passed":true,"totals":{}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_NODE", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_RUST", "0")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        return_value={
+            "ok": True,
+            "code": 0,
+            "stdout": "[]",
+            "stderr": "",
+            "cmd": [],
+        },
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+    assert status["schema_version"] == "dependency_security_preflight.v3"
+
+
 def test_dependency_preflight_fails_on_high_threshold_breach(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("OPENCLAW_DEP_SECURITY_MAX_CRITICAL", "0")
     monkeypatch.setenv("OPENCLAW_DEP_SECURITY_MAX_HIGH", "0")
@@ -42,7 +234,7 @@ def test_dependency_preflight_fails_on_high_threshold_breach(tmp_path: Path, mon
         if "pip_audit" in cmd_str:
             return {"ok": True, "code": 0, "stdout": "[]", "stderr": "", "cmd": cmd}
         if cmd and Path(cmd[0]).name.startswith("npm"):
-            stdout = '{"metadata":{"vulnerabilities":{"critical":0,"high":2,"moderate":0,"low":0}}}'
+            stdout = '{"metadata":{"vulnerabilities":{"info":0,"critical":0,"high":2,"moderate":0,"low":0,"total":2}}}'
             return {"ok": True, "code": 1, "stdout": stdout, "stderr": "", "cmd": cmd}
         return {"ok": True, "code": 0, "stdout": "{}", "stderr": "", "cmd": cmd}
 
@@ -83,9 +275,9 @@ def test_dependency_preflight_scans_all_node_lockfiles(tmp_path: Path, monkeypat
             return {"ok": True, "code": 0, "stdout": "[]", "stderr": "", "cmd": cmd}
         if cmd and Path(cmd[0]).name.startswith("npm"):
             if cwd and str(cwd).endswith("apps\\web"):
-                stdout = '{"metadata":{"vulnerabilities":{"critical":0,"high":3,"moderate":0,"low":0}}}'
+                stdout = '{"metadata":{"vulnerabilities":{"info":0,"critical":0,"high":3,"moderate":0,"low":0,"total":3}}}'
             else:
-                stdout = '{"metadata":{"vulnerabilities":{"critical":0,"high":2,"moderate":0,"low":0}}}'
+                stdout = '{"metadata":{"vulnerabilities":{"info":0,"critical":0,"high":2,"moderate":0,"low":0,"total":2}}}'
             return {"ok": True, "code": 1, "stdout": stdout, "stderr": "", "cmd": cmd}
         return {"ok": True, "code": 0, "stdout": "{}", "stderr": "", "cmd": cmd}
 
@@ -115,7 +307,7 @@ def test_dependency_preflight_ignores_hidden_nested_worktree_lockfiles(tmp_path:
         if "pip_audit" in cmd_str:
             return {"ok": True, "code": 0, "stdout": "[]", "stderr": "", "cmd": cmd}
         if cmd and Path(cmd[0]).name.startswith("npm"):
-            stdout = '{"metadata":{"vulnerabilities":{"critical":0,"high":0,"moderate":0,"low":0}}}'
+            stdout = '{"metadata":{"vulnerabilities":{"info":0,"critical":0,"high":0,"moderate":0,"low":0,"total":0}}}'
             return {"ok": True, "code": 0, "stdout": stdout, "stderr": "", "cmd": cmd}
         return {"ok": True, "code": 0, "stdout": "{}", "stderr": "", "cmd": cmd}
 
@@ -148,3 +340,306 @@ def test_dependency_preflight_counts_pip_audit_dict_payload_and_unknown_threshol
     assert status["totals"]["unknown"] == 1
     assert status["max_unknown"] == 0
     assert status["passed"] is False
+
+
+def _clean_scanner_run(cmd, timeout_sec=180, cwd=None):
+    if "pip_audit" in " ".join(cmd):
+        stdout = "[]"
+    else:
+        stdout = (
+            '{"metadata":{"vulnerabilities":{"info":0,"low":0,'
+            '"moderate":0,"high":0,"critical":0,"total":0}}}'
+        )
+    return {"ok": True, "code": 0, "stdout": stdout, "stderr": "", "cmd": cmd}
+
+
+def _disable_non_python_scanners(monkeypatch) -> None:
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_NODE", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_RUST", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "0")
+
+
+def _cache_file(repo_root: Path) -> Path:
+    return (
+        repo_root
+        / "modules"
+        / "infrastructure"
+        / "wre_core"
+        / "reports"
+        / "dependency_security_cache.json"
+    )
+
+
+def test_dependency_preflight_cache_is_advisory_only(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=AssertionError("cache should avoid a live advisory scan"),
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert status["cached"] is True
+    assert status["cache_authority"] == "ADVISORY_ONLY"
+    assert status["passed"] is False
+    assert status["degraded"] is True
+    assert status["counts_withheld"] is True
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_enforced_mode_ignores_cache(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "1")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+    assert status["cache_authority"] == "LIVE_SCAN"
+
+
+def test_dependency_preflight_cache_rejects_threshold_change(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_MAX_HIGH", "5")
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_MAX_HIGH", "0")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+
+
+def test_dependency_preflight_cache_rejects_dependency_change(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_RUST", "0")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "0")
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["node_lock_count"] == 1
+    assert status["cached"] is False
+
+
+def test_dependency_preflight_cache_rejects_future_timestamp(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    cache = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+    cache["checked_at"] = 99_999_999_999
+    _cache_file(tmp_path).write_text(json.dumps(cache), encoding="utf-8")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+
+
+def test_dependency_preflight_cache_rejects_internal_contradiction(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    cache = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+    cache.update(evidence_failures=1, passed=True)
+    _cache_file(tmp_path).write_text(json.dumps(cache), encoding="utf-8")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+
+
+def test_dependency_preflight_cache_rejects_tampered_policy(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    cache = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+    cache.update(max_high=999, passed=True)
+    _cache_file(tmp_path).write_text(json.dumps(cache), encoding="utf-8")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+
+
+def test_dependency_preflight_cache_rejects_nan_timestamp(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ):
+        run_dependency_security_preflight(tmp_path, force=True)
+    cache = json.loads(_cache_file(tmp_path).read_text(encoding="utf-8"))
+    cache["checked_at"] = float("nan")
+    _cache_file(tmp_path).write_text(json.dumps(cache), encoding="utf-8")
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=_clean_scanner_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=False)
+
+    assert mocked.called
+    assert status["cached"] is False
+
+
+def test_dependency_preflight_rejects_inconsistent_npm_total(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_RUST", "0")
+    (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+    def fake_run(cmd, timeout_sec=180, cwd=None):
+        result = _clean_scanner_run(cmd, timeout_sec, cwd)
+        if "pip_audit" not in " ".join(cmd):
+            result["stdout"] = (
+                '{"metadata":{"vulnerabilities":{"info":0,"low":0,'
+                '"moderate":0,"high":0,"critical":0,"total":9}}}'
+            )
+        return result
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_rejects_inconsistent_cargo_summary(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_NODE", "0")
+    (tmp_path / "Cargo.lock").write_text("", encoding="utf-8")
+
+    def fake_run(cmd, timeout_sec=180, cwd=None):
+        if "pip_audit" in " ".join(cmd):
+            return _clean_scanner_run(cmd, timeout_sec, cwd)
+        return {
+            "ok": True,
+            "code": 1,
+            "stdout": '{"vulnerabilities":{"found":true,"count":3,"list":[]}}',
+            "stderr": "",
+            "cmd": cmd,
+        }
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=fake_run,
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["evidence_failures"] == 1
+
+
+def test_dependency_preflight_audits_each_cargo_lock(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_CHECK_NODE", "0")
+    (tmp_path / "Cargo.lock").write_text("", encoding="utf-8")
+    nested = tmp_path / "crates" / "worker"
+    nested.mkdir(parents=True)
+    (nested / "Cargo.lock").write_text("", encoding="utf-8")
+
+    def fake_run(cmd, timeout_sec=180, cwd=None):
+        if "pip_audit" in " ".join(cmd):
+            return _clean_scanner_run(cmd, timeout_sec, cwd)
+        vulnerable = Path(cwd or tmp_path) == nested
+        item = '{"severity":"high"}' if vulnerable else ""
+        return {
+            "ok": True,
+            "code": 1 if vulnerable else 0,
+            "stdout": (
+                '{"vulnerabilities":{"found":'
+                f'{str(vulnerable).lower()},"count":{int(vulnerable)},'
+                f'"list":[{item}]}}}}'
+            ),
+            "stderr": "",
+            "cmd": cmd,
+        }
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        side_effect=fake_run,
+    ) as mocked:
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    cargo_calls = [call for call in mocked.call_args_list if "pip_audit" not in " ".join(call.args[0])]
+    assert len(cargo_calls) == 2
+    assert {Path(call.kwargs["cwd"]) for call in cargo_calls} == {tmp_path, nested}
+    assert status["cargo_lock_count"] == 2
+    assert status["totals"]["high"] == 1
+    assert status["passed"] is False
+
+
+def test_dependency_preflight_missing_optional_scanner_is_degraded(tmp_path: Path, monkeypatch):
+    _disable_non_python_scanners(monkeypatch)
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_REQUIRE_TOOLS", "0")
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight._run",
+        return_value={
+            "ok": False,
+            "failure_kind": "process_error",
+            "code": 127,
+            "stdout": "",
+            "stderr": "missing",
+            "cmd": [],
+        },
+    ):
+        status = run_dependency_security_preflight(tmp_path, force=True)
+
+    assert status["passed"] is False
+    assert status["degraded"] is True
+    assert status["available"] is False
+    assert status["checks"][0]["passed"] is False

--- a/tests/TestModLog.md
+++ b/tests/TestModLog.md
@@ -1,5 +1,11 @@
 # TestModLog - shared tests
 
+## 2026-08-08: Startup dependency-evidence enforcement
+
+- Proved malformed dependency scanner evidence remains visible in startup
+  telemetry and blocks when enforcement is active. Incomplete optional scans
+  are reported as `WARN`, never `PASS`; the 28-test startup matrix passes.
+
 ## 2026-07-24: WSP 97 repository-evidence receipt v1.1
 
 - Files: `tests/test_wsp97_execution_validator.py`, `tests/test_wsp97_repository_evidence.py`

--- a/tests/test_main_runtime_bootstrap.py
+++ b/tests/test_main_runtime_bootstrap.py
@@ -12,6 +12,102 @@ main = importlib.util.module_from_spec(_MAIN_SPEC)
 _MAIN_SPEC.loader.exec_module(main)
 
 
+def test_dependency_evidence_failure_warns_when_not_enforced(monkeypatch, capsys):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "1")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "0")
+    status = {
+        "totals": {"critical": 0, "high": 0, "unknown": 0},
+        "tool_failures": 1,
+        "evidence_failures": 1,
+        "cached": False,
+        "passed": False,
+    }
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight.run_dependency_security_preflight",
+        return_value=status,
+    ):
+        assert main.run_dependency_security_preflight(Path.cwd()) is True
+
+    output = capsys.readouterr().out
+    assert "preflight=FAIL" in output
+    assert "evidence_failures=1" in output
+
+
+def test_dependency_incomplete_optional_scan_reports_warn(monkeypatch, capsys):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "1")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "0")
+    status = {
+        "totals": {"critical": 0, "high": 0, "unknown": 0},
+        "tool_failures": 1,
+        "evidence_failures": 0,
+        "cached": False,
+        "passed": False,
+        "degraded": True,
+    }
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight.run_dependency_security_preflight",
+        return_value=status,
+    ):
+        assert main.run_dependency_security_preflight(Path.cwd()) is True
+
+    assert "preflight=WARN" in capsys.readouterr().out
+
+
+def test_dependency_cached_advisory_withholds_counts(monkeypatch, capsys):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "1")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "0")
+    status = {
+        "totals": {"critical": 99, "high": 99, "unknown": 99},
+        "tool_failures": 0,
+        "evidence_failures": 1,
+        "cached": True,
+        "passed": False,
+        "degraded": True,
+        "counts_withheld": True,
+    }
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight.run_dependency_security_preflight",
+        return_value=status,
+    ), patch(
+        "modules.ai_intelligence.ai_overseer.src.preflight_resolution.on_preflight_fail"
+    ) as on_fail:
+        assert main.run_dependency_security_preflight(Path.cwd()) is True
+
+    output = capsys.readouterr().out
+    assert "preflight=WARN (cached) counts=WITHHELD" in output
+    assert "critical=99" not in output
+    payload = on_fail.call_args.kwargs["payload"]
+    assert payload["counts_withheld"] is True
+    assert payload["cache_authority"] == "ADVISORY_ONLY"
+    assert "critical" not in payload
+    assert "high" not in payload
+    assert "unknown" not in payload
+
+
+def test_dependency_evidence_failure_blocks_when_enforced(monkeypatch, capsys):
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT", "1")
+    monkeypatch.setenv("OPENCLAW_DEP_SECURITY_PREFLIGHT_ENFORCED", "1")
+    status = {
+        "totals": {"critical": 0, "high": 0, "unknown": 0},
+        "tool_failures": 1,
+        "evidence_failures": 1,
+        "cached": False,
+        "passed": False,
+    }
+
+    with patch(
+        "modules.infrastructure.wre_core.src.dependency_security_preflight.run_dependency_security_preflight",
+        return_value=status,
+    ):
+        assert main.run_dependency_security_preflight(Path.cwd()) is False
+
+    output = capsys.readouterr().out
+    assert "Startup blocked" in output
+
+
 def test_bootstrap_runtime_dae_launches_registers_openclaw(monkeypatch):
     daemon = MagicMock()
     daemon.running = True


### PR DESCRIPTION
## Summary
- complete the existing `runtime_allowed_root` contract between `main.py` and the RedDog WRE queue bootstrap
- confine authoritative work-state reads to the external runtime root using the shared descriptor-safe helper
- capture dependency scanner output as bytes and decode JSON as strict UTF-8, avoiding the Windows CP932 reader crash
- fail closed on malformed/inconsistent npm, pip-audit, and per-crate Cargo evidence
- make unsigned dependency caches advisory-only, with counts withheld; enforced startup always live-scans

## WSP 97 truth boundary
- OBSERVED: the supplied startup reached the menu but emitted a queue interface `TypeError` and a CP932 reader-thread exception
- OBSERVED: live `clerk-nextjs` audit contains 2 critical and 7 high findings that now reach policy unchanged
- OBSERVED: two independent adversarial reviews returned GO after cache, telemetry, symlink, and multi-crate findings were folded
- NO queue mutation, worker dispatch, shell/worktree authority, HoloIndex reindex, extension runtime change, or VSIX change

## Validation
- `49 passed, 2 skipped`: queue confinement + dependency evidence matrix
- `28 passed`: product startup matrix
- `46 passed, 2 skipped`: queue neighborhood
- `22 passed`: AI Overseer preflight resolution
- `21 passed, 1 skipped`: shared runtime-artifact confinement
- `53 passed`: OpenClaw integration and RedDog backend-manifest tests
- `12 passed`: applicable WSP 62 security repair checks
- Ruff, py_compile, `git diff --check`, ASCII-added-lines: pass
- infrastructure file: 599/600 lines; all changed production functions <= 50 lines

## Known baseline
The complete WSP 62 exemption suite retains one pre-existing `origin/main` failure: `moltbot_bridge/INTERFACE.md` is 1507 lines while its existing exemption records 1484. This PR does not touch either file.