### PR TITLE
fix(reddog): seal single-input action admission

### DIFF
--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -1,5 +1,21 @@
 # RedDog Interface
 
+Version 0.4.71 hardens the single-input authority boundary. Plain operator
+requests are classified inside the ingress parser; diagnostic-shaped content
+never falls back to whole-message action classification. Timestamped, JSON,
+logfmt, and terse command-result logs remain inert evidence. Resident
+AgentDB/OpenClaw submission additionally requires an accepted receipt-bearing
+Wardrobe selection with no execution or enqueue effects.
+The accepted selector result must carry the canonical digest produced for the
+exact input and an immutable process-local owner proof. Serialized copies and
+injected mappings are not admission capabilities. Selector execution uses the
+approved workspace `.venv`, isolated `-I -S -B` startup, and the existing
+manifest-materialized sealed runtime. The explicit WRE valve, live enqueue,
+and resident session independently require the process-local proof. Mixed
+intent and logs use
+an explicit `DAEmon output:` or `## Run Trace` delimiter in the one textarea;
+unmarked mixed text remains evidence-only.
+
 Version 0.4.70 exposes one `012 conversation with RedDog` textarea. Enter sends
 and Shift+Enter inserts a newline. A bounded deterministic parser separates a
 leading assessment/action paragraph from following diagnostic-shaped lines;

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -1,5 +1,28 @@
 # RedDog ModLog
 
+## 2026-08-09 - Single-input authority boundary hardening (0.4.71)
+
+- Moved plain operator-only classification into the diagnostic ingress parser,
+  removing the whole-message action fallback that could promote diagnostic
+  fields such as `fix: false` or terse command-failure text.
+- Added bounded recognition for timestamped, JSON, and logfmt diagnostics so
+  common log formats begin inert evidence instead of entering operator scope.
+- Required an accepted receipt-bearing Wardrobe selection, with no execution
+  or enqueue side effects, before the resident AgentDB/OpenClaw session can be
+  submitted. The receipt digest is recomputed against the exact selector input
+  and admitted through the existing immutable process-local owner-proof
+  pattern. Rejected, copied, injected, or malformed selections fail closed.
+- Routed both the Python bootstrap and selector through the approved workspace
+  `.venv`, isolated `-I -S -B` startup, and manifest-materialized source. A
+  private per-runner capability binds canonical output to the Wardrobe proof;
+  WRE invocation, live enqueue, and action-bearing resident submission each
+  reject direct calls without it.
+- Added the common `Please analyze and fix ...` imperative without weakening
+  assessment-only questions or evidence isolation.
+- Removed ambiguous intent inference from unmarked mixed text. One-field
+  request-plus-log pastes require `DAEmon output:` or `## Run Trace`; otherwise
+  diagnostic-shaped content remains evidence-only.
+
 ## 2026-08-09 - Single conversation input and governed action routing (0.4.70)
 
 - Removed the duplicate diagnostic-evidence textarea. The single conversation

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -1,11 +1,25 @@
 # RedDog
 
-Version: 0.4.70
+Version: 0.4.71
+
+Version 0.4.71 closes the remaining single-input authority ambiguities found
+by exact-SHA review. Plain work requests are now identified by the ingress
+parser itself; diagnostic payloads never fall back to whole-message action
+classification. Timestamped, JSON, logfmt, and terse command-result logs stay
+in inert evidence. The durable resident cycle is requested only after the
+existing Wardrobe selector returns an accepted receipt with explicit
+no-execution and no-enqueue attestations. The selector receipt is digest-
+verified and held by an immutable process-local owner proof; copied or
+caller-constructed mappings cannot admit resident work. The selector runs
+only through the approved workspace `.venv` interpreter with `-I -S -B` and
+the existing manifest-materialized sealed source boundary. WRE invocation,
+live enqueue, and resident submission each consume that same process-local
+proof before they can advance.
 
 Version 0.4.70 restores one conversational input. Enter sends and Shift+Enter
-adds a line; diagnostic logs and the operator request are pasted together.
-RedDog deterministically separates an explicit leading assessment or action
-from following diagnostic-shaped data. The data remains inert and cannot
+adds a line. Version 0.4.71 requires mixed operator intent and diagnostic logs
+to use an explicit `DAEmon output:` or `## Run Trace` boundary in that one
+input. Unmarked mixed text is evidence-only. The data remains inert and cannot
 request work. A diagnostic-shaped first line is never inferred as operator
 intent, and merely mentioning a fix in a question is not an action.
 Assessment-only diagnostics remain non-actionable. An explicit

--- a/extensions/reddog/ROADMAP.md
+++ b/extensions/reddog/ROADMAP.md
@@ -6,6 +6,8 @@ Phase: RedDog 0.4.6 resident architect thin-client surface.
 
 Current implementation:
 
+- REDDOG_SINGLE_INPUT_AUTHORITY_BOUNDARY_HARDENING_PHASE1 (v0.4.71): operator-only input is classified at ingress; unmarked mixed text and timestamped/JSON/logfmt/command-result diagnostics remain inert; explicit one-field evidence boundaries are supported; resident submission requires a digest-verified process-local Wardrobe owner proof.
+
 - REDDOG_SINGLE_CONVERSATION_INPUT_AND_GOVERNED_ACTION_ROUTING_PHASE1 (v0.4.70): one conversational textarea; bounded intent/evidence separation; assessment-only diagnostics remain advisory; explicit action requests automatically submit to the existing authenticated resident AgentDB/OpenClaw architect cycle after all local gates pass. Signed worker promotion and effects remain backend-owned.
 
 - Semantic HoloIndex grounding is generation-bound to the authenticated owner service. Stale, lexical, unreceipted, or repository-mismatched owner results are withheld and surfaced as an index gap; RedDog never re-indexes during a reasoning run.

--- a/extensions/reddog/daemon_diagnostic_analysis.js
+++ b/extensions/reddog/daemon_diagnostic_analysis.js
@@ -10,9 +10,6 @@ const RUN_TRACE_ASSESSMENT = [
   /\brun trace\b[\s\S]{0,160}\b(?:assess|evaluate|review|diagnose|score|rate|why|blocked|slow|failed)\b/i,
   /\bwhy\b[\s\S]{0,120}\b(?:blocked|slow|failed|took forever)\b/i
 ];
