### PR TITLE
test(reddog): separate candidate WSP62 from release

### DIFF
--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -1,5 +1,20 @@
 # RedDog ModLog
 
+## 2026-08-21 - Mainline release gate repair (0.4.102)
+
+- Kept the WSP 62 changed-surface proof candidate-only and removed it from the
+  exhaustive committed-main release closure. A squashed main checkout has no
+  working-tree diff, so treating that proof as a release member made the
+  documented promotion command fail after otherwise successful groups.
+- Generalized the candidate proof to derive the exact current changed/new
+  JavaScript surface instead of retaining a one-slice historical path list,
+  and added a tier regression guard plus aligned test documentation.
+- Production extension code, backend authority, package surface, and version
+  remain unchanged. WSP 15/22/62/97.
+- Validation: fast, contract, candidate, deterministic package, and exhaustive
+  release gates passed; release completed 4/4 groups in 311,358 ms without a
+  timeout.
+
 ## 2026-08-21 - Native Hermes/OpenClaw upstream worker truth (0.4.102)
 
 - Updated packaged backend provenance from Hermes text-only inference to one

--- a/extensions/reddog/tests/README.md
+++ b/extensions/reddog/tests/README.md
@@ -51,8 +51,10 @@ npm run test:release        # exact exhaustive promotion closure
 ```
 
 The release command is the legacy `node tests/verify_extension_contract.js`
-entry. It authenticates the unchanged 18-shard aggregate and exactly five tail
-members before starting four process-isolated groups. Worker cap 4, child
+entry. It authenticates the 18-shard aggregate and exactly seven committed-
+main tail members before starting four process-isolated groups. The separate
+candidate WSP 62 proof derives the current changed/new JavaScript surface and
+is intentionally excluded from release. Worker cap 4, child
 timeout 400 seconds, per-stream output cap 2 MiB, and the unchanged total
 release ceiling of 420 seconds are fixed in `reddog_test_plan.js`. Output is
 buffered and printed in plan order with group timings and a slowest-group
@@ -128,9 +130,10 @@ and semicolon-comment config forms accepted by Git. The receipt is structural
 only: exact 40/64 hex and config-byte binding. Cross-format shapes must fail
 all named outputs and projections through Git's `HEAD^{commit}` semantics;
 readiness may remain structurally READY and does not assert command success.
-`test_reddog_candidate_wsp62.js` is the separate candidate file/function/doc
-size proof; it does not replace the backend runtime WSP_62 gate or claim
-repository-wide compliance.
+`test_reddog_candidate_wsp62.js` is the separate changed-worktree candidate
+file/function/doc size proof; it fails closed when no governed candidate
+surface exists, is not a release member, and does not replace the backend
+runtime WSP_62 gate or claim repository-wide compliance.
 
 R7 adds real Windows case-alias index coverage,
 platform-aware ignored exact/prefix/separator intersections, NFC aliases,

--- a/extensions/reddog/tests/TestModLog.md
+++ b/extensions/reddog/tests/TestModLog.md
@@ -1,5 +1,21 @@
 # Foundups(R)Agent TestModLog
 
+## 2026-08-21 - Mainline release/candidate gate separation
+
+- Removed the changed-worktree-only WSP 62 proof from the committed-main
+  release closure after `npm run test:release` correctly exposed its empty
+  `git diff HEAD` mismatch on the squashed main commit.
+- Replaced the historical hard-coded JavaScript candidate list with the exact
+  current changed/new RedDog JavaScript surface. The focused proof now remains
+  useful for future candidate worktrees and fails closed when invoked without
+  a governed candidate surface.
+- Added a tier contract preventing the candidate-only proof from re-entering
+  promotion. The seven committed-main tail members remain authenticated by the
+  shard manifest and release plan.
+- Validation: fast 12/12 in 6,005 ms; contract 3/3 in 1,036 ms; candidate WSP
+  62 PASS; deterministic package surface 65 files / 941,467 raw bytes; release
+  4/4 groups in 311,358 ms with no timeout (core slowest at 311,273 ms).
+
 ## 2026-08-21 - CI conversational-draft grounding repair
 
 - Replaced both stale inline `wireFusionWebview` source assertions for

--- a/extensions/reddog/tests/contract_shards/manifest.json
+++ b/extensions/reddog/tests/contract_shards/manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "reddog_extension_contract_shards.v1",
   "source_path": "extensions/reddog/tests/verify_extension_contract.js",
-  "source_sha256": "sha256:f6a5843e7a19f112714595ef3afbf328b954a0e41e003e8e0ea1ab9745ff3d2e",
-  "source_line_count": 6914,
+  "source_sha256": "sha256:6eff2b49c864b21a22d4d2454d15127a20658b4fb096593357ba2820d5466adc",
+  "source_line_count": 6913,
   "assertion_call_count": 483,
   "canonical_line_endings": "LF",
   "max_shard_lines": 400,
@@ -148,9 +148,9 @@
       "order": 18,
       "path": "contract_shards/verify_extension_contract.part18.js",
       "source_line_start": 6670,
-      "source_line_end": 6914,
-      "line_count": 245,
-      "sha256": "sha256:856605427b387203f99fe3b4d1e045b42f9314a885ce57f556665b90afd79342"
+      "source_line_end": 6913,
+      "line_count": 244,
+      "sha256": "sha256:6a3e68071c66f7c238db6ddcb2ece665f51cb8dba30b81867620e04d96d93f1c"
     }
   ]
 }

--- a/extensions/reddog/tests/contract_shards/verify_extension_contract.part18.js
+++ b/extensions/reddog/tests/contract_shards/verify_extension_contract.part18.js
@@ -239,7 +239,6 @@ require('./test_governed_git_executable');
 require('./test_governed_git_production_scan');
 require('./test_governed_git_ref_formats');
 require('./test_bridge_python_environment');
-require('./test_reddog_candidate_wsp62');
 require('./test_package_surface');
 
 console.log('RedDog extension contract checks passed.');

--- a/extensions/reddog/tests/reddog_contract_execution.js
+++ b/extensions/reddog/tests/reddog_contract_execution.js
@@ -7,8 +7,8 @@ const path = require('path');
 const vm = require('vm');
 const plan = require('./reddog_test_plan');
 
-const SOURCE_SHA256 = 'sha256:f6a5843e7a19f112714595ef3afbf328b954a0e41e003e8e0ea1ab9745ff3d2e';
-const SOURCE_LINES = 6914;
+const SOURCE_SHA256 = 'sha256:6eff2b49c864b21a22d4d2454d15127a20658b4fb096593357ba2820d5466adc';
+const SOURCE_LINES = 6913;
 const ASSERTION_CALLS = 483;
 const manifestPath = path.join(__dirname, 'contract_shards', 'manifest.json');
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));

--- a/extensions/reddog/tests/reddog_test_plan.js
+++ b/extensions/reddog/tests/reddog_test_plan.js
@@ -37,8 +37,7 @@ const RELEASE_GROUPS = Object.freeze([
     './test_governed_git_production_scan', './test_governed_git_ref_formats'
   ]) }),
   Object.freeze({ id: 'bridge_wsp62', tests: Object.freeze([
-    './test_bridge_python_environment', './test_reddog_candidate_wsp62',
-    './test_package_surface'
+    './test_bridge_python_environment', './test_package_surface'
   ]) })
 ]);
 

--- a/extensions/reddog/tests/test_extension_contract_shards.js
+++ b/extensions/reddog/tests/test_extension_contract_shards.js
@@ -5,8 +5,8 @@ const path = require('path');
 const vm = require('vm');
 const contractExecution = require('./reddog_contract_execution');
 
-const EXPECTED_SOURCE_SHA256 = 'sha256:f6a5843e7a19f112714595ef3afbf328b954a0e41e003e8e0ea1ab9745ff3d2e';
-const EXPECTED_SOURCE_LINES = 6914;
+const EXPECTED_SOURCE_SHA256 = 'sha256:6eff2b49c864b21a22d4d2454d15127a20658b4fb096593357ba2820d5466adc';
+const EXPECTED_SOURCE_LINES = 6913;
 const EXPECTED_ASSERTION_CALLS = 483;
 const MAX_SHARD_LINES = 400;
 const MAX_ORCHESTRATOR_LINES = 200;

--- a/extensions/reddog/tests/test_reddog_candidate_wsp62.js
+++ b/extensions/reddog/tests/test_reddog_candidate_wsp62.js
@@ -6,73 +6,12 @@ const fs = require('fs');
 const path = require('path');
 
 const repoRoot = path.resolve(__dirname, '..', '..', '..');
-const candidateJavaScript = [
-  'extensions/reddog/backend_compatibility_constants.js',
-  'extensions/reddog/conversation_session_authority_source.js',
-  'extensions/reddog/extension.js',
-  'extensions/reddog/governed_git_context.js',
-  'extensions/reddog/governed_git_executable.js',
-  'extensions/reddog/governed_git_projection.js',
-  'extensions/reddog/governed_git_readiness.js',
-  'extensions/reddog/governed_git_repo_state.js',
-  'extensions/reddog/governed_git_storage.js',
-  'extensions/reddog/holoindex_bundle_projection.js',
-  'extensions/reddog/holoindex_generation_bound_query.js',
-  'extensions/reddog/holoindex_incident_repair.js',
-  'extensions/reddog/holoindex_interpreter_provenance.js',
-  'extensions/reddog/holoindex_owner_runtime.js',
-  'extensions/reddog/start_operations_control.js',
-  'extensions/reddog/start_operations_environment.js',
-  'extensions/reddog/start_operations_extension_adapter.js',
-  'extensions/reddog/tests/governed_git_authority_contracts.js',
-  'extensions/reddog/tests/governed_git_executable_test_helpers.js',
-  'extensions/reddog/tests/governed_git_projection_contracts.js',
-  'extensions/reddog/tests/governed_git_projection_final_order_contracts.js',
-  'extensions/reddog/tests/governed_git_projection_race_contracts.js',
-  'extensions/reddog/tests/governed_git_ref_contracts.js',
-  'extensions/reddog/tests/governed_git_storage_contracts.js',
-  'extensions/reddog/tests/governed_git_test_helpers.js',
-  'extensions/reddog/tests/test_bridge_python_environment.js',
-  'extensions/reddog/tests/test_extension_contract_shards.js',
-  'extensions/reddog/tests/test_governed_git_context_hardening.js',
-  'extensions/reddog/tests/test_governed_git_executable.js',
-  'extensions/reddog/tests/test_governed_git_production_scan.js',
-  'extensions/reddog/tests/test_governed_git_environment.js',
-  'extensions/reddog/tests/test_governed_git_ref_formats.js',
-  'extensions/reddog/tests/test_holoindex_async_bridge.js',
-  'extensions/reddog/tests/test_holoindex_incident_repair.js',
-  'extensions/reddog/tests/reddog_package_surface_contract.js',
-  'extensions/reddog/tests/reddog_test_plan.js',
-  'extensions/reddog/tests/reddog_contract_execution.js',
-  'extensions/reddog/tests/reddog_release_supervisor.js',
-  'extensions/reddog/tests/reddog_release_worker.js',
-  'extensions/reddog/tests/run_reddog_test_tier.js',
-  'extensions/reddog/tests/start_operations_control_test_helpers.js',
-  'extensions/reddog/tests/test_backend_compatibility_contract.js',
-  'extensions/reddog/tests/test_reddog_release_supervisor.js',
-  'extensions/reddog/tests/test_reddog_test_tiering.js',
-  'extensions/reddog/tests/test_package_manifest.js',
-  'extensions/reddog/tests/test_package_surface.js',
-  'extensions/reddog/tests/test_reddog_candidate_wsp62.js',
-  'extensions/reddog/tests/test_start_operations_control.js',
-  'extensions/reddog/tests/verify_extension_contract.js',
-  'extensions/reddog/tests/verify_fusion_panel_input_contract.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part01.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part02.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part03.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part09.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part12.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part13.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part14.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part17.js',
-  'extensions/reddog/tests/contract_shards/verify_extension_contract.part18.js'
-];
-const candidateDocuments = [
+const governedDocuments = new Set([
   'extensions/reddog/INTERFACE.md',
   'extensions/reddog/README.md',
   'extensions/reddog/ROADMAP.md',
   'extensions/reddog/tests/README.md'
-];
+]);
 
 function source(relative) {
   return fs.readFileSync(path.join(repoRoot, relative), 'utf8');
@@ -183,7 +122,7 @@ function assertJavaScriptLimits(relative) {
   }
 }
 
-function changedJavaScript() {
+function changedCandidatePaths() {
   const commands = [
     ['diff', '--name-only', 'HEAD', '--', 'extensions/reddog'],
     ['ls-files', '--others', '--exclude-standard', '--', 'extensions/reddog']
@@ -194,7 +133,7 @@ function changedJavaScript() {
       cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']
     });
     for (const relative of output.split(/\r?\n/)) {
-      if (/\.(?:js|ts)$/.test(relative)) found.add(relative.replace(/\\/g, '/'));
+      if (relative) found.add(relative.replace(/\\/g, '/'));
     }
   }
   return [...found].sort();
@@ -205,8 +144,11 @@ function assertDocumentLimits(relative) {
     relative + ' exceeds the candidate documentation 1000-line ceiling');
 }
 
-assert.deepStrictEqual([...candidateJavaScript].sort(), changedJavaScript(),
-  'candidate JavaScript audit list must equal the complete Git changed/new surface');
+const changedPaths = changedCandidatePaths();
+const candidateJavaScript = changedPaths.filter((relative) => /\.(?:js|ts)$/.test(relative));
+const candidateDocuments = changedPaths.filter((relative) => governedDocuments.has(relative));
+assert(candidateJavaScript.length + candidateDocuments.length > 0,
+  'candidate WSP 62 proof requires a changed/new JavaScript or governed-document surface');
 for (const relative of candidateJavaScript) assertJavaScriptLimits(relative);
 for (const relative of candidateDocuments) assertDocumentLimits(relative);
 

--- a/extensions/reddog/tests/test_reddog_test_tiering.js
+++ b/extensions/reddog/tests/test_reddog_test_tiering.js
@@ -27,6 +27,8 @@ assert.strictEqual(plan.RELEASE_CEILING_MS, 420000);
 assert(plan.RELEASE_GROUPS.length <= plan.RELEASE_WORKER_CAP);
 assert(!plan.FAST_TESTS.includes('verify_extension_contract.js'),
   'default tier must not silently run promotion');
+assert(!plan.releaseTests().includes('./test_reddog_candidate_wsp62'),
+  'candidate-only WSP 62 proof must not enter committed-main release closure');
 
 const manifest = require('./contract_shards/manifest.json');
 const aggregate = manifest.shards.map((shard) => fs.readFileSync(


### PR DESCRIPTION
## Summary
- keep the changed-worktree WSP 62 proof out of committed-main release promotion
- derive candidate JavaScript/governed-document scope dynamically instead of retaining a historical path list
- rebind the authenticated seven-member release tail and align RedDog test documentation

## Validation
- `npm test` — 12/12 PASS
- `npm run test:contract` — 3/3 PASS
- `npm run test:package` — 65 files / 941,467 raw bytes PASS
- `node tests/test_reddog_candidate_wsp62.js` — PASS, including independent empty-surface rejection probe
- `npm run test:release` — 4/4 groups PASS in 311,358 ms; no timeout
- independent WSP_00/WSP_97 verifier — SHIP
- `git diff --check` — clean

Production extension code, authority surfaces, package version, and remote-tool scope are unchanged.