### PR TITLE
feat(reddog): add signer WSP 71 resolver supply

### DIFF
--- a/WSP_knowledge/WSP_Test_Registry.json
+++ b/WSP_knowledge/WSP_Test_Registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "wsp_test_registry.v2",
   "generation_policy": "git-tracked-python-tests.v1",
-  "total_tests": 1503,
+  "total_tests": 1504,
   "quarantined_tests": 263,
   "tests": [
     {
@@ -10597,6 +10597,19 @@
       "description": "Privileged Linux integration tests for signer owner-config admission."
     },
     {
+      "id": "test::modules::communication::moltbot_bridge::tests::test_reddog_signer_system_service_wsp71_resolver_supply",
+      "path": "modules/communication/moltbot_bridge/tests/test_reddog_signer_system_service_wsp71_resolver_supply.py",
+      "owner": "modules/communication/moltbot_bridge",
+      "suite_class": "unit",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-09",
+      "capabilities": [],
+      "execution_type": "unit",
+      "collectable": true,
+      "timeout_s": 180,
+      "quarantine_reasons": [],
+      "description": "Security tests for signer-owned production WSP 71 resolver supply."
+    },
+    {
       "id": "test::modules::communication::moltbot_bridge::tests::test_reddog_signer_wsp71_ephemeral_backend_factory",
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_signer_wsp71_ephemeral_backend_factory.py",
       "owner": "modules/communication/moltbot_bridge",
@@ -10880,7 +10893,7 @@
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_wre_governed_shell_runner_contract_doc.py",
       "owner": "modules/communication/moltbot_bridge",
       "suite_class": "unit",
-      "shard_id": "modules-communication-moltbot-bridge-unit-part-09",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-10",
       "capabilities": [],
       "execution_type": "unit",
       "collectable": true,

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -193,7 +193,7 @@ current E0 policy, generation, authority, target signer, and durable store.
 An uncomposed local witness and policy v3 bind the root-state anchor; the oracle
 requires three-way agreement; two mutable root mirrors can be rolled back while the
 static installation domain remains unchanged. Root-service transport, protected-use client,
-and composed oracle exist; the production backend factory, grant issuer, and WSP71 resolver remain absent, so system-service signing still fails closed.
+and composed oracle exist. A root-owned WSP71 resolver factory exists but remains uncomposed; the production backend and grant issuer remain absent, so system-service signing fails closed.
 Native-memory zeroization and complete signer lifecycle supervision remain
 SPECIFIED_NOT_IMPLEMENTED.
 No private key, resolved secret, grant signature, or audit key is serialized.

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,4 +1,15 @@
 # ModLog - moltbot_bridge
+## 2026-08-14: Signer system-service WSP 71 resolver supply
+- Reused the existing `OpCliSecretResolver` behind a signer-owned factory
+  that binds an authenticated owner-configuration identifier.
+- Production accepts only the fixed `/usr/bin/op` executable when it is a
+  root-owned regular executable with secure ancestry and no group/other write
+  bits. Invalid owner identity, missing binary, unsafe permissions, and vault
+  failures remain fail closed without secret persistence or shell execution.
+- The production entrypoint remains fail closed. Grant-aware resolve-per-sign
+  composition, lifecycle deployment, live worker authority, merge authority,
+  and HoloIndex mutation remain unavailable.
+  (WSP 00/15/22/50/62/71/97)
 ## 2026-08-14: Progressive-policy resident-chain regression repair
 - Reconciled resident-chain test fixtures with the existing signed progressive
   execution-stage policy. Valid fixtures now model genuinely bounded FoundUp

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -208,8 +208,11 @@ now verifies one request-bound secret-access grant, atomically consumes durable
 replay state, resolves WSP71 keys for that sign only, and rechecks revocation,
 expiry, provider identity, and the returned signature. The stable entrypoint
 now applies the executable OS-isolation boundary before resolver construction.
-Its production WSP71 secret resolver remains unavailable, so production signing
-still fails closed. The owner-controlled E0 admission layer binds one signed
+An uncomposed WSP71 factory reuses `OpCliSecretResolver` and accepts only a
+fixed root-owned, executable, non-writable `/usr/bin/op`. The production
+entrypoint retains its unavailable resolver until the existing grant-aware
+resolve-per-sign backend is composed, so system-service signing fails closed.
+The owner-controlled E0 admission layer binds one signed
 policy to the exact current signer generation, key-reference digests,
 manifest-bound grant/revocation authorities, disjoint durable-state roots,
 operation/tier consensus rules, and rate limits. Its opaque one-use capability

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -97,8 +97,10 @@
   signer callback, FINISH, and revocation advancement. Both race orderings,
   replay, lost FINISH response, active-use crash, peer/policy/context
   substitution, and Linux-root socket transport fail closed.
+- COMPLETE: an uncomposed WSP 71 op CLI resolver factory requires a fixed,
+  root-owned executable with secure ancestry and no group/other write access.
 - NEXT: independently administered grant issuance, production E0 backend
-  factory composition, WSP 71 permissioned resolution, native-memory
+  factory composition, WSP 71 resolve-per-sign composition, native-memory
   zeroization evidence, and supervised handling of a crashed active use.
   The protected-use client is available through the current owner-config
   loader, but no production grant issuer or service startup path consumes it.

--- a/modules/communication/moltbot_bridge/src/reddog_signer_system_service_wsp71_resolver_supply.py
+++ b/modules/communication/moltbot_bridge/src/reddog_signer_system_service_wsp71_resolver_supply.py
@@ -1,0 +1,100 @@
+"""Root-owned WSP 71 resolver supply for the signer system service."""
+
+from __future__ import annotations
+
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from modules.infrastructure.secrets_mcp.src.op_cli_secret_resolver import (
+    DEFAULT_MAX_SECRET_CHARS,
+    DEFAULT_OP_TIMEOUT_SECONDS,
+    OpCliCommandRunner,
+    OpCliSecretResolver,
+)
+
+
+SYSTEM_SERVICE_OP_EXECUTABLE = Path("/usr/bin/op")
+SYSTEM_SERVICE_SECRET_TTL_SECONDS = 60
+
+
+@dataclass(frozen=True, slots=True)
+class SystemServiceWsp71ResolverFactory:
+    """Create one resolve-per-sign client after signer admission."""
+
+    owner_config_id: str
+    runner: OpCliCommandRunner | None = None
+
+    def __call__(self) -> OpCliSecretResolver:
+        if not _sha256(self.owner_config_id):
+            raise ValueError("system_service_owner_config_id_invalid")
+        _require_root_owned_executable(SYSTEM_SERVICE_OP_EXECUTABLE)
+        return OpCliSecretResolver(
+            op_executable=str(SYSTEM_SERVICE_OP_EXECUTABLE),
+            timeout_s=DEFAULT_OP_TIMEOUT_SECONDS,
+            ttl_seconds=SYSTEM_SERVICE_SECRET_TTL_SECONDS,
+            max_secret_chars=DEFAULT_MAX_SECRET_CHARS,
+            session_id="reddog-signer:" + self.owner_config_id[7:23],
+            runner=self.runner,
+        )
+
+
+def build_system_service_wsp71_resolver_factory(
+    *, owner_config_id: str,
+) -> SystemServiceWsp71ResolverFactory:
+    """Bind production resolver construction to root-selected authority."""
+
+    return SystemServiceWsp71ResolverFactory(owner_config_id=owner_config_id)
+
+
+def _require_root_owned_executable(path: Path) -> None:
+    if not sys.platform.startswith("linux"):
+        raise ValueError("system_service_wsp71_linux_required")
+    if not path.is_absolute() or path.is_symlink():
+        raise ValueError("system_service_op_executable_invalid")
+    try:
+        metadata = path.stat(follow_symlinks=False)
+    except OSError as exc:
+        raise ValueError("system_service_op_executable_unavailable") from exc
+    mode = stat.S_IMODE(metadata.st_mode)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or mode & 0o022
+        or not mode & 0o111
+    ):
+        raise ValueError("system_service_op_executable_untrusted")
+    _require_root_owned_ancestry(path.parent)
+
+
+def _require_root_owned_ancestry(path: Path) -> None:
+    for directory in (path, *path.parents):
+        try:
+            metadata = directory.stat(follow_symlinks=False)
+        except OSError as exc:
+            raise ValueError("system_service_op_ancestry_unavailable") from exc
+        if (
+            directory.is_symlink()
+            or not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != 0
+            or stat.S_IMODE(metadata.st_mode) & 0o022
+        ):
+            raise ValueError("system_service_op_ancestry_untrusted")
+
+
+def _sha256(value: object) -> bool:
+    text = value if isinstance(value, str) else ""
+    return bool(
+        len(text) == 71
+        and text.startswith("sha256:")
+        and all(char in "0123456789abcdef" for char in text[7:])
+    )
+
+
+__all__ = [
+    "SYSTEM_SERVICE_OP_EXECUTABLE",
+    "SYSTEM_SERVICE_SECRET_TTL_SECONDS",
+    "SystemServiceWsp71ResolverFactory",
+    "build_system_service_wsp71_resolver_factory",
+]

--- a/modules/communication/moltbot_bridge/tests/README.md
+++ b/modules/communication/moltbot_bridge/tests/README.md
@@ -1,5 +1,19 @@
 # Tests - OpenClaw Bridge
 
+## Signer system-service WSP 71 resolver
+
+```powershell
+python -m pytest -q `
+  modules/communication/moltbot_bridge/tests/test_reddog_signer_system_service_wsp71_resolver_supply.py `
+  modules/communication/moltbot_bridge/tests/test_reddog_signer_system_service_entrypoint.py `
+  modules/infrastructure/secrets_mcp/tests/test_op_cli_secret_resolver.py
+```
+
+The matrix proves owner-ID binding, fixed executable policy, fail-closed
+unsafe/missing executable handling, in-memory secret use, and no shell or
+secret persistence. The supply remains uncomposed and claims no grant issuance,
+service deployment, or live worker authority.
+
 ## Canonical elevated-authority consensus capability
 
 ```powershell

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,8 @@
+## 2026-08-14: Signer system-service WSP 71 resolver supply
+- Added Windows and Linux coverage for fixed root-owned `op` executable
+  admission, invalid authority rejection before executable observation,
+  secret-free audit output, and the uncomposed production boundary.
+
 ## 2026-08-14: Progressive resident-chain CI regression
 - Added a Linux-visible end-to-end fixture for the signed progressive chain and
   extracted its fake worktree/PR runner into bounded test support. The legacy

--- a/modules/communication/moltbot_bridge/tests/test_reddog_signer_system_service_wsp71_resolver_supply.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_signer_system_service_wsp71_resolver_supply.py
@@ -1,0 +1,122 @@
+"""Security tests for signer-owned production WSP 71 resolver supply."""
+
+from __future__ import annotations
+
+import ast
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from modules.communication.moltbot_bridge.src import (
+    reddog_signer_system_service_wsp71_resolver_supply as target,
+)
+from modules.infrastructure.secrets_mcp.src.op_cli_secret_resolver import (
+    OpCliCommandResult,
+)
+
+
+MODULE_PATH = Path(target.__file__).resolve()
+OWNER_ID = "sha256:" + "a" * 64
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(self, argv, *, timeout_s, max_stdout_chars):
+        self.calls.append(tuple(argv))
+        return OpCliCommandResult(returncode=0, stdout="secret-in-memory")
+
+
+def _trusted_executable(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"#!/bin/sh\n")
+    os.chmod(path, 0o755)
+
+
+def test_factory_resolves_only_after_root_owned_executable_validation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    executable = tmp_path / "usr" / "bin" / "op"
+    _trusted_executable(executable)
+    runner = _Runner()
+    monkeypatch.setattr(target, "SYSTEM_SERVICE_OP_EXECUTABLE", executable)
+    monkeypatch.setattr(target.sys, "platform", "linux")
+    monkeypatch.setattr(target, "_require_root_owned_executable", lambda path: None)
+
+    factory = target.SystemServiceWsp71ResolverFactory(OWNER_ID, runner=runner)
+    assert runner.calls == []
+
+    result = factory().resolve("op://Foundups/reddog/private", "signer:reddog")
+
+    assert result.success is True
+    assert result.get_value() == "secret-in-memory"
+    assert runner.calls == [
+        (str(executable), "read", "op://Foundups/reddog/private", "--no-newline")
+    ]
+    assert "secret-in-memory" not in str(result.to_audit_dict())
+
+
+def test_factory_rejects_invalid_owner_before_secret_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _Runner()
+    executable_checks: list[Path] = []
+    monkeypatch.setattr(
+        target,
+        "_require_root_owned_executable",
+        lambda path: executable_checks.append(path),
+    )
+
+    with pytest.raises(ValueError, match="owner_config_id_invalid"):
+        target.SystemServiceWsp71ResolverFactory("sha256-looking", runner=runner)()
+
+    assert runner.calls == []
+    assert executable_checks == []
+
+
+def test_executable_gate_rejects_missing_symlink_and_writable_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(target.sys, "platform", "linux")
+    missing = tmp_path / "missing" / "op"
+    with pytest.raises(ValueError, match="executable_unavailable"):
+        target._require_root_owned_executable(missing)
+
+    executable = tmp_path / "op"
+    _trusted_executable(executable)
+    link = tmp_path / "op-link"
+    try:
+        link.symlink_to(executable)
+    except OSError:
+        pytest.skip("symlinks unavailable")
+    with pytest.raises(ValueError, match="executable_invalid"):
+        target._require_root_owned_executable(link)
+
+    os.chmod(executable, stat.S_IRWXU | stat.S_IWGRP | stat.S_IXGRP)
+    with pytest.raises(ValueError, match="executable_untrusted"):
+        target._require_root_owned_executable(executable)
+
+
+@pytest.mark.skipif(not target.sys.platform.startswith("linux"), reason="Linux only")
+def test_executable_gate_accepts_root_owned_linux_binary() -> None:
+    target._require_root_owned_executable(Path("/usr/bin/env"))
+
+
+def test_supply_module_has_no_secret_persistence_or_shell_surface() -> None:
+    tree = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    banned_calls = {"open", "eval", "exec", "compile", "write_text", "write_bytes"}
+    banned_imports = {"subprocess", "socket", "requests", "httpx"}
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            assert not {alias.name.split(".", 1)[0] for alias in node.names} & banned_imports
+        if isinstance(node, ast.ImportFrom):
+            assert (node.module or "").split(".", 1)[0] not in banned_imports
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                assert node.func.id not in banned_calls
+            if isinstance(node.func, ast.Attribute):
+                assert node.func.attr not in banned_calls


### PR DESCRIPTION
## Summary
- add an uncomposed signer-owned factory for the existing WSP 71 `OpCliSecretResolver`
- require a fixed root-owned `/usr/bin/op` executable and root-owned non-writable ancestry
- bind resolver sessions to an authenticated owner-configuration identifier
- preserve the production entrypoint's unavailable resolver until the existing grant-aware resolve-per-sign backend is composed

## Truth boundary
- reusable resolver supply only; production entrypoint remains fail closed
- no startup-resident key activation
- no production grant issuance or grant-aware backend composition
- no signer lifecycle provisioning or live signing authority
- no OpenClaw/Hermes coding dispatch, repository write, PR, or merge authority
- no RedDog VSIX/runtime change

## Validation
- Windows focused/WSP 62 matrix: 23 passed, 2 skipped
- WSL target-OS matrix: 23 passed, including a real root-owned executable gate
- test registry: current, 1,504 tests
- backend manifest unchanged and current: 1,311 runtime files
- Ruff, ASCII and diff checks passed

Worker-Lane: REDDOG_SIGNER_SYSTEM_SERVICE_WSP71_RESOLVER_PHASE1
Slice: REDDOG_SIGNER_SYSTEM_SERVICE_WSP71_RESOLVER_PHASE1
