### PR TITLE
fix(holoindex): reconcile final-main test registry count

### DIFF
--- a/WSP_knowledge/WSP_Test_Registry.json
+++ b/WSP_knowledge/WSP_Test_Registry.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "wsp_test_registry.v2",
   "generation_policy": "git-tracked-python-tests.v1",
-  "total_tests": 1569,
+  "total_tests": 1570,
   "quarantined_tests": 267,
   "tests": [
     {


### PR DESCRIPTION
## What changed

Regenerates the canonical test registry at exact final main so `total_tests` equals the 1,570 canonical entries already present.

## Root cause

PR #1543 and PR #1542 each independently added one test while based on a 1,568-entry registry, and each correctly generated `total_tests: 1569`. Git combined both distinct array entries during final-main reconciliation but retained the identical scalar value `1569`. The final file therefore contained 1,570 entries with a declared count of 1,569.

The strict Holo test-registry loader correctly rejected that inconsistency as `test_registry_counts_invalid`, and governed exact-main maintenance failed closed with only `navigation_tests` missing. No completeness or integrity check is relaxed here.

## Validation

- deterministic generator `--check`: **CURRENT**, 1,570 total / 267 quarantined
- canonical registry loader: **PASS**, 1,570 entries / 267 quarantined
- WRE registry, differential-plan, and Holo registry-indexing suites: **52 passed**
- Git diff: exactly one scalar change in one generated file
- WSP_15: P0/ULTRA, exact one-path scope
- WSP_97 receipt: repository-bound and compliant

## Merge race control

Immediately before squash merge, the PR base SHA must still equal remote `main`. If it changes, regenerate the registry on the new exact base and rerun these gates. After merge, `generate_test_registry.py --check` will be rerun against exact final main before Holo maintenance resumes.
