### PR TITLE
feat(reddog): bind resident requests to authenticated scope

### DIFF
--- a/NAVIGATION.py
+++ b/NAVIGATION.py
@@ -116,6 +116,9 @@ NEED_TO = {
     "openclaw security tests": "modules/ai_intelligence/ai_overseer/tests/test_openclaw_security_sentinel.py",
     "openclaw dae tests": "modules/communication/moltbot_bridge/tests/test_openclaw_dae.py",
     "moltbot bridge digital twin": "modules/communication/moltbot_bridge/README.md",
+    "reddog authenticated conversation scope": "modules/communication/moltbot_bridge/src/reddog_authenticated_conversation_scope_state.py",
+    "reddog resident conversation request scope binding": "modules/communication/moltbot_bridge/src/reddog_resident_conversation_scope_binding.py:bind_resident_conversation_request_to_authenticated_scope()",
+    "reddog current conversation session authority": "modules/communication/moltbot_bridge/src/reddog_conversation_session_authority_source.py:lease_current_generation_conversation_session()",
     "moltbot bridge workspace skills": "modules/communication/moltbot_bridge/workspace/AGENTS.md",
 
     # M2M Compression (Machine-to-Machine 0102-0102 Documentation)
@@ -166,6 +169,7 @@ NEED_TO = {
     "wsp_00 awakening script": "WSP_agentic/scripts/functional_0102_awakening_v2.py",
 
     # Digital Twin (Core Components)
+    "digital twin resident conversation transport": "modules/ai_intelligence/digital_twin/src/resident_conversation_transport_contract.py:request_from_mapping()",
     "digital twin voice memory": "modules/ai_intelligence/digital_twin/src/voice_memory.py:VoiceMemory",
     "build voice memory index": "modules/ai_intelligence/digital_twin/src/voice_memory.py:VoiceMemory.build_index()",
     "query voice memory": "modules/ai_intelligence/digital_twin/src/voice_memory.py:VoiceMemory.query()",

--- a/WSP_knowledge/WSP_Test_Registry.json
+++ b/WSP_knowledge/WSP_Test_Registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "wsp_test_registry.v2",
   "generation_policy": "git-tracked-python-tests.v1",
-  "total_tests": 1567,
+  "total_tests": 1568,
   "quarantined_tests": 267,
   "tests": [
     {
@@ -9737,6 +9737,19 @@
       "description": "Tests for runtime control-loop signer context resolution."
     },
     {
+      "id": "test::modules::communication::moltbot_bridge::tests::test_reddog_resident_conversation_scope_binding",
+      "path": "modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py",
+      "owner": "modules/communication/moltbot_bridge",
+      "suite_class": "unit",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-07",
+      "capabilities": [],
+      "execution_type": "unit",
+      "collectable": true,
+      "timeout_s": 180,
+      "quarantine_reasons": [],
+      "description": "Adversarial tests for resident request-to-scope admission binding."
+    },
+    {
       "id": "test::modules::communication::moltbot_bridge::tests::test_reddog_resident_cycle_grounding_v2",
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_resident_cycle_grounding_v2.py",
       "owner": "modules/communication/moltbot_bridge",
@@ -10019,7 +10032,7 @@
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_resident_queue_orchestration_plan.py",
       "owner": "modules/communication/moltbot_bridge",
       "suite_class": "unit",
-      "shard_id": "modules-communication-moltbot-bridge-unit-part-07",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-08",
       "capabilities": [],
       "execution_type": "unit",
       "collectable": true,
@@ -10513,7 +10526,7 @@
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_signed_worker_real_readonly_audit.py",
       "owner": "modules/communication/moltbot_bridge",
       "suite_class": "unit",
-      "shard_id": "modules-communication-moltbot-bridge-unit-part-08",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-09",
       "capabilities": [],
       "execution_type": "unit",
       "collectable": true,
@@ -11048,7 +11061,7 @@
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_signer_system_service_entrypoint.py",
       "owner": "modules/communication/moltbot_bridge",
       "suite_class": "unit",
-      "shard_id": "modules-communication-moltbot-bridge-unit-part-09",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-10",
       "capabilities": [
         "process"
       ],
@@ -11528,7 +11541,7 @@
       "path": "modules/communication/moltbot_bridge/tests/test_reddog_wre_queue_authorized_pattern_memory_admission_invoke.py",
       "owner": "modules/communication/moltbot_bridge",
       "suite_class": "unit",
-      "shard_id": "modules-communication-moltbot-bridge-unit-part-10",
+      "shard_id": "modules-communication-moltbot-bridge-unit-part-11",
       "capabilities": [],
       "execution_type": "unit",
       "collectable": true,

--- a/modules/ai_intelligence/digital_twin/INTERFACE.md
+++ b/modules/ai_intelligence/digital_twin/INTERFACE.md
@@ -52,15 +52,16 @@ control operations require a conversation ID and non-negative CAS revision.
 
 The envelope is deliberately untrusted and zero-authority. It has no fields for
 principal, FoundUp, credential, provider/model, effect ceiling, or work
-authority. Those bindings belong to the future resident service and must be
-derived from verified session authority and current AgentDB state. The
-content-free binding contains no operator text and explicitly grants neither
-identity nor effect authority. Its unkeyed digest is structural integrity and
-equality evidence, not authentication or replay enforcement.
+authority. The resident communication layer now binds an existing-conversation
+envelope to one consumed session capability and the exact authenticated
+AgentDB revision. The resulting content-free evidence still grants neither
+identity nor effect authority, reserves no CAS, and provides no durable replay
+enforcement.
 
 This interface does not expose an HTTP endpoint, authenticate a session, mutate
 AgentDB, invoke a model, or dispatch work. VSIX/PFMall adapters remain gated on
-the authenticated service binding and shared cross-surface vectors.
+trusted new-scope resolution, a durable idempotency journal, operation handlers,
+and shared cross-surface vectors.
 
 ---
 

--- a/modules/ai_intelligence/digital_twin/ModLog.md
+++ b/modules/ai_intelligence/digital_twin/ModLog.md
@@ -2,6 +2,16 @@
 
 **WSP Compliance**: WSP 22 (ModLog Updates)
 
+## 2026-08-22 - Resident conversation authenticated-scope binding
+
+- Synchronized the Digital Twin transport documentation with the new resident
+  communication-layer admission boundary for existing conversations.
+- Clarified that the client envelope remains zero-authority while the host
+  consumes a separate opaque session capability and verifies exact AgentDB
+  state without mutation.
+- Kept live VSIX/PFMall transport blocked on trusted new-scope resolution,
+  durable idempotency, operation handlers, and shared acceptance vectors.
+
 ## 2026-08-22 - Resident conversation transport contract phase 1
 
 - Added a strict transport-neutral request envelope for RedDog `TURN`,

--- a/modules/ai_intelligence/digital_twin/README.md
+++ b/modules/ai_intelligence/digital_twin/README.md
@@ -19,8 +19,12 @@ boundary for `TURN`, `STATUS`, and `CANCEL`. It accepts only content, opaque
 digest bindings, CAS revision, nonce/idempotency, and a maximum five-minute
 validity window. Principal, FoundUp, credential, provider/model, effect, and
 work-authority fields are deliberately outside the client envelope and must be
-derived and revalidated by the future authenticated resident service. The
-contract adds no listener, persistence, authentication, model call, or effect.
+derived and revalidated by the resident host. The communication layer now has
+an admission-only existing-scope binding that consumes one opaque session
+capability and verifies the exact current AgentDB revision without mutation.
+The client contract itself still adds no listener, persistence,
+authentication, model call, or effect. Live adapters remain gated on trusted
+new-scope resolution, durable idempotency, and operation handlers.
 
 `principal_memex_projection.py` implements the first structural, read-only
 Principal Memex projection. It validates provenance identifiers, canonical

--- a/modules/ai_intelligence/digital_twin/ROADMAP.md
+++ b/modules/ai_intelligence/digital_twin/ROADMAP.md
@@ -32,8 +32,11 @@ conversation state, AgentDB, or any FoundUp Memex.
 - Complete: strict transport-neutral `TURN` / `STATUS` / `CANCEL` request
   envelope with CAS revision, digest bindings, nonce/idempotency, five-minute
   freshness, identity/effect injection rejection, and content-free projection.
-- Next: bind that envelope to verified resident session authority and current
-  AgentDB CAS state; this authenticated service does not yet exist.
+- Complete: admission-only binding for existing conversations consumes one
+  verified session capability and binds the envelope to the exact authenticated
+  AgentDB record/revision without mutation or authority transfer.
+- Next: trusted new-scope resolution, durable request idempotency, and
+  operation-specific TURN/STATUS/CANCEL handlers with immediate CAS recheck.
 - Next: thin PFMall/phone transport adapter; the browser remains a client, not
   the model/OpenClaw host.
 - Deferred: asynchronous critics, durable cross-device history, bounded Memex/

--- a/modules/communication/moltbot_bridge/INTERFACE.md
+++ b/modules/communication/moltbot_bridge/INTERFACE.md
@@ -109,42 +109,15 @@ cannot reuse the backend. Specialized proposal, control-loop, manifest,
 verified-outcome, conversation, and peer-handshake policies retain their own
 domain-specific validation.
 ## Authenticated RedDog conversation scope
-`authenticate_conversation_scope()` derives the principal only from a verified
-`sess.v1` subject and returns an opaque one-use capability. Create, resume, and
-advance persist bounded authenticated state in AgentDB with insert/CAS, expiry,
-and turn lineage. Scope schema v3 adds `foundup`, `principal`, and `comparison`.
-FoundUp scope retains evidence, snapshot, HEAD, and HoloIndex bindings; only
-evidence already admitted by grounding may persist. Principal and comparison
-scope forbid repository/operational bindings, and comparison requires at least
-two FoundUps already present in the principal credential. Neither can promote work.
-`prepare_conversation_work_context()` binds one current revision to a verified
-resident intent. Backend determination rejects stale scope before a model call.
-`commit_pending_conversation_work_proposal()` CAS-stores one exact FIX preview;
-`verify_pending_conversation_work_proposal()` issues its one-use capability.
-Signed WSP 15 promotion consumes it only after current-record, FoundUp, Memex,
-model, and existing principal-signature checks. Admission schema v2 signs the
-complete conversation/snapshot lineage. Neither state nor capability grants
-work authority. `authenticate_signed_conversation_scope()` is the production
-editor source: it verifies a strict principal-signed credential using only the
-current-generation public key, enforces repository/audience/transport/TTL and
-FoundUp scope, and yields the same opaque operation-local capability. The
-credential never enters AgentDB, model context, receipts, logs, or child env.
-Principal-signed sessions persist scope v3 only through the existing isolated
-E0 signer. Scope v2 records fail closed and are not inferred or upgraded because
-they lack the immutable kind binding. The signer re-verifies the credential
-against current principal authority on every use, signs the complete record and
-credential, and advances a signer-owned monotonic conversation head. AgentDB
-first stages the exact
-unsigned payload as non-authoritative pending state; only a matching E0 response
-may atomically publish it. Exact replay supports crash recovery; altered pending
-content, rollback, fork, nonce replay, stale authority, wrong key epoch, forged
-peer metadata, or missing policy/resolver/anchor fails closed. Restarted consumers
-must present the same valid credential and verify the signature and attestation.
-Legacy intake HMAC remains supported; neither scheme grants work or repository
-authority. Config v3 is the only bootable schema and stale v2 fails before service
-invocation. The public supplier retains its 16 KiB request budget; the conversation
-bootstrap explicitly supplies the reviewed 160 KiB bound. Lower bounds omit
-conversation signing rather than weakening the socket limit.
+`authenticate_conversation_scope()` derives the principal only from a verified `sess.v1` subject and returns an opaque one-use capability. Create, resume, and advance persist bounded authenticated state in AgentDB with insert/CAS, expiry, and turn lineage. Scope schema v3 supports `foundup`, `principal`, and `comparison`; only FoundUp scope retains grounded evidence/snapshot/HEAD/Holo bindings or may later request work promotion.
+
+`bind_resident_conversation_request_to_authenticated_scope(store, capability, request, now_epoch)` consumes that capability and admits one existing `TURN`, `STATUS`, or `CANCEL` envelope only after rechecking envelope freshness, current AgentDB record shape/digest, record authentication, principal/session/scope equality, expiry, exact revision, and turn lineage. Its `reddog_resident_conversation_scope_binding.v1` result contains only opaque request/state digests and explicit no-authority flags. It does not reserve CAS, persist idempotency, return operator text, mutate state, call a model, or dispatch work. Empty conversation IDs reject until trusted new-scope resolution exists; every later mutation must re-authenticate current state and repeat AgentDB CAS.
+
+`prepare_conversation_work_context()` binds one current revision to a verified resident intent. Backend determination rejects stale scope before a model call. `commit_pending_conversation_work_proposal()` CAS-stores one exact FIX preview, and `verify_pending_conversation_work_proposal()` issues its one-use capability. Signed WSP 15 promotion additionally rechecks current record, FoundUp, Memex, model, and principal signature. Neither state nor capability grants work authority.
+
+`authenticate_signed_conversation_scope()` is the production editor source: it uses the current-generation public key and enforces repository, audience, transport, TTL, principal, and FoundUp scope. The credential never enters AgentDB, model context, receipts, logs, or child env. Principal-signed scope v3 persists only through the isolated E0 signer; v2 fails closed. AgentDB stages unsigned payload as non-authoritative pending state and publishes only a matching E0 response. Exact replay supports crash recovery; altered content, rollback/fork, nonce replay, stale authority, wrong key epoch, forged peer metadata, or missing policy/resolver/anchor rejects. Restart requires the same valid credential plus signature and attestation verification.
+
+Legacy intake HMAC remains test/backward-compatible and grants no work or repository authority. Config v3 is the only bootable schema. The public signer supplier remains capped at 16 KiB; the reviewed conversation bootstrap uses 160 KiB rather than weakening signer validation.
 
 ## Public API
 ### Architect proposal validity and execution readiness

--- a/modules/communication/moltbot_bridge/ModLog.md
+++ b/modules/communication/moltbot_bridge/ModLog.md
@@ -1,5 +1,27 @@
 # ModLog - moltbot_bridge
 
+## 2026-08-22: Resident conversation request-to-scope binding
+
+- Added an admission-only bridge from the strict Digital Twin `TURN`,
+  `STATUS`, and `CANCEL` envelope to one authenticated current AgentDB scope
+  revision.
+- The bridge consumes the existing opaque one-use capability, verifies record
+  shape/digest/authentication plus principal/session/scope equality, expiry,
+  exact revision, and turn lineage, then emits content-free non-authoritative
+  evidence without reserving CAS or mutating state.
+- Empty conversation IDs remain fail closed pending trusted scope resolution;
+  durable idempotency and operation handlers remain required before a live
+  VSIX/PFMall adapter.
+- A WSP 62 test exposed that adding the bridge to the existing lifecycle file
+  would push it to 490 lines. Extracted the distinct admission boundary into a
+  243-line module with a 37-line maximum function and no exemption.
+- Compressed the legacy interface registry from 1,529 to 1,502 lines while
+  adding the contract, and ratcheted its exact temporary ceiling down from
+  1,519 to 1,502; no exemption was added or widened.
+- Added the WSP 97 high-risk assumption audit and synchronized working,
+  contract, intent, navigation, and verification memory. WSP 00/15/22/50/62/
+  84/97.
+
 ## 2026-08-22: Holo owner replica response binding
 
 - Preserved the service's exact four-field query-replica capability through

--- a/modules/communication/moltbot_bridge/README.md
+++ b/modules/communication/moltbot_bridge/README.md
@@ -302,9 +302,15 @@ generation/freshness receipt, FoundUp, grounding receipt, and intent.
 Conversation state and the pending capability do not grant work authority.
 Only a `foundup` scope may request the existing proposal-promotion chain.
 WRE/OpenClaw/Hermes dispatch, repository mutation, and merge remain downstream
-gates. The extension now has a public-key-only authenticated-session source.
-Durable conversation-state consumption remains blocked until that source
-receipt is bound into the P1 state lifecycle.
+gates. `reddog_resident_conversation_scope_binding.py` now consumes one opaque
+authenticated-session capability and binds an existing `TURN`, `STATUS`, or
+`CANCEL` envelope to the exact current AgentDB record, revision receipt,
+record digest, session binding, and turn lineage. It returns content-free
+evidence, does not reserve the CAS revision, and performs no state mutation.
+The extension still needs a host-side session-capability adapter, trusted
+new-scope resolution, durable idempotency, and operation handlers before live
+conversation traffic is enabled. The WSP 97 assumption audit is attached at
+`docs/clarity/REDDOG_RESIDENT_CONVERSATION_SERVICE_BINDING_PHASE1.md`.
 
 ## Upstream Agent Execution Boundary
 

--- a/modules/communication/moltbot_bridge/ROADMAP.md
+++ b/modules/communication/moltbot_bridge/ROADMAP.md
@@ -88,15 +88,20 @@
 - COMPLETE: editor source for pre-issued principal-signed conversation
   credentials. Verification is public-key-only and binds repository, audience,
   transport, TTL, principal, FoundUp, current generation, intent and grounding.
-- BLOCKED: principal-side credential issuance UX and P1 durable-scope runtime
-  consumption. Environment principal/FoundUp values are not authentication.
+- COMPLETE: admission-only binding of an existing transport envelope to one
+  consumed session capability and exact authenticated AgentDB CAS revision.
+  It is content-free, non-reserving, and effect-free.
+- BLOCKED: principal-side credential issuance UX, trusted new-scope selection,
+  durable request idempotency, and operation-specific TURN/STATUS/CANCEL
+  handlers. Environment principal/FoundUp values are not authentication.
 - COMPLETE: one authenticated scope revision and resident intent can be bound
   to an immutable architect proposal preview. AgentDB CAS stores the exact
   pending proposal; backend determination rejects stale snapshot/HEAD/Holo
   context before Fusion; signed WSP 15 promotion requires a fresh one-use
   pending capability plus the existing principal-signed proposal policy.
-- BLOCKED: editor/runtime conversation-to-proposal consumption until the
-  verified session receipt is connected to the existing P1/P2 APIs.
+- BLOCKED: editor/runtime conversation-to-proposal consumption until the host
+  adapter supplies the verified capability and downstream mutations repeat
+  authenticated current-record/CAS checks.
 - HELD: OpenClaw/Hermes dispatch until the editor/runtime binding and all
   existing WRE work-order gates pass.
 

--- a/modules/communication/moltbot_bridge/docs/clarity/REDDOG_RESIDENT_CONVERSATION_SERVICE_BINDING_PHASE1.md
+++ b/modules/communication/moltbot_bridge/docs/clarity/REDDOG_RESIDENT_CONVERSATION_SERVICE_BINDING_PHASE1.md
@@ -15,13 +15,13 @@ dispatch a worker, or mutate AgentDB.
 
 ## 2. WSP 15 Allocation
 
-- Receipt: `sha256:65476fbc497c4aba12f5d4eb2b058d55801eecc757f4376b7fa3afe1ae2aea05`
+- Receipt: `sha256:5653bdce783c8b404e92cb2b010acf10b8e32e5219cc469c0f34c88e63241558`
 - Scores: complexity `5`, importance `5`, deferability `4`, impact `5`
 - Total/priority: `19 / P0`
 - Reasoning tier: `ULTRA`
 - Execution plane: local code and tests; WRE runtime attachment is not part of
   this layer.
-- Final allocation is bound to all 15 changed paths and five directly read
+- Final allocation is bound to all 16 changed paths and five directly read
   authority/transport sources; its canonical validator accepts with no
   rejection reasons.
 
@@ -95,6 +95,8 @@ dispatch a worker, or mutate AgentDB.
 - Cross-module transport/authentication/signing/tamper/WSP-62 matrix:
   `130 passed` with importlib collection.
 - Focused binding plus module exemption gates: `31 passed`.
+- Canonical test registry: deterministic generation and `--check` both report
+  `CURRENT` with `1,568` entries and `267` explicit quarantines.
 - Full local bridge closure: `6,220 passed`, `47 skipped`, `45 failed` in
   `17m24s`. At exact parent `f06ca1fcc4acc9e2645a3ed898bad844ac6df298`,
   44 failure node IDs reproduce. The remaining node passes at the parent and

--- a/modules/communication/moltbot_bridge/docs/clarity/REDDOG_RESIDENT_CONVERSATION_SERVICE_BINDING_PHASE1.md
+++ b/modules/communication/moltbot_bridge/docs/clarity/REDDOG_RESIDENT_CONVERSATION_SERVICE_BINDING_PHASE1.md
@@ -1,0 +1,106 @@
+# Assumption Audit: RedDog Resident Conversation Service Binding Phase 1
+
+## 1. Problem Statement
+
+- **What**: Bind one validated `reddog_resident_conversation_request.v1`
+  envelope to one authenticated, current AgentDB conversation-scope revision.
+- **Why**: The transport envelope is intentionally zero-authority. A VSIX or
+  PFMall adapter cannot safely use it until resident authority and durable
+  conversation state are verified together.
+- **Who**: Authorized by 012; executed by `0102/architect` on 2026-08-22.
+
+This phase is admission-only. It does not create a network endpoint, create a
+conversation, reserve a revision, persist an idempotency key, invoke a model,
+dispatch a worker, or mutate AgentDB.
+
+## 2. WSP 15 Allocation
+
+- Receipt: `sha256:65476fbc497c4aba12f5d4eb2b058d55801eecc757f4376b7fa3afe1ae2aea05`
+- Scores: complexity `5`, importance `5`, deferability `4`, impact `5`
+- Total/priority: `19 / P0`
+- Reasoning tier: `ULTRA`
+- Execution plane: local code and tests; WRE runtime attachment is not part of
+  this layer.
+- Final allocation is bound to all 15 changed paths and five directly read
+  authority/transport sources; its canonical validator accepts with no
+  rejection reasons.
+
+## 3. Retrieval Evaluation
+
+- Exact owner query: `CURRENT`, `index_gap_detected=false`, sealed replica;
+  no reindex was run.
+- Broad-query precision was low: the durable AgentDB cycle ranked first, but
+  the exact transport and session-authority contracts were absent.
+- A tightened exact-symbol query found the transport contract, scope store,
+  scope capability, pending store, lifecycle tests, and session-source tests.
+- Ordering improved, but one unrelated permission module remained and the
+  transport contract appeared twice across code/symbol result sets.
+- Tier-0 module documents did not rank in the Holo result. The required
+  `README.md`, `INTERFACE.md`, `ROADMAP.md`, `ModLog.md`, `tests/README.md`,
+  and `tests/TestModLog.md` were therefore read directly as explicit
+  must-includes.
+- Staleness risk is low because the query reported exact-current HEAD and no
+  index gap. The ranking noise is recorded but does not justify an index
+  mutation in this transaction.
+
+## 4. Assumptions
+
+| ID | Assumption | Evidence | Confidence |
+|---|---|---|---|
+| A1 | Client identity and FoundUp scope must never come from the envelope. | `resident_conversation_transport_contract.py`; injected identity/routing fields reject. | HIGH |
+| A2 | The existing opaque conversation capability is the correct one-use identity proof. | `reddog_conversation_scope_capability.py`; capabilities are process-local, one-use, immutable, and scope-restricted. | HIGH |
+| A3 | The current AgentDB record is authoritative only after structural, digest, authority, and record-authentication verification. | `reddog_conversation_scope_store.py`; `reddog_authenticated_conversation_scope_state.py`. | HIGH |
+| A4 | Admission can bind a CAS precondition but cannot reserve it. | The store mutates only through compare-and-swap; this phase performs no mutation. | HIGH |
+| A5 | A new conversation cannot be derived from operator text alone. | Scope creation also requires host-selected scope, grounding/snapshot inputs, and authenticated authority. | HIGH |
+| A6 | Request nonce/idempotency fields are equality inputs, not durable replay prevention, until a resident request journal exists. | The envelope has no persistence and its digest is explicitly non-authenticating. | HIGH |
+
+## 5. Failure Modes
+
+| ID | Failure Mode | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| F1 | Forged or replayed capability admits another principal/session. | LOW | CRITICAL | Consume the existing opaque capability once; verify exact scope, authority fields, and authenticated record. |
+| F2 | State changes after admission but before a later operation. | MEDIUM | HIGH | Mark the result non-reserving; every later mutation must repeat current-record authentication and AgentDB CAS. |
+| F3 | New-scope defaults silently select a FoundUp or scope kind. | MEDIUM | HIGH | Reject empty conversation IDs with `resident_conversation_new_scope_resolution_required`. |
+| F4 | STATUS/CANCEL targets a stale or different turn. | MEDIUM | HIGH | Require the request turn ID to equal the current stored turn and require the exact revision. |
+| F5 | Operator text or principal/FoundUp identifiers leak into receipts. | LOW | HIGH | Emit only digest-shaped request/state bindings and explicit no-authority flags. |
+| F6 | A request is replayed with a newly issued capability. | MEDIUM | HIGH | Do not execute any operation in this phase; require a durable idempotency journal before handlers are enabled. |
+| F7 | Store errors reveal whether a conversation exists. | MEDIUM | MEDIUM | Collapse missing, malformed, and unavailable load outcomes to the same access-denied result. |
+
+## 6. Alternatives Considered
+
+| Alternative | Why Rejected |
+|---|---|
+| Add an HTTP/WebSocket service now | Prematurely combines ingress, authentication, state, idempotency, and execution before the authority/CAS seam is proven. |
+| Reuse the architect intent-coupled session source as the chat service | Its binding is intentionally tied to an already-grounded resident work intent; a conversation turn is earlier and broader than that boundary. |
+| Advance or cancel AgentDB state during admission | The envelope does not contain the trusted continuity patch, grounding, or cancellation-state contract required for a valid mutation. |
+| Create a second conversation database | Duplicates the existing AgentDB store and breaks the single durable authority boundary. |
+| Put the bridge in the Digital Twin module | The Digital Twin owns the zero-authority client contract; authentication and AgentDB state belong to the resident communication module. |
+
+## 7. Decision Record
+
+- **Decision**: PROCEED
+- **Owner**: `0102/architect`
+- **Timestamp**: `2026-08-22`
+- **Boundary**: Existing conversations only; admission result is content-free,
+  non-reserving, non-persistent, and grants no identity, model, work, or effect
+  authority.
+- **Required follow-ons before a live adapter**: trusted new-scope resolution,
+  durable idempotency/replay journal, operation-specific TURN/STATUS/CANCEL
+  handlers, and immediate pre-mutation CAS revalidation.
+
+## 8. Verification Record
+
+- Focused admission tests: `15 passed`; statement and branch coverage:
+  `106/106` statements and `24/24` branches.
+- Cross-module transport/authentication/signing/tamper/WSP-62 matrix:
+  `130 passed` with importlib collection.
+- Focused binding plus module exemption gates: `31 passed`.
+- Full local bridge closure: `6,220 passed`, `47 skipped`, `45 failed` in
+  `17m24s`. At exact parent `f06ca1fcc4acc9e2645a3ed898bad844ac6df298`,
+  44 failure node IDs reproduce. The remaining node passes at the parent and
+  in isolated candidate execution, proving order pollution rather than a
+  persistent candidate failure. This is differential evidence, not a clean
+  promotion-suite claim.
+- Repository-wide FMAS is not clean because of missing security-audit tools
+  and inherited structure/parse/exemption debt. Independent CI is still the
+  publication authority.

--- a/modules/communication/moltbot_bridge/src/reddog_resident_conversation_scope_binding.py
+++ b/modules/communication/moltbot_bridge/src/reddog_resident_conversation_scope_binding.py
@@ -1,0 +1,243 @@
+"""Bind a zero-authority resident request to authenticated AgentDB state."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping
+
+from modules.ai_intelligence.digital_twin.src.resident_conversation_transport_contract import (
+    ResidentConversationOperation,
+    ResidentConversationRequest,
+    enforce_request_freshness,
+    resident_conversation_request_reasons,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_capability import (
+    AuthenticatedConversationScopeCapability,
+    consume_conversation_scope_capability,
+    conversation_scope_authority_view,
+    discard_conversation_scope_capability,
+    verify_record_with_scope_authority,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    canonical_digest,
+    validate_record,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_record import (
+    authority_matches,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_store import (
+    AgentDbConversationScopeStore,
+)
+
+
+SCHEMA_VERSION = "reddog_resident_conversation_scope_binding.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ResidentConversationScopeBindingResult:
+    """Content-free, non-authoritative result of one scope admission."""
+
+    accepted: bool
+    status: str
+    binding_id: str = ""
+    operation: str = ""
+    request_id: str = ""
+    request_digest: str = ""
+    conversation_id: str = ""
+    expected_revision: int = -1
+    current_revision: int = -1
+    turn_id: str = ""
+    current_turn_id: str = ""
+    scope_kind: str = ""
+    record_digest: str = ""
+    revision_receipt_id: str = ""
+    principal_record_digest: str = ""
+    session_binding_digest: str = ""
+    rejection_reasons: tuple[str, ...] = ()
+    schema_version: str = SCHEMA_VERSION
+    cas_reserved: bool = False
+    grants_identity_authority: bool = False
+    grants_effect_authority: bool = False
+    no_agentdb_mutation_performed: bool = True
+    no_model_invocation_performed: bool = True
+    no_worker_dispatch_performed: bool = True
+    no_holoindex_reindex_performed: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def bind_resident_conversation_request_to_authenticated_scope(
+    *,
+    store: AgentDbConversationScopeStore,
+    capability: AuthenticatedConversationScopeCapability,
+    request: ResidentConversationRequest,
+    now_epoch: int,
+) -> ResidentConversationScopeBindingResult:
+    """Consume identity proof and bind one request to current AgentDB state."""
+
+    reason = _resident_request_rejection_reason(request, now_epoch)
+    if reason:
+        return _retire_and_reject_binding(capability, reason)
+    if not request.conversation_id:
+        return _retire_and_reject_binding(
+            capability, "resident_conversation_new_scope_resolution_required"
+        )
+    record = _load_binding_record(store, request.conversation_id)
+    if record is None:
+        return _retire_and_reject_binding(
+            capability, "resident_conversation_access_denied"
+        )
+    authority, view = _consume_current_record_authority(
+        capability, record, now_epoch
+    )
+    if authority is None or view is None:
+        return _binding_rejected("resident_conversation_access_denied")
+    try:
+        reason = _current_record_request_rejection_reason(
+            record, request, now_epoch
+        )
+        return (
+            _binding_rejected(reason)
+            if reason
+            else _accepted_scope_binding(record, view, request)
+        )
+    finally:
+        discard_conversation_scope_capability(authority)
+
+
+def _resident_request_rejection_reason(
+    request: ResidentConversationRequest, now_epoch: int
+) -> str:
+    if type(now_epoch) is not int or now_epoch < 0:
+        return "resident_conversation_now_invalid"
+    reasons = resident_conversation_request_reasons(request)
+    if reasons:
+        return reasons[0]
+    try:
+        enforce_request_freshness(request, now_epoch=now_epoch)
+    except ValueError as exc:
+        return str(exc) or "resident_conversation_request_invalid"
+    return ""
+
+
+def _load_binding_record(
+    store: AgentDbConversationScopeStore, conversation_id: str
+) -> Mapping[str, Any] | None:
+    try:
+        loaded = store.load(conversation_id)
+        if not isinstance(loaded, Mapping):
+            return None
+        record = loaded.get("record")
+        if (
+            not isinstance(record, Mapping)
+            or record.get("conversation_id") != conversation_id
+            or validate_record(record)
+        ):
+            return None
+        return record
+    except Exception:
+        return None
+
+
+def _consume_current_record_authority(
+    capability: AuthenticatedConversationScopeCapability,
+    record: Mapping[str, Any],
+    now_epoch: int,
+) -> tuple[Any, Mapping[str, Any] | None]:
+    authority = None
+    try:
+        authority = consume_conversation_scope_capability(
+            capability,
+            active_foundup_id=str(record["authorized_foundup_id"]),
+            discussion_foundup_ids=tuple(record["discussion_foundup_ids"]),
+            now_epoch=now_epoch,
+            scope_kind=str(record["scope_kind"]),
+        )
+        view = conversation_scope_authority_view(authority)
+        verified = bool(
+            authority is not None
+            and view is not None
+            and authority_matches(record, view)
+            and verify_record_with_scope_authority(authority, record)
+        )
+    except Exception:
+        view, verified = None, False
+    if not verified:
+        discard_conversation_scope_capability(authority)
+        return None, None
+    return authority, view
+
+
+def _current_record_request_rejection_reason(
+    record: Mapping[str, Any],
+    request: ResidentConversationRequest,
+    now_epoch: int,
+) -> str:
+    if int(now_epoch) >= int(record["expires_at"]):
+        return "resident_conversation_scope_expired"
+    if request.expected_revision != int(record["conversation_revision"]):
+        return "resident_conversation_revision_conflict"
+    current_turn = str(record["turn_id"])
+    if request.operation is ResidentConversationOperation.TURN:
+        return (
+            "resident_conversation_turn_conflict"
+            if request.turn_id == current_turn
+            else ""
+        )
+    return (
+        "resident_conversation_turn_conflict"
+        if request.turn_id != current_turn
+        else ""
+    )
+
+
+def _accepted_scope_binding(
+    record: Mapping[str, Any],
+    authority: Mapping[str, Any],
+    request: ResidentConversationRequest,
+) -> ResidentConversationScopeBindingResult:
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "operation": request.operation.value,
+        "request_id": request.request_id,
+        "request_digest": request.request_digest(),
+        "conversation_id": request.conversation_id,
+        "expected_revision": request.expected_revision,
+        "current_revision": int(record["conversation_revision"]),
+        "turn_id": request.turn_id,
+        "current_turn_id": str(record["turn_id"]),
+        "scope_kind": str(record["scope_kind"]),
+        "record_digest": str(record["record_digest"]),
+        "revision_receipt_id": str(record["revision_receipts"][-1]["receipt_id"]),
+        "principal_record_digest": str(authority["principal_record_digest"]),
+        "session_binding_digest": str(authority["session_binding_digest"]),
+    }
+    return ResidentConversationScopeBindingResult(
+        accepted=True,
+        status="RESIDENT_CONVERSATION_SCOPE_BOUND",
+        binding_id=canonical_digest(payload),
+        **{key: value for key, value in payload.items() if key != "schema_version"},
+    )
+
+
+def _retire_and_reject_binding(
+    capability: Any, reason: str
+) -> ResidentConversationScopeBindingResult:
+    discard_conversation_scope_capability(capability)
+    return _binding_rejected(reason)
+
+
+def _binding_rejected(reason: str) -> ResidentConversationScopeBindingResult:
+    return ResidentConversationScopeBindingResult(
+        accepted=False,
+        status="RESIDENT_CONVERSATION_SCOPE_REJECT",
+        rejection_reasons=(reason,),
+    )
+
+
+__all__ = [
+    "ResidentConversationScopeBindingResult",
+    "SCHEMA_VERSION",
+    "bind_resident_conversation_request_to_authenticated_scope",
+]

--- a/modules/communication/moltbot_bridge/tests/README.md
+++ b/modules/communication/moltbot_bridge/tests/README.md
@@ -1,5 +1,20 @@
 # Tests - OpenClaw Bridge
 
+## Resident conversation request-to-scope binding
+
+`test_reddog_resident_conversation_scope_binding.py` uses the existing
+temporary SQLite AgentDB fixture and opaque conversation capabilities. It
+proves existing TURN/STATUS/CANCEL admission, content-free output, zero
+mutation, one-use consumption, exact revision/turn checks, expiry, missing
+state, current principal-signed E0 scope, forged/cross-session/cross-principal
+authority, attacker-rehashed record tampering, dependency failure, and WSP 62
+file/function limits.
+
+```powershell
+$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'
+python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py -q
+```
+
 ## HoloIndex owner replica response contracts
 
 `test_reddog_holoindex_owner_client_transport.py` proves a successful owner

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -1,3 +1,47 @@
+## 2026-08-22: Resident conversation request-to-scope regressions
+
+- Test-first collection initially failed because the binding did not exist.
+- The first implementation produced 10 behavioral passes but failed its WSP
+  62 guard after growing the existing lifecycle source to 490 lines. The
+  bridge was extracted into its own bounded admission module without weakening
+  the guard.
+- Focused adversarial matrix: **15 passed** with expected repo-level pytest
+  configuration warnings and no runtime/network dependency.
+- Focused branch coverage: **100%** (`106` statements, `24` branches).
+- Cross-module transport/authentication/signing/tamper/WSP-62 matrix:
+  **130 passed** using `--import-mode=importlib`. The default prepend import
+  mode cannot collect both modules' same-basename `tests` packages in one
+  process; separate module runs also passed (`36` Digital Twin + `94` bridge).
+- Full local bridge closure (`406` test files; approximately `5,179` test
+  functions): **6,220 passed, 47 skipped, 45 failed** in `17m24s` with plugin
+  autoload disabled. Exact-parent differential at
+  `f06ca1fcc4acc9e2645a3ed898bad844ac6df298` reproduced 44/45 candidate
+  failures. The remaining hardening test passed at the parent and passed when
+  isolated on the candidate, identifying full-suite order pollution rather
+  than a persistent candidate regression. The 44 reproduced failures are
+  inherited environment, stale-boundary, and WSP-62 debt; this is not a clean
+  promotion-suite claim. Independent CI remains required.
+- Repository-wide FMAS was also run and is not a pass: the environment lacks
+  `bandit`/`pip-audit`, and the scan reports inherited structure, parse, and
+  exemption-expiry debt across the repository. The focused binding and module
+  exemption regressions remain green; no clean FMAS claim is made.
+- Covered current TURN/STATUS/CANCEL admission, no AgentDB mutation, one-use
+  capability retirement, stale revision/turn/TTL, new-scope rejection,
+  current principal-signed E0 scope, missing/raising/malformed stores,
+  forged/cross-session/cross-principal authority,
+  attacker-rehashed record authentication, dependency exceptions, content
+  exclusion, and WSP 62 ceilings.
+
+**Commands**:
+
+```powershell
+$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'
+python -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py -q
+python -m coverage run --branch --source=modules.communication.moltbot_bridge.src.reddog_resident_conversation_scope_binding -m pytest modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py -q
+python -m coverage report -m
+python -m pytest --import-mode=importlib modules/ai_intelligence/digital_twin/tests/test_resident_conversation_transport_contract.py modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py modules/communication/moltbot_bridge/tests/test_reddog_authenticated_conversation_scope_state.py modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_authentication.py modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_signing.py modules/communication/moltbot_bridge/tests/test_reddog_conversation_session_authority_source.py modules/communication/moltbot_bridge/tests/test_reddog_conversation_scope_tamper_and_rotation.py modules/communication/moltbot_bridge/tests/test_reddog_wsp62_security_repair_exemptions.py -q
+```
+
 ## 2026-08-22: Holo owner response-replica regressions
 
 - Added four missing-field client cases and one one-shot different-replica

--- a/modules/communication/moltbot_bridge/tests/TestModLog.md
+++ b/modules/communication/moltbot_bridge/tests/TestModLog.md
@@ -25,6 +25,11 @@
   `bandit`/`pip-audit`, and the scan reports inherited structure, parse, and
   exemption-expiry debt across the repository. The focused binding and module
   exemption regressions remain green; no clean FMAS claim is made.
+- The first independent CI test job correctly rejected a stale canonical test
+  registry after this file was added. The deterministic WSP-6 generator added
+  the binding suite to `modules-communication-moltbot-bridge-unit-part-07`,
+  shifted later shard boundaries, and `--check` then reported `CURRENT`
+  (`1,568` entries; `267` explicit quarantines).
 - Covered current TURN/STATUS/CANCEL admission, no AgentDB mutation, one-use
   capability retirement, stale revision/turn/TTL, new-scope rejection,
   current principal-signed E0 scope, missing/raising/malformed stores,

--- a/modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py
+++ b/modules/communication/moltbot_bridge/tests/test_reddog_resident_conversation_scope_binding.py
@@ -1,0 +1,389 @@
+"""Adversarial tests for resident request-to-scope admission binding."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from modules.ai_intelligence.digital_twin.src.resident_conversation_transport_contract import (
+    request_from_mapping,
+)
+from modules.communication.moltbot_bridge.src.reddog_authenticated_conversation_scope_state import (
+    create_authenticated_conversation_scope,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_request import (
+    ConversationScopeCreateRequest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_contract import (
+    with_record_digest,
+)
+from modules.communication.moltbot_bridge.src.reddog_conversation_scope_store import (
+    AgentDbConversationScopeStore,
+)
+from modules.communication.moltbot_bridge.src.reddog_resident_conversation_scope_binding import (
+    bind_resident_conversation_request_to_authenticated_scope,
+)
+from modules.communication.moltbot_bridge.tests.reddog_conversation_scope_test_support import (
+    FOCUS,
+    NOW,
+    SNAPSHOT_DIGEST,
+    SNAPSHOT_ID,
+    TestAgentDb,
+    capability,
+    digest,
+    grounding_receipt,
+    item,
+)
+from modules.communication.moltbot_bridge.tests.reddog_conversation_scope_signing_test_support import (
+    capability as signed_capability,
+    context as signed_context,
+    create as create_signed_scope,
+    credential as signed_credential,
+)
+
+
+_UNSET = object()
+
+
+def _store(path: Path) -> AgentDbConversationScopeStore:
+    return AgentDbConversationScopeStore(lambda: TestAgentDb(path))
+
+
+def _create(path: Path, *, ttl_seconds: int = 3600):
+    return create_authenticated_conversation_scope(
+        store=_store(path),
+        capability=capability(),
+        repo_root=Path(__file__).resolve().parents[4],
+        request=ConversationScopeCreateRequest(
+            work_focus=FOCUS,
+            grounding_receipt=grounding_receipt(),
+            discussion_foundup_ids=("trade",),
+            conversation_nonce="resident-service-binding",
+            turn_id=digest({"turn": "first"}),
+            active_topic="TRADE runtime",
+            current_objective="Bind one authenticated resident request.",
+            accepted_decisions=(
+                item("Use current repository evidence.", "repository_fact"),
+            ),
+            repository_evidence_refs=("code:trade",),
+            source_snapshot_id=SNAPSHOT_ID,
+            source_snapshot_digest=SNAPSHOT_DIGEST,
+            ttl_seconds=ttl_seconds,
+        ),
+        now_epoch=NOW,
+    )
+
+
+def _request(conversation_id: str, **overrides: object):
+    payload: dict[str, object] = {
+        "schema_version": "reddog_resident_conversation_request.v1",
+        "operation": "TURN",
+        "request_id": digest({"request": "one"}),
+        "conversation_id": conversation_id,
+        "expected_revision": 0,
+        "turn_id": digest({"turn": "second"}),
+        "client_nonce": digest({"nonce": "one"}),
+        "idempotency_key": digest({"idempotency": "one"}),
+        "issued_at": NOW,
+        "expires_at": NOW + 60,
+        "operator_text": "Continue the grounded RedDog audit.",
+    }
+    payload.update(overrides)
+    return request_from_mapping(payload, now_epoch=NOW)
+
+
+def _bind(path: Path, request, *, scope_capability=_UNSET, now_epoch: int = NOW):
+    return bind_resident_conversation_request_to_authenticated_scope(
+        store=_store(path),
+        capability=(capability() if scope_capability is _UNSET else scope_capability),
+        request=request,
+        now_epoch=now_epoch,
+    )
+
+
+def test_existing_turn_binds_current_authenticated_cas_without_mutation(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    current = _store(path).load(created.conversation_id)["record"]
+
+    result = _bind(path, _request(created.conversation_id))
+
+    assert result.accepted is True
+    assert result.status == "RESIDENT_CONVERSATION_SCOPE_BOUND"
+    assert result.operation == "TURN"
+    assert result.expected_revision == result.current_revision == 0
+    assert result.current_turn_id == current["turn_id"]
+    assert result.record_digest == current["record_digest"]
+    assert result.binding_id.startswith("sha256:")
+    assert result.cas_reserved is False
+    assert result.grants_identity_authority is False
+    assert result.grants_effect_authority is False
+    assert _store(path).load(created.conversation_id)["record"] == current
+
+    serialized = json.dumps(result.to_dict(), sort_keys=True)
+    assert "Continue the grounded RedDog audit" not in serialized
+    assert "principal_012" not in serialized
+    assert '"trade"' not in serialized
+
+
+def test_capability_is_consumed_once_even_though_binding_grants_no_authority(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    request = _request(created.conversation_id)
+    one_use = capability()
+
+    assert _bind(path, request, scope_capability=one_use).accepted is True
+    replay = _bind(path, request, scope_capability=one_use)
+    assert replay.accepted is False
+    assert replay.rejection_reasons == ("resident_conversation_access_denied",)
+
+
+def test_current_principal_signed_e0_scope_is_admitted(tmp_path: Path) -> None:
+    path = tmp_path / "signed-scope.sqlite"
+    serialized = signed_credential()
+    signing_context, _anchor = signed_context(serialized)
+    created = create_signed_scope(path, signing_context, serialized)
+
+    result = _bind(
+        path,
+        _request(created.conversation_id),
+        scope_capability=signed_capability(signing_context, serialized),
+    )
+
+    assert result.accepted is True
+    assert result.status == "RESIDENT_CONVERSATION_SCOPE_BOUND"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"expected_revision": 1}, "resident_conversation_revision_conflict"),
+        (
+            {"turn_id": digest({"turn": "first"})},
+            "resident_conversation_turn_conflict",
+        ),
+    ],
+)
+def test_turn_rejects_stale_revision_or_current_turn_reuse(
+    tmp_path: Path, overrides: dict[str, object], reason: str
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    result = _bind(path, _request(created.conversation_id, **overrides))
+    assert result.accepted is False
+    assert result.rejection_reasons == (reason,)
+
+
+@pytest.mark.parametrize("operation", ["STATUS", "CANCEL"])
+def test_control_operations_bind_only_the_current_turn(
+    tmp_path: Path, operation: str
+) -> None:
+    path = tmp_path / f"{operation.lower()}.sqlite"
+    created = _create(path)
+    current_turn = _store(path).load(created.conversation_id)["record"]["turn_id"]
+    request = _request(
+        created.conversation_id,
+        operation=operation,
+        turn_id=current_turn,
+        operator_text="",
+    )
+    assert _bind(path, request).accepted is True
+
+    stale = _request(
+        created.conversation_id,
+        operation=operation,
+        turn_id=digest({"turn": "stale-control"}),
+        operator_text="",
+    )
+    rejected = _bind(path, stale)
+    assert rejected.rejection_reasons == ("resident_conversation_turn_conflict",)
+
+
+def test_new_scope_expiry_and_store_failures_remain_fail_closed(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path, ttl_seconds=10)
+    new_scope = _request("", expected_revision=-1)
+    assert _bind(path, new_scope).rejection_reasons == (
+        "resident_conversation_new_scope_resolution_required",
+    )
+    assert _bind(path, _request(created.conversation_id), now_epoch=NOW + 10).rejection_reasons == (
+        "resident_conversation_scope_expired",
+    )
+    missing = _bind(path, _request(digest({"conversation": "missing"})))
+    assert missing.rejection_reasons == ("resident_conversation_access_denied",)
+
+
+def test_expired_or_mutated_envelope_retires_the_operation_capability(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    expired = _request(created.conversation_id)
+    one_use = capability()
+    rejected = _bind(path, expired, scope_capability=one_use, now_epoch=NOW + 60)
+    assert rejected.rejection_reasons == ("resident_conversation_request_expired",)
+    assert _bind(
+        path, _request(created.conversation_id), scope_capability=one_use
+    ).rejection_reasons == ("resident_conversation_access_denied",)
+
+    mutated = _request(created.conversation_id)
+    object.__setattr__(mutated, "schema_version", "forged")
+    assert _bind(path, mutated).rejection_reasons == (
+        "resident_conversation_schema_invalid",
+    )
+
+
+def test_invalid_clock_and_store_exception_reject_without_state_oracle(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    request = _request(created.conversation_id)
+    assert _bind(path, request, now_epoch=True).rejection_reasons == (
+        "resident_conversation_now_invalid",
+    )
+
+    class RaisingStore:
+        def load(self, _conversation_id: str):
+            raise RuntimeError("must not escape")
+
+    result = bind_resident_conversation_request_to_authenticated_scope(
+        store=RaisingStore(),  # type: ignore[arg-type]
+        capability=capability(),
+        request=request,
+        now_epoch=NOW,
+    )
+    assert result.rejection_reasons == ("resident_conversation_access_denied",)
+
+    class RaisingPayload(dict):
+        def get(self, _key, _default=None):
+            raise RuntimeError("malformed mapping must not escape")
+
+    class MalformedStore:
+        def load(self, _conversation_id: str):
+            return RaisingPayload()
+
+    malformed = bind_resident_conversation_request_to_authenticated_scope(
+        store=MalformedStore(),  # type: ignore[arg-type]
+        capability=capability(),
+        request=request,
+        now_epoch=NOW,
+    )
+    assert malformed.rejection_reasons == ("resident_conversation_access_denied",)
+
+    class NonMappingStore:
+        def load(self, _conversation_id: str):
+            return None
+
+    non_mapping = bind_resident_conversation_request_to_authenticated_scope(
+        store=NonMappingStore(),  # type: ignore[arg-type]
+        capability=capability(),
+        request=request,
+        now_epoch=NOW,
+    )
+    assert non_mapping.rejection_reasons == ("resident_conversation_access_denied",)
+
+
+def test_dependency_exceptions_and_empty_validation_reasons_fail_closed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    request = _request(created.conversation_id)
+    target = (
+        "modules.communication.moltbot_bridge.src."
+        "reddog_resident_conversation_scope_binding"
+    )
+    monkeypatch.setattr(
+        f"{target}.consume_conversation_scope_capability",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("closed")),
+    )
+    assert _bind(path, request).rejection_reasons == (
+        "resident_conversation_access_denied",
+    )
+
+    monkeypatch.undo()
+    monkeypatch.setattr(
+        f"{target}.enforce_request_freshness",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError()),
+    )
+    assert _bind(path, request).rejection_reasons == (
+        "resident_conversation_request_invalid",
+    )
+
+
+@pytest.mark.parametrize(
+    "scope_capability",
+    [
+        pytest.param(None, id="not-a-capability"),
+        pytest.param("forged", id="forged-string"),
+    ],
+)
+def test_forged_capability_and_cross_session_authority_are_denied(
+    tmp_path: Path, scope_capability
+) -> None:
+    path = tmp_path / "scope.sqlite"
+    created = _create(path)
+    request = _request(created.conversation_id)
+    if scope_capability is None:
+        scope_capability = object()
+    assert _bind(
+        path, request, scope_capability=scope_capability
+    ).rejection_reasons == ("resident_conversation_access_denied",)
+    assert _bind(
+        path,
+        request,
+        scope_capability=capability(session_binding="window:other"),
+    ).rejection_reasons == ("resident_conversation_access_denied",)
+    wrong_principal = _request(created.conversation_id, expected_revision=99)
+    assert _bind(
+        path,
+        wrong_principal,
+        scope_capability=capability(principal_id="principal_999"),
+    ).rejection_reasons == ("resident_conversation_access_denied",)
+
+
+def test_attacker_rehashed_record_still_fails_record_authentication(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "tampered.sqlite"
+    created = _create(path)
+    record = dict(_store(path).load(created.conversation_id)["record"])
+    record["active_topic"] = "attacker-selected"
+    tampered = with_record_digest(record)
+    with TestAgentDb(path).db.get_connection() as connection:
+        connection.execute(
+            "UPDATE reddog_conversation_scopes SET scope_json = ? WHERE conversation_id = ?",
+            (
+                json.dumps(tampered, sort_keys=True, separators=(",", ":")),
+                created.conversation_id,
+            ),
+        )
+
+    result = _bind(path, _request(created.conversation_id))
+    assert result.rejection_reasons == ("resident_conversation_access_denied",)
+
+
+def test_binding_implementation_respects_wsp62_limits() -> None:
+    source_path = (
+        Path(__file__).parents[1]
+        / "src"
+        / "reddog_resident_conversation_scope_binding.py"
+    )
+    source = source_path.read_text(encoding="utf-8")
+    functions = [
+        node
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    assert len(source.splitlines()) <= 500
+    assert all(node.end_lineno - node.lineno + 1 <= 50 for node in functions)

--- a/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
+++ b/modules/communication/moltbot_bridge/wsp_62_exemptions.yaml
@@ -36,7 +36,7 @@ exemptions:
       revocation, bounded renewal, and proposal signer-policy runtime
       boundaries; splitting the historical registry remains separate
       documentation-maintenance work.
-    threshold_override: 1519
+    threshold_override: 1502
     temporary: true
     review_date: "2026-Q3"
     reviewer: "0102 Technical Architect"


### PR DESCRIPTION
## Summary

- bind one strict zero-authority RedDog TURN/STATUS/CANCEL envelope to one consumed authenticated conversation capability and the exact current AgentDB record
- fail closed for new-scope resolution, malformed/unavailable state, forged or cross-authority capability, expiry, stale revision, and turn-lineage conflict
- emit content-free non-authoritative binding evidence without AgentDB mutation, CAS reservation, model invocation, worker dispatch, Git authority, or effect authority
- align Digital Twin/moltbot navigation, interfaces, roadmaps, ModLogs, and test memory; reduce the inherited INTERFACE WSP-62 ceiling from 1,519 to 1,502 lines
- register the new suite through the deterministic WSP-6 registry generator (`CURRENT`: 1,568 entries / 267 quarantines)

## Validation

- focused admission suite: 15 passed
- focused coverage: 106/106 statements and 24/24 branches (100%)
- cross-module transport/authentication/signing/tamper/WSP-62 matrix: 130 passed
- focused binding plus module WSP-62 gates: 31 passed
- canonical test registry `--check`: current
- Python compile and `git diff --check`: passed
- WSP-15 receipt: 19/P0/ULTRA, canonical validation accepted across the exact 16-path payload
- WSP-97 v1.1 receipt: repository-bound at `f06ca1fcc4acc9e2645a3ed898bad844ac6df298`, compliant, zero violations

## Differential macro evidence

The local bridge closure produced 6,220 passed / 47 skipped / 45 failed in 17m24s with plugin autoload disabled. An exact-parent rerun at `f06ca1f` reproduced 44 of the 45 failure node IDs. The remaining hardening test passed at the parent and passed when isolated on the candidate, identifying full-suite order pollution rather than a persistent candidate regression.

This is not presented as a clean promotion-suite claim. Repository-wide FMAS is also non-clean because the environment lacks Bandit/pip-audit and the repository has inherited structure, parse, and exemption-expiry debt. Independent CI remains the publication authority.

## Deliberate boundary

This phase does not provide trusted new-conversation scope selection, a durable idempotency/replay journal, operation-specific state mutation handlers, or a live VSIX/PFMall ingress adapter. Those gates remain explicit so browser text cannot become identity, FoundUp, model, worker, repository, or effect authority.

`main` is intentionally unchanged while this PR runs, preserving the exact-current Holo replica route at `f06ca1f`.