### PR TITLE
feat(reddog): add resident conversation transport contract

### DIFF
--- a/ModLog.md
+++ b/ModLog.md
@@ -1,5 +1,26 @@
 # FoundUps Agent - Development Log
 
+## [2026-08-22] RedDog Resident Conversation Transport Contract
+
+**WSP Protocol:** WSP 00, 15, 22, 50, 62, 73, 97
+
+- Added a strict, transport-neutral `TURN` / `STATUS` / `CANCEL` envelope with
+  canonical digest bindings, CAS revision, nonce/idempotency, and a maximum
+  five-minute validity window.
+- Kept principal, FoundUp, credential, provider/model, effect, and work
+  authority outside the untrusted client payload. The future service must
+  derive them from verified session authority and current AgentDB state.
+- Added adversarial injection/replay/type/Unicode/forgery tests and a
+  content-free structural binding that explicitly grants no authority.
+- Corrected RedDog, Digital Twin, and architecture documents: AgentDB/session
+  substrate and the envelope exist; authenticated service binding and
+  VSIX/PFMall/phone adapters do not.
+- Verification: 36/36 focused tests with 100% statement/branch coverage,
+  117/117 Digital Twin module tests, and the existing RedDog conversation tier
+  with 15 JavaScript vectors plus 32 Python contracts.
+- Regenerated and rechecked the canonical WSP test registry at 1,567 tracked
+  Python test files; the new contract test is collectable and not quarantined.
+
 ## [2026-08-22] RedDog Continuous Digital Twin Conversation Plane
 
 **WSP Protocol:** WSP 00, 15, 22, 50, 62, 73, 97

--- a/WSP_knowledge/WSP_Test_Registry.json
+++ b/WSP_knowledge/WSP_Test_Registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "wsp_test_registry.v2",
   "generation_policy": "git-tracked-python-tests.v1",