-const RUN_TRACE_ACTION = [
-  /\b(?:implement|fix|patch|author|provide|create|draft|enhance|write|merge|land|dispatch|assign|spawn|execute|start)\b/i
-];
 const OUTPUT_TERMS = [
   /\bdae?mon\b/i, /\bdaemon\b/i, /\bdae\b/i, /\bbrowser\b/i,
   /\bpage\b/i, /\byoutube\b/i, /\bstudio\.youtube\.com\b/i,
@@ -31,7 +28,7 @@ const ASSESSMENT = [
 const ACTION_VERB = '(?:implement|fix|repair|harden|improve|enhance|patch|author|merge|land|dispatch|assign|spawn|execute|run|build|edit|add|create)';
 const ACTION = [
   new RegExp('^(?:(?:0102|reddog)[,:]?\\s+)?(?:please\\s+)?' + ACTION_VERB + '\\b', 'i'),
-  new RegExp('^(?:(?:0102|reddog)[,:]?\\s+)?(?:analy[sz]e|diagnose|assess|review)\\s+and\\s+' + ACTION_VERB + '\\b', 'i'),
+  new RegExp('^(?:(?:0102|reddog)[,:]?\\s+)?(?:please\\s+)?(?:analy[sz]e|diagnose|assess|review)\\s+and\\s+' + ACTION_VERB + '\\b', 'i'),
   new RegExp('^(?:(?:0102|reddog)[,:]?\\s+)?(?:i\\s+(?:want|need)\\s+you\\s+to|you\\s+(?:need|must|should)\\s+|(?:can|could|would)\\s+you\\s+|go\\s+ahead\\s+and\\s+)(?:please\\s+)?(?:(?:analy[sz]e|diagnose|assess|review)\\s+and\\s+)?' + ACTION_VERB + '\\b', 'i'),
   /^(?:(?:0102|reddog)[,:]?\s+)?(?:continue|proceed|do\s+it|start\s+operations|start\s+work)\b/i,
   /^(?:(?:0102|reddog)[,:]?\s+)?(?:please\s+)?(?:create|open|draft)\s+(?:a\s+|the\s+)?(?:pr|pull\s+request)\b/i,
@@ -40,42 +37,83 @@ const ACTION = [
   /^(?:(?:0102|reddog)[,:]?\s+)?(?:please\s+)?(?:create|write|provide|author)\s+(?:the\s+)?(?:(?:worker|slice|next|m2m)\s+)?prompt\b/i
 ];
 
-const DIAGNOSTIC_LINE = /^(?:[-*]\s*)?(?:status|error|warning|warn|traceback|exception|failed|failure|blocked|exit code|extension_version|mode|made_network_call|runtime_consumption_gate_rejection_reasons)\s*[:=]|^\[[A-Z0-9_-]+\]|\b(?:Traceback \(most recent call last\)|BLOCKED_LOCALLY|HOLOINDEX_[A-Z0-9_]+|Error:|Exception:)\b/i;
+const DIAGNOSTIC_LINE = /^(?:[-*]\s*)?(?:status|error|warning|warn|traceback|exception|failed|failure|blocked|exit code|extension_version|mode|made_network_call|runtime_consumption_gate_rejection_reasons)\s*[:=]|^\[[A-Z0-9_-]+\]|^npm\s+ERR!|(?:Traceback \(most recent call last\)|BLOCKED_LOCALLY|HOLOINDEX_[A-Z0-9_]+|Error:\s|Exception:\s)/i;
+const TIMESTAMP_PREFIX = /^(?:\[?\d{4}[-\/]\d{2}[-\/]\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[.,]\d+)?(?:Z|[+-]\d{2}:?\d{2})?\]?|\d{2}:\d{2}:\d{2}(?:[.,]\d+)?|(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2})\s+/i;
+const DIAGNOSTIC_SEVERITY = /(?:^|[\s[\]-])(?:TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|CRITICAL)(?=$|[\s:\]-])/i;
+const JSON_DIAGNOSTIC_LINE = /^\s*\{[^\r\n]{0,400}"(?:level|severity|status|error|exception|message|msg|timestamp|time)"\s*:/i;
+const LOGFMT_DIAGNOSTIC_LINE = /^(?=[^\r\n]{0,500}$)(?=.*\b(?:level|severity|status|error|exception|msg|message|time|timestamp)=)(?=.*\b(?:error|warn|warning|fatal|critical|failed|blocked|timeout|info|debug|trace)\b)/i;
+const COMMAND_RESULT_LINE = /^[A-Za-z][A-Za-z0-9_.-]{0,40}\s+(?:(?:[A-Za-z-]{2,36}(?:ed|en|ful|less))|ok|pass|fail|error|blocked|done|timeout|timed\s+out)[.!]?$/i;
 const STRUCTURED_LINE = /^(?:[-*]\s*)?[A-Za-z][A-Za-z0-9_. -]{1,64}\s*[:=]\s*\S/;
-const COLON_ACTION_DIRECTIVE = /^(?:(?:0102|reddog)[,:]?\s+)?(?:please\s+)?(?:implement|fix|repair|harden|improve|enhance|patch|build|edit)\s*:\s+(?!(?:false|true|null|none|unknown|\d+)\b)\S/i;
-
+const COLON_ACTION_DIRECTIVE = new RegExp(
+  '^(?:(?:0102|reddog)[,:]?\\s+)?(?:please\\s+)?' + ACTION_VERB
+  + '\\s*:\\s+\\S',
+  'i'
+);
+const COLON_ACTION_PREFIX = new RegExp(
+  '^(?:(?:0102|reddog)[,:]?\\s+)?(?:please\\s+)?' + ACTION_VERB + '\\s*:', 'i'
+);
+const ACTION_TARGET_WORD = /^(?:(?:bug|code|contract|dependency|documentation|failure|file|fix|function|issue|migration|module|parser|prompt|queue|receipt|runtime|test|validation|validator|worker|worktree)s?|pr)$/i;
+function hasColonActionTarget(value) {
+  const target = String(value || '').trim();
+  const parts = target.split(/\s+/); const token = parts[parts.length - 1].replace(/[.,;:!?]+$/, '');
+  if (ACTION_TARGET_WORD.test(token)) return true;
+  if (token.includes(':') || token.startsWith('/') || token.startsWith('\\')) return false;
+  const pathParts = token.replace(/\\/g, '/').split('/'); const fileName = pathParts[pathParts.length - 1];
+  return pathParts.length > 1 && pathParts.every((part) => part && part !== '.' && part !== '..')
+    && fileName.lastIndexOf('.') > 0;
+}
 function hasActionIntent(text) {
   const source = String(text || '').trim().slice(0, 1200);
+  const colonPrefix = COLON_ACTION_PREFIX.exec(source);
+  if (colonPrefix) {
+    const directive = source.slice(colonPrefix[0].length).trim();
+    return COLON_ACTION_DIRECTIVE.test(source) && hasColonActionTarget(directive);
+  }
+  if (!source.includes('\n') && COMMAND_RESULT_LINE.test(source)) return false;
   return ACTION.some((pattern) => pattern.test(source));
+}
+
+function isDiagnosticLine(line) {
+  const value = String(line || '').trim();
+  return DIAGNOSTIC_LINE.test(value)
+    || isTimestampedDiagnosticLine(value)
+    || JSON_DIAGNOSTIC_LINE.test(value)
+    || LOGFMT_DIAGNOSTIC_LINE.test(value)
+    || COMMAND_RESULT_LINE.test(value);
+}
+
+function isTimestampedDiagnosticLine(value) {
+  const prefix = TIMESTAMP_PREFIX.exec(value);
+  return Boolean(prefix && DIAGNOSTIC_SEVERITY.test(
+    value.slice(prefix[0].length, prefix[0].length + 120)
+  ));
 }
 
 function resemblesDiagnosticPayload(text) {
   const value = String(text || '').trim();
   if (!value) return false;
   const lines = value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
-  if (lines.length === 1) return DIAGNOSTIC_LINE.test(lines[0]);
-  return lines.some((line) => DIAGNOSTIC_LINE.test(line));
+  if (lines.length === 1) return isDiagnosticLine(lines[0]);
+  return lines.some((line) => isDiagnosticLine(line));
 }
 
-function inferConversationBoundary(operator) {
-  const lines = /(^|\r?\n)([^\r\n]*)/g;
-  let match;
-  while ((match = lines.exec(operator)) !== null) {
-    const lineStart = match.index + match[1].length;
-    if (lineStart === 0 || !DIAGNOSTIC_LINE.test(match[2].trim())) continue;
-    const intent = operator.slice(0, lineStart).trim();
-    const payload = operator.slice(lineStart).trim();
-    const action = hasActionIntent(intent);
-    const assessment = ASSESSMENT.some((pattern) => pattern.test(intent));
-    const structuredIntentAllowed = !STRUCTURED_LINE.test(intent)
-      || COLON_ACTION_DIRECTIVE.test(intent);
-    if (
-      intent && !DIAGNOSTIC_LINE.test(intent)
-      && structuredIntentAllowed && (action || assessment)
-      && resemblesDiagnosticPayload(payload)
-    ) {
-      return { intent, payload };
-    }
+function isExplicitDiagnosticBoundary(line) {
+  const value = String(line || '').trim().toLowerCase();
+  if (value === '## run trace' || value === '## run trace:') return true;
+  if (!value.endsWith(':')) return false;
+  const words = value.slice(0, -1).trim().split(/\s+/);
+  return words.length === 2 && words[0] === 'daemon' && words[1] === 'output';
+}
+
+function findExplicitDiagnosticBoundary(text) {
+  let lineStart = 0;
+  while (lineStart <= text.length) {
+    const lineEnd = text.indexOf('\n', lineStart);
+    const end = lineEnd === -1 ? text.length : lineEnd;
+    const line = text.slice(lineStart, end).replace(/\r$/, '');
+    if (isExplicitDiagnosticBoundary(line)) return { index: lineStart };
+    if (lineEnd === -1) break;
+    lineStart = lineEnd + 1;
   }
   return null;
 }
@@ -89,16 +127,11 @@ function splitInput(operatorText, diagnosticEvidence) {
     combined_focus: operator + '\n\nDAEmon output:\n' + evidence,
     boundary: 'typed_diagnostic_evidence'
   };
-  const marker = /^(?:\s*#{1,6}\s*(?:Run Trace|DAEmon Output|Diagnostic Evidence)|\s*(?:DAEmon|runtime|browser|worker|service)\s+(?:output|logs?|trace|diagnostics?)\s*:)/im.exec(operator);
-  const inline = /\b(?:DAEmon|runtime|browser|worker|service)\s+(?:output|logs?|trace|diagnostics?)\s*:/i.exec(operator);
-  const boundary = marker && (!inline || marker.index <= inline.index) ? marker : inline;
+  const boundary = findExplicitDiagnosticBoundary(operator);
   if (!boundary) {
-    const inferred = inferConversationBoundary(operator);
-    if (inferred) return {
-      operator_intent_source: inferred.intent,
-      diagnostic_payload: inferred.payload,
-      combined_focus: operator,
-      boundary: 'inferred_conversation_boundary'
+    if (!resemblesDiagnosticPayload(operator)) return {
+      operator_intent_source: operator, diagnostic_payload: '',
+      combined_focus: operator, boundary: 'operator_only'
     };
     return {
       operator_intent_source: '', diagnostic_payload: operator,
@@ -272,10 +305,10 @@ function buildLocalResult(d, workFocus) {
 }
 
 function isRunTraceRequest(text) {
-    const raw = String(text || '');
+    const raw = String(text || ''); const intent = splitInput(raw, '').operator_intent_source;
     if (!/##\s*Run Trace\b/i.test(raw) || !/\bextension_version\s*:/i.test(raw)) return false;
-    if (RUN_TRACE_ACTION.some((pattern) => pattern.test(raw.slice(0, 1200)))) return false;
-    return RUN_TRACE_ASSESSMENT.some((pattern) => pattern.test(raw.slice(0, 2000)))
+    if (hasActionIntent(intent)) return false;
+    return RUN_TRACE_ASSESSMENT.some((pattern) => pattern.test(intent.slice(0, 2000)))
       || /\bredaction gate status\s*:\s*BLOCKED_LOCALLY/i.test(raw);
 }
 

--- a/extensions/reddog/extension.js
+++ b/extensions/reddog/extension.js
@@ -1,6 +1,8 @@
 const vscode = require('vscode');
 const cp = require('child_process');
 const crypto = require('crypto');
+const sealedPythonJsonOnce = require('./sealed_python_json_once').createSealedPythonJsonRunner();
+const operatorWardrobeSelectionProof = require('./operator_wardrobe_selection_proof').createWardrobeSelectionProof(sealedPythonJsonOnce.isAccepted);
 const path = require('path');
 const fs = require('fs');
 const {
@@ -33,7 +35,7 @@ const repoAuditGrounding = require('./repo_audit_grounding');
 const localDiagnosticRouter = require('./local_diagnostic_router');
 const foundupWorkRuntime = require('./foundup_work_runtime_binding');
 const groundingFailureDialogue = require('./grounding_failure_dialogue');
-const EXTENSION_VERSION = '0.4.70';
+const EXTENSION_VERSION = '0.4.71';
 const REDDOG_EXTENSION_ID = 'foundups.reddog';
 const REDDOG_LEGACY_EXTENSION_ID = 'foundups.foundups-fusion-worker';
 const REDDOG_CONFIG_NAMESPACE = 'reddog';
@@ -3200,21 +3202,17 @@ function runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, p
   const configuredPython = reddogConfigValue('pythonPath', 'python');
   const interpreter = resolvePythonInterpreter(root, configuredPython);
   try {
-    const stdout = cp.execFileSync(interpreter.path, ['-B', script], {
-      cwd: root,
-      input: JSON.stringify(payload),
-      encoding: 'utf8',
-      env: buildBridgePythonEnv(process.env),
-      windowsHide: true,
+    const result = sealedPythonJsonOnce.run({
+      repoRoot: root, interpreter: interpreter.path, script,
+      request: payload, env: buildBridgePythonEnv(process.env),
+      mapResult: (selected) => Object.assign({
+        slice_name: REDDOG_OPERATOR_WARDROBE_SELECTION_RUNTIME_SLICE,
+        python_invocation_performed: true, python_interpreter_source: interpreter.source,
+        no_execution_performed: true, no_enqueue_performed: true
+      }, selected),
       maxBuffer: WRE_OPERATIONAL_SPINE_INVOKE_MAX_BYTES
     });
-    return Object.assign({
-      slice_name: REDDOG_OPERATOR_WARDROBE_SELECTION_RUNTIME_SLICE,
-      python_invocation_performed: true,
-      python_interpreter_source: interpreter.source,
-      no_execution_performed: true,
-      no_enqueue_performed: true
-    }, JSON.parse(stdout));
+    return operatorWardrobeSelectionProof.verifyAndObserve(payload, result);
   } catch (err) {
     return {
       slice_name: REDDOG_OPERATOR_WARDROBE_SELECTION_RUNTIME_SLICE,
@@ -3228,7 +3226,6 @@ function runOperatorWardrobeSelectionBridge(context, workFocus, holoScorecard, p
     };
   }
 }
-
 function buildOperatorWardrobeSelectionSection(selectionResult) {
   const r = selectionResult && typeof selectionResult === 'object' ? selectionResult : {};
   const receipt = r.receipt && typeof r.receipt === 'object' ? r.receipt : {};
@@ -3469,9 +3466,10 @@ function buildWreOperationalSpineInvokeResult(decision, fields) {
     rejection_reasons: []
   }, payload);
 }
-
 function invokeWreOperationalSpineExplicitValveBridge(context, preview, options) {
   const opts = options && typeof options === 'object' ? options : {};
+  const proofRejection = operatorWardrobeSelectionProof.rejection(opts.selectionResult, true, buildWreOperationalSpineInvokeResult, 'EXTENSION_WRE_OPERATIONAL_SPINE_INVOKE_SKIPPED');
+  if (proofRejection) return proofRejection;
   const payloadResult = buildWreOperationalSpineInvokePayload(preview, opts);
   if (!payloadResult.ok) {
     return buildWreOperationalSpineInvokeResult('EXTENSION_WRE_OPERATIONAL_SPINE_INVOKE_SKIPPED', {
@@ -3645,9 +3643,10 @@ function buildOpenClawLiveEnqueueRuntimeBindingResult(decision, fields) {
     rejection_reasons: []
   }, payload);
 }
-
 function invokeOpenClawLiveEnqueueRuntimeBindingBridge(context, packet, selectionResult, runtimeGate, options) {
   const opts = options && typeof options === 'object' ? options : {};
+  const proofRejection = operatorWardrobeSelectionProof.rejection(selectionResult, true, buildOpenClawLiveEnqueueRuntimeBindingResult, 'EXTENSION_OPENCLAW_LIVE_ENQUEUE_SKIPPED');
+  if (proofRejection) return proofRejection;
   const payloadResult = buildOpenClawLiveEnqueueRuntimeBindingPayload(
     packet,
     selectionResult,
@@ -3725,15 +3724,15 @@ function buildResidentArchitectSessionPayload(workFocus, options) {
     workFocus, options, residentArchitectSessionBindings()
   );
 }
-
 function buildResidentArchitectSessionResult(decision, fields) {
   return residentArchitectSessionContract.buildResult(
     decision, fields, residentArchitectSessionBindings()
   );
 }
-
 function runResidentArchitectSessionBridge(context, workFocus, options) {
   const opts = options && typeof options === 'object' ? options : {};
+  const proofRejection = operatorWardrobeSelectionProof.rejection(opts.wardrobeSelectionResult, opts.actionPlanningAllowed === true, buildResidentArchitectSessionResult, 'RESIDENT_ARCHITECT_SESSION_SKIPPED');
+  if (proofRejection) return proofRejection;
   const payloadResult = buildResidentArchitectSessionPayload(workFocus, opts);
   if (!payloadResult.ok) {
     return buildResidentArchitectSessionResult('RESIDENT_ARCHITECT_SESSION_SKIPPED', {
@@ -4158,8 +4157,7 @@ function classifyTaskForRedDog(prompt, contextMode, workerType, options) {
   const text = String(prompt || '');
   const opts = options && typeof options === 'object' ? options : {};
   const daemonIngress = opts.daemonDiagnosticIngress || splitDaemonDiagnosticInput(text, '');
-  const operatorControlText = daemonIngress.boundary === 'none'
-    ? text : daemonIngress.operator_intent_source;
+  const operatorControlText = daemonIngress.operator_intent_source;
   const worker = cleanWorkerType(workerType);
   const mode = cleanContextMode(contextMode);
   const haystack = text + ' ' + mode + ' ' + worker;
@@ -5400,7 +5398,6 @@ function wireFusionWebview(context, webview, worker, state) {
       workTrail.push('holoindex_result', 'wsp_hits=' + holoScorecard.wsp_hits + '; code_hits=' + holoScorecard.code_hits);
     }
     workTrail.push('wsp_prompt_assembled');
-
     let validationState = { validated: false, skipped: true, reason: 'not_validated' };
     let unicodeMeta = emptyUnicodeNormalizationMeta();
     const absorbUnicodeMeta = (bridgeResult) => {
@@ -5717,6 +5714,7 @@ function wireFusionWebview(context, webview, worker, state) {
       : null;
     const wreSpineInvokeResult = wreSpineDryRunPreview
       ? invokeWreOperationalSpineExplicitValveBridge(context, wreSpineDryRunPreview, {
+        selectionResult: operatorWardrobeSelectionResult,
         selectionReceipt: operatorWardrobeSelectionResult && operatorWardrobeSelectionResult.receipt
       })
       : null;
@@ -5741,7 +5739,7 @@ function wireFusionWebview(context, webview, worker, state) {
     }
     const residentArchitectSessionResult = recoveryContext ? null : await runConfiguredResidentArchitectSession(
       context, governedWorkFocus, {
-        actionPlanningAllowed, residentArchitectSessionEnabled,
+        actionPlanningAllowed, wardrobeSelectionResult: operatorWardrobeSelectionResult, residentArchitectSessionEnabled,
         explicitResidentArchitectSessionRequested: classification.governedActionRequested === true,
         groundingPreflight, holoScorecard
       }
@@ -5860,7 +5858,6 @@ function wireFusionWebview(context, webview, worker, state) {
     webview.postMessage({ command: 'result', result });
     return result;
   };
-
   const attempt = () => attemptBlockedRequestRecovery({
     context, state, options: recoveryOptions, executeAsk, webview });
   webview.onDidReceiveMessage(

--- a/extensions/reddog/operator_wardrobe_selection_proof.js
+++ b/extensions/reddog/operator_wardrobe_selection_proof.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const crypto = require('crypto');
+const { createOwnerProof } = require('./holoindex_owner_proof');
+
+const RECEIPT_FIELDS = Object.freeze([
+  'selection_id', 'work_focus_digest', 'selected_wardrobe', 'wsp97_depth',
+  'selected_context_mode', 'selected_model_mode', 'selected_effort',
+  'execution_plane', 'wre_required', 'authority_boundary',
+  'holoindex_query_digest', 'holoindex_freshness_label', 'index_gap_detected',
+  'direct_read_required', 'grounding_preflight_applied',
+  'grounding_preflight_passed', 'grounding_preflight_digest',
+  'grounding_preflight_rejection_reasons', 'foundup_id',
+  'registered_foundup_target_receipt_id', 'skillz_candidates', 'lane_refs',
+  'rejection_reasons', 'no_execution_performed', 'no_enqueue_performed',
+  'implementation_status'
+]);
+const PLANES = Object.freeze({
+  wsp97_solo_retrieval: 'advisory_only',
+  wsp97_architect_audit: 'audit_only',
+  wsp97_implementation_slice: 'worker_draft_pr',
+  wsp97_sovereign_execution: 'governed_execution_candidate'
+});
+const AUTHORITIES = Object.freeze({
+  wsp97_solo_retrieval: Object.freeze(['no_authority']),
+  wsp97_architect_audit: Object.freeze(['no_authority']),
+  wsp97_implementation_slice: Object.freeze(['draft_pr_only']),
+  wsp97_sovereign_execution: Object.freeze(['signed_valve_required', 'sovereign_token_required'])
+});
+
+function canonicalJson(value) {
+  if (Array.isArray(value)) return '[' + value.map(canonicalJson).join(',') + ']';
+  if (value && typeof value === 'object') return '{' + Object.keys(value).sort()
+    .map((key) => JSON.stringify(key) + ':' + canonicalJson(value[key])).join(',') + '}';
+  return JSON.stringify(value);
+}
+
+function shapeAccepted(result) {
+  const receipt = result && result.receipt;
+  const strings = receipt && ['work_focus_digest', 'wsp97_depth', 'selected_context_mode',
+    'selected_model_mode', 'selected_effort', 'holoindex_query_digest',
+    'holoindex_freshness_label', 'foundup_id', 'implementation_status'];
+  return Boolean(result && result.decision === 'WARDROBE_SELECTION_ACCEPT' && receipt
+    && Object.keys(receipt).sort().join('|') === RECEIPT_FIELDS.slice().sort().join('|')
+    && /^[a-f0-9]{64}$/.test(receipt.selection_id)
+    && strings.every((key) => typeof receipt[key] === 'string')
+    && ['work_focus_digest', 'holoindex_query_digest', 'grounding_preflight_digest']
+      .every((key) => /^[a-f0-9]{64}$/.test(receipt[key]))
+    && ['wsp97_depth', 'selected_context_mode', 'selected_model_mode', 'selected_effort']
+      .every((key) => receipt[key].length > 0)
+    && PLANES[receipt.selected_wardrobe] === receipt.execution_plane
+    && AUTHORITIES[receipt.selected_wardrobe].includes(receipt.authority_boundary)
+    && receipt.implementation_status === 'SPECIFIED_NOT_IMPLEMENTED'
+    && ['wre_required', 'index_gap_detected', 'direct_read_required', 'grounding_preflight_applied',
+      'grounding_preflight_passed', 'no_execution_performed', 'no_enqueue_performed']
+      .every((key) => typeof receipt[key] === 'boolean')
+    && ['grounding_preflight_rejection_reasons', 'skillz_candidates', 'lane_refs', 'rejection_reasons']
+      .every((key) => Array.isArray(receipt[key]))
+    && receipt.rejection_reasons.length === 0
+    && receipt.grounding_preflight_rejection_reasons.length === 0
+    && (!receipt.grounding_preflight_applied || receipt.grounding_preflight_passed)
+    && receipt.no_execution_performed && receipt.no_enqueue_performed
+    && result.no_execution_performed === true && result.no_enqueue_performed === true
+    && (!Object.prototype.hasOwnProperty.call(result, 'rejection_reasons')
+      || (Array.isArray(result.rejection_reasons) && result.rejection_reasons.length === 0)));
+}
+
+function digestPayload(payload, result) {
+  const receipt = result.receipt;
+  const value = {};
+  RECEIPT_FIELDS.filter((key) => key !== 'selection_id')
+    .forEach((key) => { value[key] = receipt[key]; });
+  value.principal_ref = String(payload.principal_ref || 'unknown');
+  value.authority_request = String(result.authority_request || 'none');
+  value.wsp_refs = Array.isArray(result.governing_wsps) ? result.governing_wsps : [];
+  value.continuation_packet_digest = String(payload.continuation_packet_digest || '');
+  return value;
+}
+
+function createWardrobeSelectionProof(originAccepted) {
+  const sourceAccepted = typeof originAccepted === 'function'
+    ? originAccepted : () => false;
+  const proof = createOwnerProof(shapeAccepted);
+  return Object.freeze({
+    verifyAndObserve(payload, result) {
+      if (!sourceAccepted(result) || !shapeAccepted(result)) return result;
+      const expected = crypto.createHash('sha256')
+        .update(canonicalJson(digestPayload(payload, result)), 'utf8').digest('hex');
+      return expected === result.receipt.selection_id ? proof.observe(result) : result;
+    },
+    isAccepted(result) { return proof.isAccepted(result); },
+    rejection(result, required, build, decision) {
+      if (!required || proof.isAccepted(result)) return null;
+      return build(decision, {
+        rejection_reasons: ['selection_proof_missing'],
+        not_invoked_reason: 'selection_proof_missing'
+      });
+    }
+  });
+}
+
+module.exports = { createWardrobeSelectionProof };

--- a/extensions/reddog/package.json
+++ b/extensions/reddog/package.json
@@ -2,7 +2,7 @@
   "name": "reddog",
   "displayName": "RedDog - FoundUps Architect",
   "description": "Open the RedDog resident 0102 architect thin client for FoundUps.",
-  "version": "0.4.70",
+  "version": "0.4.71",
   "publisher": "foundups",
   "icon": "icon.png",
   "engines": {

--- a/extensions/reddog/principal_memex_disclosure_source.js
+++ b/extensions/reddog/principal_memex_disclosure_source.js
@@ -127,6 +127,8 @@ async function invokeStoredExclusive(secretStorage, invoke) {
 async function runConfigured(input) {
   const sessionOptions = {
     explicitResidentArchitectSessionRequested: true,
+    actionPlanningAllowed: input.options.actionPlanningAllowed === true,
+    wardrobeSelectionResult: input.options.wardrobeSelectionResult,
     groundingPreflight: input.options.groundingPreflight,
     holoScorecard: input.options.holoScorecard,
     authenticatedPrincipal: input.claims.principalId,

--- a/extensions/reddog/sealed_python_json_once.js
+++ b/extensions/reddog/sealed_python_json_once.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const cp = require('child_process');
+const { createOwnerProof } = require('./holoindex_owner_proof');
+const interpreterPolicy = require('./start_operations_interpreter');
+const runtimeMaterializer = require('./backend_compatibility_runtime_materializer');
+const startOperationsBridge = require('./start_operations_bridge');
+
+function createSealedPythonJsonRunner() {
+  const outputProof = createOwnerProof((value) => Boolean(
+    value && typeof value === 'object' && !Array.isArray(value)
+  ));
+  return Object.freeze({
+    run(options) {
+      const opts = options && typeof options === 'object' ? options : {};
+      const runtime = interpreterPolicy.approved(opts.interpreter, opts.repoRoot);
+      if (!runtime) throw new Error('unapproved_interpreter');
+      const source = (opts.materialize || runtimeMaterializer.materialize)(
+        runtime.repoRoot, opts.materializerOptions
+      );
+      try {
+        const args = [
+          '-I', '-S', '-B', source.scriptPath(startOperationsBridge.PYTHON_BOOTSTRAP),
+          source.scriptPath(opts.script), source.runtimeRoot,
+          source.targetRepoRoot, runtime.sitePackages,
+          source.manifestPath, source.manifestDigest
+        ];
+        const stdout = (opts.execFileSync || cp.execFileSync)(runtime.interpreter, args, {
+          cwd: source.runtimeRoot, input: JSON.stringify(opts.request || {}),
+          encoding: 'utf8', env: startOperationsBridge.sealedEnvironment(opts.env, source, runtime),
+          windowsHide: true, maxBuffer: Number(opts.maxBuffer || 262144)
+        });
+        const parsed = JSON.parse(stdout);
+        const result = typeof opts.mapResult === 'function' ? opts.mapResult(parsed) : parsed;
+        return outputProof.observe(result);
+      } finally {
+        source.cleanup();
+      }
+    },
+    isAccepted(value) { return outputProof.isAccepted(value); }
+  });
+}
+
+module.exports = { createSealedPythonJsonRunner };

--- a/extensions/reddog/start_operations_bridge.js
+++ b/extensions/reddog/start_operations_bridge.js
@@ -42,7 +42,7 @@ function launch(options) {
   );
   try {
     const args = [
-      '-I', '-S', '-B', PYTHON_BOOTSTRAP,
+      '-I', '-S', '-B', source.scriptPath(PYTHON_BOOTSTRAP),
       source.scriptPath(options.script), source.runtimeRoot,
       source.targetRepoRoot, runtime.sitePackages,
       source.manifestPath, source.manifestDigest
@@ -205,5 +205,6 @@ module.exports = {
   MAX_FRAMES,
   PYTHON_BOOTSTRAP,
   consumeLines,
+  sealedEnvironment,
   run
 };

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,27 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-08-09 - Single-input authority boundary hardening (0.4.71)
+
+- Proved false-valued diagnostic fields and terse command-result logs cannot
+  request resident work.
+- Proved timestamped, JSON, and logfmt evidence starts at the exact diagnostic
+  boundary while preceding operator constraints remain authoritative input.
+- Proved timestamped logger prefixes (`[worker] ERROR`, dashed logger names),
+  and `npm ERR!` remain inert without an explicit boundary, while inline prose
+  such as `Fix runtime output formatting` remains ordinary operator scope.
+- Proved accepted Wardrobe output requires a receipt and that resident
+  submission consumes the Wardrobe admission result rather than the earlier
+  generic runtime gate.
+- Proved the canonical selector digest and process-local owner proof reject
+  copied, mutated, injected, or malformed Wardrobe mappings.
+- Proved selector execution rejects an unapproved interpreter, uses sealed
+  `-I -S -B` startup with a materialized bootstrap, and that WRE, live-enqueue,
+  and action-bearing resident consumers cannot advance when called directly
+  without the immutable selector proof.
+- Proved unmarked mixed action-looking text plus diagnostics cannot infer
+  operator authority; the one-input route requires an explicit evidence marker.
+- Proved polite compound implementation directives remain actionable.
+
 ## 2026-08-09 - Single conversation input and governed action routing (0.4.70)
 
 - Proved the webview exposes exactly one textarea, Enter sends, and the legacy

--- a/extensions/reddog/tests/test_holoindex_incident_repair.js
+++ b/extensions/reddog/tests/test_holoindex_incident_repair.js
@@ -161,8 +161,8 @@ assert(extensionSource.includes('holoGenerationBoundQuery.isObserved(ownerResult
 assert(extensionSource.includes('holoIncidentRepair.shouldCoordinate(ownerResult, ownerObserved)'));
 assert(extensionSource.includes('coordinateHoloIndexIncident(root, query, ownerResult, ownerObserved)'));
 assert((extensionSource.match(/holoIncidentRepair\.metadata\(incidentRepair\)/g) || []).length >= 4);
-assert.strictEqual(pkg.version, '0.4.70');
-assert(extensionSource.includes("const EXTENSION_VERSION = '0.4.70'"));
+assert.strictEqual(pkg.version, '0.4.71');
+assert(extensionSource.includes("const EXTENSION_VERSION = '0.4.71'"));
 assert(!fs.readFileSync(path.join(extDir, 'holoindex_incident_repair.js'), 'utf8').includes('qwen'));
 
 console.log('RedDog HoloIndex incident repair extension tests passed.');

--- a/extensions/reddog/tests/test_start_operations_control.js
+++ b/extensions/reddog/tests/test_start_operations_control.js
@@ -10,6 +10,8 @@ const path = require('path');
 
 const protocol = require(path.join('..', 'start_operations_control.js'));
 const bridge = require(path.join('..', 'start_operations_bridge.js'));
+const sealedJsonOnce = require(path.join('..', 'sealed_python_json_once.js'))
+  .createSealedPythonJsonRunner();
 const runtimeMaterializer = require(
   path.join('..', 'backend_compatibility_runtime_materializer.js')
 );
@@ -105,7 +107,7 @@ function fakeMaterializer(runtime) {
     targetRepoRoot: runtime.repoRoot,
     manifestPath: path.join(runtime.repoRoot, 'runtime-manifest.json'),
     manifestDigest: '0'.repeat(64),
-    scriptPath: (value) => value,
+    scriptPath: (value) => path.join(runtime.repoRoot, 'sealed', path.basename(value)),
     cleanup() {}
   });
 }
@@ -334,6 +336,27 @@ async function main() {
   assert.strictEqual(approved.interpreter, fs.realpathSync(runtime.interpreter));
   assert.strictEqual(approved.sitePackages, fs.realpathSync(runtime.sitePackages));
   assert.strictEqual(interpreterPolicy.approved('python', runtime.repoRoot), '');
+  let sealedInvocation = null;
+  const sealedResult = sealedJsonOnce.run({
+    interpreter: runtime.interpreter, repoRoot: runtime.repoRoot,
+    script: 'selector.py', request: { action: 'select' }, env: {},
+    materialize: fakeMaterializer(runtime),
+    execFileSync: (command, args, options) => {
+      sealedInvocation = { command, args, options };
+      return JSON.stringify({ accepted: true });
+    }
+  });
+  assert.deepStrictEqual(sealedResult, { accepted: true });
+  assert.strictEqual(sealedJsonOnce.isAccepted(sealedResult), true);
+  assert.strictEqual(sealedJsonOnce.isAccepted(Object.assign({}, sealedResult)), false);
+  assert.strictEqual(sealedInvocation.command, fs.realpathSync(runtime.interpreter));
+  assert.deepStrictEqual(sealedInvocation.args.slice(0, 3), ['-I', '-S', '-B']);
+  assert(sealedInvocation.args[3].startsWith(runtime.repoRoot));
+  assert.strictEqual(sealedInvocation.options.env.REDDOG_SEALED_RUNTIME_REQUIRED, '1');
+  assert.throws(() => sealedJsonOnce.run({
+    interpreter: process.execPath, repoRoot: runtime.repoRoot,
+    script: 'selector.py', request: {}
+  }), /unapproved_interpreter/);
   assertStartupHooksExcluded();
   assertRedirectedVenvRejected();
   const result = await bridge.run({

--- a/extensions/reddog/tests/verify_extension_contract.js
+++ b/extensions/reddog/tests/verify_extension_contract.js
@@ -37,6 +37,10 @@ const conversationSessionAuthoritySourceJs = fs.readFileSync(
   path.join(extDir, 'conversation_session_authority_source.js'), 'utf8'
 );
 const conversationSessionAuthoritySource = require(path.join(extDir, 'conversation_session_authority_source.js'));
+const testWardrobeSourceProof = require(path.join(extDir, 'holoindex_owner_proof.js'))
+  .createOwnerProof((value) => Boolean(value && typeof value === 'object'));
+const testWardrobeProof = require(path.join(extDir, 'operator_wardrobe_selection_proof.js'))
+  .createWardrobeSelectionProof(testWardrobeSourceProof.isAccepted);
 const startOperationsInterpreterJs = fs.readFileSync(path.join(extDir, 'start_operations_interpreter.js'), 'utf8');
 const runtimeMaterializerJs = fs.readFileSync(
   path.join(extDir, 'backend_compatibility_runtime_materializer.js'), 'utf8'
@@ -234,8 +238,8 @@ function assertFusionRedactionGateFails(contextText, expectedReason, label) {
   assertFusionRedactionGateBlocks(contextText, expectedReason, label);
 }
 
-assert.strictEqual(pkg.version, '0.4.70', 'package version must be 0.4.70');
-includes(extensionJs, "const EXTENSION_VERSION = '0.4.70'", 'extension build mismatch');
+assert.strictEqual(pkg.version, '0.4.71', 'package version must be 0.4.71');
+includes(extensionJs, "const EXTENSION_VERSION = '0.4.71'", 'extension build mismatch');
 assert.strictEqual(pkg.name, 'reddog', 'package id must be canonical RedDog in 0.4.0');
 assert.strictEqual(pkg.displayName, 'RedDog - FoundUps Architect', 'display name must be canonical RedDog');
 includes(JSON.stringify(pkg), 'RedDog: Open', 'canonical command title must use RedDog');
@@ -382,7 +386,7 @@ includes(extensionJs, 'REDDOG_STAGE_ACTIONS', 'structured stage map missing');
 includes(extensionJs, 'REDDOG_PROGRESS_ACTIONS', 'progress regex fallback missing');
 includes(extensionJs, 'function matchReddogProgress', 'matchReddogProgress missing');
 includes(extensionJs, 'function formatElapsed', 'formatElapsed missing');
-includes(readme, 'Version: 0.4.70', 'README version mismatch');
+includes(readme, 'Version: 0.4.71', 'README version mismatch');
 includes(extensionJs, 'function buildBridgePythonEnv', 'bridge Python UTF-8 env helper missing');
 includes(extensionJs, 'PYTHONIOENCODING', 'bridge must set PYTHONIOENCODING=utf-8');
 includes(extensionJs, 'PYTHONUTF8', 'bridge must set PYTHONUTF8=1');
@@ -1546,7 +1550,22 @@ const traceGate = orchestrator.buildRuntimeConsumptionGate(
 assert.strictEqual(traceGate.passed, false, 'RTLA-001: trace assessment must not enable runtime consumption');
 assert(traceGate.rejection_reasons.includes('local_run_trace_assessment_not_actionable'), 'RTLA-001: runtime gate must name trace assessment rejection');
 const actionTracePrompt = blockedTracePrompt + '\n\nImplement the fix.';
-assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(actionTracePrompt), false, 'RTLA-002: action-oriented trace prompt must use governed path');
+assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(actionTracePrompt), true,
+  'RTLA-002: action words inside bounded trace evidence remain inert');
+const explicitActionTracePrompt = 'Implement the fix.\n\n'
+  + blockedTracePrompt.slice(blockedTracePrompt.indexOf('## Run Trace'));
+assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(explicitActionTracePrompt), false,
+  'RTLA-002: operator action before the trace boundary must use governed path');
+for (const actionVerb of [
+  'Implement', 'Fix', 'Repair', 'Harden', 'Improve', 'Enhance', 'Patch',
+  'Author', 'Merge', 'Land', 'Dispatch', 'Assign', 'Spawn', 'Execute', 'Run',
+  'Build', 'Edit', 'Add', 'Create'
+]) {
+  const actionPrompt = actionVerb + ' the runtime module.\n\n'
+    + blockedTracePrompt.slice(blockedTracePrompt.indexOf('## Run Trace'));
+  assert.strictEqual(orchestrator.isRunTraceAssessmentRequest(actionPrompt), false,
+    'RTLA-002: canonical action must not route locally: ' + actionVerb);
+}
 
 // REDDOG_DAEMON_DIAGNOSTIC_ARCHITECT_ANALYSIS_PHASE1: pasted DAEmon/log
 // diagnostics are data, not instructions. Bare dumps stay local; an explicit
@@ -1726,19 +1745,43 @@ const structuredActionLogIngress = orchestrator.splitDaemonDiagnosticInput([
 ].join('\n'), '');
 assert.strictEqual(structuredActionLogIngress.operator_intent_source, '',
   'DOLA-009A: structured diagnostic fields cannot become action directives');
+const structuredActionLogClass = orchestrator.classifyTaskForRedDog(
+  structuredActionLogIngress.combined_focus, 'auto', 'reddog_architect',
+  { daemonDiagnosticIngress: structuredActionLogIngress }
+);
+assert.strictEqual(structuredActionLogClass.governedActionRequested, false,
+  'DOLA-009B: false-valued diagnostic fields cannot request resident work');
+const buildFailureClass = orchestrator.classifyTaskForRedDog(
+  'Build failed', 'auto', 'reddog_architect'
+);
+assert.strictEqual(buildFailureClass.governedActionRequested, false,
+  'DOLA-009B: terse command-result diagnostics cannot request resident work');
+for (const diagnosticResult of [
+  'Build succeeded', 'Build successful', 'Run completed', 'Run finished',
+  'Execute denied', 'Fix resolved', 'Create generated', 'Patch accepted',
+  'Run OK', 'execute: false', 'fix: false', 'create: completed'
+]) {
+  assert.strictEqual(orchestrator.classifyTaskForRedDog(
+    diagnosticResult, 'auto', 'reddog_architect'
+  ).governedActionRequested, false,
+  'DOLA-009C: result-shaped text cannot request resident work: ' + diagnosticResult);
+}
 const structuredRequirementsIngress = orchestrator.splitDaemonDiagnosticInput([
   'Implement the login change.', '',
   'Target: modules/auth/src/token.js',
   'Behavior: reject expired tokens'
 ].join('\n'), '');
-assert.strictEqual(structuredRequirementsIngress.boundary, 'none',
+assert.strictEqual(structuredRequirementsIngress.boundary, 'operator_only',
   'DOLA-009A: ordinary structured work requirements are not diagnostic evidence');
 assert(structuredRequirementsIngress.combined_focus.includes('modules/auth/src/token.js'),
   'DOLA-009A: structured work targets must remain in the governed work focus');
 for (const directive of [
   'Create a PR for this fix.', 'Open the pull request.', 'Start a slice for this work.',
   'Add a regression test for modules/auth/token.js.',
-  'Create a module for token validation.', 'Analyze and fix this failure.'
+  'Create a module for token validation.', 'Analyze and fix this failure.',
+  'Please analyze and fix this failure.', 'Fix failed tests',
+  'Create: a PR for this fix.', 'Run: the focused tests.',
+  'Execute: the migration.'
 ]) {
   const directiveClass = orchestrator.classifyTaskForRedDog(
     directive, 'auto', 'reddog_architect'
@@ -1747,21 +1790,64 @@ for (const directive of [
     'DOLA-009A: established explicit action form must request resident work: ' + directive);
 }
 const colonDirectiveIngress = orchestrator.splitDaemonDiagnosticInput([
-  'Fix: update token validation.', 'ERROR: worker failed'
+  'Fix: update token validation.', 'DAEmon output:', 'ERROR: worker failed'
 ].join('\n'), '');
 assert.strictEqual(colonDirectiveIngress.operator_intent_source, 'Fix: update token validation.',
   'DOLA-009A: a recognized colon-form directive must outrank generic structured-line detection');
 const oneLineEvidenceIngress = orchestrator.splitDaemonDiagnosticInput([
   'Fix this runtime failure.', 'ERROR: worker failed'
 ].join('\n'), '');
-assert.strictEqual(oneLineEvidenceIngress.boundary, 'inferred_conversation_boundary',
-  'DOLA-009A: one strongly diagnostic line is sufficient after an explicit request');
-assert.strictEqual(oneLineEvidenceIngress.operator_intent_source, 'Fix this runtime failure.',
-  'DOLA-009A: single-line evidence must not swallow the explicit request');
+assert.strictEqual(oneLineEvidenceIngress.boundary, 'none',
+  'DOLA-009A: untyped mixed text cannot infer authority from an action-looking preamble');
+assert.strictEqual(oneLineEvidenceIngress.operator_intent_source, '',
+  'DOLA-009A: untyped diagnostic evidence cannot mint operator intent');
+for (const evidenceLine of [
+  '2026-08-09T10:01:00Z ERROR: worker failed',
+  '2026-08-09 10:01:00,123 ERROR worker failed',
+  '2026-08-09 10:01:00.123 [ERROR] worker failed',
+  '2026-08-09T10:01:00Z [worker] ERROR failed',
+  '2026-08-09 10:01:00,123 - worker - ERROR - failed',
+  '[2026-08-09T10:01:00Z] [worker] ERROR failed',
+  '2026/08/09 10:01:00 [worker] ERROR failed',
+  'Aug 09 10:01:00 host worker[123]: ERROR failed',
+  'npm ERR! lifecycle command failed',
+  '{"timestamp":"2026-08-09T10:01:00Z","level":"error","message":"worker failed"}',
+  'timestamp=2026-08-09T10:01:00Z level=error msg="worker failed"'
+]) {
+  const unmarked = orchestrator.splitDaemonDiagnosticInput(
+    'Fix this runtime failure.\n' + evidenceLine, ''
+  );
+  assert.strictEqual(unmarked.boundary, 'none',
+    'DOLA-009B: unmarked common log format must remain wholly inert: ' + evidenceLine);
+  assert.strictEqual(unmarked.operator_intent_source, '',
+    'DOLA-009B: unmarked common log format cannot mint operator intent: ' + evidenceLine);
+  const ingress = orchestrator.splitDaemonDiagnosticInput(
+    'Fix this runtime failure.\nDAEmon output:\n' + evidenceLine, ''
+  );
+  assert.strictEqual(ingress.operator_intent_source, 'Fix this runtime failure.',
+    'DOLA-009B: common log format must start inert evidence: ' + evidenceLine);
+  assert(ingress.diagnostic_payload.includes(evidenceLine),
+    'DOLA-009B: common log format remains evidence: ' + evidenceLine);
+}
+for (const ordinaryRequest of [
+  'Fix runtime output: formatting in the status table.',
+  'Improve worker logs: alignment in the dashboard.'
+]) {
+  const ingress = orchestrator.splitDaemonDiagnosticInput(ordinaryRequest, '');
+  assert.strictEqual(ingress.boundary, 'operator_only',
+    'DOLA-009D: inline prose is not an explicit evidence boundary: ' + ordinaryRequest);
+  assert.strictEqual(ingress.operator_intent_source, ordinaryRequest,
+    'DOLA-009D: ordinary requested scope must remain intact: ' + ordinaryRequest);
+  assert.strictEqual(orchestrator.classifyTaskForRedDog(
+    ordinaryRequest, 'auto', 'reddog_architect'
+  ).governedActionRequested, true,
+  'DOLA-009D: ordinary inline-colon request must remain actionable: ' + ordinaryRequest);
+}
 const multilineDirectiveIngress = orchestrator.splitDaemonDiagnosticInput([
   'Fix this failure.',
   'Only edit modules/auth/token.js.',
   'Preserve the public API.',
+  'DAEmon output:',
   'ERROR: timeout',
   'status: stopped'
 ].join('\n'), '');
@@ -1782,19 +1868,57 @@ assert.strictEqual(orchestrator.classifyTaskForRedDog(
   'Write tests for modules/auth/src/token.js.', 'auto', 'reddog_architect'
 ).governedActionRequested, true,
 'DOLA-009A: explicit code/test writing remains actionable');
+for (const terminalResult of [
+  'Fix: failed', 'Execute: error', 'Build: succeeded', 'Run: timeout',
+  'Create: blocked', 'Patch: 0.4.71', 'Fix: failed.', 'Execute: error!',
+  'Build: succeeded.', 'Patch: 0.4.71.', 'Fix: "failed"',
+  'Execute: [error]', "Build: 'succeeded'", 'Fix: !!!', 'Execute: []',
+  'Build: ""', 'Patch: (...?)', 'Patch: rejected', 'Run: aborted',
+  'Build: finished', 'Execute: cancelled', 'Create: skipped', 'Fix: unsuccessful',
+  'Run: pass/fail', 'Build: 1/2', 'Patch: N/A',
+  'Execute: https://ci.example/job/123', 'Build: validation failed',
+  'Fix: tests failed', 'Execute: runtime blocked', 'Patch: module rejected',
+  'Create: worker cancelled', 'Patch: ../outside/token.py',
+  'Patch: /tmp/token.py', 'Patch: C:\\temp\\token.py',
+  'Patch: \\\\server\\share\\token.py', 'Patch: //host/share/token.py',
+  'Patch: file:\\temp\\token.py'
+]) {
+  assert.strictEqual(orchestrator.classifyTaskForRedDog(
+    terminalResult, 'auto', 'reddog_architect'
+  ).governedActionRequested, false,
+  'DOLA-009D: terminal colon result cannot mint action: ' + terminalResult);
+}
+for (const explicitDirective of [
+  'Fix: failed tests', 'Run: the focused tests',
+  'Patch: modules/auth/token.py', 'Edit: modules\\auth\\token.py'
+]) {
+  assert.strictEqual(orchestrator.classifyTaskForRedDog(
+    explicitDirective, 'auto', 'reddog_architect'
+  ).governedActionRequested, true,
+  'DOLA-009D: explicit colon directive remains actionable: ' + explicitDirective);
+}
 
 const inferredSingleInput = orchestrator.splitDaemonDiagnosticInput([
-  'Fix this runtime failure.', '',
+  'Fix this runtime failure.', '', 'DAEmon output:',
   'ERROR: HoloIndex owner exited',
   'status: stopped',
   'result: failed'
 ].join('\n'), '');
-assert.strictEqual(inferredSingleInput.boundary, 'inferred_conversation_boundary',
-  'DOLA-009A: one-input conversation must infer the intent/evidence boundary');
+assert.strictEqual(inferredSingleInput.boundary, 'explicit_text_boundary',
+  'DOLA-009A: one-input conversation uses an explicit intent/evidence boundary');
 assert.strictEqual(inferredSingleInput.operator_intent_source, 'Fix this runtime failure.',
-  'DOLA-009A: inferred operator intent must exclude diagnostic data');
+  'DOLA-009A: explicitly bounded operator intent must exclude diagnostic data');
 assert(inferredSingleInput.diagnostic_payload.includes('HoloIndex owner exited'),
   'DOLA-009A: inferred evidence payload must retain diagnostic lines');
+const longBoundaryPrefix = '## Run Trace' + '\t'.repeat(200000);
+const longBoundaryStarted = Date.now();
+const longBoundaryIngress = orchestrator.splitDaemonDiagnosticInput(
+  'Fix this runtime failure.\n' + longBoundaryPrefix + '\nERROR: failed', ''
+);
+assert.strictEqual(longBoundaryIngress.boundary, 'explicit_text_boundary',
+  'DOLA-009D: canonical boundary semantics survive an oversized whitespace suffix');
+assert(Date.now() - longBoundaryStarted < 500,
+  'DOLA-009D: explicit boundary scanning must remain bounded on oversized input');
 const inferredSingleClass = orchestrator.classifyTaskForRedDog(
   inferredSingleInput.combined_focus, 'auto', 'reddog_architect',
   { daemonDiagnosticIngress: inferredSingleInput }
@@ -2609,7 +2733,7 @@ assert.strictEqual(spinePreview.dry_run_only, true, 'WRE preview must be dry-run
 assert.strictEqual(spinePreview.candidate_work_order_emitted, true, 'WRE preview emits typed candidate shape');
 assert(spinePreview.governed_work_order_candidate, 'WRE preview must include governed work-order candidate');
 assert(/^rdog-wo-[a-f0-9]{16}$/.test(spinePreview.governed_work_order_candidate.work_order_id), 'candidate work_order_id shape');
-assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.70', 'candidate must bind extension version');
+assert.strictEqual(spinePreview.governed_work_order_candidate.red_dog_instance_id, 'foundups-agent-0.4.71', 'candidate must bind extension version');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.source, 'extension_runtime_candidate', 'candidate must not forge permission source');
 assert.strictEqual(spinePreview.governed_work_order_candidate.repo_permission_snapshot.permission_level, 'needs_verification', 'candidate must fail closed on permission');
 assert.deepStrictEqual(spinePreview.governed_work_order_candidate.allowed_paths, [],
@@ -2774,15 +2898,28 @@ assert.strictEqual(fakeWardrobeSelection.python_invocation_performed, false, 'fa
 assert.strictEqual(fakeWardrobeSelection.no_execution_performed, true, 'fake wardrobe bridge performs no execution');
 assert.strictEqual(fakeWardrobeSelection.no_enqueue_performed, true, 'fake wardrobe bridge performs no enqueue');
 assert.strictEqual(fakeWardrobeSelection.receipt.authority_boundary, 'sovereign_token_required', 'fake wardrobe receipt requires sovereign boundary');
+assert.strictEqual(testWardrobeProof.isAccepted({
+  decision: 'WARDROBE_SELECTION_REJECT', receipt: null,
+  no_execution_performed: true, no_enqueue_performed: true
+}), false, 'rejected wardrobe selection cannot admit resident submission');
+assert.strictEqual(testWardrobeProof.isAccepted({
+  decision: 'WARDROBE_SELECTION_ACCEPT', receipt: null,
+  no_execution_performed: true, no_enqueue_performed: true
+}), false, 'receipt-less wardrobe acceptance cannot admit resident submission');
+assert.strictEqual(testWardrobeProof.isAccepted({
+  decision: 'WARDROBE_SELECTION_ACCEPT', receipt: {},
+  no_execution_performed: true, no_enqueue_performed: true
+}), false, 'empty wardrobe receipts cannot admit resident submission');
+includes(extensionJs,
+  'wardrobeSelectionResult: operatorWardrobeSelectionResult, residentArchitectSessionEnabled',
+  'resident submission must consume the receipt-bearing wardrobe admission result');
 const fakeWardrobeSection = orchestrator.buildOperatorWardrobeSelectionSection(fakeWardrobeSelection);
 includes(fakeWardrobeSection, '## RedDog Operator Wardrobe Selection', 'wardrobe selection section header');
 includes(fakeWardrobeSection, 'selected_wardrobe: wsp97_sovereign_execution [OBSERVED]', 'wardrobe selection section shows selected wardrobe');
 includes(fakeWardrobeSection, 'no_execution_performed: true [OBSERVED]', 'wardrobe selection section shows no execution');
 
 const realWardrobeSelection = JSON.parse(cp.execFileSync('python', ['-B', path.join(root, 'scripts', 'reddog_operator_wardrobe_selection_once.py')], {
-  cwd: root,
-  input: JSON.stringify(wardrobePayload),
-  encoding: 'utf8',
+  cwd: root, input: JSON.stringify(wardrobePayload), encoding: 'utf8',
   env: Object.assign({}, process.env, { PYTHONIOENCODING: 'utf-8', PYTHONUTF8: '1' }),
   maxBuffer: 262144
 }));
@@ -2792,6 +2929,28 @@ assert.strictEqual(realWardrobeSelection.no_enqueue_performed, true, 'one-shot w
 assert.strictEqual(realWardrobeSelection.receipt.selected_wardrobe, 'wsp97_sovereign_execution', 'one-shot wardrobe bridge selects sovereign wardrobe');
 assert.strictEqual(realWardrobeSelection.receipt.authority_boundary, 'sovereign_token_required', 'one-shot wardrobe bridge preserves sovereign boundary');
 assert.strictEqual(realWardrobeSelection.receipt.wre_required, true, 'one-shot wardrobe bridge marks WRE required for worktree authority');
+testWardrobeSourceProof.observe(realWardrobeSelection);
+testWardrobeProof.verifyAndObserve(wardrobePayload, realWardrobeSelection);
+assert.strictEqual(testWardrobeProof.isAccepted(realWardrobeSelection), true,
+  'canonical receipt-bearing wardrobe selection admits resident submission');
+const unsafeWardrobeReceipt = JSON.parse(JSON.stringify(realWardrobeSelection));
+unsafeWardrobeReceipt.receipt.no_execution_performed = false;
+unsafeWardrobeReceipt.receipt.no_enqueue_performed = false;
+unsafeWardrobeReceipt.receipt.rejection_reasons = ['unsafe'];
+assert.strictEqual(testWardrobeProof.isAccepted(unsafeWardrobeReceipt), false,
+  'receipt-level side effects or rejection must block resident submission');
+const extendedWardrobeReceipt = JSON.parse(JSON.stringify(realWardrobeSelection));
+extendedWardrobeReceipt.receipt.attacker_extra = true;
+assert.strictEqual(testWardrobeProof.isAccepted(extendedWardrobeReceipt), false,
+  'unknown wardrobe receipt fields fail closed');
+const recomputedWardrobeReceipt = JSON.parse(JSON.stringify(realWardrobeSelection));
+recomputedWardrobeReceipt.receipt.foundup_id = 'attacker-selected';
+recomputedWardrobeReceipt.receipt.selection_id = require('crypto').createHash('sha256').update(
+  JSON.stringify({ attacker: true }), 'utf8'
+).digest('hex');
+assert.strictEqual(testWardrobeProof.verifyAndObserve(wardrobePayload, recomputedWardrobeReceipt), recomputedWardrobeReceipt);
+assert.strictEqual(testWardrobeProof.isAccepted(recomputedWardrobeReceipt), false,
+  'recomputed receipt without sealed source proof cannot acquire admission');
 
 // REDDOG_EXTENSION_TO_OPENCLAW_LIVE_ENQUEUE_RUNTIME_BINDING_PHASE1:
 // extension may reach the explicit live-enqueue invoke guard only after runtime gating,
@@ -2927,7 +3086,10 @@ const fakeLiveInvoke = orchestrator.invokeOpenClawLiveEnqueueRuntimeBindingBridg
     }
   }
 );
-assert.strictEqual(fakeLiveInvoke.decision, 'EXTENSION_LIVE_ENQUEUE_INVOKE_REJECT', 'fake live enqueue bridge preserves guard rejection');
+assert.strictEqual(fakeLiveInvoke.decision, 'EXTENSION_OPENCLAW_LIVE_ENQUEUE_SKIPPED',
+  'direct live enqueue call without process-local selector proof is skipped');
+assert(fakeLiveInvoke.rejection_reasons.includes('selection_proof_missing'),
+  'direct live enqueue call exposes the missing proof');
 assert.strictEqual(fakeLiveInvoke.openclaw_enqueue_performed, false, 'fake live enqueue bridge performs no enqueue');
 assert.strictEqual(fakeLiveInvoke.concrete_writer_enabled, false, 'fake live enqueue bridge keeps writer disabled');
 const fakeLiveInvokeSection = orchestrator.buildOpenClawLiveEnqueueRuntimeBindingSection(fakeLiveInvoke);
@@ -3125,7 +3287,8 @@ assert(!authorityBoundSection.includes('must-not-leak'), 'candidate section must
 const skippedInvoke = orchestrator.invokeWreOperationalSpineExplicitValveBridge(null, spinePreview, {});
 assert.strictEqual(skippedInvoke.decision, 'EXTENSION_WRE_OPERATIONAL_SPINE_INVOKE_SKIPPED', 'runtime wire must skip without explicit invoke metadata');
 assert.strictEqual(skippedInvoke.python_invocation_performed, false, 'skipped runtime wire must not invoke Python');
-assert(skippedInvoke.rejection_reasons.includes('explicit_wre_operational_spine_request_missing'), 'skipped runtime wire must cite missing explicit request');
+assert(skippedInvoke.rejection_reasons.includes('selection_proof_missing'),
+  'skipped runtime wire must reject before payload assembly without selector proof');
 const skippedInvokeSection = orchestrator.buildWreOperationalSpineInvokeSection(skippedInvoke);
 includes(skippedInvokeSection, '## WRE Operational Spine Runtime Wire', 'runtime wire section header');
 includes(skippedInvokeSection, 'python_invocation_performed: false [OBSERVED]', 'runtime wire skipped section must show no Python invocation');
@@ -3202,8 +3365,11 @@ const fakeInvoke = orchestrator.invokeWreOperationalSpineExplicitValveBridge(nul
     };
   }
 });
-assert.strictEqual(fakeInvoke.decision, 'EXTENSION_WRE_OPERATIONAL_SPINE_INVOKE_ACCEPT', 'runtime wire should accept fake bridge result');
-assert.strictEqual(fakeInvoke.wre_spine_invoked, true, 'runtime wire fake bridge should mark spine invoked');
+assert.strictEqual(fakeInvoke.decision, 'EXTENSION_WRE_OPERATIONAL_SPINE_INVOKE_SKIPPED',
+  'direct WRE call without process-local selector proof is skipped');
+assert(fakeInvoke.rejection_reasons.includes('selection_proof_missing'),
+  'direct WRE call exposes the missing proof');
+assert.strictEqual(fakeInvoke.wre_spine_invoked, false, 'unproved WRE call cannot invoke the spine');
 const fakeInvokeSection = orchestrator.buildWreOperationalSpineInvokeSection(fakeInvoke);
 assert(!fakeInvokeSection.includes('must-not-leak'), 'runtime wire section must not leak sovereign token or signature');
 
@@ -4117,7 +4283,7 @@ const recallTargets = orchestrator.inferRecallTargetPaths(extAcc001Prompt);
 assert(recallTargets.includes(fixtures.EXT_ACC_001_TARGET_PATH), 'EXT-ACC-001 prompt must map to extension.js');
 
 const extensionSnippet = orchestrator.readBoundedTargetSnippet(root, fixtures.EXT_ACC_001_TARGET_PATH, 24000);
-includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.70'", 'target snippet must include extension.js source');
+includes(extensionSnippet.content, "const EXTENSION_VERSION = '0.4.71'", 'target snippet must include extension.js source');
 assert(extensionSnippet.chars > 0, 'target snippet chars must be nonzero');
 assert.strictEqual(extensionSnippet.omitted_reason, 'none', 'extension.js snippet must not be omitted');
 
@@ -4131,7 +4297,7 @@ assert.strictEqual(safeResolve.ok, true, 'extension.js must resolve inside works
 const targetSection = orchestrator.buildTargetRecallContentSection(root, extAcc001Prompt, 24000);
 includes(targetSection.text, '### Target recall content', 'target recall section header missing');
 includes(targetSection.text, fixtures.EXT_ACC_001_TARGET_PATH, 'target recall must cite extension.js path');
-includes(targetSection.text, "const EXTENSION_VERSION = '0.4.70'", 'target recall must include source snippet');
+includes(targetSection.text, "const EXTENSION_VERSION = '0.4.71'", 'target recall must include source snippet');
 assert.strictEqual(targetSection.meta.target_content_included, true, 'target_content_included must be true when snippets present');
 assert(targetSection.meta.target_content_chars > 0, 'target_content_chars must be > 0');
 
@@ -4143,7 +4309,7 @@ assert.strictEqual(wsp97Excerpt.meta.wsp97_excerpt_included, true, 'wsp97_excerp
 const boundedContext = orchestrator.buildBoundedRepoContext('wsp_holo_skillz', extAcc001Prompt);
 includes(boundedContext.text, '### Target recall content', 'bounded context must include target recall section');
 includes(boundedContext.text, fixtures.EXT_ACC_001_TARGET_PATH, 'bounded context must include extension.js path');
-includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.70'", 'bounded context must include source snippet');
+includes(boundedContext.text, "const EXTENSION_VERSION = '0.4.71'", 'bounded context must include source snippet');
 includes(boundedContext.text, '### WSP protocol excerpt (bounded)', 'WSP_97 task must include protocol excerpt');
 includes(boundedContext.text, 'WSP 97: System Execution Prompting Protocol', 'bounded context must include WSP_97 excerpt body');
 assert.strictEqual(boundedContext.holoindex_scorecard.target_content_included, true, 'scorecard target_content_included must be true');
@@ -5326,7 +5492,8 @@ assert.strictEqual(diagnosticPreflight.grounding_target_universe_required, false
 assert(!/runtime[^\n]{0,80}(?:reindex|--index)/i.test(extensionJs.slice(extensionJs.indexOf('function buildTypedGroundingPreflight'), extensionJs.indexOf('function buildGroundingPreflightBlockedResult'))),
   'TGP-013: grounding preflight remains query-only and never triggers runtime reindex');
 const actionableLogPrompt = [
-  'Implement a fix for this runtime output:',
+  'Implement a fix for this runtime failure.',
+  'DAEmon output:',
   '- runtime status: stopped',
   '- stderr: timeout',
   '- warning: worker failed',
@@ -5536,7 +5703,7 @@ vscodeMock.extensions.getExtension = (id) => (
   id === 'foundups.foundups-fusion-worker'
     ? { id, packageJSON: { version: '0.3.68' } }
     : id === 'foundups.reddog'
-      ? { id, packageJSON: { version: '0.4.70' } }
+      ? { id, packageJSON: { version: '0.4.71' } }
       : undefined
 );
 const duplicateDetectedState = orchestrator.detectRedDogInstallState({
@@ -5689,6 +5856,17 @@ assert.strictEqual(residentBridgeResult.red_dog_intent_submitted, true, 'RPI-005
 assert.strictEqual(residentBridgeResult.intent_id, residentRunnerPayload.intent_id, 'RPI-005: bridge result binds intent id');
 assert.strictEqual(residentBridgeResult.queue_candidate_count, 1, 'RAS-005: queue candidate count preserved');
 assert.strictEqual(residentBridgeResult.no_repo_mutation_performed, true, 'RAS-005: no repo mutation preserved');
+let unprovedActionRunnerCalled = false;
+const unprovedActionSession = orchestrator.runResidentArchitectSessionBridge(null, 'fix work', Object.assign({}, residentGroundingOptions, {
+  explicitResidentArchitectSessionRequested: true,
+  actionPlanningAllowed: true,
+  conversationSessionCredential: testSessionCredential,
+  sessionRunner: () => { unprovedActionRunnerCalled = true; return {}; }
+}));
+assert.strictEqual(unprovedActionSession.not_invoked_reason, 'selection_proof_missing',
+  'RAS-005: action session requires process-local selector proof at the admission seam');
+assert.strictEqual(unprovedActionRunnerCalled, false,
+  'RAS-005: action session runner is never called without selector proof');
 const missingSessionSource = orchestrator.runResidentArchitectSessionBridge(null, 'audit work', Object.assign({}, residentGroundingOptions, {
   explicitResidentArchitectSessionRequested: true,
   sessionRunner: () => { throw new Error('must not run'); }


### PR DESCRIPTION
## Summary
- keep RedDog on one conversational input while making diagnostic evidence inert unless separated by the canonical line-anchored boundary
- execute Wardrobe selection through the approved manifest-materialized Python runtime and bind accepted output to a private process-local proof
- enforce that proof at WRE, live-enqueue, and action-bearing resident admission seams

## Verification
- 18/18 RedDog JavaScript suites passed
- 72/72 focused backend tests passed
- independent exact-SHA security review: GO
- independent exact-SHA integration review: GO
- extension.js parent-relative no-growth: 21 additions / 24 deletions
- git diff --check and ASCII checks passed

## Truth Boundary
- no new shell, worktree, enqueue, merge, or signing authority
- no HoloIndex reindex
- no second input or whole-message authority fallback