### PR TITLE
fix(gotjunk): restore deploy path via Artifact Registry

### DIFF
--- a/modules/foundups/gotjunk/cloudbuild.yaml
+++ b/modules/foundups/gotjunk/cloudbuild.yaml
@@ -1,8 +1,12 @@
-# Cloud Build configuration for GotJUNK? FoundUp
+# Cloud Build configuration for GotJunk FoundUp
 # Deploys from modules/foundups/gotjunk/frontend/ to Cloud Run
 
+substitutions:
+  _REGION: us-west1
+  _REPOSITORY: cloud-run-source-deploy
+  _IMAGE: gotjunk
+
 steps:
-  # Step 1: Build Docker image with Firebase secrets
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
     args:
@@ -12,8 +16,7 @@ steps:
           --build-arg VITE_FIREBASE_API_KEY=$$VITE_FIREBASE_API_KEY \
           --build-arg VITE_FIREBASE_APP_ID=$$VITE_FIREBASE_APP_ID \
           --build-arg VITE_FIREBASE_SENDER_ID=$$VITE_FIREBASE_SENDER_ID \
-          -t gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA \
-          -t gcr.io/$PROJECT_ID/gotjunk:latest \
+          -t ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/${_IMAGE}:$COMMIT_SHA \
           -f modules/foundups/gotjunk/frontend/Dockerfile \
           modules/foundups/gotjunk/frontend
     secretEnv:
@@ -21,21 +24,19 @@ steps:
       - 'VITE_FIREBASE_APP_ID'
       - 'VITE_FIREBASE_SENDER_ID'
 
-  # Step 2: Push Docker image to Container Registry
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'push'
-      - 'gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/${_IMAGE}:$COMMIT_SHA'
 
-  # Step 3: Deploy to Cloud Run
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     entrypoint: 'gcloud'
     args:
       - 'run'
       - 'deploy'
       - 'gotjunk'
-      - '--image=gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA'
-      - '--region=us-west1'
+      - '--image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/${_IMAGE}:$COMMIT_SHA'
+      - '--region=${_REGION}'
       - '--platform=managed'
       - '--allow-unauthenticated'
       - '--port=8080'
@@ -46,12 +47,9 @@ steps:
       - '--min-instances=0'
       - '--set-env-vars=NODE_ENV=production'
 
-# Push image to Container Registry
 images:
-  - 'gcr.io/$PROJECT_ID/gotjunk:$COMMIT_SHA'
-  - 'gcr.io/$PROJECT_ID/gotjunk:latest'
+  - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPOSITORY}/${_IMAGE}:$COMMIT_SHA'
 
-# Access secrets from Secret Manager
 availableSecrets:
   secretManager:
     - versionName: projects/$PROJECT_ID/secrets/VITE_FIREBASE_API_KEY/versions/latest
@@ -61,9 +59,7 @@ availableSecrets:
     - versionName: projects/$PROJECT_ID/secrets/VITE_FIREBASE_SENDER_ID/versions/latest
       env: 'VITE_FIREBASE_SENDER_ID'
 
-# Build options
 options:
   logging: CLOUD_LOGGING_ONLY
 
-# Timeout
 timeout: '1200s'


### PR DESCRIPTION
Recovery slice for the persistent GotJunk Cloud Run server error.

- Preserve existing Cloud Run service `gotjunk` in `us-west1`.
- Move image publishing from legacy `gcr.io` to Artifact Registry `us-west1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/gotjunk`.
- Preserve existing Firebase Secret Manager build args and runtime Gemini secret.
- Merging to main should exercise the existing `gotjunk-main-trigger` and redeploy the production PWA.

WSP_00/WSP_97 scope: deployment-path repair only; no GotJunk application behavior changes.