-  "total_tests": 1566,
+  "total_tests": 1567,
   "quarantined_tests": 267,
   "tests": [
     {
@@ -3635,6 +3635,19 @@
       "timeout_s": 180,
       "quarantine_reasons": [],
       "description": "Read-only 012 Principal Memex projection contract tests."
+    },
+    {
+      "id": "test::modules::ai_intelligence::digital_twin::tests::test_resident_conversation_transport_contract",
+      "path": "modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py",
+      "owner": "modules/ai_intelligence/digital_twin",
+      "suite_class": "unit",
+      "shard_id": "modules-ai-intelligence-digital-twin-unit",
+      "capabilities": [],
+      "execution_type": "unit",
+      "collectable": true,
+      "timeout_s": 180,
+      "quarantine_reasons": [],
+      "description": "Adversarial tests for the resident RedDog conversation envelope."
     },
     {
       "id": "test::modules::ai_intelligence::digital_twin::tests::test_trajectory_logger",

--- a/docs/audits/architecture/REDDOG_DIGITAL_TWIN_CONVERSATION_PLANE_PHASE1.md
+++ b/docs/audits/architecture/REDDOG_DIGITAL_TWIN_CONVERSATION_PLANE_PHASE1.md
@@ -1,7 +1,7 @@
 # RedDog Digital Twin Conversation Plane - Phase 1
 
 **Date:** 2026-08-22 (JST)
-**State:** Implemented candidate; production PFMall/phone channel remains gated
+**State:** Conversation policy and transport envelope implemented; authenticated service and production PFMall/phone channel remain gated
 **Protocols:** WSP 00, 15, 22, 50, 62, 73, 97
 
 ## Decision
@@ -66,6 +66,11 @@ against the deterministic ceiling and cannot elevate it.
   ceiling.
 - Existing AgentDB scope, signer, promotion, OpenClaw, WRE, and Hermes modules
   are reused. No second router, database, signer, queue, or worker stack exists.
+- `resident_conversation_transport_contract.py` owns an exact zero-authority
+  `TURN` / `STATUS` / `CANCEL` envelope. It validates canonical digest IDs,
+  CAS revision, nonce/idempotency, a maximum five-minute lifetime, and emits a
+  content-free binding. It contains no endpoint, authentication, persistence,
+  model, queue, or effect implementation.
 - `npm run test:conversation` is the dedicated cross-language fast lane.
 
 The `asynchronous_readonly_allowed` decision field is admission metadata only.
@@ -86,9 +91,10 @@ The scalable channel is hybrid:
    (and later voice), renders replies/receipts, and may cancel its own turn.
 2. A resident RedDog hub owns model access, secrets, current conversation
    authority, and the OpenClaw supervisor connection.
-3. Each turn will carry principal, conversation, FoundUp, revision, nonce,
-   idempotency, and expiry bindings. The server revalidates them; browser
-   claims never widen scope.
+3. The client envelope carries conversation, revision, turn, nonce,
+   idempotency, and expiry bindings. The admitted server-side turn must add
+   principal and FoundUp scope derived from verified session authority and
+   current AgentDB state; browser claims never supply or widen them.
 4. AgentDB CAS/event order provides current single-host continuity. Multi-host
    scale requires the already-planned PostgreSQL/shared event-store migration,
    not browser localStorage as authority.
@@ -101,8 +107,9 @@ person. WSP 98's mesh/zero-server direction is a target state. This phase does
 not claim mesh-native RedDog: shared ordering, replay, and authority must be
 resolved before a resident hub can be replaced or federated.
 
-Therefore the PFMall/phone adapter is `SPECIFIED_NOT_IMPLEMENTED` in this
-slice. Shipping an unauthenticated fetch hook would be false progress and a
+Therefore the transport envelope is `OBSERVED`, while authenticated service
+binding and the PFMall/phone adapter remain `SPECIFIED_NOT_IMPLEMENTED`.
+Shipping an unauthenticated fetch hook would be false progress and a
 cross-principal risk.
 
 ## Memory and continuity truth
@@ -140,6 +147,8 @@ Total: `4 + 5 + 5 + 5 = 19`, canonical `P0`.
 | Chat/model text can execute work | FALSE / FORBIDDEN |
 | Prior work-packet continuation enters foreground chat | FALSE / FORBIDDEN |
 | Existing authenticated work promotion reused | OBSERVED, not invoked by ordinary chat |
+| Strict content-free turn/status/cancel envelope | OBSERVED |
+| Envelope authenticates principal or FoundUp scope | FALSE / FORBIDDEN |
 | Durable cross-device conversation | SPECIFIED_NOT_IMPLEMENTED |
 | PFMall authenticated conversation adapter | SPECIFIED_NOT_IMPLEMENTED |
 | Phone voice ingress/barge-in | SPECIFIED_NOT_IMPLEMENTED |
@@ -152,9 +161,26 @@ Total: `4 + 5 + 5 + 5 = 19`, canonical `P0`.
 
 ## Next gated layers
 
-1. Authenticated resident conversation service using the existing conversation
-   session authority and AgentDB CAS ports.
-2. Thin VSIX and PFMall transport adapters with idempotent turn/status/cancel
-   envelopes and content-free progress receipts.
+1. Authenticated resident conversation service binding the implemented
+   envelope to existing conversation-session authority and AgentDB CAS ports.
+2. Thin VSIX and PFMall transport adapters plus content-free progress receipts.
 3. Governed bounded memory recall with source/freshness labels.
 4. Local STT/TTS and interruption after consent and cancellation proofs.
+
+## WSP 97 high-risk assumption audit
+
+- Assumption: the host derives principal and FoundUp scope from a verified,
+  current resident session. The envelope cannot assert either value.
+- Failure modes held closed by this slice: identity/effect/provider injection,
+  unknown operations, stale or future envelopes, revision-shape ambiguity,
+  malformed digest bindings, raw operator text in public bindings, and direct
+  dataclass construction with invalid static state.
+- Still-open service failures: atomic idempotency storage, credential replay,
+  authenticated cancellation ownership, current AgentDB CAS binding, durable
+  progress ordering, and cross-surface contract parity.
+- Rejected alternatives: browser localStorage as authority, extending the
+  unauthenticated read-only PFMall API, adding a second database/router, or
+  treating request digests as authentication.
+- Decision: `PROCEED` for the pure contract and tests; `HALT` for any live
+  endpoint or adapter until the existing signer/session/AgentDB authority chain
+  is bound and adversarially verified.

--- a/extensions/reddog/INTERFACE.md
+++ b/extensions/reddog/INTERFACE.md
@@ -223,9 +223,12 @@ use Fusion without changing the `NONE` effect ceiling.
 Raw provider history and the opt-in last-work-packet summary are both withheld
 from foreground chat, even if the UI continuation checkbox is selected.
 
-This is a package-internal policy interface, not a network API. PFMall and phone
-clients require a future authenticated resident adapter with durable event
-ordering; the browser `reddog:command` event is not that transport.
+This is a package-internal policy interface, not a network API. The Digital
+Twin backend now defines a strict zero-authority turn/status/cancel envelope,
+but RedDog does not yet bind it to verified resident session authority or
+current AgentDB CAS state. PFMall and phone clients therefore still require an
+authenticated resident adapter with durable event ordering; the browser
+`reddog:command` event is not that transport.
 
 ### VS Code workspace and package capabilities
 

--- a/extensions/reddog/ModLog.md
+++ b/extensions/reddog/ModLog.md
@@ -1,5 +1,15 @@
 # RedDog ModLog
 
+## 2026-08-22 - Resident conversation envelope documentation alignment
+
+- Corrected the roadmap to distinguish the already-implemented AgentDB
+  conversation/session authority substrate from the missing live service.
+- Documented the new backend zero-authority turn/status/cancel envelope and
+  kept authenticated service binding plus VSIX/PFMall/phone adapters explicitly
+  unimplemented.
+- RedDog package/runtime files and version remain unchanged; the existing
+  `test:conversation` dependency tier passed unchanged.
+
 ## 2026-08-22 - Exact model lifecycle and continuous conversation (0.4.105)
 
 - Added deterministic `CHAT`, `RESEARCH`, `PROPOSE`, `AUTHORIZE`, `STATUS`, and

--- a/extensions/reddog/README.md
+++ b/extensions/reddog/README.md
@@ -6,7 +6,7 @@ Version: 0.4.105
 
 `conversation_plane_policy.js` keeps intent, reasoning depth, and effect ceiling independent; unknown text is `CHAT / FAST / NONE`, and risk never raises effects.
 Chat gets no repository/HoloIndex context or work authority; shared Python/JavaScript vectors run through `npm run test:conversation`.
-OpenClaw is the resident 0102 execution/supervision layer, Hermes is bounded, and the authenticated PFMall/phone adapter remains specified, not implemented.
+OpenClaw is the resident 0102 execution/supervision layer and Hermes is bounded. The backend now has a strict zero-authority turn/status/cancel envelope; authenticated service binding and VSIX/PFMall/phone transport adapters remain specified, not implemented.
 
 ## Model-routing authority
 

--- a/extensions/reddog/ROADMAP.md
+++ b/extensions/reddog/ROADMAP.md
@@ -9,8 +9,11 @@ Current implementation:
 - [x] Continuous foreground conversation classifier and VSIX adapter with
   independent intent/depth/effect axes, zero-effect chat, shared cross-language
   vectors, and a dedicated bounded test tier.
-- [ ] Authenticated AgentDB-backed resident conversation service and thin
-  PFMall/phone transport. The existing browser event remains presentation-only.
+- [x] AgentDB conversation-scope/session authority substrate and a strict
+  transport-neutral turn/status/cancel envelope exist in backend modules.
+- [ ] Bind the envelope to verified resident session authority and current
+  AgentDB CAS state, then add thin VSIX/PFMall/phone adapters. The existing
+  browser event remains presentation-only.
 - [ ] Durable personalized memory, voice, automatic async critic dispatch, and
   promotion-to-execution binding; each remains separately gated.
 

--- a/modules/ai_intelligence/digital_twin/INTERFACE.md
+++ b/modules/ai_intelligence/digital_twin/INTERFACE.md
@@ -32,6 +32,38 @@ closed.
 
 ---
 
+## Resident conversation transport envelope
+
+```python
+from modules.ai_intelligence.digital_twin.src.resident_conversation_transport_contract import (
+    request_from_mapping,
+)
+
+request = request_from_mapping(untrusted_payload, now_epoch=trusted_now)
+receipt_binding = request.content_free_binding()
+```
+
+The exact `reddog_resident_conversation_request.v1` shape supports `TURN`,
+`STATUS`, and `CANCEL`. It binds request, conversation, revision, turn, client
+nonce, idempotency key, issue time, expiry, and bounded NFKC-normalized operator
+text. All opaque identifiers use canonical `sha256:` shape. A new conversation
+turn uses an empty `conversation_id` with revision `-1`; existing turns and
+control operations require a conversation ID and non-negative CAS revision.
+
+The envelope is deliberately untrusted and zero-authority. It has no fields for
+principal, FoundUp, credential, provider/model, effect ceiling, or work
+authority. Those bindings belong to the future resident service and must be
+derived from verified session authority and current AgentDB state. The
+content-free binding contains no operator text and explicitly grants neither
+identity nor effect authority. Its unkeyed digest is structural integrity and
+equality evidence, not authentication or replay enforcement.
+
+This interface does not expose an HTTP endpoint, authenticate a session, mutate
+AgentDB, invoke a model, or dispatch work. VSIX/PFMall adapters remain gated on
+the authenticated service binding and shared cross-surface vectors.
+
+---
+
 ## Principal Memex read-only projection
 
 ```python

--- a/modules/ai_intelligence/digital_twin/ModLog.md
+++ b/modules/ai_intelligence/digital_twin/ModLog.md
@@ -2,6 +2,21 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## 2026-08-22 - Resident conversation transport contract phase 1
+
+- Added a strict transport-neutral request envelope for RedDog `TURN`,
+  `STATUS`, and `CANCEL` traffic without adding a network endpoint or runtime.
+- Bound canonical request/conversation/turn IDs, CAS revision, client nonce,
+  idempotency, and a maximum five-minute freshness window.
+- Rejected client-supplied identity, FoundUp, credential, model/provider,
+  effect, and work-authority fields; those remain host-derived obligations for
+  the future authenticated resident service.
+- Added content-free receipt projection, exact native-type enforcement,
+  Unicode normalization, adversarial tests, 100% focused branch coverage, and
+  WSP-62 file/function assertions.
+- Corrected RedDog and Digital Twin roadmaps to distinguish the implemented
+  AgentDB/session substrate and envelope from the still-missing service/adapters.
+
 ## 2026-08-22 - RedDog continuous conversation plane phase 1
 
 - Added independent interaction-intent, reasoning-depth, and effect-ceiling

--- a/modules/ai_intelligence/digital_twin/README.md
+++ b/modules/ai_intelligence/digital_twin/README.md
@@ -14,6 +14,14 @@ text can emit at most a proposal and cannot authorize bounded execution.
 The contract performs no model, memory, HoloIndex, database, repository, or
 network operation.
 
+`resident_conversation_transport_contract.py` defines the next transport-neutral
+boundary for `TURN`, `STATUS`, and `CANCEL`. It accepts only content, opaque
+digest bindings, CAS revision, nonce/idempotency, and a maximum five-minute
+validity window. Principal, FoundUp, credential, provider/model, effect, and
+work-authority fields are deliberately outside the client envelope and must be
+derived and revalidated by the future authenticated resident service. The
+contract adds no listener, persistence, authentication, model call, or effect.
+
 `principal_memex_projection.py` implements the first structural, read-only
 Principal Memex projection. It validates provenance identifiers, canonical
 content/item/projection digests, principal isolation, sensitivity, and
@@ -95,6 +103,8 @@ Phase 3: Tool-Use Training
 | `comment_drafter.py` | RAG → LLM → Guardrails pipeline |
 | `decision_policy.py` | Comment/like/ignore heuristics |
 | `trajectory_logger.py` | JSONL training data collector |
+| `conversation_plane.py` | Deterministic intent/depth/effect classification |
+| `resident_conversation_transport_contract.py` | Strict zero-authority turn/status/cancel envelope |
 
 ## Pipeline
 

--- a/modules/ai_intelligence/digital_twin/ROADMAP.md
+++ b/modules/ai_intelligence/digital_twin/ROADMAP.md
@@ -29,7 +29,11 @@ conversation state, AgentDB, or any FoundUp Memex.
 - Complete: default `CHAT / FAST / NONE`, ambiguous-authority rejection, risk
   reasoning escalation without effect escalation, and VSIX thin adapter.
 - Complete: dedicated cross-language `test:conversation` vectors.
-- Next: authenticated AgentDB-backed resident turn/status/cancel service.
+- Complete: strict transport-neutral `TURN` / `STATUS` / `CANCEL` request
+  envelope with CAS revision, digest bindings, nonce/idempotency, five-minute
+  freshness, identity/effect injection rejection, and content-free projection.
+- Next: bind that envelope to verified resident session authority and current
+  AgentDB CAS state; this authenticated service does not yet exist.
 - Next: thin PFMall/phone transport adapter; the browser remains a client, not
   the model/OpenClaw host.
 - Deferred: asynchronous critics, durable cross-device history, bounded Memex/

--- a/modules/ai_intelligence/digital_twin/src/resident_conversation_transport_contract.py
+++ b/modules/ai_intelligence/digital_twin/src/resident_conversation_transport_contract.py
@@ -1,0 +1,295 @@
+"""Strict zero-authority envelope for resident RedDog conversation traffic."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+
+SCHEMA_VERSION = "reddog_resident_conversation_request.v1"
+BINDING_SCHEMA_VERSION = "reddog_resident_conversation_binding.v1"
+MAX_OPERATOR_TEXT_SCALARS = 12_000
+MAX_REQUEST_TTL_SECONDS = 300
+MAX_CLOCK_SKEW_SECONDS = 30
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_REQUEST_FIELDS = frozenset(
+    {
+        "schema_version",
+        "operation",
+        "request_id",
+        "conversation_id",
+        "expected_revision",
+        "turn_id",
+        "client_nonce",
+        "idempotency_key",
+        "issued_at",
+        "expires_at",
+        "operator_text",
+    }
+)
+
+
+class ResidentConversationOperation(str, Enum):
+    """Transport operations; none grants model or effect authority."""
+
+    TURN = "TURN"
+    STATUS = "STATUS"
+    CANCEL = "CANCEL"
+
+
+@dataclass(frozen=True, slots=True)
+class ResidentConversationRequest:
+    """One untrusted client envelope after strict structural validation."""
+
+    operation: ResidentConversationOperation
+    request_id: str
+    conversation_id: str
+    expected_revision: int
+    turn_id: str
+    client_nonce: str
+    idempotency_key: str
+    issued_at: int
+    expires_at: int
+    operator_text: str
+    schema_version: str = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        reasons = resident_conversation_request_reasons(self)
+        if reasons:
+            raise ValueError(reasons[0])
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "operation": self.operation.value,
+            "request_id": self.request_id,
+            "conversation_id": self.conversation_id,
+            "expected_revision": self.expected_revision,
+            "turn_id": self.turn_id,
+            "client_nonce": self.client_nonce,
+            "idempotency_key": self.idempotency_key,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "operator_text": self.operator_text,
+        }
+
+    def request_digest(self) -> str:
+        """Return a canonical integrity digest, not an authentication proof."""
+
+        return _canonical_digest(self.to_dict())
+
+    def content_free_binding(self) -> dict[str, Any]:
+        """Project receipt-safe metadata without operator text or identity claims."""
+
+        return {
+            "schema_version": BINDING_SCHEMA_VERSION,
+            "operation": self.operation.value,
+            "request_id": self.request_id,
+            "request_digest": self.request_digest(),
+            "conversation_id": self.conversation_id,
+            "expected_revision": self.expected_revision,
+            "turn_id": self.turn_id,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "grants_identity_authority": False,
+            "grants_effect_authority": False,
+        }
+
+
+def request_from_mapping(
+    payload: Mapping[str, Any], *, now_epoch: int
+) -> ResidentConversationRequest:
+    """Strictly rehydrate and freshness-check an untrusted client request."""
+
+    if type(payload) is not dict or set(payload) != _REQUEST_FIELDS:
+        raise ValueError("resident_conversation_request_shape_invalid")
+    request = ResidentConversationRequest(
+        schema_version=_strict_string(payload["schema_version"]),
+        operation=_strict_operation(payload["operation"]),
+        request_id=_strict_string(payload["request_id"]),
+        conversation_id=_strict_string(payload["conversation_id"]),
+        expected_revision=_strict_integer(payload["expected_revision"]),
+        turn_id=_strict_string(payload["turn_id"]),
+        client_nonce=_strict_string(payload["client_nonce"]),
+        idempotency_key=_strict_string(payload["idempotency_key"]),
+        issued_at=_strict_integer(payload["issued_at"]),
+        expires_at=_strict_integer(payload["expires_at"]),
+        operator_text=_normalized_operator_text(payload["operator_text"]),
+    )
+    enforce_request_freshness(request, now_epoch=now_epoch)
+    return request
+
+
+def enforce_request_freshness(
+    request: ResidentConversationRequest, *, now_epoch: int
+) -> None:
+    """Reject expired or implausibly future-dated envelopes."""
+
+    if type(request) is not ResidentConversationRequest:
+        raise ValueError("resident_conversation_request_type_invalid")
+    if type(now_epoch) is not int or now_epoch < 0:
+        raise ValueError("resident_conversation_now_invalid")
+    if request.issued_at > now_epoch + MAX_CLOCK_SKEW_SECONDS:
+        raise ValueError("resident_conversation_request_not_yet_valid")
+    if request.expires_at <= now_epoch:
+        raise ValueError("resident_conversation_request_expired")
+
+
+def resident_conversation_request_reasons(
+    request: ResidentConversationRequest,
+) -> tuple[str, ...]:
+    """Return stable violations without consulting authentication or runtime state."""
+
+    if type(request) is not ResidentConversationRequest:
+        return ("resident_conversation_request_type_invalid",)
+    reasons: list[str] = []
+    if request.schema_version != SCHEMA_VERSION:
+        reasons.append("resident_conversation_schema_invalid")
+    if type(request.operation) is not ResidentConversationOperation:
+        reasons.append("resident_conversation_operation_invalid")
+    if not _native_request_scalars(request):
+        reasons.append("resident_conversation_request_type_invalid")
+    if not _canonical_operator_text(request.operator_text):
+        reasons.append("resident_conversation_operator_text_invalid")
+    if not all(
+        _SHA256_RE.fullmatch(value)
+        for value in (
+            request.request_id,
+            request.turn_id,
+            request.client_nonce,
+            request.idempotency_key,
+        )
+    ):
+        reasons.append("resident_conversation_request_binding_invalid")
+    if request.conversation_id and not _SHA256_RE.fullmatch(request.conversation_id):
+        reasons.append("resident_conversation_conversation_id_invalid")
+    if not _valid_time_window(request):
+        reasons.append("resident_conversation_request_ttl_invalid")
+    reasons.extend(_operation_reasons(request))
+    return tuple(dict.fromkeys(reasons))
+
+
+def _operation_reasons(request: ResidentConversationRequest) -> tuple[str, ...]:
+    if type(request.operation) is not ResidentConversationOperation:
+        return ()
+    if request.operation is ResidentConversationOperation.TURN:
+        if not request.operator_text:
+            return ("resident_conversation_operator_text_required",)
+        if request.conversation_id:
+            return (
+                ()
+                if request.expected_revision >= 0
+                else ("resident_conversation_revision_invalid",)
+            )
+        return (
+            ()
+            if request.expected_revision == -1
+            else ("resident_conversation_revision_invalid",)
+        )
+    if request.operator_text:
+        return ("resident_conversation_operator_text_forbidden",)
+    if not request.conversation_id:
+        return ("resident_conversation_conversation_id_required",)
+    if request.expected_revision < 0:
+        return ("resident_conversation_revision_invalid",)
+    return ()
+
+
+def _native_request_scalars(request: ResidentConversationRequest) -> bool:
+    string_values = (
+        request.schema_version,
+        request.request_id,
+        request.conversation_id,
+        request.turn_id,
+        request.client_nonce,
+        request.idempotency_key,
+        request.operator_text,
+    )
+    integer_values = (
+        request.expected_revision,
+        request.issued_at,
+        request.expires_at,
+    )
+    return all(type(value) is str for value in string_values) and all(
+        type(value) is int for value in integer_values
+    )
+
+
+def _valid_time_window(request: ResidentConversationRequest) -> bool:
+    return (
+        request.issued_at >= 0
+        and request.expires_at > request.issued_at
+        and request.expires_at - request.issued_at <= MAX_REQUEST_TTL_SECONDS
+    )
+
+
+def _canonical_operator_text(value: object) -> bool:
+    if type(value) is not str or "\x00" in value:
+        return False
+    if any(ord(char) < 32 and char not in "\n\r\t" for char in value):
+        return False
+    return (
+        value == unicodedata.normalize("NFKC", value).strip()
+        and len(value) <= MAX_OPERATOR_TEXT_SCALARS
+    )
+
+
+def _normalized_operator_text(value: object) -> str:
+    text = _strict_string(value)
+    if "\x00" in text or any(ord(char) < 32 and char not in "\n\r\t" for char in text):
+        raise ValueError("resident_conversation_operator_text_invalid")
+    normalized = unicodedata.normalize("NFKC", text).strip()
+    if len(normalized) > MAX_OPERATOR_TEXT_SCALARS:
+        raise ValueError("resident_conversation_operator_text_invalid")
+    return normalized
+
+
+def _strict_operation(value: object) -> ResidentConversationOperation:
+    text = _strict_string(value)
+    try:
+        return ResidentConversationOperation(text)
+    except ValueError as exc:
+        raise ValueError("resident_conversation_operation_invalid") from exc
+
+
+def _strict_integer(value: object) -> int:
+    if type(value) is not int:
+        raise ValueError("resident_conversation_request_type_invalid")
+    return value
+
+
+def _strict_string(value: object) -> str:
+    if type(value) is not str:
+        raise ValueError("resident_conversation_request_type_invalid")
+    return value
+
+
+def _canonical_digest(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+__all__ = [
+    "BINDING_SCHEMA_VERSION",
+    "MAX_CLOCK_SKEW_SECONDS",
+    "MAX_OPERATOR_TEXT_SCALARS",
+    "MAX_REQUEST_TTL_SECONDS",
+    "ResidentConversationOperation",
+    "ResidentConversationRequest",
+    "SCHEMA_VERSION",
+    "enforce_request_freshness",
+    "request_from_mapping",
+    "resident_conversation_request_reasons",
+]

--- a/modules/ai_intelligence/digital_twin/tests/README.md
+++ b/modules/ai_intelligence/digital_twin/tests/README.md
@@ -6,11 +6,16 @@
 - Validate core pipeline stages: memory → draft → guardrails → decision.
 - Validate conversation intent, reasoning, and effects independently; shared
   vectors must match the VSIX adapter and no text may grant execution.
+- Treat resident transport as an adversarial boundary: reject unknown identity,
+  routing, credential, or effect fields; validate replay/CAS shapes; keep public
+  bindings content-free.
 
 ## How to Run
 - All tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest modules/ai_intelligence/digital_twin/tests`
 - Focused: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest modules/ai_intelligence/digital_twin/tests/test_comment_drafter.py`
 - Conversation: `cd extensions/reddog && npm run test:conversation`
+- Resident transport contract: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py`
+- Resident transport coverage: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q -p pytest_cov modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py --cov=modules.ai_intelligence.digital_twin.src.resident_conversation_transport_contract --cov-report=term-missing --cov-fail-under=100`
 
 ## Test Data
 - Use minimal fixtures embedded in tests or small local JSON snippets.

--- a/modules/ai_intelligence/digital_twin/tests/TestModLog.md
+++ b/modules/ai_intelligence/digital_twin/tests/TestModLog.md
@@ -15,6 +15,20 @@
 
 ## Entries
 - 2026-08-22
+  - Command: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q -p pytest_cov modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py --cov=modules.ai_intelligence.digital_twin.src.resident_conversation_transport_contract --cov-report=term-missing --cov-fail-under=100`
+  - Result: PASS (36/36); 100% statement and branch coverage for the new contract.
+  - Coverage: exact shape, authority-field injection, native JSON types,
+    operation/revision semantics, digest bindings, expiry/future clock bounds,
+    use-time freshness, Unicode/control characters, content-free projection,
+    forged object rejection, and WSP-62 limits.
+  - Environment note: two pre-existing pytest configuration warnings reported
+    missing async plugin options; no test was skipped, deselected, or failed.
+  - Module closure: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q modules/ai_intelligence/digital_twin/tests` PASS (117/117).
+  - Dependency closure: `cd extensions/reddog && npm run test:conversation`
+    PASS (15 JavaScript vectors; 32 Python contracts).
+  - Registry: `python modules/infrastructure/wre_core/scripts/generate_test_registry.py --check`
+    PASS (`current`, 1,567 tracked tests; new test is collectable and not quarantined).
+- 2026-08-22
   - Command: `cd extensions/reddog && npm run test:conversation`
   - Result: PASS (15 shared JS vectors; 32 Python contract tests).
   - Coverage: default chat, read-only research/status, proposal-only work and

--- a/modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py
+++ b/modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py
@@ -1,0 +1,279 @@
+"""Adversarial tests for the resident RedDog conversation envelope."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.ai_intelligence.digital_twin.src.conversation_plane import MAX_TURN_CHARS
+from modules.ai_intelligence.digital_twin.src.resident_conversation_transport_contract import (
+    MAX_CLOCK_SKEW_SECONDS,
+    MAX_OPERATOR_TEXT_SCALARS,
+    ResidentConversationOperation,
+    ResidentConversationRequest,
+    enforce_request_freshness,
+    request_from_mapping,
+    resident_conversation_request_reasons,
+)
+
+
+NOW = 1_800_000_000
+
+
+def _digest(character: str) -> str:
+    return "sha256:" + character * 64
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": "reddog_resident_conversation_request.v1",
+        "operation": "TURN",
+        "request_id": _digest("a"),
+        "conversation_id": _digest("b"),
+        "expected_revision": 2,
+        "turn_id": _digest("c"),
+        "client_nonce": _digest("d"),
+        "idempotency_key": _digest("e"),
+        "issued_at": NOW,
+        "expires_at": NOW + 60,
+        "operator_text": "Hello RedDog.",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_turn_round_trip_normalizes_text_and_projects_content_free_binding() -> None:
+    request = request_from_mapping(
+        _payload(operator_text="  Ｈｅｌｌｏ RedDog.  "), now_epoch=NOW
+    )
+    assert request.operation is ResidentConversationOperation.TURN
+    assert request.operator_text == "Hello RedDog."
+    assert request_from_mapping(request.to_dict(), now_epoch=NOW) == request
+    binding = request.content_free_binding()
+    assert binding["request_digest"] == request.request_digest()
+    assert binding["grants_identity_authority"] is False
+    assert binding["grants_effect_authority"] is False
+    serialized = json.dumps(binding, sort_keys=True)
+    assert "operator_text" not in serialized
+    assert "Hello RedDog" not in serialized
+
+
+@pytest.mark.parametrize(
+    "injected",
+    [
+        "principal_id",
+        "foundup_id",
+        "credential",
+        "provider",
+        "model",
+        "effect_ceiling",
+        "work_authority",
+    ],
+)
+def test_identity_routing_and_effect_injection_is_rejected(injected: str) -> None:
+    payload = _payload()
+    payload[injected] = "attacker-selected"
+    with pytest.raises(ValueError, match="resident_conversation_request_shape_invalid"):
+        request_from_mapping(payload, now_epoch=NOW)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("expected_revision", True),
+        ("issued_at", False),
+        ("expires_at", 1.5),
+        ("operator_text", ["hello"]),
+        ("request_id", 7),
+    ],
+)
+def test_non_native_scalar_types_fail_closed(field: str, value: object) -> None:
+    with pytest.raises(ValueError, match="resident_conversation_request_type_invalid"):
+        request_from_mapping(_payload(**{field: value}), now_epoch=NOW)
+
+
+@pytest.mark.parametrize("operation", ["EXECUTE", "AUTHORIZE", "turn"])
+def test_unknown_or_authority_operations_fail_closed(operation: str) -> None:
+    with pytest.raises(ValueError, match="resident_conversation_operation_invalid"):
+        request_from_mapping(_payload(operation=operation), now_epoch=NOW)
+
+
+def test_new_and_existing_turn_revision_shapes_are_distinct() -> None:
+    created = request_from_mapping(
+        _payload(conversation_id="", expected_revision=-1), now_epoch=NOW
+    )
+    assert created.conversation_id == ""
+    with pytest.raises(ValueError, match="resident_conversation_revision_invalid"):
+        request_from_mapping(
+            _payload(conversation_id="", expected_revision=0), now_epoch=NOW
+        )
+    with pytest.raises(ValueError, match="resident_conversation_revision_invalid"):
+        request_from_mapping(_payload(expected_revision=-1), now_epoch=NOW)
+
+
+@pytest.mark.parametrize("operation", ["STATUS", "CANCEL"])
+def test_control_operations_require_target_and_forbid_operator_text(
+    operation: str,
+) -> None:
+    accepted = request_from_mapping(
+        _payload(operation=operation, operator_text=""), now_epoch=NOW
+    )
+    assert accepted.operation.value == operation
+    with pytest.raises(
+        ValueError, match="resident_conversation_operator_text_forbidden"
+    ):
+        request_from_mapping(_payload(operation=operation), now_epoch=NOW)
+    with pytest.raises(
+        ValueError, match="resident_conversation_conversation_id_required"
+    ):
+        request_from_mapping(
+            _payload(
+                operation=operation,
+                operator_text="",
+                conversation_id="",
+                expected_revision=-1,
+            ),
+            now_epoch=NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"expires_at": NOW}, "resident_conversation_request_ttl_invalid"),
+        ({"expires_at": NOW + 301}, "resident_conversation_request_ttl_invalid"),
+        (
+            {"issued_at": NOW + MAX_CLOCK_SKEW_SECONDS + 1, "expires_at": NOW + 90},
+            "resident_conversation_request_not_yet_valid",
+        ),
+    ],
+)
+def test_ttl_and_clock_bounds_fail_closed(
+    overrides: dict[str, object], reason: str
+) -> None:
+    with pytest.raises(ValueError, match=reason):
+        request_from_mapping(_payload(**overrides), now_epoch=NOW)
+
+
+def test_expiry_is_rechecked_at_use_time() -> None:
+    request = request_from_mapping(_payload(), now_epoch=NOW)
+    enforce_request_freshness(request, now_epoch=NOW + 59)
+    with pytest.raises(ValueError, match="resident_conversation_request_expired"):
+        enforce_request_freshness(request, now_epoch=NOW + 60)
+    with pytest.raises(ValueError, match="resident_conversation_now_invalid"):
+        enforce_request_freshness(request, now_epoch=True)
+    with pytest.raises(ValueError, match="resident_conversation_request_type_invalid"):
+        enforce_request_freshness(object(), now_epoch=NOW)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["request_id", "conversation_id", "turn_id", "client_nonce", "idempotency_key"],
+)
+def test_all_transport_bindings_use_canonical_digest_shape(field: str) -> None:
+    with pytest.raises(ValueError, match="resident_conversation_.*_invalid"):
+        request_from_mapping(_payload(**{field: "client-selected-text"}), now_epoch=NOW)
+
+
+@pytest.mark.parametrize(
+    "operator_text",
+    ["hello\x00world", "hello\x01world", "x" * (MAX_OPERATOR_TEXT_SCALARS + 1)],
+)
+def test_invalid_operator_text_fails_closed(operator_text: str) -> None:
+    with pytest.raises(ValueError, match="resident_conversation_operator_text_invalid"):
+        request_from_mapping(_payload(operator_text=operator_text), now_epoch=NOW)
+
+
+def test_empty_turn_and_negative_control_revision_fail_closed() -> None:
+    with pytest.raises(
+        ValueError, match="resident_conversation_operator_text_required"
+    ):
+        request_from_mapping(_payload(operator_text="  "), now_epoch=NOW)
+    with pytest.raises(ValueError, match="resident_conversation_revision_invalid"):
+        request_from_mapping(
+            _payload(operation="STATUS", operator_text="", expected_revision=-1),
+            now_epoch=NOW,
+        )
+
+
+def test_transport_and_classifier_scalar_limits_are_identical() -> None:
+    assert MAX_OPERATOR_TEXT_SCALARS == MAX_TURN_CHARS
+
+
+def test_direct_construction_cannot_bypass_static_contract() -> None:
+    with pytest.raises(
+        ValueError, match="resident_conversation_request_binding_invalid"
+    ):
+        ResidentConversationRequest(
+            operation=ResidentConversationOperation.TURN,
+            request_id="not-a-digest",
+            conversation_id="",
+            expected_revision=-1,
+            turn_id=_digest("c"),
+            client_nonce=_digest("d"),
+            idempotency_key=_digest("e"),
+            issued_at=NOW,
+            expires_at=NOW + 60,
+            operator_text="hello",
+        )
+    for operator_text in (
+        "  hello  ",
+        "hello\x00world",
+        "hello\x01world",
+        "x" * 12_001,
+    ):
+        with pytest.raises(
+            ValueError, match="resident_conversation_operator_text_invalid"
+        ):
+            ResidentConversationRequest(
+                operation=ResidentConversationOperation.TURN,
+                request_id=_digest("a"),
+                conversation_id="",
+                expected_revision=-1,
+                turn_id=_digest("c"),
+                client_nonce=_digest("d"),
+                idempotency_key=_digest("e"),
+                issued_at=NOW,
+                expires_at=NOW + 60,
+                operator_text=operator_text,
+            )
+
+
+def test_mutated_or_forged_request_objects_report_stable_reasons() -> None:
+    request = request_from_mapping(_payload(), now_epoch=NOW)
+    object.__setattr__(request, "schema_version", "forged")
+    assert resident_conversation_request_reasons(request) == (
+        "resident_conversation_schema_invalid",
+    )
+    request = request_from_mapping(_payload(), now_epoch=NOW)
+    object.__setattr__(request, "operation", "TURN")
+    assert "resident_conversation_operation_invalid" in (
+        resident_conversation_request_reasons(request)
+    )
+    request = request_from_mapping(_payload(), now_epoch=NOW)
+    object.__setattr__(request, "issued_at", True)
+    assert "resident_conversation_request_type_invalid" in (
+        resident_conversation_request_reasons(request)
+    )
+    assert resident_conversation_request_reasons(object()) == (
+        "resident_conversation_request_type_invalid",
+    )
+
+
+def test_transport_contract_respects_wsp62_limits() -> None:
+    source_path = (
+        Path(__file__).parents[1]
+        / "src"
+        / "resident_conversation_transport_contract.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+    functions = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    assert len(source.splitlines()) <= 500
+    assert all(node.end_lineno - node.lineno + 1 <= 50 for node in functions)


### PR DESCRIPTION
## Outcome

Adds the first strict, transport-neutral RedDog resident conversation envelope without creating a live endpoint or new authority system.

## WSP 15 / WSP 97 scope

- P0 selected: authenticated resident turn/status/cancel path.
- This layer implements only the untrusted request contract and content-free binding.
- Existing AgentDB conversation scope/session authority remains the substrate.
- Principal, FoundUp, credential, model/provider, effect, and work authority cannot be supplied by the client envelope.
- Live service binding, VSIX/PFMall/phone adapters, persistence, model calls, and work dispatch remain explicitly gated.
- No HoloIndex query, replica, route, shared checkout, or VSIX package mutation.

## Contract

- Exact TURN / STATUS / CANCEL operations.
- Canonical digest-shaped request/conversation/turn/nonce/idempotency bindings.
- New-versus-existing conversation CAS revision rules.
- Maximum five-minute validity window with use-time freshness checks.
- NFKC-normalized bounded operator text.
- Content-free binding that grants neither identity nor effect authority.

## Verification at exact commit 565ffbda

- 36/36 focused adversarial tests.
- 100% statement and branch coverage for the new contract.
- 117/117 Digital Twin module tests.
- RedDog conversation tier: 15 JavaScript vectors + 32 Python contracts.
- Ruff lint and format checks pass.
- Canonical WSP test registry current at 1,567; new test collectable and not quarantined.

## Documentation

Aligns root, RedDog, Digital Twin, test, and architecture documentation. The corrected truth boundary is: AgentDB/session substrate and envelope exist; authenticated resident service binding and VSIX/PFMall/phone adapters do not.